### PR TITLE
1666 Add API endpoint for PROTECTED rdf.

### DIFF
--- a/tests/api/test_views.py
+++ b/tests/api/test_views.py
@@ -2,6 +2,7 @@ import secrets
 from datetime import datetime
 
 import pytest
+from django.test import TestCase
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.models import Site
 from django.urls import reverse
@@ -2216,3 +2217,40 @@ def test_get_dataset_publisher(app: DjangoTestApp):
         'datasetId': ds1.pk
     }))
     assert int(res.json['id']) == ds1.pk
+
+
+class EdpDcatApRestrictedRdfTests(TestCase):
+    def test_edp_dcat_ap_restricted_rdf_returns_rdf(self):
+        organization = OrganizationFactory()
+        Dataset.objects.create(
+            title="Restricted Dataset",
+            access_rights=Dataset.RESTRICTED,
+            deleted=None,
+            deleted_on=None,
+            organization_id=organization.pk,
+        )
+
+        response = self.client.get(reverse("edp-dcat-ap-restricted-rdf"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/rdf+xml")
+        self.assertIn(b"Restricted Dataset", response.content)
+
+
+    def test_edp_dcat_ap_restricted_rdf_with_no_datasets(self):
+        response = self.client.get(reverse("edp-dcat-ap-restricted-rdf"))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/rdf+xml")
+        self.assertNotIn(b"<dcat:Dataset>", response.content)
+
+    def test_edp_dcat_ap_restricted_rdf_excludes_public(self):
+        organization = OrganizationFactory()
+        Dataset.objects.create(
+            title="Public Dataset",
+            access_rights="public",  # Not Dataset.RESTRICTED
+            deleted=None,
+            deleted_on=None,
+            organization_id=organization.pk,
+        )
+        response = self.client.get(reverse("edp-dcat-ap-restricted-rdf"))
+        self.assertNotIn(b"Public Dataset", response.content)

--- a/tests/api/test_views.py
+++ b/tests/api/test_views.py
@@ -2006,6 +2006,7 @@ def test_edp_dcat_ap_rdf(app: DjangoTestApp):
             title='Data Enterprise',
             email='data@example.com',
         ),
+        access_rights=Dataset.PUBLIC,
     )
     dist1 = DatasetDistributionFactory(
         dataset=dataset,
@@ -2254,3 +2255,39 @@ class EdpDcatApRestrictedRdfTests(TestCase):
         )
         response = self.client.get(reverse("edp-dcat-ap-restricted-rdf"))
         self.assertNotIn(b"Public Dataset", response.content)
