### PR TITLE
[1713] API Endpoints for synchronization: Part 3

### DIFF
--- a/tests/oauth/test_oauth.py
+++ b/tests/oauth/test_oauth.py
@@ -1,7 +1,9 @@
-from unittest.mock import patch, MagicMock
+import time
+from typing import Any, Tuple, Optional, List
+from unittest.mock import patch, MagicMock, Mock
 
 import pytest
-from authlib.jose import JWTClaims
+from authlib.jose import JWTClaims, JsonWebKey, jwt
 from authlib.jose.errors import BadSignatureError
 from django.core.exceptions import ImproperlyConfigured
 from oauthlib.oauth2 import TokenExpiredError
@@ -12,149 +14,289 @@ from vitrina.api.oauth import (
     OAuth2AuthenticationWithLocalJWK,
     IsOAuthTokenValid,
     OAuthTokenHasScopes,
-    OAuthTokenHasValidOrganizationClaim, OAuthClientAuthenticator
+    OAuthTokenHasValidOrganizationClaim,
+    OAuthClientAuthenticator
 )
+from vitrina.orgs.factories import OrganizationFactory
 
 
-@pytest.fixture
-def factory():
-    return APIRequestFactory()
-
-
-class DummyView:
-    def __init__(self, required_scopes=None, kwargs=None):
+class TestView:
+    def __init__(self, required_scopes: list | None = None, kwargs: Any = None):
         self.required_scopes = required_scopes or []
         self.kwargs = kwargs or {}
 
 
-def test_authenticate_success(factory):
-    request = factory.get("/")
-
-    mock_claims = MagicMock()
-
-    with patch("vitrina.api.oauth.OAuthClientAuthenticator.retrieve_and_verify_token", return_value=mock_claims):
-        auth = OAuth2AuthenticationWithLocalJWK()
-        user, claims = auth.authenticate(request)
-
-        assert user.is_anonymous
-        assert claims == mock_claims
+@pytest.fixture
+def request_factory():
+    return APIRequestFactory()
 
 
-def test_authenticate_token_missing(factory):
-    request = factory.get("/")
+@pytest.fixture
+def encoded_decoded_jwt() -> Tuple[str, JWTClaims]:
+    key = JsonWebKey.generate_key(kty="oct", crv_or_size=256, is_private=True)
+    claims = {
+        "iss": "issuer",
+        "sub": "client",
+        "scope": "test_scope",
+        "organization_id": 1,
+        "iat": int(time.time()),
+        "exp": int(time.time()) + 300
+    }
+    encoded = jwt.encode({"alg": "HS256"}, claims, key).decode()
+    decoded = jwt.decode(encoded, key)
 
-    with patch.object(OAuthClientAuthenticator, "retrieve_and_verify_token", return_value=None):
-        auth = OAuth2AuthenticationWithLocalJWK()
-        with pytest.raises(AuthenticationFailed, match="Token not supplied"):
-            auth.authenticate(request)
-
-
-@pytest.mark.parametrize("error", ["bad", "expired"])
-def test_authenticate_token_invalid(factory, error):
-    request = factory.get("/")
-
-    error_cls = {
-        "bad": BadSignatureError,
-        "expired": TokenExpiredError
-    }[error]
-
-    mock_error = error_cls("Invalid")
-
-    with patch.object(OAuthClientAuthenticator, "retrieve_and_verify_token", side_effect=mock_error):
-        auth = OAuth2AuthenticationWithLocalJWK()
-        with pytest.raises(AuthenticationFailed):
-            auth.authenticate(request)
+    return encoded, decoded
 
 
-def test_is_oauth_token_valid_true():
-    request = MagicMock()
-    request.auth = MagicMock(spec=JWTClaims)
-    permission = IsOAuthTokenValid()
+@pytest.fixture
+def decoded_jwt() -> JWTClaims:
+    key = JsonWebKey.generate_key(kty="oct", crv_or_size=256, is_private=True)
+    claims = {
+        "iss": "issuer",
+        "sub": "client",
+        "scope": "test_scope",
+        "organization_id": 1,
+        "iat": int(time.time()),
+        "exp": int(time.time()) + 300
+    }
+    encoded = jwt.encode({"alg": "HS256"}, claims, key).decode()
+    decoded = jwt.decode(encoded, key)
 
-    assert permission.has_permission(request, None) is True
-    request.auth.validate.assert_called_once()
-
-
-def test_is_oauth_token_valid_invalid_auth():
-    request = MagicMock()
-    request.auth = None
-    permission = IsOAuthTokenValid()
-
-    with pytest.raises(AttributeError):  # Because validate() is called unconditionally
-        permission.has_permission(request, None)
-
-
-def test_oauth_token_has_scopes_valid():
-    request = MagicMock()
-    request.auth = {"scope": "read write"}
-    view = DummyView(required_scopes=["read"])
-
-    permission = OAuthTokenHasScopes()
-    assert permission.has_permission(request, view) is True
+    return decoded
 
 
-def test_oauth_token_has_scopes_missing():
-    request = MagicMock()
-    request.auth = {"scope": "read"}
-    view = DummyView(required_scopes=["write"])
+def test_authentication_with_local_jwk_authenticate_success(request_factory: APIRequestFactory, decoded_jwt: JWTClaims):
+    request = request_factory.get("/", HTTP_AUTHORIZATION="Bearer <token>")
 
-    permission = OAuthTokenHasScopes()
-    assert permission.has_permission(request, view) is False
+    with patch.object(OAuthClientAuthenticator, "retrieve_and_verify_token", return_value=decoded_jwt):
+        user, token = OAuth2AuthenticationWithLocalJWK().authenticate(request)
 
-
-def test_oauth_token_has_scopes_unspecified():
-    request = MagicMock()
-    request.auth = {"scope": "read"}
-    view = DummyView(required_scopes=[])
-
-    permission = OAuthTokenHasScopes()
-    assert permission.has_permission(request, view) is True
+    assert user.is_anonymous is True
+    assert token == decoded_jwt
 
 
-def test_oauth_token_get_scopes_missing_attribute():
-    request = MagicMock()
-    view = object()
+@pytest.mark.parametrize(
+    "raised_exception, exception_message",
+    [
+        [BadSignatureError("Very bad signature"), "bad_signature"],
+        [TokenExpiredError("Very expired token"), "token_expired"]
+    ]
+)
+def test_authentication_with_local_jwk_authenticate_exception_raised(
+    raised_exception: Exception,
+    exception_message: str,
+    request_factory: APIRequestFactory
+):
+    request = request_factory.get("/", HTTP_AUTHORIZATION="Bearer <token>")
 
-    with pytest.raises(ImproperlyConfigured):
-        OAuthTokenHasScopes.get_scopes(request, view)
+    with (
+        patch.object(
+            OAuthClientAuthenticator,
+            "retrieve_and_verify_token",
+            side_effect=raised_exception
+        ),
+        pytest.raises(AuthenticationFailed) as exc_info
+    ):
+        OAuth2AuthenticationWithLocalJWK().authenticate(request)
+
+    assert str(exc_info.value) == exception_message
 
 
-def test_oauth_token_valid_org_success():
-    request = MagicMock()
-    claims = {"form": "org", "org": "VSSA"}
+@pytest.mark.parametrize(
+    "auth_header",
+    [
+        None,  # No Authorization header
+        "InvalidHeaderWithoutSpace",  # Header causes ValueError when splitting
+        "Basic <token>",  # Header not starting with `Bearer`
+    ]
+)
+def test_authentication_with_local_jwk_authenticate_no_access_token_in_request(
+    auth_header: Optional[str],
+    request_factory: APIRequestFactory,
+):
+    headers = {}
+    if auth_header:
+        headers["HTTP_AUTHORIZATION"] = auth_header
+
+    request = request_factory.get("/", **headers)
+    token = OAuthClientAuthenticator.retrieve_access_token_from_request(request)
+
+    assert token is None
+
+
+def test_authentication_with_local_jwk_authenticate_token_not_verified(request_factory: APIRequestFactory):
+    request = request_factory.get("/", HTTP_AUTHORIZATION="Bearer <token>")
+
+    with (
+        patch.object(
+            OAuthClientAuthenticator,
+            "retrieve_and_verify_token",
+            return_value=None,
+        ),
+        pytest.raises(AuthenticationFailed) as exc_info
+    ):
+        OAuth2AuthenticationWithLocalJWK().authenticate(request)
+
+    assert str(exc_info.value) == "Token not supplied"
+
+
+def test_token_validation_success(
+    request_factory: APIRequestFactory,
+    decoded_jwt: JWTClaims,
+):
+    request = request_factory.get("/")
+    request.auth = decoded_jwt
+
+    assert IsOAuthTokenValid().has_permission(request, view=MagicMock()) is True
+
+
+def test_token_validation_failure(
+    request_factory: APIRequestFactory,
+    decoded_jwt: JWTClaims,
+):
+    claims = decoded_jwt
+    claims.validate = MagicMock(side_effect=ValueError("Simulated validation error"))
+
+    request = request_factory.get("/")
     request.auth = claims
 
-    mock_org = MagicMock()
-    mock_org.kind = "org"
-    mock_org.name = "VSSA"
+    with pytest.raises(ValueError) as exc_info:
+        IsOAuthTokenValid().has_permission(request, view=MagicMock())
 
-    view = DummyView(kwargs={"form": "org", "org": "VSSA"})
-
-    with patch.object(OAuthClientAuthenticator, "resolve_organization_from_token", return_value=mock_org):
-        permission = OAuthTokenHasValidOrganizationClaim()
-        assert permission.has_permission(request, view) is True
-        assert request.organization == mock_org
+    assert str(exc_info.value) == "Simulated validation error"
 
 
-def test_oauth_token_valid_org_mismatch():
-    request = MagicMock()
-    request.auth = {"form": "org", "org": "VSSA"}
-    view = DummyView(kwargs={"form": "org", "org": "Not VSSA"})
+def test_token_validation_failure_due_to_invalid_auth_object(request_factory: APIRequestFactory):
+    request = request_factory.get("/")
+    request.auth = {}  # Passing a regular-empty dictionary.
 
-    mock_org = MagicMock()
-    mock_org.kind = "org"
-    mock_org.name = "VSSA"
+    with pytest.raises(AttributeError) as exc_info:
+        IsOAuthTokenValid().has_permission(request, view=MagicMock())
 
-    with patch.object(OAuthClientAuthenticator, "resolve_organization_from_token", return_value=mock_org):
-        permission = OAuthTokenHasValidOrganizationClaim()
-        assert permission.has_permission(request, view) is False
+    assert str(exc_info.value) == "'dict' object has no attribute 'validate'"
 
 
-def test_oauth_token_valid_org_none():
-    request = MagicMock()
-    request.auth = {"org_id": "123"}
-    view = DummyView(kwargs={"organization_id": "123"})
+def test_token_has_permissions_success(request_factory: APIRequestFactory):
+    request = request_factory.get("/")
+    request.auth = {"scope": "read write execute"}
+    view = TestView(required_scopes=["read", "write", "execute"])
 
