### PR TITLE
fix: fix broken test because of package update

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -205,7 +205,7 @@ version = "1.1.0"
 description = "Python bindings for the Brotli compression library"
 optional = false
 python-versions = "*"
-groups = ["dev"]
+groups = ["main"]
 markers = "platform_python_implementation == \"CPython\""
 files = [
     {file = "Brotli-1.1.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e1140c64812cb9b06c922e77f1c26a75ec5e3f0fb2bf92cc8c58720dec276752"},
@@ -341,7 +341,7 @@ version = "1.1.0.0"
 description = "Python CFFI bindings to the Brotli library"
 optional = false
 python-versions = ">=3.7"
-groups = ["dev"]
+groups = ["main"]
 markers = "platform_python_implementation != \"CPython\""
 files = [
     {file = "brotlicffi-1.1.0.0-cp37-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9b7ae6bd1a3f0df532b6d67ff674099a96d22bc0948955cb338488c31bfb8851"},
@@ -409,7 +409,7 @@ name = "cattrs"
 version = "25.1.1"
 description = "Composable complex class support for attrs and dataclasses."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
     {file = "cattrs-25.1.1-py3-none-any.whl", hash = "sha256:1b40b2d3402af7be79a7e7e097a9b4cd16d4c06e6d526644b0b26a063a1cc064"},
@@ -424,8 +424,8 @@ typing-extensions = ">=4.12.2"
 bson = ["pymongo (>=4.4.0)"]
 cbor2 = ["cbor2 (>=5.4.6)"]
 msgpack = ["msgpack (>=1.0.5)"]
-msgspec = ["msgspec (>=0.18.5) ; implementation_name == \"cpython\""]
-orjson = ["orjson (>=3.9.2) ; implementation_name == \"cpython\""]
+msgspec = ["msgspec (>=0.19.0) ; implementation_name == \"cpython\""]
+orjson = ["orjson (>=3.10.7) ; implementation_name == \"cpython\""]
 pyyaml = ["pyyaml (>=6.0)"]
 tomlkit = ["tomlkit (>=0.11.8)"]
 ujson = ["ujson (>=5.10.0)"]
@@ -1689,7 +1689,7 @@ name = "editorconfig"
 version = "0.17.1"
 description = "EditorConfig File Locator and Interpreter for Python"
 optional = false
-python-versions = "*"
+python-versions = ">=3.9"
 groups = ["dev"]
 files = [
     {file = "editorconfig-0.17.1-py3-none-any.whl", hash = "sha256:1eda9c2c0db8c16dbd50111b710572a5e6de934e39772de1959d41f64fc17c82"},
@@ -1790,7 +1790,7 @@ version = "4.58.2"
 description = "Tools to manipulate font files"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "fonttools-4.58.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:4baaf34f07013ba9c2c3d7a95d0c391fcbb30748cb86c36c094fab8f168e49bb"},
     {file = "fonttools-4.58.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2e26e4a4920d57f04bb2c3b6e9a68b099c7ef2d70881d4fee527896fa4f7b5aa"},
@@ -2615,7 +2615,7 @@ version = "20250506"
 description = "PDF parser and analyzer"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "pdfminer_six-20250506-py3-none-any.whl", hash = "sha256:d81ad173f62e5f841b53a8ba63af1a4a355933cfc0ffabd608e568b9193909e3"},
     {file = "pdfminer_six-20250506.tar.gz", hash = "sha256:b03cc8df09cf3c7aba8246deae52e0bca7ebb112a38895b5e1d4f5dd2b8ca2e7"},
@@ -2934,7 +2934,7 @@ version = "0.11.0"
 description = "A low-level PDF generator."
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "pydyf-0.11.0-py3-none-any.whl", hash = "sha256:0aaf9e2ebbe786ec7a78ec3fbffa4cdcecde53fd6f563221d53c6bc1328848a3"},
     {file = "pydyf-0.11.0.tar.gz", hash = "sha256:394dddf619cca9d0c55715e3c55ea121a9bf9cbc780cdc1201a2427917b86b64"},
@@ -3017,7 +3017,7 @@ version = "0.17.2"
 description = "Pure Python module to hyphenate text"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "pyphen-0.17.2-py3-none-any.whl", hash = "sha256:3a07fb017cb2341e1d9ff31b8634efb1ae4dc4b130468c7c39dd3d32e7c3affd"},
     {file = "pyphen-0.17.2.tar.gz", hash = "sha256:f60647a9c9b30ec6c59910097af82bc5dd2d36576b918e44148d8b07ef3b4aa3"},