+
+class EdpDcatApPublicRdfTests(TestCase):
+    def test_edp_dcat_ap_public_rdf_returns_rdf(self):
+        organization = OrganizationFactory()
+        Dataset.objects.create(
+            title="Public Dataset",
+            access_rights=Dataset.PUBLIC,
+            deleted=None,
+            deleted_on=None,
+            organization_id=organization.pk,
+        )
+
+        response = self.client.get(reverse("edp-dcat-ap-rdf"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/rdf+xml")
+        self.assertIn(b"Public Dataset", response.content)
+
+
+    def test_edp_dcat_ap_public_rdf_with_no_datasets(self):
+        response = self.client.get(reverse("edp-dcat-ap-rdf"))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/rdf+xml")
+        self.assertNotIn(b"<dcat:Dataset>", response.content)
+
+    def test_edp_dcat_ap_public_rdf_excludes_restricted(self):
+        organization = OrganizationFactory()
+        Dataset.objects.create(
+            title="Restricted Dataset",
+            access_rights=Dataset.RESTRICTED,  # Not Dataset.PUBLIC
+            deleted=None,
+            deleted_on=None,
+            organization_id=organization.pk,
+        )
+        response = self.client.get(reverse("edp-dcat-ap-rdf"))
+        self.assertNotIn(b"Restricted Dataset", response.content)

--- a/vitrina/api/urls.py
+++ b/vitrina/api/urls.py
@@ -20,6 +20,7 @@ from vitrina.api.views import (
     edp_dcat_ap_rdf,
     TaskViewSet,
     DistributionCreateAfterUploadToStorage,
+    edp_dcat_ap_protected_rdf,
 )
 
 router = DefaultRouter(trailing_slash=False)
@@ -153,4 +154,9 @@ urlpatterns = [
         name="public-api",
     ),
     path("edp/dcat-ap.rdf", edp_dcat_ap_rdf, name="edp-dcat-ap-rdf"),
+    path(
+        "edp/dcat-ap-restricted.rdf",
+        edp_dcat_ap_restricted_rdf,
+        name="edp-dcat-ap-restricted-rdf",
+    ),
 ]

--- a/vitrina/api/urls.py
+++ b/vitrina/api/urls.py
@@ -18,9 +18,9 @@ from vitrina.api.views import (
     PartnerApiView,
     UploadToStorageViewSet,
     edp_dcat_ap_rdf,
+    edp_dcat_ap_restricted_rdf,
     TaskViewSet,
     DistributionCreateAfterUploadToStorage,
-    edp_dcat_ap_protected_rdf,
 )
 
 router = DefaultRouter(trailing_slash=False)

--- a/vitrina/api/views.py
+++ b/vitrina/api/views.py
@@ -796,12 +796,26 @@ class DatasetModelDownloadViewSet(CreateModelMixin, UpdateModelMixin, GenericVie
         return Response(serializer.data, status=status.HTTP_200_OK, headers=headers)
 
 
+DCAT_AP_RDF_TEMPLATE_NAME = "vitrina/api/edp/dcat_ap_rdf.html"
+
+
 def edp_dcat_ap_rdf(request: HttpRequest) -> HttpResponse:
     return render(
         request,
-        "vitrina/api/edp/dcat_ap_rdf.html",
+        DCAT_AP_RDF_TEMPLATE_NAME,
         {
             "datasets": get_datasets_for_rdf(Dataset.public.all()),
+        },
+        content_type="application/rdf+xml",
+    )
+
+
+def edp_dcat_ap_restricted_rdf(request: HttpRequest) -> HttpResponse:
+    return render(
+        request,
+        DCAT_AP_RDF_TEMPLATE_NAME,
+        {
+            "datasets": get_datasets_for_rdf(Dataset.edp_restricted.all()),
         },
         content_type="application/rdf+xml",
     )

--- a/vitrina/api/views.py
+++ b/vitrina/api/views.py
@@ -804,7 +804,7 @@ def edp_dcat_ap_rdf(request: HttpRequest) -> HttpResponse:
         request,
         DCAT_AP_RDF_TEMPLATE_NAME,
         {
-            "datasets": get_datasets_for_rdf(Dataset.public.all()),
+            "datasets": get_datasets_for_rdf(Dataset.edp_public.all()),
         },
         content_type="application/rdf+xml",
     )

--- a/vitrina/datasets/factories.py
+++ b/vitrina/datasets/factories.py
@@ -60,6 +60,7 @@ class DatasetFactory(DjangoModelFactory):
     will_be_financed = False
     status = Dataset.HAS_DATA
     frequency = factory.SubFactory(FrequencyFactory)
+    access_rights = Dataset.PUBLIC
     published = factory.Faker(
         "date_time",
         tzinfo=timezone.get_current_timezone(),

--- a/vitrina/datasets/managers.py
+++ b/vitrina/datasets/managers.py
@@ -18,6 +18,20 @@ class PublicDatasetManager(TranslatableManager):
         return self.get(id=kwargs.get("pk"))
 
 
+class EdpPublicDatasetManager(TranslatableManager):
+    def get_queryset(self):
+        return (
+            super()
+            .get_queryset()
+            .filter(
+                access_rights=self.model.PUBLIC,
+                deleted__isnull=True,
+                deleted_on__isnull=True,
+                organization_id__isnull=False,
+            )
+        )
+
+
 class EdpRestrictedDatasetManager(TranslatableManager):
     def get_queryset(self):
         return (

--- a/vitrina/datasets/managers.py
+++ b/vitrina/datasets/managers.py
@@ -16,3 +16,17 @@ class PublicDatasetManager(TranslatableManager):
 
     def get_from_url_args(self, **kwargs):
         return self.get(id=kwargs.get("pk"))
+
+
+class EdpRestrictedDatasetManager(TranslatableManager):
+    def get_queryset(self):
+        return (
+            super()
+            .get_queryset()
+            .filter(
+                access_rights=self.model.RESTRICTED,
+                deleted__isnull=True,
+                deleted_on__isnull=True,
+                organization_id__isnull=False,
+            )
+        )

--- a/vitrina/datasets/models.py
+++ b/vitrina/datasets/models.py
@@ -22,7 +22,11 @@ from vitrina.users.models import User
 from vitrina.orgs.models import Organization, Representative
 from vitrina.catalogs.models import Catalog, HarvestingJob
 from vitrina.classifiers.models import Category, Frequency
-from vitrina.datasets.managers import PublicDatasetManager, EdpRestrictedDatasetManager
+from vitrina.datasets.managers import (
+    EdpPublicDatasetManager,
+    EdpRestrictedDatasetManager,
+    PublicDatasetManager,
+)
 
 from vitrina.settings import TRANSLATION_CLIENT_ID
 
@@ -398,6 +402,7 @@ class Dataset(TranslatableModel):
 
     objects = TranslatableManager()
     public = PublicDatasetManager()
+    edp_public = EdpPublicDatasetManager()
     edp_restricted = EdpRestrictedDatasetManager()
 
     class Meta:

--- a/vitrina/datasets/models.py
+++ b/vitrina/datasets/models.py
@@ -22,7 +22,7 @@ from vitrina.users.models import User
 from vitrina.orgs.models import Organization, Representative
 from vitrina.catalogs.models import Catalog, HarvestingJob
 from vitrina.classifiers.models import Category, Frequency
-from vitrina.datasets.managers import PublicDatasetManager
+from vitrina.datasets.managers import PublicDatasetManager, EdpRestrictedDatasetManager
 
 from vitrina.settings import TRANSLATION_CLIENT_ID
 
@@ -398,6 +398,7 @@ class Dataset(TranslatableModel):
 
     objects = TranslatableManager()
     public = PublicDatasetManager()
+    edp_restricted = EdpRestrictedDatasetManager()
 
     class Meta:
         db_table = "dataset"


### PR DESCRIPTION
Instead of modifying existing `PublicDatasetManager`, which is used in few different places, introduced new `EdpPublicDatasetManager` that is used specifically for `edp/dcat-ap.rdf` endpoint.