-    with patch.object(OAuthClientAuthenticator, "resolve_organization_from_token", return_value=None):
-        permission = OAuthTokenHasValidOrganizationClaim()
-        assert permission.has_permission(request, view) is False
+    assert OAuthTokenHasScopes().has_permission(request, view) is True
+
+
+def test_token_has_permissions_success_specific_scopes_defined_for_endpoint(request_factory: APIRequestFactory):
+    request = request_factory.get("/")
+    request.auth = {"scope": "read write execute"}
+    view = TestView(required_scopes=["read"])
+
+    assert OAuthTokenHasScopes().has_permission(request, view) is True
+
+
+def test_token_has_permissions_no_token(request_factory: APIRequestFactory):
+    request = request_factory.get("/")
+    request.auth = None
+    view = TestView(required_scopes=["read"])
+
+    assert OAuthTokenHasScopes().has_permission(request, view) is False
+
+
+def test_token_has_permissions_view_has_no_scopes(
+    request_factory: APIRequestFactory,
+    decoded_jwt: JWTClaims,
+):
+    """Even though this test returns True, Views without defined scopes will throw `ImproperlyConfigured` exception."""
+    request = request_factory.get("/")
+    request.auth = decoded_jwt
+    view = TestView(required_scopes=[])
+
+    assert OAuthTokenHasScopes().has_permission(request, view) is True
+
+
+@pytest.mark.parametrize(
+    "required_scopes, token_scopes, expected_result",
+    [
+        ([], "read write", True),           # No required scopes
+        (["admin"], "read write", False),   # Required scope not in token scopes
+        (["read"], "read write", True),     # Required scope in token scopes
+    ],
+)
+def test_token_has_permissions_invalid_scopes(
+    required_scopes: List[str],
+    token_scopes: str,
+    expected_result: bool,
+    request_factory: APIRequestFactory,
+    decoded_jwt: JWTClaims,
+):
+    decoded_jwt["scope"] = token_scopes
+
+    request = request_factory.get("/")
+    request.auth = decoded_jwt
+    view = TestView(required_scopes=required_scopes)
+
+    assert OAuthTokenHasScopes().has_permission(request, view) is expected_result
+
+
+def test_token_has_permissions_no_view_scopes_defined(
+    request_factory: APIRequestFactory,
+    decoded_jwt: JWTClaims,
+):
+    request = request_factory.get("/")
+    request.auth = decoded_jwt
+
+    view = Mock(spec=[])
+
+    with pytest.raises(ImproperlyConfigured) as exc_info:
+        OAuthTokenHasScopes().has_permission(request, view)
+
+    assert str(exc_info.value) == "TokenHasScope requires the view to define the required_scopes attribute"
+
+
+@pytest.mark.django_db
+def test_token_has_valid_organization_claim_has_permission_success(
+    request_factory: APIRequestFactory,
+    decoded_jwt: JWTClaims,
+):
+    organization = OrganizationFactory(id=decoded_jwt["organization_id"], kind="org", name="vssa")
+
+    request = request_factory.get("/")
+    request.auth = decoded_jwt
+
+    view = TestView(kwargs={"form": "org", "org": "vssa"})
+
+    result = OAuthTokenHasValidOrganizationClaim().has_permission(request, view)
+    assert result is True
+    assert request.organization == organization
+
+
+@pytest.mark.django_db
+def test_token_has_valid_organization_claim_no_organization_id_in_jwt_payload(
+    request_factory: APIRequestFactory,
+    decoded_jwt: JWTClaims,
+):
+    decoded_jwt["organization_id"] = 1_000_000 # Non-existent ID
+
+    request = request_factory.get("/")
+    request.auth = decoded_jwt
+
+    view = TestView(kwargs={"form": "org", "org": "vssa"})
+
+    result = OAuthTokenHasValidOrganizationClaim().has_permission(request, view)
+    assert result is False
+    assert not hasattr(request, "organization")
+
+
+@pytest.mark.django_db
+def test_token_has_valid_organization_claim_jwt_token_has_different_id_than_organization_in_url(
+    request_factory: APIRequestFactory,
+    decoded_jwt: JWTClaims,
+):
+    OrganizationFactory(id=decoded_jwt["organization_id"], kind="gov", name="not vssa")
+
+    request = request_factory.get("/")
+    request.auth = decoded_jwt
+
+    view = TestView(kwargs={"form": "org", "org": "vssa"})
+
+    result = OAuthTokenHasValidOrganizationClaim().has_permission(request, view)
+    assert result is False
+    assert not hasattr(request, "organization")