@@ -3342,7 +3342,7 @@ name = "redis"
 version = "6.2.0"
 description = "Python client for Redis database and key-value store"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
     {file = "redis-6.2.0-py3-none-any.whl", hash = "sha256:c8ddf316ee0aab65f04a11229e94a64b2618451dab7a67cb2f77eb799d872d5e"},
@@ -4100,7 +4100,7 @@ name = "typing-extensions"
 version = "4.14.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main", "dev"]
 files = [
     {file = "typing_extensions-4.14.0-py3-none-any.whl", hash = "sha256:a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af"},
@@ -4155,7 +4155,7 @@ name = "uritemplate"
 version = "4.2.0"
 description = "Implementation of RFC 6570 URI Templates"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
     {file = "uritemplate-4.2.0-py3-none-any.whl", hash = "sha256:962201ba1c4edcab02e60f9a0d3821e82dfc5d2d6662a21abd533879bdb8a686"},
@@ -4235,7 +4235,7 @@ version = "62.3"
 description = "The Awesome Document Factory"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "weasyprint-62.3-py3-none-any.whl", hash = "sha256:d31048646ce15084e135b33e334a61f526aa68d2f679fcc109ed0e0f5edaed21"},
     {file = "weasyprint-62.3.tar.gz", hash = "sha256:8d8680d732f7fa0fcbc587692a5a5cb095c3525627066918d6e203cbf42b7fcd"},
@@ -4337,7 +4337,7 @@ version = "0.2.3.post1"
 description = "Zopfli module for python"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "zopfli-0.2.3.post1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e0137dd64a493ba6a4be37405cfd6febe650a98cc1e9dca8f6b8c63b1db11b41"},
     {file = "zopfli-0.2.3.post1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:aa588b21044f8a74e423d8c8a4c7fc9988501878aacced793467010039c50734"},
@@ -4430,4 +4430,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "96c27096d1f5a57b4487659257f7bbf1427b25afd1ee7a74a1a5a4f2fcb66e25"
+content-hash = "35e674b0fbe3425997a11102d7a34d3c8c5d53b0d239782b521617063ea4fe7d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,9 @@ django-redis = "^5.4.0"
 setuptools = "^75.7.0"
 dataset = "^1.5.2"
 psutil = "^7.0.0"
+weasyprint = "^62.0"
+pdfminer-six = "^20250506"
+
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.1.2"
 pytest-cov = "^3.0.0"
@@ -83,9 +86,6 @@ xlsxwriter = "^3.0.3"
 django-browser-reload = "^1.10.0"
 ruff = "^0.9.3"
 djlint = "^1.36.4"
-weasyprint = "^62.0"
-markdown = "^3.6"
-pdfminer-six = "^20250506"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/comments/test_views.py
+++ b/tests/comments/test_views.py
@@ -171,8 +171,10 @@ def test_reply_for_reply(app: DjangoTestApp):
 
     app.set_user(user)
     form = app.get(comment.content_object.get_absolute_url()).forms['reply-form']
-    form['is_public'] = True
-    form['body'] = "Test reply"
+    form.fields['is_public'][0].value = True
+    form.fields['body'][0].value = "Test reply"
+    form.fields['is_public'][1].value = True
+    form.fields['body'][1].value = "Test reply"
     resp = form.submit().follow()
     comments = Comment.objects.filter(content_type=comment.content_type, object_id=comment.object_id)
     new_reply = Comment.objects.filter(content_type=comment.content_type, parent=reply).first()


### PR DESCRIPTION
Kadangi MR pipeline ne visada paleidžia testus, per klaidą buvo sumerginta pakeitimai su neveikiančiu testu (kodėl ne visada paleidžia testus būtų dar galima pasiaiškinti). Testas sulūžo, nes pridėjus papildomus packages pasikėlė webtest package versija iš 3.0.4 į 3.0.6 ir pasikeitė, kaip operuojama su vienodų pavadinimų laukais, t.y. esant vienodo pavadinimo laukams į juos kreiptis reikia atskirai naudojant indeksą, kitaip gaunama klaida. Prieš tai reikšmė budavo priskiriama abiems laukams naudojant vieną raktažodį.

Pakeitimai:
- test nurodomi vienodo pavadinimo laukai naudojant indeksą
- nauji packages per klaidą buvo pridėti prie dev group, packages pridėti prie main dependencies ir pridėjau tuščią eilutę, kad matytusi atskirimas tarp dev ir main grupių