### PR TITLE
Minimalios optimizacijos Django Admin formoms

### DIFF
--- a/vitrina/api/admin.py
+++ b/vitrina/api/admin.py
@@ -25,11 +25,15 @@ class ClientIdFilter(admin.SimpleListFilter):
 class ApiScopeInline(admin.TabularInline):
     model = ApiScope
 
+    search_fields = ('organization', 'dataset')
+    autocomplete_fields = ('organization', 'dataset')
+
 
 class ApiKeyAdmin(VersionAdmin):
     list_display = ("organization", "client_id", "client_name")
     list_filter = [ClientIdFilter]
-    search_fields = ("organization",)
+    search_fields = ("organization", 'representative', 'project')
+    autocomplete_fields = ('organization', 'representative', 'project')
     inlines = [ApiScopeInline]
 
 

--- a/vitrina/datasets/admin.py
+++ b/vitrina/datasets/admin.py
@@ -43,6 +43,7 @@ class AttributionAdmin(admin.ModelAdmin):
 
 
 class DatasetAdmin(TranslatableAdmin, VersionAdmin):
+    search_fields = ('title',)
     list_display = ("title", "description", "is_public")
     form = DatasetAdminForm
 

--- a/vitrina/orgs/admin.py
+++ b/vitrina/orgs/admin.py
@@ -61,6 +61,8 @@ class OrganizationAdmin(VersionAdmin, TreeAdmin):
 
 
 class RepresentativeAdmin(admin.ModelAdmin):
+    search_fields = ("email",)
+
     def delete_model(self, request, obj):
         pre_representative_delete(obj)
         super().delete_model(request, obj)

--- a/vitrina/projects/admin.py
+++ b/vitrina/projects/admin.py
@@ -6,6 +6,7 @@ from vitrina.projects.models import Project
 
 class ProjectAdmin(VersionAdmin):
     list_filter = ("status",)
+    search_fields = ("title",)
 
 
 admin.site.register(Project, ProjectAdmin)


### PR DESCRIPTION
- Pridėti `auto_complete` laukai, kad formos krovimo metu, neturėtų iškart būtų užkraunamos visos foreign-key reikšmės.

---

Prieš (~5s):

https://github.com/user-attachments/assets/7e01dca1-6543-46b4-a171-47cb02aab326

Po: (<1s):

https://github.com/user-attachments/assets/2bf1e3df-a147-49c0-a97d-ce35b64f51a4


Susiję su:
- https://github.com/atviriduomenys/katalogas/issues/1570, Kadangi šios užduoties analizės metu, reikėjo eiti į šią formą ir trumpa optimizacija padėjo išvengti ilgo krovimo laiko.