### PR TITLE
[1603] Adjust form check to not check through Agents that are archived

### DIFF
--- a/tests/orgs/agents/test_forms.py
+++ b/tests/orgs/agents/test_forms.py
@@ -52,11 +52,11 @@ def test_failure_agent_create_form_open_data_is_published_but_no_url_is_provided
 def test_agent_form_duplicate_codename():
     organization = OrganizationFactory()
     dataset = DatasetFactory(service=True, organization=organization)
-    Agent.objects.create(title="Pasikartojantis", organization=organization, service=dataset)
+    Agent.objects.create(title="Repeating", organization=organization, service=dataset)
 
     form = AgentForm(
         data={
-            "title": "Pasikartojantis",
+            "title": "Repeating",
             "is_enabled": True,
             "is_open_data_published": False,
             "object_type": AgentType.SPINTA,
@@ -68,3 +68,23 @@ def test_agent_form_duplicate_codename():
     assert form.errors["title"] == [
         "Agentas su tokiu pavadinimu jau registruotas organizacijoje, pasirinkite kitą pavadinimą."
     ]
+
+
+@pytest.mark.django_db
+def test_agent_form_duplicate_codename_first_agent_is_archived():
+    """Only forbid creating an Agent with a repeating name if the initial Agent is not archived."""
+    organization = OrganizationFactory()
+    dataset = DatasetFactory(service=True, organization=organization)
+    Agent.objects.create(title="Repeating", organization=organization, service=dataset, is_archived=True)
+
+    form = AgentForm(
+        data={
+            "title": "Repeating",
+            "is_enabled": True,
+            "is_open_data_published": False,
+            "object_type": AgentType.SPINTA,
+        },
+        organization=organization
+    )
+    assert form.is_valid()
+

--- a/vitrina/orgs/forms.py
+++ b/vitrina/orgs/forms.py
@@ -1347,7 +1347,7 @@ class AgentForm(ModelForm):
 
         if (title := cleaned_data.get("title")) and self.organization:
             existing_agent = Agent.objects.filter(
-                organization=self.organization, codename=Agent.get_codename(title)
+                organization=self.organization, codename=Agent.get_codename(title), is_archived=False,
             ).exclude(
                 pk=self.instance.pk,
             ).exists()


### PR DESCRIPTION
Bugfix on Agents, the database level check assures that Agent codenames are not repeating through Agents that are not archived. But the form, did not check if the Agent is archived or not thus we were getting a form error, when we repeat the name of an Agent that was archived already.