--- a/tests/oauth/test_oauth.py
+++ b/tests/oauth/test_oauth.py
@@ -283,20 +283,3 @@ def test_token_has_valid_organization_claim_no_organization_id_in_jwt_payload(
     result = OAuthTokenHasValidOrganizationClaim().has_permission(request, view)
     assert result is False
     assert not hasattr(request, "organization")
-
-
-@pytest.mark.django_db
-def test_token_has_valid_organization_claim_jwt_token_has_different_id_than_organization_in_url(
-    request_factory: APIRequestFactory,
-    decoded_jwt: JWTClaims,
-):
-    OrganizationFactory(id=decoded_jwt["organization_id"], kind="gov", name="not vssa")
-
-    request = request_factory.get("/")
-    request.auth = decoded_jwt
-
-    view = TestView(kwargs={"form": "org", "org": "vssa"})
-
-    result = OAuthTokenHasValidOrganizationClaim().has_permission(request, view)
-    assert result is False
-    assert not hasattr(request, "organization")

--- a/tests/uapi/agents/test_views.py
+++ b/tests/uapi/agents/test_views.py
@@ -157,5 +157,3 @@ def test_delete_view(app: DjangoTestApp, representative_user: User, organization
     assert Agent.objects.count() == 1
     agent = Agent.objects.first()
     assert agent.is_archived is True
-    assert agent.apikey.deleted is True
-    assert agent.apikey.deleted_on is not None

--- a/tests/uapi/conftest.py
+++ b/tests/uapi/conftest.py
@@ -1,9 +1,10 @@
+from datetime import datetime, timedelta
+
 import pytest
-from typing import Any
-from unittest.mock import patch
+from typing import Any, Iterable
 
 import reversion
-from django.contrib.auth.models import AnonymousUser
+from authlib.jose import RSAKey, jwt, JsonWebKey
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.models import Site
 from django.urls import reverse
@@ -14,6 +15,7 @@ from vitrina.orgs.factories import OrganizationFactory
 from vitrina.orgs.models import Organization
 from vitrina.resources.factories import DatasetDistributionFactory
 from vitrina.resources.models import DatasetDistribution
+from vitrina.settings import OAUTH_AGENT_DEFAULT_SCOPES
 from vitrina.structure.factories import MetadataFactory
 
 
@@ -30,17 +32,45 @@ def _build_reverse_uapi_url(name: str, organization: Organization, **kwargs: Any
     )
 
 
+def _generate_test_token(
+    jwk: RSAKey,
+    client_id: str = "test-client",
+    scopes: Iterable[str] = ("datasets:write",),
+    organization_id: int = 1,
+    expires_in: int = 900
+):
+    now = datetime.utcnow()
+    claims = {
+        "iss": "test-issuer",
+        "sub": client_id,
+        "scope": " ".join(scopes),
+        "organization_id": organization_id,
+        "iat": now,
+        "exp": now + timedelta(seconds=expires_in),
+    }
+
+    header = {"alg": "RS256", "kid": "test-key"}
+
+    return jwt.encode(header, claims, key=jwk).decode()
+
+
 @pytest.fixture(autouse=True)
-def mock_auth_and_permissions():
-    """A Fixture to avoid permission/auth checking for specific API's."""
-    with patch("vitrina.api.oauth.OAuth2AuthenticationWithLocalJWK.authenticate") as mock_auth:
-        mock_auth.return_value = (AnonymousUser(), {"scope": "read write", "organization_id": 1, "sub": "agentname"})
-        with (
-            patch("vitrina.api.oauth.IsOAuthTokenValid.has_permission", return_value=True),
-            patch("vitrina.api.oauth.OAuthTokenHasScopes.has_permission", return_value=True),
-            patch("vitrina.api.oauth.OAuthTokenHasValidOrganizationClaim.has_permission", return_value=True)
-        ):
-            yield
+def override_oauth_jwk(settings, test_jwk):
+    settings.OAUTH_SERVER_PUBLIC_JWK_JSON = test_jwk.as_dict(is_private=False)
+
+
+@pytest.fixture(scope="session")
+def test_jwk() -> RSAKey:
+    key = JsonWebKey.generate_key("RSA", crv_or_size=2048, is_private=True)
+    return key
+
+
+@pytest.fixture()
+def valid_token(
+    test_jwk: RSAKey,
+    organization: Organization
+) -> str:
+    return _generate_test_token(test_jwk, organization_id=organization.id, scopes=OAUTH_AGENT_DEFAULT_SCOPES)
 
 
 @pytest.fixture

--- a/tests/uapi/conftest.py
+++ b/tests/uapi/conftest.py
@@ -19,17 +19,8 @@ from vitrina.settings import OAUTH_AGENT_DEFAULT_SCOPES
 from vitrina.structure.factories import MetadataFactory
 
 
-def _build_reverse_uapi_url(name: str, organization: Organization, **kwargs: Any) -> str:
-    return reverse(
-        name,
-        kwargs={
-            "form": organization.kind,
-            "org": organization.name,
-            "catalog": "default",
-            "catalog_sub": "v1",
-            **kwargs,
-        }
-    )
+def _build_reverse_uapi_url(name: str, **kwargs: Any) -> str:
+    return reverse(name, kwargs=kwargs)
 
 
 def _generate_test_token(
@@ -116,18 +107,18 @@ def distribution(organization: Organization, dataset: Dataset) -> DatasetDistrib
 
 
 @pytest.fixture
-def url_dataset(organization: Organization) -> str:
-    return _build_reverse_uapi_url("dataset", organization)
+def url_dataset() -> str:
+    return _build_reverse_uapi_url("uapi-dataset")
 
 
 @pytest.fixture
-def url_distribution(organization: Organization) -> str:
-    return _build_reverse_uapi_url("distribution", organization)
+def url_distribution() -> str:
+    return _build_reverse_uapi_url("uapi-distribution")
 
 
 @pytest.fixture
-def url_dataset_structure(organization: Organization, dataset: Dataset) -> str:
-    return _build_reverse_uapi_url("dataset-structure", organization, dataset_id=dataset.id)
+def url_dataset_structure(dataset: Dataset) -> str:
+    return _build_reverse_uapi_url("uapi-dataset-structure", dataset_id=dataset.id)
 
 
 @pytest.fixture

--- a/tests/uapi/dataset/test_views.py
+++ b/tests/uapi/dataset/test_views.py
@@ -1,8 +1,10 @@
+from typing import Iterable
 from unittest.mock import patch, PropertyMock
 from urllib.parse import quote
 
 import pytest
 import pytz
+from authlib.jose import RSAKey
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from django_webtest import DjangoTestApp
@@ -10,9 +12,11 @@ from rest_framework import status
 from rest_framework.exceptions import ErrorDetail
 from reversion.models import Version
 
+from tests.uapi.conftest import _generate_test_token
 from vitrina import settings
 from vitrina.datasets.factories import DatasetFactory
 from vitrina.datasets.models import Dataset, DatasetStructure
+from vitrina.orgs.factories import OrganizationFactory
 from vitrina.orgs.models import Organization
 from vitrina.structure.factories import MetadataFactory
 from vitrina.structure.models import Metadata
@@ -73,6 +77,158 @@ def test_create(
         "theme": [],
         "organization_id": organization.id,
         "organization_title": organization.title,
+    }
+
+
+def test_create_specific_scope(
+    app: DjangoTestApp,
+    organization: Organization,
+    url_dataset: str,
+    domain: str,
+    test_jwk: RSAKey,
+):
+    token = _generate_test_token(
+        test_jwk,
+        organization_id=organization.id,
+        scopes=["spinta_datasets_gov_vssa_dataset_insert"],
+    )
+    data = {
+        "name": "/datasets/gov/vssa/isris/dcat/uapi/Model",
+        "title": "DataSet 1",
+        "description": "DataSet 1 description",
+    }
+    response = app.post(
+        url_dataset,
+        data,
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"},
+    )
+
+    assert response.status_code == status.HTTP_201_CREATED
+
+    assert Metadata.objects.count() == 1
+    dataset = Dataset.objects.filter(
+        metadata__name=data["name"],
+        access_rights=Dataset.NON_PUBLIC,
+        organization=organization,
+    ).first()
+    assert dataset
+    assert response.json == {
+        "@context": "",
+        "_type": url_dataset.rstrip("/"),
+        "_id": str(dataset.id),
+        "_revision": str(Version.objects.get_for_object(dataset).first().revision_id),
+        "_txn": "",
+        "_created": dataset.created.astimezone(timezone).isoformat(),
+        "_updated": dataset.modified.astimezone(timezone).isoformat(),
+        "created": dataset.created.astimezone(timezone).isoformat(),
+        "modified": dataset.modified.astimezone(timezone).isoformat(),
+        "id": str(dataset.id),
+        "internalId": dataset.internal_id,
+        "origin": dataset.origin,
+        "title": data["title"],
+        "description": data["description"],
+        "temporalCoverage": dataset.temporal_coverage,
+        "language": [],
+        "publisher": dataset.publisher,
+        "spatial": dataset.spatial_coverage,
+        "keyword": dataset.tag_name_array,
+        "landingPage": f"http://{domain}{reverse('dataset-detail', args=[dataset.id])}",
+        "theme": [],
+        "organization_id": organization.id,
+        "organization_title": organization.title,
+    }
+
+
+@pytest.mark.parametrize("invalid_scopes", [["invalid_scope"], [], [""]])
+def test_create_token_does_not_have_necessary_scopes(
+    invalid_scopes: Iterable[str],
+    app: DjangoTestApp,
+    organization: Organization,
+    url_dataset: str,
+    domain: str,
+    test_jwk: RSAKey,
+):
+    token = _generate_test_token(test_jwk, organization_id=organization.id, scopes=invalid_scopes)
+    response = app.post(
+        url_dataset,
+        {},  # Empty data, since it should not get to the part where it is used.
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"},
+        expect_errors=True,
+    )
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    response_json = response.json
+    response_json.pop("context")  # Full error traceback is removed.
+    assert response_json == {
+        "code": "server_error",
+        "type": "PermissionDenied",
+        "template": "An unexpected server error occurred.",
+        "message": "You do not have permission to perform this action.",
+        "additionalProperties": None,
+    }
+
+
+def test_create_no_organization_id_inside_token_payload(
+    app: DjangoTestApp,
+    organization: Organization,
+    url_dataset: str,
+    domain: str,
+    test_jwk: RSAKey,
+):
+    token = _generate_test_token(test_jwk, organization_id=None, scopes=settings.OAUTH_AGENT_DEFAULT_SCOPES)
+    response = app.post(
+        url_dataset,
+        {},  # Empty data, since it should not get to the part where it is used.
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"},
+        expect_errors=True,
+    )
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    response_json = response.json
+    response_json.pop("context")  # Full error traceback is removed.
+    assert response_json == {
+        "code": "server_error",
+        "type": "PermissionDenied",
+        "template": "An unexpected server error occurred.",
+        "message": "You do not have permission to perform this action.",
+        "additionalProperties": None,
+    }
+
+
+def test_create_organization_retrieved_from_token_mismatch_from_provided_in_url(
+    app: DjangoTestApp,
+    organization: Organization,
+    url_dataset: str,
+    domain: str,
+    test_jwk: RSAKey,
+):
+    """Tests that the organization inside the JWT matches the organization provided in the URL `org` part.
+
+    E.g., if the url is: uapi/datasets/gov/vssa/isris/dcat/uapi/Model.
+    - The organization in the system identified by `organization_id` inside JWT should match the `name = 'vssa'`.
+    """
+    organization_2 = OrganizationFactory()
+    token = _generate_test_token(
+        test_jwk,
+        organization_id=organization_2.id,
+        scopes=settings.OAUTH_AGENT_DEFAULT_SCOPES,
+    )
+    response = app.post(
+        url_dataset,  # Builds a URL for `organization` (not `organization_2`)
+        {},  # Empty data, since it should not get to the part where it is used.
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"},
+        expect_errors=True,
+    )
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    response_json = response.json
+    response_json.pop("context")  # Full error traceback is removed.
+    assert response_json == {
+        "code": "server_error",
+        "type": "PermissionDenied",
+        "template": "An unexpected server error occurred.",
+        "message": "You do not have permission to perform this action.",
+        "additionalProperties": None,
     }
 
 
@@ -195,6 +351,141 @@ def test_list(
                 "id": str(dataset.id),
             }
         ]
+    }
+
+
+def test_list_specific_scope(
+    app: DjangoTestApp,
+    organization: Organization,
+    dataset: Dataset,
+    url_dataset: str,
+    domain: str,
+    test_jwk: RSAKey,
+):
+    token = _generate_test_token(
+        test_jwk,
+        organization_id=organization.id,
+        scopes=["spinta_datasets_gov_vssa_dataset_getall"],
+    )
+
+    response = app.get(url_dataset, extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"})
+
+    assert response.status_code == status.HTTP_200_OK
+    assert Dataset.objects.filter(organization=organization).count() == 1
+    assert response.json == {
+        "_type": url_dataset.rstrip("/"),
+        "_data": [
+            {
+                "@context": "",
+                "_type": url_dataset.rstrip("/"),
+                "_id": str(dataset.id),
+                "_revision": "",
+                "_txn": "",
+                "_created": dataset.created.astimezone(timezone).isoformat(),
+                "_updated": dataset.modified.astimezone(timezone).isoformat(),
+                "created": dataset.created.astimezone(timezone).isoformat(),
+                "internalId": dataset.internal_id,
+                "origin": dataset.origin,
+                "title": dataset.title,
+                "description": dataset.description,
+                "modified": dataset.modified.astimezone(timezone).isoformat(),
+                "temporalCoverage": dataset.temporal_coverage,
+                "language": [],
+                "publisher": dataset.publisher,
+                "spatial": dataset.spatial_coverage,
+                "periodicity": dataset.frequency.title,
+                "keyword": dataset.tag_name_array,
+                "landingPage": f"http://{domain}{reverse('dataset-detail', args=[dataset.id])}",
+                "theme": [],
+                "organization_id": organization.id,
+                "organization_title": organization.title,
+                "id": str(dataset.id),
+            }
+        ]
+    }
+
+
+@pytest.mark.parametrize("invalid_scopes", [["invalid_scope"], [], [""]])
+def test_list_token_does_not_have_necessary_scopes(
+    invalid_scopes: Iterable[str],
+    app: DjangoTestApp,
+    organization: Organization,
+    dataset: Dataset,
+    url_dataset: str,
+    domain: str,
+    test_jwk: RSAKey,
+):
+    token = _generate_test_token(test_jwk, organization_id=organization.id, scopes=invalid_scopes)
+
+    response = app.get(url_dataset, extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"}, expect_errors=True)
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    response_json = response.json
+    response_json.pop("context")  # Full error traceback is removed.
+    assert response_json == {
+        "code": "server_error",
+        "type": "PermissionDenied",
+        "template": "An unexpected server error occurred.",
+        "message": "You do not have permission to perform this action.",
+        "additionalProperties": None,
+    }
+
+
+def test_list_no_organization_id_inside_token_payload(
+    app: DjangoTestApp,
+    organization: Organization,
+    dataset: Dataset,
+    url_dataset: str,
+    domain: str,
+    test_jwk: RSAKey,
+):
+    token = _generate_test_token(test_jwk, organization_id=None, scopes=settings.OAUTH_AGENT_DEFAULT_SCOPES)
+
+    response = app.get(url_dataset, extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"}, expect_errors=True)
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    response_json = response.json
+    response_json.pop("context")  # Full error traceback is removed.
+    assert response_json == {
+        "code": "server_error",
+        "type": "PermissionDenied",
+        "template": "An unexpected server error occurred.",
+        "message": "You do not have permission to perform this action.",
+        "additionalProperties": None,
+    }
+
+
+def test_list_organization_retrieved_from_token_mismatch_from_provided_in_url(
+    app: DjangoTestApp,
+    organization: Organization,
+    dataset: Dataset,
+    url_dataset: str,
+    domain: str,
+    test_jwk: RSAKey,
+):
+    """Tests that the organization inside the JWT matches the organization provided in the URL `org` part.
+
+    E.g., if the url is: uapi/datasets/gov/vssa/isris/dcat/uapi/Model.
+    - The organization in the system identified by `organization_id` inside JWT should match the `name = 'vssa'`.
+    """
+    organization_2 = OrganizationFactory()
+    token = _generate_test_token(
+        test_jwk,
+        organization_id=organization_2.id,
+        scopes=settings.OAUTH_AGENT_DEFAULT_SCOPES,
+    )
+
+    response = app.get(url_dataset, extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"}, expect_errors=True)
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    response_json = response.json
+    response_json.pop("context")  # Full error traceback is removed.
+    assert response_json == {
+        "code": "server_error",
+        "type": "PermissionDenied",
+        "template": "An unexpected server error occurred.",
+        "message": "You do not have permission to perform this action.",
+        "additionalProperties": None,
     }
 
 
@@ -406,6 +697,132 @@ def test_action_upload_dataset_structure(
     assert file.label == f"dataset_{dataset.id}_structure.csv"
 
 
+def test_action_upload_dataset_structure_specific_scope(
+    app: DjangoTestApp,
+    organization: Organization,
+    dataset: Dataset,
+    dsa: str,
+    url_dataset_structure: str,
+    test_jwk: RSAKey,
+):
+    token = _generate_test_token(
+        test_jwk,
+        organization_id=organization.id,
+        scopes=["spinta_datasets_gov_vssa_dataset_dsa_insert"],
+    )
+    response = app.post(
+        url_dataset_structure,
+        dsa,
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"},
+        content_type="text/csv",
+    )
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    assert not response.body
+    # Dataset is saved and stored in DatasetStructure.
+    assert dataset.datasetstructure_set.count() == 1
+    file = dataset.datasetstructure_set.first().file
+    assert file is not None
+    assert file.label == f"dataset_{dataset.id}_structure.csv"
+
+
+@pytest.mark.parametrize("invalid_scopes", [["invalid_scope"], [], [""]])
+def test_action_upload_dataset_structure_token_does_not_have_necessary_scopes(
+    invalid_scopes: Iterable[str],
+    app: DjangoTestApp,
+    organization: Organization,
+    dataset: Dataset,
+    dsa: str,
+    url_dataset_structure: str,
+    test_jwk: RSAKey,
+):
+    token = _generate_test_token(test_jwk, organization_id=organization.id, scopes=invalid_scopes)
+
+    response = app.post(
+        url_dataset_structure,
+        dsa,
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"},
+        content_type="text/csv",
+        expect_errors=True,
+    )
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    response_json = response.json
+    response_json.pop("context")  # Full error traceback is removed.
+    assert response_json == {
+        "code": "server_error",
+        "type": "PermissionDenied",
+        "template": "An unexpected server error occurred.",
+        "message": "You do not have permission to perform this action.",
+        "additionalProperties": None,
+    }
+
+
+def test_action_upload_dataset_structure_no_organization_id_inside_token_payload(
+    app: DjangoTestApp,
+    organization: Organization,
+    dataset: Dataset,
+    dsa: str,
+    url_dataset_structure: str,
+    test_jwk: RSAKey,
+):
+    token = _generate_test_token(test_jwk, organization_id=None, scopes=settings.OAUTH_AGENT_DEFAULT_SCOPES)
+
+    response = app.post(
+        url_dataset_structure,
+        dsa,
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"},
+        content_type="text/csv",
+        expect_errors=True
+    )
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    response_json = response.json
+    response_json.pop("context")  # Full error traceback is removed.
+    assert response_json == {
+        "code": "server_error",
+        "type": "PermissionDenied",
+        "template": "An unexpected server error occurred.",
+        "message": "You do not have permission to perform this action.",
+        "additionalProperties": None,
+    }
+
+
+def test_action_upload_dataset_structure_organization_retrieved_from_token_mismatch_from_provided_in_url(
+    app: DjangoTestApp,
+    organization: Organization,
+    dataset: Dataset,
+    dsa: str,
+    url_dataset_structure: str,
+    test_jwk: RSAKey,
+):
+    organization_2 = OrganizationFactory()
+    token = _generate_test_token(
+        test_jwk,
+        organization_id=organization_2.id,
+        scopes=settings.OAUTH_AGENT_DEFAULT_SCOPES,
+    )
+
+    response = app.post(
+        url_dataset_structure,
+        dsa,
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"},
+        content_type="text/csv",
+        expect_errors=True
+    )
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    response_json = response.json
+    response_json.pop("context")  # Full error traceback is removed.
+    assert response_json == {
+        "code": "server_error",
+        "type": "PermissionDenied",
+        "template": "An unexpected server error occurred.",
+        "message": "You do not have permission to perform this action.",
+        "additionalProperties": None,
+    }
+
+
 def test_action_upload_dataset_structure_no_object(
     app: DjangoTestApp,
     organization: Organization,
@@ -520,7 +937,7 @@ def test_action_upload_dataset_structure_transaction_rollback_on_failure(
     }
 
 
-def test_action_update_dataset_structure_update(
+def test_action_update_dataset_structure(
     app: DjangoTestApp,
     organization: Organization,
     dataset: Dataset,
@@ -538,3 +955,125 @@ def test_action_update_dataset_structure_update(
     )
 
     assert response.status_code == status.HTTP_501_NOT_IMPLEMENTED
+
+
+def test_action_update_dataset_structure_specific_scope(
+    app: DjangoTestApp,
+    organization: Organization,
+    dataset: Dataset,
+    dsa: str,
+    url_dataset_structure: str,
+    test_jwk: RSAKey,
+):
+    token = _generate_test_token(
+        test_jwk,
+        organization_id=organization.id,
+        scopes=["spinta_datasets_gov_vssa_dataset_dsa_update"],
+    )
+
+    response = app.put(
+        url_dataset_structure,
+        dsa,
+        content_type="text/csv",
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"},
+        expect_errors=True,
+    )
+
+    assert response.status_code == status.HTTP_501_NOT_IMPLEMENTED
+
+
+@pytest.mark.parametrize("invalid_scopes", [["invalid_scope"], [], [""]])
+def test_action_update_dataset_structure_token_does_not_have_necessary_scopes(
+    invalid_scopes: Iterable[str],
+    app: DjangoTestApp,
+    organization: Organization,
+    dataset: Dataset,
+    dsa: str,
+    url_dataset_structure: str,
+    test_jwk: RSAKey,
+):
+    token = _generate_test_token(test_jwk, organization_id=organization.id, scopes=invalid_scopes)
+
+    response = app.put(
+        url_dataset_structure,
+        dsa,
+        content_type="text/csv",
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"},
+        expect_errors=True,
+    )
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    response_json = response.json
+    response_json.pop("context")  # Full error traceback is removed.
+    assert response_json == {
+        "code": "server_error",
+        "type": "PermissionDenied",
+        "template": "An unexpected server error occurred.",
+        "message": "You do not have permission to perform this action.",
+        "additionalProperties": None,
+    }
+
+
+def test_action_update_dataset_structure_no_organization_id_inside_token_payload(
+    app: DjangoTestApp,
+    organization: Organization,
+    dataset: Dataset,
+    dsa: str,
+    url_dataset_structure: str,
+    test_jwk: RSAKey,
+):
+    token = _generate_test_token(test_jwk, organization_id=None, scopes=settings.OAUTH_AGENT_DEFAULT_SCOPES)
+
+    response = app.put(
+        url_dataset_structure,
+        dsa,
+        content_type="text/csv",
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"},
+        expect_errors=True,
+    )
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    response_json = response.json
+    response_json.pop("context")  # Full error traceback is removed.
+    assert response_json == {
+        "code": "server_error",
+        "type": "PermissionDenied",
+        "template": "An unexpected server error occurred.",
+        "message": "You do not have permission to perform this action.",
+        "additionalProperties": None,
+    }
+
+
+def test_action_update_dataset_structure_organization_retrieved_from_token_mismatch_from_provided_in_url(
+    app: DjangoTestApp,
+    organization: Organization,
+    dataset: Dataset,
+    dsa: str,
+    url_dataset_structure: str,
+    test_jwk: RSAKey,
+):
+    organization_2 = OrganizationFactory()
+    token = _generate_test_token(
+        test_jwk,
+        organization_id=organization_2.id,
+        scopes=settings.OAUTH_AGENT_DEFAULT_SCOPES,
+    )
+
+    response = app.put(
+        url_dataset_structure,
+        dsa,
+        content_type="text/csv",
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"},
+        expect_errors=True,
+    )
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    response_json = response.json
+    response_json.pop("context")  # Full error traceback is removed.
+    assert response_json == {
+        "code": "server_error",
+        "type": "PermissionDenied",
+        "template": "An unexpected server error occurred.",
+        "message": "You do not have permission to perform this action.",
+        "additionalProperties": None,
+    }

--- a/tests/uapi/dataset/test_views.py
+++ b/tests/uapi/dataset/test_views.py
@@ -16,7 +16,6 @@ from tests.uapi.conftest import _generate_test_token
 from vitrina import settings
 from vitrina.datasets.factories import DatasetFactory
 from vitrina.datasets.models import Dataset, DatasetStructure
-from vitrina.orgs.factories import OrganizationFactory
 from vitrina.orgs.models import Organization
 from vitrina.structure.factories import MetadataFactory
 from vitrina.structure.models import Metadata
@@ -178,43 +177,6 @@ def test_create_no_organization_id_inside_token_payload(
     token = _generate_test_token(test_jwk, organization_id=None, scopes=settings.OAUTH_AGENT_DEFAULT_SCOPES)
     response = app.post(
         url_dataset,
-        {},  # Empty data, since it should not get to the part where it is used.
-        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"},
-        expect_errors=True,
-    )
-
-    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
-    response_json = response.json
-    response_json.pop("context")  # Full error traceback is removed.
-    assert response_json == {
-        "code": "server_error",
-        "type": "PermissionDenied",
-        "template": "An unexpected server error occurred.",
-        "message": "You do not have permission to perform this action.",
-        "additionalProperties": None,
-    }
-
-
-def test_create_organization_retrieved_from_token_mismatch_from_provided_in_url(
-    app: DjangoTestApp,
-    organization: Organization,
-    url_dataset: str,
-    domain: str,
-    test_jwk: RSAKey,
-):
-    """Tests that the organization inside the JWT matches the organization provided in the URL `org` part.
-
-    E.g., if the url is: uapi/datasets/gov/vssa/isris/dcat/uapi/Model.
-    - The organization in the system identified by `organization_id` inside JWT should match the `name = 'vssa'`.
-    """
-    organization_2 = OrganizationFactory()
-    token = _generate_test_token(
-        test_jwk,
-        organization_id=organization_2.id,
-        scopes=settings.OAUTH_AGENT_DEFAULT_SCOPES,
-    )
-    response = app.post(
-        url_dataset,  # Builds a URL for `organization` (not `organization_2`)
         {},  # Empty data, since it should not get to the part where it is used.
         extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"},
         expect_errors=True,
@@ -455,40 +417,6 @@ def test_list_no_organization_id_inside_token_payload(
     }
 
 
-def test_list_organization_retrieved_from_token_mismatch_from_provided_in_url(
-    app: DjangoTestApp,
-    organization: Organization,
-    dataset: Dataset,
-    url_dataset: str,
-    domain: str,
-    test_jwk: RSAKey,
-):
-    """Tests that the organization inside the JWT matches the organization provided in the URL `org` part.
-
-    E.g., if the url is: uapi/datasets/gov/vssa/isris/dcat/uapi/Model.
-    - The organization in the system identified by `organization_id` inside JWT should match the `name = 'vssa'`.
-    """
-    organization_2 = OrganizationFactory()
-    token = _generate_test_token(
-        test_jwk,
-        organization_id=organization_2.id,
-        scopes=settings.OAUTH_AGENT_DEFAULT_SCOPES,
-    )
-
-    response = app.get(url_dataset, extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"}, expect_errors=True)
-
-    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
-    response_json = response.json
-    response_json.pop("context")  # Full error traceback is removed.
-    assert response_json == {
-        "code": "server_error",
-        "type": "PermissionDenied",
-        "template": "An unexpected server error occurred.",
-        "message": "You do not have permission to perform this action.",
-        "additionalProperties": None,
-    }
-
-
 def test_list_with_query_parameters(
     app: DjangoTestApp,
     organization: Organization,
@@ -563,7 +491,9 @@ def test_list_no_datasets_exist(
         "code": "dataset_not_found",
         "type": "DatasetNotFound",
         "template": "The requested Dataset could not be found.",
-        "message": f"No dataset matched the provided query — http://testserver/uapi/datasets/org/{organization.name}/default/v1/Dataset/.",
+        "message": (
+            f"No dataset matched the provided query — http://testserver/uapi/datasets/org/vssa/isris/dcat/Dataset/."
+        ),
         "additionalProperties": None
     }
 
@@ -596,7 +526,7 @@ def test_list_only_archived_datasets(
         "type": "DatasetNotFound",
         "template": "The requested Dataset could not be found.",
         "message": (
-            f"No dataset matched the provided query — http://testserver/uapi/datasets/{organization.kind}/{organization.name}/default/v1/Dataset/."
+            f"No dataset matched the provided query — http://testserver/uapi/datasets/org/vssa/isris/dcat/Dataset/."
         ),
         "additionalProperties": None
     }
@@ -636,8 +566,7 @@ def test_list_with_query_parameters_archived_dataset(
         "template": "The requested Dataset could not be found.",
         "message": (
             f"No dataset matched the provided query — "
-            f"http://testserver/uapi/datasets/"
-            f"{organization.kind}/{organization.name}/default/v1/Dataset/?name={quote(metadata.name, safe='')}."
+            f"http://testserver/uapi/datasets/org/vssa/isris/dcat/Dataset/?name={quote(metadata.name, safe='')}."
         ),
         "additionalProperties": None
     }
@@ -666,8 +595,7 @@ def test_list_no_datasets_for_the_organization_passed_in_path_parameters(
         "message": (
             f"No dataset matched the provided query — "
             f"http://testserver/uapi/datasets/"
-            f"{organization.kind}/{organization.name}"
-            f"/default/v1/Dataset/?name={quote('dataset/that/does/not/exist', safe='')}."
+            f"org/vssa/isris/dcat/Dataset/?name={quote('dataset/that/does/not/exist', safe='')}."
         ),
         "additionalProperties": None
     }
@@ -788,54 +716,13 @@ def test_action_upload_dataset_structure_no_organization_id_inside_token_payload
     }
 
 
-def test_action_upload_dataset_structure_organization_retrieved_from_token_mismatch_from_provided_in_url(
-    app: DjangoTestApp,
-    organization: Organization,
-    dataset: Dataset,
-    dsa: str,
-    url_dataset_structure: str,
-    test_jwk: RSAKey,
-):
-    organization_2 = OrganizationFactory()
-    token = _generate_test_token(
-        test_jwk,
-        organization_id=organization_2.id,
-        scopes=settings.OAUTH_AGENT_DEFAULT_SCOPES,
-    )
-
-    response = app.post(
-        url_dataset_structure,
-        dsa,
-        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"},
-        content_type="text/csv",
-        expect_errors=True
-    )
-
-    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
-    response_json = response.json
-    response_json.pop("context")  # Full error traceback is removed.
-    assert response_json == {
-        "code": "server_error",
-        "type": "PermissionDenied",
-        "template": "An unexpected server error occurred.",
-        "message": "You do not have permission to perform this action.",
-        "additionalProperties": None,
-    }
-
-
 def test_action_upload_dataset_structure_no_object(
     app: DjangoTestApp,
     organization: Organization,
     dsa: str,
     valid_token: str,
 ):
-    url = reverse("dataset-structure", kwargs={
-        "form": organization.kind,
-        "org": organization.name,
-        "catalog": "default",
-        "catalog_sub": "v1",
-        "dataset_id": 1,
-    })
+    url = reverse("uapi-dataset-structure", kwargs={"dataset_id": 1})
 
     response = app.post(
         url,
@@ -1023,41 +910,6 @@ def test_action_update_dataset_structure_no_organization_id_inside_token_payload
     test_jwk: RSAKey,
 ):
     token = _generate_test_token(test_jwk, organization_id=None, scopes=settings.OAUTH_AGENT_DEFAULT_SCOPES)
-
-    response = app.put(
-        url_dataset_structure,
-        dsa,
-        content_type="text/csv",
-        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"},
-        expect_errors=True,
-    )
-
-    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
-    response_json = response.json
-    response_json.pop("context")  # Full error traceback is removed.
-    assert response_json == {
-        "code": "server_error",
-        "type": "PermissionDenied",
-        "template": "An unexpected server error occurred.",
-        "message": "You do not have permission to perform this action.",
-        "additionalProperties": None,
-    }
-
-
-def test_action_update_dataset_structure_organization_retrieved_from_token_mismatch_from_provided_in_url(
-    app: DjangoTestApp,
-    organization: Organization,
-    dataset: Dataset,
-    dsa: str,
-    url_dataset_structure: str,
-    test_jwk: RSAKey,
-):
-    organization_2 = OrganizationFactory()
-    token = _generate_test_token(
-        test_jwk,
-        organization_id=organization_2.id,
-        scopes=settings.OAUTH_AGENT_DEFAULT_SCOPES,
-    )
 
     response = app.put(
         url_dataset_structure,

--- a/tests/uapi/dataset/test_views.py
+++ b/tests/uapi/dataset/test_views.py
@@ -27,14 +27,18 @@ def test_create(
     organization: Organization,
     url_dataset: str,
     domain: str,
+    valid_token: str,
 ):
     data = {
         "name": "/datasets/gov/vssa/isris/dcat/uapi/Model",
         "title": "DataSet 1",
         "description": "DataSet 1 description",
     }
-
-    response = app.post(url_dataset, data)
+    response = app.post(
+        url_dataset,
+        data,
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+    )
 
     assert response.status_code == status.HTTP_201_CREATED
 
@@ -76,8 +80,14 @@ def test_create_serialization_validation_error(
     app: DjangoTestApp,
     organization: Organization,
     url_dataset: str,
+    valid_token: str,
 ):
-    response = app.post(url_dataset, {}, expect_errors=True)
+    response = app.post(
+        url_dataset,
+        {},
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+        expect_errors=True,
+    )
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert Dataset.objects.filter(organization=organization).count() == 0
@@ -107,6 +117,7 @@ def test_create_unexpected_exception_raised_and_rollback_executed(
     app: DjangoTestApp,
     organization: Organization,
     url_dataset: str,
+    valid_token: str,
 ):
     """Check that unexpected errors still return a standard UAPI formatted response."""
     data = {
@@ -121,7 +132,12 @@ def test_create_unexpected_exception_raised_and_rollback_executed(
             new_callable=PropertyMock,
             side_effect=Exception("Unexpected error")
     ):
-        response = app.post(url_dataset, data, expect_errors=True)
+        response = app.post(
+            url_dataset,
+            data,
+            extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+            expect_errors=True,
+        )
 
     assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
     assert Dataset.objects.filter(organization=organization).count() == 0
@@ -143,8 +159,9 @@ def test_list(
     dataset: Dataset,
     url_dataset: str,
     domain: str,
+    valid_token: str,
 ):
-    response = app.get(url_dataset)
+    response = app.get(url_dataset, extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"})
 
     assert response.status_code == status.HTTP_200_OK
     assert Dataset.objects.filter(organization=organization).count() == 1
@@ -187,6 +204,7 @@ def test_list_with_query_parameters(
     dataset: Dataset,
     url_dataset: str,
     domain: str,
+    valid_token: str,
 ):
     dataset_2 = DatasetFactory(
         organization=organization,
@@ -203,6 +221,7 @@ def test_list_with_query_parameters(
     response = app.get(
         url_dataset,
         params={"name": dataset.metadata.first().name},
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
     )  # w/ Query parameters, we should only get one.
 
     assert response.status_code == status.HTTP_200_OK
@@ -244,8 +263,9 @@ def test_list_no_datasets_exist(
     app: DjangoTestApp,
     organization: Organization,
     url_dataset: str,
+    valid_token: str,
 ):
-    response = app.get(url_dataset, expect_errors=True)
+    response = app.get(url_dataset, extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"}, expect_errors=True)
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
     assert response.json == {
@@ -261,6 +281,7 @@ def test_list_only_archived_datasets(
     app: DjangoTestApp,
     organization: Organization,
     url_dataset: str,
+    valid_token: str,
 ):
     dataset = DatasetFactory(
         organization=organization,
@@ -275,7 +296,7 @@ def test_list_only_archived_datasets(
         name="test/dataset/TestModel",
     )
 
-    response = app.get(url_dataset, expect_errors=True)
+    response = app.get(url_dataset, extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"}, expect_errors=True)
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
     assert Dataset.objects.filter(organization=organization).count() == 1
@@ -294,6 +315,7 @@ def test_list_with_query_parameters_archived_dataset(
     app: DjangoTestApp,
     organization: Organization,
     url_dataset: str,
+    valid_token: str,
 ):
     dataset = DatasetFactory(
         organization=organization,
@@ -308,7 +330,12 @@ def test_list_with_query_parameters_archived_dataset(
         name="test/dataset/TestModel",
     )
 
-    response = app.get(url_dataset, params={"name": dataset.metadata.first().name}, expect_errors=True)
+    response = app.get(
+        url_dataset,
+        params={"name": dataset.metadata.first().name},
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+        expect_errors=True
+    )
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
     assert Dataset.objects.filter(organization=organization).count() == 1
@@ -330,8 +357,14 @@ def test_list_no_datasets_for_the_organization_passed_in_path_parameters(
     organization: Organization,
     dataset: Dataset,
     url_dataset: str,
+    valid_token: str,
 ):
-    response = app.get(url_dataset, params={"name": "dataset/that/does/not/exist"}, expect_errors=True)
+    response = app.get(
+        url_dataset,
+        params={"name": "dataset/that/does/not/exist"},
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+        expect_errors=True,
+    )
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
     assert Dataset.objects.filter(metadata__name="dataset/that/does/not/exist").count() == 0
@@ -355,8 +388,14 @@ def test_action_upload_dataset_structure(
     dataset: Dataset,
     dsa: str,
     url_dataset_structure: str,
+    valid_token: str,
 ):
-    response = app.post(url_dataset_structure, dsa, content_type="text/csv")
+    response = app.post(
+        url_dataset_structure,
+        dsa,
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+        content_type="text/csv",
+    )
 
     assert response.status_code == status.HTTP_204_NO_CONTENT
     assert not response.body
@@ -371,6 +410,7 @@ def test_action_upload_dataset_structure_no_object(
     app: DjangoTestApp,
     organization: Organization,
     dsa: str,
+    valid_token: str,
 ):
     url = reverse("dataset-structure", kwargs={
         "form": organization.kind,
@@ -380,7 +420,13 @@ def test_action_upload_dataset_structure_no_object(
         "dataset_id": 1,
     })
 
-    response = app.post(url, dsa, content_type="text/csv", expect_errors=True)
+    response = app.post(
+        url,
+        dsa,
+        content_type="text/csv",
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+        expect_errors=True,
+    )
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
     assert Dataset.objects.filter(organization=organization).count() == 0
@@ -399,8 +445,15 @@ def test_action_upload_dataset_structure_empty_csv(
     organization: Organization,
     dataset: Dataset,
     url_dataset_structure: str,
+    valid_token: str,
 ):
-    response = app.post(url_dataset_structure, "", content_type="text/csv", expect_errors=True)
+    response = app.post(
+        url_dataset_structure,
+        "",
+        content_type="text/csv",
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+        expect_errors=True,
+    )
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.json == {
@@ -417,8 +470,15 @@ def test_action_upload_dataset_structure_file_only_contains_special_characters(
     organization: Organization,
     dataset: Dataset,
     url_dataset_structure: str,
+    valid_token: str,
 ):
-    response = app.post(url_dataset_structure, "\r\n\t ", content_type="text/csv", expect_errors=True)
+    response = app.post(
+        url_dataset_structure,
+        "\r\n\t ",
+        content_type="text/csv",
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+        expect_errors=True,
+    )
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.json == {
@@ -435,10 +495,17 @@ def test_action_upload_dataset_structure_transaction_rollback_on_failure(
     dataset: Dataset,
     dsa: str,
     url_dataset_structure: str,
+    valid_token: str,
 ):
 
     with patch("vitrina.uapi.views.views.Dataset.save", side_effect=Exception("Unexpected error")):
-        response = app.post(url_dataset_structure, dsa, content_type="text/csv", expect_errors=True)
+        response = app.post(
+            url_dataset_structure,
+            dsa,
+            content_type="text/csv",
+            extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+            expect_errors=True,
+        )
 
     assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
     assert DatasetStructure.objects.count() == 0
@@ -459,8 +526,15 @@ def test_action_update_dataset_structure_update(
     dataset: Dataset,
     dsa: str,
     url_dataset_structure: str,
+    valid_token: str,
 ):
     """This test currently proves that the endpoint returns 501 NOT IMPLEMENTED."""
-    response = app.put(url_dataset_structure, dsa, content_type="text/csv", expect_errors=True)
+    response = app.put(
+        url_dataset_structure,
+        dsa,
+        content_type="text/csv",
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+        expect_errors=True,
+    )
 
     assert response.status_code == status.HTTP_501_NOT_IMPLEMENTED

--- a/tests/uapi/distribution/test_views.py
+++ b/tests/uapi/distribution/test_views.py
@@ -27,6 +27,7 @@ def test_create(
     dataset: Dataset,
     url_distribution: str,
     domain: str,
+    valid_token: str,
 ):
     file_content = b"Sample CSV content"
     data = {
@@ -34,7 +35,12 @@ def test_create(
         "title": "Title of the Distribution",
     }
 
-    response = app.post(url_distribution, data, upload_files=[("file", "test.csv", file_content)])
+    response = app.post(
+        url_distribution,
+        data,
+        upload_files=[("file", "test.csv", file_content)],
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+    )
 
     assert response.status_code == status.HTTP_201_CREATED
     distribution = DatasetDistribution.objects.filter(
@@ -71,8 +77,14 @@ def test_create_serializer_is_invalid(
     organization: Organization,
     dataset: Dataset,
     url_distribution: str,
+    valid_token: str,
 ):
-    response = app.post(url_distribution, {"dataset": str(dataset.id)}, expect_errors=True)
+    response = app.post(
+        url_distribution,
+        {"dataset": str(dataset.id)},
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+        expect_errors=True,
+    )
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert DatasetDistribution.objects.count() == 0
@@ -91,6 +103,7 @@ def test_create_unexpected_exception_raised(
     organization: Organization,
     dataset: Dataset,
     url_distribution: str,
+    valid_token: str,
 ):
     file_content = b"Sample CSV content"
     data = {
@@ -103,7 +116,13 @@ def test_create_unexpected_exception_raised(
             new_callable=PropertyMock,
             side_effect=Exception("Unexpected error")
     ):
-        response = app.post(url_distribution, data, upload_files=[("file", "test.csv", file_content)], expect_errors=True,)
+        response = app.post(
+            url_distribution,
+            data,
+            upload_files=[("file", "test.csv", file_content)],
+            extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+            expect_errors=True,
+        )
 
     assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
     assert DatasetDistribution.objects.count() == 0
@@ -125,8 +144,9 @@ def test_list(
     distribution: DatasetDistribution,
     url_distribution: str,
     domain: str,
+    valid_token: str,
 ):
-    response = app.get(url_distribution)
+    response = app.get(url_distribution, extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"})
 
     assert response.status_code == status.HTTP_200_OK
     assert response.json == {
@@ -164,6 +184,7 @@ def test_list_with_query_parameters(
     distribution: DatasetDistribution,
     url_distribution: str,
     domain: str,
+    valid_token: str,
 ):
     distribution_2 = DatasetDistributionFactory(
         dataset=dataset,
@@ -181,7 +202,8 @@ def test_list_with_query_parameters(
         params={
             "dataset._id": dataset.id,
             "name": distribution.metadata.first().name
-        }
+        },
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
     )  # w/ Query parameters, we should only get one.
 
     assert response.status_code == status.HTTP_200_OK
@@ -218,6 +240,7 @@ def test_list_with_query_parameters_dataset_does_not_exist(
     app: DjangoTestApp,
     organization: Organization,
     url_distribution: str,
+    valid_token: str,
 ):
     response = app.get(
         url_distribution,
@@ -225,6 +248,7 @@ def test_list_with_query_parameters_dataset_does_not_exist(
             "dataset._id": 1,
             "name": "not_existing_distribution"
         },
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
         expect_errors=True
     )
 
@@ -244,6 +268,7 @@ def test_list_with_query_parameters_no_given_distribution(
     organization: Organization,
     dataset: Dataset,
     url_distribution: str,
+    valid_token: str,
 ):
     response = app.get(
         url_distribution,
@@ -251,6 +276,7 @@ def test_list_with_query_parameters_no_given_distribution(
             "dataset._id": dataset.id,
             "name": "not_existing_distribution"
         },
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
         expect_errors=True
     )
 
@@ -270,6 +296,7 @@ def test_list_distributions_the_distributions_dataset_is_deleted(
     dataset: Dataset,
     distribution: DatasetDistribution,
     url_distribution: str,
+    valid_token: str,
 ):
     dataset.deleted = True
     dataset.save(update_fields=["deleted"])
@@ -280,6 +307,7 @@ def test_list_distributions_the_distributions_dataset_is_deleted(
             "dataset._id": dataset.id,
             "name": distribution.metadata.first().name,
         },
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
         expect_errors=True
     )
 
@@ -300,6 +328,7 @@ def test_list_distributions_the_distribution_is_deleted(
     dataset: Dataset,
     distribution: DatasetDistribution,
     url_distribution: str,
+    valid_token: str,
 ):
     distribution.deleted = True
     distribution.save(update_fields=["deleted"])
@@ -310,6 +339,7 @@ def test_list_distributions_the_distribution_is_deleted(
             "dataset._id": dataset.id,
             "name": distribution.metadata.first().name,
         },
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
         expect_errors=True
     )
 
@@ -330,6 +360,7 @@ def test_list_unexpected_exception_raised(
     dataset: Dataset,
     distribution: DatasetDistribution,
     url_distribution: str,
+    valid_token: str,
 ):
     with patch(
         "vitrina.uapi.views.views.BaseObjectListSerializer.data",
@@ -342,6 +373,7 @@ def test_list_unexpected_exception_raised(
                 "dataset._id": dataset.id,
                 "name": distribution.metadata.first().name,
             },
+            extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
             expect_errors=True
         )
 

--- a/tests/uapi/distribution/test_views.py
+++ b/tests/uapi/distribution/test_views.py
@@ -14,7 +14,6 @@ from reversion.models import Version
 from tests.uapi.conftest import _generate_test_token
 from vitrina import settings
 from vitrina.datasets.models import Dataset
-from vitrina.orgs.factories import OrganizationFactory
 from vitrina.orgs.models import Organization
 from vitrina.resources.factories import DatasetDistributionFactory
 from vitrina.resources.models import DatasetDistribution
@@ -175,40 +174,6 @@ def test_create_no_organization_id_inside_token_payload(
         organization_id=None,
         scopes=settings.OAUTH_AGENT_DEFAULT_SCOPES,
     )
-    response = app.post(
-        url_distribution,
-        {},
-        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"},
-        expect_errors=True,
-    )
-
-    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
-    response_json = response.json
-    response_json.pop("context")  # Full error traceback is removed.
-    assert response_json == {
-        "code": "server_error",
-        "type": "PermissionDenied",
-        "template": "An unexpected server error occurred.",
-        "message": "You do not have permission to perform this action.",
-        "additionalProperties": None,
-    }
-
-
-def test_create_organization_retrieved_from_token_mismatch_from_provided_in_url(
-    app: DjangoTestApp,
-    organization: Organization,
-    dataset: Dataset,
-    url_distribution: str,
-    domain: str,
-    test_jwk: RSAKey,
-):
-    organization_2 = OrganizationFactory()
-    token = _generate_test_token(
-        test_jwk,
-        organization_id=organization_2.id,
-        scopes=settings.OAUTH_AGENT_DEFAULT_SCOPES,
-    )
-
     response = app.post(
         url_distribution,
         {},
@@ -443,44 +408,6 @@ def test_list_no_organization_id_inside_token_payload(
         "additionalProperties": None,
     }
 
-
-def test_list_organization_retrieved_from_token_mismatch_from_provided_in_url(
-    app: DjangoTestApp,
-    organization: Organization,
-    dataset: Dataset,
-    distribution: DatasetDistribution,
-    url_distribution: str,
-    domain: str,
-    test_jwk: RSAKey,
-):
-    """Tests that the organization inside the JWT matches the organization provided in the URL `org` part.
-
-    E.g., if the url is: uapi/datasets/gov/vssa/isris/dcat/uapi/Model.
-    - The organization in the system identified by `organization_id` inside JWT should match the `name = 'vssa'`.
-    """
-    organization_2 = OrganizationFactory()
-    token = _generate_test_token(
-        test_jwk,
-        organization_id=organization_2.id,
-        scopes=settings.OAUTH_AGENT_DEFAULT_SCOPES,
-    )
-
-    response = app.get(
-        url_distribution,
-        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"},
-        expect_errors=True
-    )
-
-    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
-    response_json = response.json
-    response_json.pop("context")  # Full error traceback is removed.
-    assert response_json == {
-        "code": "server_error",
-        "type": "PermissionDenied",
-        "template": "An unexpected server error occurred.",
-        "message": "You do not have permission to perform this action.",
-        "additionalProperties": None,
-    }
 
 def test_list_with_query_parameters(
     app: DjangoTestApp,

--- a/tests/uapi/distribution/test_views.py
+++ b/tests/uapi/distribution/test_views.py
@@ -1,7 +1,9 @@
+from typing import Iterable
 from unittest.mock import patch, PropertyMock
 
 import pytest
 import pytz
+from authlib.jose import RSAKey
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from django_webtest import DjangoTestApp
@@ -9,8 +11,10 @@ from rest_framework import status
 from rest_framework.exceptions import ErrorDetail
 from reversion.models import Version
 
+from tests.uapi.conftest import _generate_test_token
 from vitrina import settings
 from vitrina.datasets.models import Dataset
+from vitrina.orgs.factories import OrganizationFactory
 from vitrina.orgs.models import Organization
 from vitrina.resources.factories import DatasetDistributionFactory
 from vitrina.resources.models import DatasetDistribution
@@ -69,6 +73,158 @@ def test_create(
         "url": f"http://{domain}{reverse('dataset-detail', args=[dataset.id])}",
         "version": None,
         "upload_to_storage": distribution.upload_to_storage,
+    }
+
+
+def test_create_specific_scope(
+    app: DjangoTestApp,
+    organization: Organization,
+    dataset: Dataset,
+    url_distribution: str,
+    domain: str,
+    test_jwk: RSAKey,
+):
+    token = _generate_test_token(
+        test_jwk,
+        organization_id=organization.id,
+        scopes=["spinta_datasets_gov_vssa_distribution_insert"],
+    )
+    file_content = b"Sample CSV content"
+    data = {
+        "dataset": str(dataset.id),
+        "title": "Title of the Distribution",
+    }
+
+    response = app.post(
+        url_distribution,
+        data,
+        upload_files=[("file", "test.csv", file_content)],
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"},
+    )
+
+    assert response.status_code == status.HTTP_201_CREATED
+    distribution = DatasetDistribution.objects.filter(
+        metadata__name=dataset.datasetdistribution_set.first().metadata.name,
+        dataset__organization__kind=organization.kind,
+        dataset__organization__name=organization.name
+    ).first()
+    assert distribution
+    assert response.json == {
+        "@context": "",
+        "_type": url_distribution.rstrip("/"),
+        "_id": str(distribution.id),
+        "_revision": str(Version.objects.get_for_object(distribution).first().revision_id),
+        "_txn": "",
+        "_created": distribution.created.astimezone(timezone).isoformat(),
+        "_updated": distribution.modified.astimezone(timezone).isoformat(),
+        "description": distribution.description,
+        "file": distribution.file.label,
+        "id": distribution.id,
+        "issued": distribution.issued,
+        "periodEnd": distribution.period_end,
+        "periodStart": distribution.period_start,
+        "geo_location": distribution.geo_location,
+        "title": data["title"],
+        "type": distribution.type,
+        "url": f"http://{domain}{reverse('dataset-detail', args=[dataset.id])}",
+        "version": None,
+        "upload_to_storage": distribution.upload_to_storage,
+    }
+
+
+@pytest.mark.parametrize("invalid_scopes", [["invalid_scope"], [], [""]])
+def test_create_token_does_not_have_necessary_scopes(
+    invalid_scopes: Iterable[str],
+    app: DjangoTestApp,
+    organization: Organization,
+    dataset: Dataset,
+    url_distribution: str,
+    domain: str,
+    test_jwk: RSAKey,
+):
+    token = _generate_test_token(test_jwk, organization_id=organization.id, scopes=invalid_scopes)
+    response = app.post(
+        url_distribution,
+        {},
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"},
+        expect_errors=True,
+    )
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    response_json = response.json
+    response_json.pop("context")  # Full error traceback is removed.
+    assert response_json == {
+        "code": "server_error",
+        "type": "PermissionDenied",
+        "template": "An unexpected server error occurred.",
+        "message": "You do not have permission to perform this action.",
+        "additionalProperties": None,
+    }
+
+
+def test_create_no_organization_id_inside_token_payload(
+    app: DjangoTestApp,
+    organization: Organization,
+    dataset: Dataset,
+    url_distribution: str,
+    domain: str,
+    test_jwk: RSAKey,
+):
+    token = _generate_test_token(
+        test_jwk,
+        organization_id=None,
+        scopes=settings.OAUTH_AGENT_DEFAULT_SCOPES,
+    )
+    response = app.post(
+        url_distribution,
+        {},
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"},
+        expect_errors=True,
+    )
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    response_json = response.json
+    response_json.pop("context")  # Full error traceback is removed.
+    assert response_json == {
+        "code": "server_error",
+        "type": "PermissionDenied",
+        "template": "An unexpected server error occurred.",
+        "message": "You do not have permission to perform this action.",
+        "additionalProperties": None,
+    }
+
+
+def test_create_organization_retrieved_from_token_mismatch_from_provided_in_url(
+    app: DjangoTestApp,
+    organization: Organization,
+    dataset: Dataset,
+    url_distribution: str,
+    domain: str,
+    test_jwk: RSAKey,
+):
+    organization_2 = OrganizationFactory()
+    token = _generate_test_token(
+        test_jwk,
+        organization_id=organization_2.id,
+        scopes=settings.OAUTH_AGENT_DEFAULT_SCOPES,
+    )
+
+    response = app.post(
+        url_distribution,
+        {},
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"},
+        expect_errors=True,
+    )
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    response_json = response.json
+    response_json.pop("context")  # Full error traceback is removed.
+    assert response_json == {
+        "code": "server_error",
+        "type": "PermissionDenied",
+        "template": "An unexpected server error occurred.",
+        "message": "You do not have permission to perform this action.",
+        "additionalProperties": None,
     }
 
 
@@ -176,6 +332,155 @@ def test_list(
         ]
     }
 
+
+def test_list_specific_scope(
+    app: DjangoTestApp,
+    organization: Organization,
+    dataset: Dataset,
+    distribution: DatasetDistribution,
+    url_distribution: str,
+    domain: str,
+    test_jwk: RSAKey,
+):
+    token = _generate_test_token(
+        test_jwk,
+        organization_id=organization.id,
+        scopes=["spinta_datasets_gov_vssa_distribution_getall"],
+    )
+    response = app.get(url_distribution, extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"})
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json == {
+        "_type": url_distribution.rstrip("/"),
+        "_data": [
+            {
+                "@context": "",
+                "_type": url_distribution.rstrip("/"),
+                "_id": str(distribution.id),
+                "_revision": str(Version.objects.get_for_object(distribution).first().revision_id),
+                "_txn": "",
+                "_created": distribution.created.astimezone(timezone).isoformat(),
+                "_updated": distribution.modified.astimezone(timezone).isoformat(),
+                "description": distribution.description,
+                "file": distribution.file.label,
+                "id": distribution.id,
+                "issued": distribution.issued,
+                "periodEnd": distribution.period_end.isoformat(),
+                "periodStart": distribution.period_start.isoformat(),
+                "geo_location": distribution.geo_location,
+                "title": distribution.title,
+                "type": distribution.type,
+                "url": f"http://{domain}{reverse('dataset-detail', args=[dataset.id])}",
+                "version": None,
+                "upload_to_storage": distribution.upload_to_storage,
+            }
+        ]
+    }
+
+
+@pytest.mark.parametrize("invalid_scopes", [["invalid_scope"], [], [""]])
+def test_list_token_does_not_have_necessary_scopes(
+    invalid_scopes: Iterable[str],
+    app: DjangoTestApp,
+    organization: Organization,
+    dataset: Dataset,
+    distribution: DatasetDistribution,
+    url_distribution: str,
+    domain: str,
+    test_jwk: RSAKey,
+):
+    token = _generate_test_token(
+        test_jwk,
+        organization_id=organization.id,
+        scopes=invalid_scopes,
+    )
+    response = app.get(
+        url_distribution,
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"},
+        expect_errors=True
+    )
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    response_json = response.json
+    response_json.pop("context")  # Full error traceback is removed.
+    assert response_json == {
+        "code": "server_error",
+        "type": "PermissionDenied",
+        "template": "An unexpected server error occurred.",
+        "message": "You do not have permission to perform this action.",
+        "additionalProperties": None,
+    }
+
+
+def test_list_no_organization_id_inside_token_payload(
+    app: DjangoTestApp,
+    organization: Organization,
+    dataset: Dataset,
+    distribution: DatasetDistribution,
+    url_distribution: str,
+    domain: str,
+    test_jwk: RSAKey,
+):
+    token = _generate_test_token(
+        test_jwk,
+        organization_id=None,
+        scopes=settings.OAUTH_AGENT_DEFAULT_SCOPES,
+    )
+    response = app.get(
+        url_distribution,
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"},
+        expect_errors=True
+    )
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    response_json = response.json
+    response_json.pop("context")  # Full error traceback is removed.
+    assert response_json == {
+        "code": "server_error",
+        "type": "PermissionDenied",
+        "template": "An unexpected server error occurred.",
+        "message": "You do not have permission to perform this action.",
+        "additionalProperties": None,
+    }
+
+
+def test_list_organization_retrieved_from_token_mismatch_from_provided_in_url(
+    app: DjangoTestApp,
+    organization: Organization,
+    dataset: Dataset,
+    distribution: DatasetDistribution,
+    url_distribution: str,
+    domain: str,
+    test_jwk: RSAKey,
+):
+    """Tests that the organization inside the JWT matches the organization provided in the URL `org` part.
+
+    E.g., if the url is: uapi/datasets/gov/vssa/isris/dcat/uapi/Model.
+    - The organization in the system identified by `organization_id` inside JWT should match the `name = 'vssa'`.
+    """
+    organization_2 = OrganizationFactory()
+    token = _generate_test_token(
+        test_jwk,
+        organization_id=organization_2.id,
+        scopes=settings.OAUTH_AGENT_DEFAULT_SCOPES,
+    )
+
+    response = app.get(
+        url_distribution,
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"},
+        expect_errors=True
+    )
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    response_json = response.json
+    response_json.pop("context")  # Full error traceback is removed.
+    assert response_json == {
+        "code": "server_error",
+        "type": "PermissionDenied",
+        "template": "An unexpected server error occurred.",
+        "message": "You do not have permission to perform this action.",
+        "additionalProperties": None,
+    }
 
 def test_list_with_query_parameters(
     app: DjangoTestApp,

--- a/vitrina/api/oauth.py
+++ b/vitrina/api/oauth.py
@@ -163,9 +163,5 @@ class OAuthTokenHasValidOrganizationClaim(BasePermission):
         if not (organization := OAuthClientAuthenticator.resolve_organization_from_token(request.auth)):
             return False
 
-        url_path_organization_kind, url_path_organization_name = view.kwargs["form"], view.kwargs["org"]
-        if organization.kind != url_path_organization_kind or organization.name != url_path_organization_name:
-            return False
-
         setattr(request, "organization", organization)
         return True

--- a/vitrina/api/oauth.py
+++ b/vitrina/api/oauth.py
@@ -1,6 +1,7 @@
 import base64
 import math
 import os
+from typing import Iterable
 
 import requests
 from authlib.jose import jwt, JsonWebKey, JWTClaims
@@ -8,6 +9,7 @@ from authlib.jose.errors import BadSignatureError
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ImproperlyConfigured
+from django.views import View
 from oauthlib.oauth2 import TokenExpiredError
 from rest_framework.authentication import BaseAuthentication
 from rest_framework.exceptions import AuthenticationFailed
@@ -105,7 +107,7 @@ class OAuthClientAuthenticator:
 
 class OAuth2AuthenticationWithLocalJWK(BaseAuthentication):
 
-    def authenticate(self, request: Request) -> tuple[AnonymousUser, JWTClaims] | None:
+    def authenticate(self, request: Request) -> tuple[AnonymousUser, JWTClaims]:
         try:
             verified_token = OAuthClientAuthenticator.retrieve_and_verify_token(request)
         except (BadSignatureError, TokenExpiredError) as e:
@@ -118,39 +120,42 @@ class OAuth2AuthenticationWithLocalJWK(BaseAuthentication):
 
 class IsOAuthTokenValid(BasePermission):
 
-    def has_permission(self, request, view):
+    def has_permission(self, request: Request, view: View) -> bool:
         request.auth.validate()
         return isinstance(request.auth, JWTClaims)
 
 
 class OAuthTokenHasScopes(BasePermission):
 
-    def has_permission(self, request, view):
-        token = request.auth
-
-        if not token:
+    def has_permission(self, request: Request, view: View) -> bool:
+        if not (token := request.auth):
             return False
-        required_scopes = self.get_scopes(request, view)
-        if not required_scopes:
+
+        if not (required_scopes := self.get_scopes(request, view)):
             return True
 
-        scopes = token["scope"].split(" ")
-        if not scopes:
+        if not (scopes := token.get("scope", "").split(" ")):
             return False
+
         missing_scopes = set(required_scopes) - set(scopes)
         return not bool(missing_scopes)
 
     @staticmethod
-    def get_scopes(request, view):
+    def get_scopes(request: Request, view: View) -> Iterable[str]:
         try:
-            return getattr(view, "required_scopes")
+            scopes = getattr(view, "required_scopes")
         except AttributeError:
             raise ImproperlyConfigured("TokenHasScope requires the view to define the required_scopes attribute")
+
+        if isinstance(scopes, dict):
+            return scopes.get(view.action, [])
+
+        return scopes
 
 
 class OAuthTokenHasValidOrganizationClaim(BasePermission):
 
-    def has_permission(self, request, view):
+    def has_permission(self, request: Request, view: View) -> bool:
         if not (organization := OAuthClientAuthenticator.resolve_organization_from_token(request.auth)):
             return False
 

--- a/vitrina/api/oauth.py
+++ b/vitrina/api/oauth.py
@@ -97,8 +97,12 @@ class OAuthClientAuthenticator:
 
     @staticmethod
     def resolve_organization_from_token(decoded_token: JWTClaims) -> Organization | None:
-        organization_id = decoded_token.get("organization_id")
-        return Organization.objects.get(pk=organization_id) if organization_id else None
+        if not (organization_id := decoded_token.get("organization_id")):
+            return None
+        try:
+            return Organization.objects.get(pk=organization_id)
+        except Organization.DoesNotExist:
+            return None
 
     @staticmethod
     def resolve_client_id_from_token(decoded_token: JWTClaims) -> str:

--- a/vitrina/settings.py
+++ b/vitrina/settings.py
@@ -66,10 +66,11 @@ OAUTH_CLIENTS_MANAGEMENT_SCOPE = env("OAUTH_CLIENTS_MANAGEMENT_SCOPE", default="
 OAUTH_AGENT_DEFAULT_SCOPES = (
     "spinta_datasets_gov_vssa_dataset_getall",
     "spinta_datasets_gov_vssa_dataset_insert",
+    "spinta_datasets_gov_vssa_dataset_dsa_getone",
+    "spinta_datasets_gov_vssa_dataset_dsa_insert",
+    "spinta_datasets_gov_vssa_dataset_dsa_update",
     "spinta_datasets_gov_vssa_distribution_getall",
     "spinta_datasets_gov_vssa_distribution_insert",
-    "spinta_datasets_gov_vssa_distribution_dsa_getone",
-    "spinta_datasets_gov_vssa_distribution_dsa_update"
 )
 
 SPINTA_EXECUTABLE = BASE_DIR / env("SPINTA_EXECUTABLE")

--- a/vitrina/uapi/urls.py
+++ b/vitrina/uapi/urls.py
@@ -4,7 +4,7 @@ from vitrina.uapi.views.template_views import AgentDeleteView, AgentUpdateView, 
 from vitrina.uapi.views.views import DatasetViewSet, DistributionViewSet
 
 
-UAPI_BASE_PATH = "uapi/datasets/<str:form>/<str:org>/<str:catalog>/<str:catalog_sub>/"
+STATIC_UAPI_BASE_PATH = "uapi/datasets/org/vssa/isris/dcat/"
 
 
 urlpatterns = [
@@ -34,21 +34,21 @@ urlpatterns = [
         name="agent-delete"
     ),
     path(
-        f"{UAPI_BASE_PATH}Dataset/",
+        f"{STATIC_UAPI_BASE_PATH}Dataset/",
         DatasetViewSet.as_view({"post": "create", "get": "list"}),
-        name="dataset",
+        name="uapi-dataset",
     ),
     path(
-        f"{UAPI_BASE_PATH}Dataset/<str:dataset_id>/dsa/",
+        f"{STATIC_UAPI_BASE_PATH}Dataset/<str:dataset_id>/dsa/",
         DatasetViewSet.as_view({
             "post": "upload_dataset_structure",
             "put": "update_dataset_structure",
         }),
-        name="dataset-structure",
+        name="uapi-dataset-structure",
     ),
     path(
-        f"{UAPI_BASE_PATH}Distribution/",
+        f"{STATIC_UAPI_BASE_PATH}Distribution/",
         DistributionViewSet.as_view({"post": "create", "get": "list"}),
-        name="distribution",
+        name="uapi-distribution",
     ),
 ]

--- a/vitrina/uapi/views/template_views.py
+++ b/vitrina/uapi/views/template_views.py
@@ -270,9 +270,6 @@ class AgentDeleteView(DeleteView, BaseAgentView):
 
     def delete(self, request: WSGIRequest, *args: Any, **kwargs: Any) -> HttpResponse:
         """Object is soft-deleted (archived) so to not lose the related service and other related objects."""
-        self.object.apikey.deleted = True
-        self.object.apikey.deleted_on = timezone.now()
-        self.object.apikey.save(update_fields=["deleted", "deleted_on"])
         self.object.is_archived = True
         self.object.save(update_fields=["is_archived", "updated_at"])
         messages.success(self.request, _(f"Agentas {self.object.title} pašalintas sėkmingai!"))

--- a/vitrina/uapi/views/template_views.py
+++ b/vitrina/uapi/views/template_views.py
@@ -10,7 +10,6 @@ from django.forms import ModelForm
 from django.http import HttpResponseRedirect, HttpResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
-from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import (
     CreateView,

--- a/vitrina/uapi/views/views.py
+++ b/vitrina/uapi/views/views.py
@@ -69,8 +69,7 @@ class DatasetViewSet(UAPIExceptionHandlerMixin, viewsets.ModelViewSet):
         ).filter(
             ~Q(deleted=True),
             metadata__content_type_id=self.dataset_metadata_id,
-            organization__kind=self.kwargs["form"],
-            organization__name=self.kwargs["org"],
+            organization__id=self.request.auth["organization_id"],
         )
 
         if request_params := self.request.query_params:
@@ -91,7 +90,7 @@ class DatasetViewSet(UAPIExceptionHandlerMixin, viewsets.ModelViewSet):
 
     @transaction.atomic
     def create(self, request: Request, *args: Any, **kwargs: Any) -> Response:
-        organization = get_object_or_404(Organization, kind=self.kwargs["form"], name=self.kwargs["org"])
+        organization = get_object_or_404(Organization, id=self.request.auth["organization_id"])
 
         serializer_context = self.get_serializer_context()
         serializer = self.get_serializer(
@@ -151,8 +150,7 @@ class DatasetViewSet(UAPIExceptionHandlerMixin, viewsets.ModelViewSet):
             Dataset,
             ~Q(deleted=True),
             id=self.kwargs["dataset_id"],
-            organization__kind=self.kwargs["form"],
-            organization__name=self.kwargs["org"],
+            organization__id=self.request.auth["organization_id"]
         )
 
         if not request.body or not request.body.strip(b"\r\n\t "):
@@ -216,8 +214,7 @@ class DistributionViewSet(UAPIExceptionHandlerMixin, viewsets.ModelViewSet):
             ~Q(deleted=True),
             ~Q(dataset__deleted=True),
             metadata__content_type_id=self.distribution_metadata_id,
-            dataset__organization__kind=self.kwargs["form"],
-            dataset__organization__name=self.kwargs["org"]
+            dataset__organization__id=self.request.auth["organization_id"],
         )
 
         if request_params := self.request.query_params:

--- a/vitrina/uapi/views/views.py
+++ b/vitrina/uapi/views/views.py
@@ -15,7 +15,6 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 from reversion import create_revision
 
-from vitrina import settings
 from vitrina.api.oauth import (
     OAuth2AuthenticationWithLocalJWK,
     IsOAuthTokenValid,

--- a/vitrina/uapi/views/views.py
+++ b/vitrina/uapi/views/views.py
@@ -43,7 +43,7 @@ from vitrina.uapi.utils.views import UAPIExceptionHandlerMixin
 class DatasetViewSet(UAPIExceptionHandlerMixin, viewsets.ModelViewSet):
     authentication_classes = [OAuth2AuthenticationWithLocalJWK]
     permission_classes = [IsOAuthTokenValid, OAuthTokenHasScopes, OAuthTokenHasValidOrganizationClaim]
-    required_scopes = settings.OAUTH_AGENT_DEFAULT_SCOPES
+    required_scopes = settings.OAUTH_AGENT_DEFAULT_SCOPES  # TODO: Update scopes to be specific per action.
 
     @cached_property
     def dataset_metadata_id(self) -> int:
@@ -192,7 +192,7 @@ class DatasetViewSet(UAPIExceptionHandlerMixin, viewsets.ModelViewSet):
 class DistributionViewSet(UAPIExceptionHandlerMixin, viewsets.ModelViewSet):
     authentication_classes = [OAuth2AuthenticationWithLocalJWK]
     permission_classes = [IsOAuthTokenValid, OAuthTokenHasScopes, OAuthTokenHasValidOrganizationClaim]
-    required_scopes = settings.OAUTH_AGENT_DEFAULT_SCOPES
+    required_scopes = settings.OAUTH_AGENT_DEFAULT_SCOPES  # TODO: Update scopes to be specific per action.
 
     @cached_property
     def distribution_metadata_id(self) -> int:

--- a/vitrina/uapi/views/views.py
+++ b/vitrina/uapi/views/views.py
@@ -43,7 +43,12 @@ from vitrina.uapi.utils.views import UAPIExceptionHandlerMixin
 class DatasetViewSet(UAPIExceptionHandlerMixin, viewsets.ModelViewSet):
     authentication_classes = [OAuth2AuthenticationWithLocalJWK]
     permission_classes = [IsOAuthTokenValid, OAuthTokenHasScopes, OAuthTokenHasValidOrganizationClaim]
-    required_scopes = settings.OAUTH_AGENT_DEFAULT_SCOPES  # TODO: Update scopes to be specific per action.
+    required_scopes = {
+        "create": ["spinta_datasets_gov_vssa_dataset_insert"],
+        "list": ["spinta_datasets_gov_vssa_dataset_getall"],
+        "upload_dataset_structure": ["spinta_datasets_gov_vssa_dataset_dsa_insert"],
+        "update_dataset_structure": ["spinta_datasets_gov_vssa_dataset_dsa_update"],
+    }
 
     @cached_property
     def dataset_metadata_id(self) -> int:
@@ -192,7 +197,10 @@ class DatasetViewSet(UAPIExceptionHandlerMixin, viewsets.ModelViewSet):
 class DistributionViewSet(UAPIExceptionHandlerMixin, viewsets.ModelViewSet):
     authentication_classes = [OAuth2AuthenticationWithLocalJWK]
     permission_classes = [IsOAuthTokenValid, OAuthTokenHasScopes, OAuthTokenHasValidOrganizationClaim]
-    required_scopes = settings.OAUTH_AGENT_DEFAULT_SCOPES  # TODO: Update scopes to be specific per action.
+    required_scopes = {
+        "create": ["spinta_datasets_gov_vssa_distribution_insert"],
+        "list": ["spinta_datasets_gov_vssa_distribution_getall"],
+    }
 
     @cached_property
     def distribution_metadata_id(self) -> int:


### PR DESCRIPTION
Finishing touches for the current implementation of UDTS endpoints that serve the synchronization flow. This PR introduces a couple of required changes for the synchronization to work correctly.

### Changed the default scopes so they would reference the correct `Model` part:

```python
OAUTH_AGENT_DEFAULT_SCOPES = (
    "spinta_datasets_gov_vssa_dataset_getall",
    "spinta_datasets_gov_vssa_dataset_insert",
    "spinta_datasets_gov_vssa_dataset_dsa_getone",  # Added.
    "spinta_datasets_gov_vssa_dataset_dsa_insert",  # Added.
    "spinta_datasets_gov_vssa_dataset_dsa_update",  # Added.
    "spinta_datasets_gov_vssa_distribution_getall",
    "spinta_datasets_gov_vssa_distribution_insert",
)
```

**Removed:**

```python
"spinta_datasets_gov_vssa_distribution_dsa_getone",
"spinta_datasets_gov_vssa_distribution_dsa_update"
```

Due to the `DatasetStructure` that is being created if a new DSA is added, which is directly related to the `Dataset` and not the `DatasetDistribution`.

### Refactored scopes sitting atop of views

Before the change, the general scopes were used for views. That means that if you (Agent) want to reach a specific endpoint, you need ALL of the default scopes on your OAuth2 client, that is trying to reach the endpoints and their actions (Provided atop).

After the change, introduced action-specific-scopes, that map the action/method with the correct single or multiple scopes that are needed for that endpoint:

```python
class DatasetViewSet(UAPIExceptionHandlerMixin, viewsets.ModelViewSet):
    required_scopes = {
        "create": ["spinta_datasets_gov_vssa_dataset_insert"],
        "list": ["spinta_datasets_gov_vssa_dataset_getall"],
        "upload_dataset_structure": ["spinta_datasets_gov_vssa_dataset_dsa_insert"],
        "update_dataset_structure": ["spinta_datasets_gov_vssa_dataset_dsa_update"],
    }
```

and 

```python
class DistributionViewSet(UAPIExceptionHandlerMixin, viewsets.ModelViewSet):
    required_scopes = {
        "create": ["spinta_datasets_gov_vssa_distribution_insert"],
        "list": ["spinta_datasets_gov_vssa_distribution_getall"],
    }
```

Following this, `oauth.py` had to be changed to fit the intended workflow.

### Test coverage

A lot more tests were added to ensure the correct workflow of the endpoints. Authorization/Permission class tests were refactored and now use created objects instead of mocked ones, where possible. 

## Notes:
- Bulk of the change `~900/1300` lines of code are from tests and their additions/changes.
- Can be reviewed commit-by-commit.
   - [d13186f](https://github.com/atviriduomenys/katalogas/pull/1727/commits/d13186ff6dc8c20b80d093e9965e659bd242a5e7) Tests only (+ multiple linting fixes).
   -  [027b71d](https://github.com/atviriduomenys/katalogas/pull/1727/commits/027b71d1b918039775927be5f89eacfc2e4cc767) Main part: Refactoring scopes.
   - [f7ef688](https://github.com/atviriduomenys/katalogas/pull/1727/commits/f7ef6884cacbb6cf78fa2f74315edc41c0f80669) Additional tests, more specific for specific endpoints.
   - [18f6c92](https://github.com/atviriduomenys/katalogas/pull/1727/commits/18f6c923722b0c85343c55e4582f1f115ca17806) Refactoring OAuth2 tests + minimal improvements to one method retrieving organization (that was not failing nicely, found by refactoring tests).
   - [d1f6481](https://github.com/atviriduomenys/katalogas/pull/1727/commits/d1f6481bb68898e0e51e2256fd690a6ce7dd0c8a) Refactoring UAPI urls