### PR TITLE
[1580]: Generate dataset code name automatically if none is provided

### DIFF
--- a/tests/datasets/test_views.py
+++ b/tests/datasets/test_views.py
@@ -3456,6 +3456,192 @@ def test_dataset_view_organization_contacts(app: DjangoTestApp):
 
 
 @pytest.mark.django_db
+<<<<<<< HEAD
+=======
+def test_create_dataset_with_service_and_endpoint_url(app: DjangoTestApp):
+    FrequencyFactory(is_default=True)
+    service_type = TypeFactory(name=Type.SERVICE)
+    organization = OrganizationFactory()
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+    form = app.get(reverse('dataset-add', kwargs={'pk': organization.id})).forms['dataset-form']
+    form['title'] = 'Added title'
+    form['description'] = 'Added new dataset description'
+    form['type'] = [service_type.pk]
+    form['endpoint_url'] = 'https://example.com'
+    form['access_rights'] = Dataset.PUBLIC
+    form.submit()
+    assert Dataset.objects.count() == 1
+    dataset = Dataset.objects.first()
+    assert dataset.service is True
+    assert dataset.endpoint_url == 'https://example.com'
+    assert dataset.status == Dataset.HAS_DATA
+    assert dataset.comments.count() == 1
+    assert dataset.comments.first().type == Comment.STATUS
+    assert dataset.comments.first().status == Comment.OPENED
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "dataset_name, dataset_title, organization_name, organization_slug, organization_title, expected_dataset_name",
+    [
+        (None, "Test Datašet", "Test Organization", "", "", "test-organization/test-datashet"),  # generates automatically
+        ("test-organization/my-test-dataset", "Test Dataset", "Test Organization", "", "", "test-organization/my-test-dataset"),  # uses provided name
+        (None, "Test Dataset", "", "test-organization-slug", "", "test-organization-slug/test-dataset"),  # generates automatically
+        (None, "Test Dataset", "", "", "Test Organization Title", "test-organization-title/test-dataset"),  # generates automatically
+    ]
+)
+def test_create_dataset_without_name_generates_automatically(app: DjangoTestApp, dataset_name, 
+                                                             dataset_title, organization_name, organization_slug, 
+                                                             organization_title, expected_dataset_name):
+    FrequencyFactory(is_default=True)
+    org = OrganizationFactory(name=organization_name, slug=organization_slug, title=organization_title)
+    user = UserFactory(is_staff=True, organization=org)
+    app.set_user(user)
+    form = app.get(reverse('dataset-add', kwargs={'pk': org.id})).forms['dataset-form']
+    form['title'] = dataset_title
+    if dataset_name is not None:
+        form['name'] = dataset_name 
+    form['description'] = 'Added new dataset description'
+    form['access_rights'] = Dataset.PUBLIC
+    response = form.submit()
+    assert response.status_code == 302
+    assert Dataset.objects.count() == 1
+    dataset = Dataset.objects.first()
+    assert dataset.name == expected_dataset_name
+    
+
+@pytest.mark.django_db
+def test_create_dataset_without_name_generate_unique_name(app: DjangoTestApp):
+    FrequencyFactory(is_default=True)
+    org = OrganizationFactory(name='Test Organization')
+    user = UserFactory(is_staff=True, organization=org)
+    app.set_user(user)
+    
+    dataset1 = DatasetFactory(organization=org, title="Test Dataset")
+    MetadataFactory(content_type=ContentType.objects.get_for_model(Dataset),
+                    name='test-organization/test-dataset', 
+                    dataset=dataset1,
+                    object_id=dataset1.pk
+)
+    dataset2 = DatasetFactory(organization=org, title="Second Test Dataset")
+    MetadataFactory(content_type=ContentType.objects.get_for_model(Dataset),
+                    name='test-organization/test-dataset_3', 
+                    dataset=dataset2,
+                    object_id=dataset2.pk
+    )
+    
+    form = app.get(reverse('dataset-add', kwargs={'pk': org.id})).forms['dataset-form']
+    form['title'] = 'Test Dataset'
+    form['description'] = 'Added new dataset description'
+    form['access_rights'] = Dataset.PUBLIC
+    response = form.submit()
+    assert response.status_code == 302
+    assert Dataset.objects.count() == 3
+    
+    dataset1.refresh_from_db()
+    assert dataset1.name == "test-organization/test-dataset"
+    
+    dataset2.refresh_from_db()
+    assert dataset2.name == "test-organization/test-dataset_3"
+    
+    dataset3 = Dataset.objects.last()
+    assert dataset3.name == "test-organization/test-dataset_4"
+
+
+@pytest.mark.django_db
+def test_update_dateset_generates_name(app: DjangoTestApp):
+    FrequencyFactory(is_default=True)
+    org = OrganizationFactory(name='Test Organization')
+    user = UserFactory(is_staff=True, organization=org)
+    app.set_user(user)
+    
+    dataset = DatasetFactory(organization=org, title="Test Dataset")
+    MetadataFactory(content_type=ContentType.objects.get_for_model(Dataset),
+                    name="", 
+                    dataset=dataset,
+                    object_id=dataset.pk
+    )
+    
+    form = app.get(reverse('dataset-change', kwargs={'pk': dataset.id})).forms['dataset-form']
+    form['title'] = 'Updated Test Dataset'
+    form['description'] = 'Updated dataset description'
+    form['access_rights'] = Dataset.PUBLIC
+    response = form.submit()
+    
+    assert response.status_code == 302
+    dataset.refresh_from_db()
+    assert dataset.name == "test-organization/updated-test-dataset"
+    
+    
+@pytest.mark.django_db
+def test_update_dateset_existing_name_cannot_be_removed(app: DjangoTestApp):
+    FrequencyFactory(is_default=True)
+    org = OrganizationFactory(name='Test Organization')
+    user = UserFactory(is_staff=True, organization=org)
+    app.set_user(user)
+    
+    dataset = DatasetFactory(organization=org, title="Test Dataset")
+    MetadataFactory(content_type=ContentType.objects.get_for_model(Dataset),
+                    name="test-organization/test-dataset", 
+                    dataset=dataset,
+                    object_id=dataset.pk
+    )
+    
+    form = app.get(reverse('dataset-change', kwargs={'pk': dataset.id})).forms['dataset-form']
+    form['title'] = 'Updated Test Dataset'
+    form['name'] = ''  # Attempt to remove name
+    form['description'] = 'Updated dataset description'
+    form['access_rights'] = Dataset.PUBLIC
+    
+    response = form.submit()
+    assert response.status_code == 200
+    dataset.refresh_from_db()
+    assert dataset.name == "test-organization/test-dataset"
+
+
+@pytest.mark.django_db
+def test_update_dataset_with_service_and_endpoint_url(app: DjangoTestApp):
+    service_type = TypeFactory(name=Type.SERVICE)
+    organization = OrganizationFactory()
+    dataset = DatasetFactory(organization=organization)
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+    form = app.get(reverse('dataset-change', kwargs={'pk': dataset.id})).forms['dataset-form']
+    form['type'] = [service_type.pk]
+    form['endpoint_url'] = 'https://example.com'
+    form.submit()
+    dataset.refresh_from_db()
+    assert dataset.service is True
+    assert dataset.endpoint_url == 'https://example.com'
+    assert dataset.status == Dataset.HAS_DATA
+    assert dataset.comments.count() == 1
+    assert dataset.comments.first().type == Comment.STATUS
+    assert dataset.comments.first().status == Comment.OPENED
+
+
+@pytest.mark.django_db
+def test_update_dataset_without_service_and_endpoint_url(app: DjangoTestApp):
+    service_type = TypeFactory(name=Type.SERVICE)
+    organization = OrganizationFactory()
+    dataset = DatasetFactory(organization=organization, service=True)
+    dataset.type.add(service_type)
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+    form = app.get(reverse('dataset-change', kwargs={'pk': dataset.id})).forms['dataset-form']
+    form['type'] = []
+    form.submit()
+    dataset.refresh_from_db()
+    assert dataset.service is False
+    assert dataset.endpoint_url is None
+    assert dataset.status == Dataset.INVENTORED
+    assert dataset.comments.count() == 1
+    assert dataset.comments.first().type == Comment.STATUS
+    assert dataset.comments.first().status == Comment.INVENTORED
+
+
+@pytest.mark.django_db
+>>>>>>> e43e5872 ([1580] Add tests to cover changes)
 def test_dataset_landing_page(app: DjangoTestApp):
     frequency = FrequencyFactory(is_default=True)
     org = OrganizationFactory()

--- a/tests/datasets/test_views.py
+++ b/tests/datasets/test_views.py
@@ -3485,10 +3485,10 @@ def test_create_dataset_with_service_and_endpoint_url(app: DjangoTestApp):
 @pytest.mark.parametrize(
     "dataset_name, dataset_title, organization_name, organization_slug, organization_title, expected_dataset_name",
     [
-        (None, "Test Datašet", "Test Organization", "", "", "test-organization/test-datashet"),  # generates automatically
+        (None, "Test Dataset", "Test Organization", "", "", "datasets/gov/test-organization/test-dataset"),  # generates automatically
         ("test-organization/my-test-dataset", "Test Dataset", "Test Organization", "", "", "test-organization/my-test-dataset"),  # uses provided name
-        (None, "Test Dataset", "", "test-organization-slug", "", "test-organization-slug/test-dataset"),  # generates automatically
-        (None, "Test Dataset", "", "", "Test Organization Title", "test-organization-title/test-dataset"),  # generates automatically
+        (None, "Test Dataset", "", "test-organization-slug", "", "datasets/gov/test-organization-slug/test-dataset"),  # generates automatically
+        (None, "Test Dataset", "", "", "Test Organization Title", "datasets/gov/test-organization-title/test-dataset"),  # generates automatically
     ]
 )
 def test_create_dataset_without_name_generates_automatically(app: DjangoTestApp, dataset_name, 
@@ -3520,13 +3520,13 @@ def test_create_dataset_without_name_generate_unique_name(app: DjangoTestApp):
     
     dataset1 = DatasetFactory(organization=org, title="Test Dataset")
     MetadataFactory(content_type=ContentType.objects.get_for_model(Dataset),
-                    name='test-organization/test-dataset', 
+                    name='datasets/gov/test-organization/test-dataset', 
                     dataset=dataset1,
                     object_id=dataset1.pk
 )
     dataset2 = DatasetFactory(organization=org, title="Second Test Dataset")
     MetadataFactory(content_type=ContentType.objects.get_for_model(Dataset),
-                    name='test-organization/test-dataset_3', 
+                    name='datasets/gov/test-organization/test-dataset_3', 
                     dataset=dataset2,
                     object_id=dataset2.pk
     )
@@ -3540,13 +3540,13 @@ def test_create_dataset_without_name_generate_unique_name(app: DjangoTestApp):
     assert Dataset.objects.count() == 3
     
     dataset1.refresh_from_db()
-    assert dataset1.name == "test-organization/test-dataset"
+    assert dataset1.name == "datasets/gov/test-organization/test-dataset"
     
     dataset2.refresh_from_db()
-    assert dataset2.name == "test-organization/test-dataset_3"
+    assert dataset2.name == "datasets/gov/test-organization/test-dataset_3"
     
     dataset3 = Dataset.objects.last()
-    assert dataset3.name == "test-organization/test-dataset_4"
+    assert dataset3.name == "datasets/gov/test-organization/test-dataset_4"
 
 
 @pytest.mark.django_db
@@ -3571,7 +3571,7 @@ def test_update_dateset_generates_name(app: DjangoTestApp):
     
     assert response.status_code == 302
     dataset.refresh_from_db()
-    assert dataset.name == "test-organization/updated-test-dataset"
+    assert dataset.name == "datasets/gov/test-organization/updated-test-dataset"
     
     
 @pytest.mark.django_db

--- a/tests/datasets/test_views.py
+++ b/tests/datasets/test_views.py
@@ -3456,32 +3456,6 @@ def test_dataset_view_organization_contacts(app: DjangoTestApp):
 
 
 @pytest.mark.django_db
-<<<<<<< HEAD
-=======
-def test_create_dataset_with_service_and_endpoint_url(app: DjangoTestApp):
-    FrequencyFactory(is_default=True)
-    service_type = TypeFactory(name=Type.SERVICE)
-    organization = OrganizationFactory()
-    user = UserFactory(is_staff=True)
-    app.set_user(user)
-    form = app.get(reverse('dataset-add', kwargs={'pk': organization.id})).forms['dataset-form']
-    form['title'] = 'Added title'
-    form['description'] = 'Added new dataset description'
-    form['type'] = [service_type.pk]
-    form['endpoint_url'] = 'https://example.com'
-    form['access_rights'] = Dataset.PUBLIC
-    form.submit()
-    assert Dataset.objects.count() == 1
-    dataset = Dataset.objects.first()
-    assert dataset.service is True
-    assert dataset.endpoint_url == 'https://example.com'
-    assert dataset.status == Dataset.HAS_DATA
-    assert dataset.comments.count() == 1
-    assert dataset.comments.first().type == Comment.STATUS
-    assert dataset.comments.first().status == Comment.OPENED
-
-
-@pytest.mark.django_db
 @pytest.mark.parametrize(
     "dataset_name, dataset_title, organization_name, organization_slug, organization_title, expected_dataset_name",
     [
@@ -3491,17 +3465,18 @@ def test_create_dataset_with_service_and_endpoint_url(app: DjangoTestApp):
         (None, "Test Dataset", "", "", "Test Organization Title", "datasets/gov/test-organization-title/test-dataset"),  # generates automatically
     ]
 )
-def test_create_dataset_without_name_generates_automatically(app: DjangoTestApp, dataset_name, 
-                                                             dataset_title, organization_name, organization_slug, 
+def test_create_dataset_without_name_generates_automatically(app: DjangoTestApp, dataset_name,
+                                                             dataset_title, organization_name, organization_slug,
                                                              organization_title, expected_dataset_name):
     FrequencyFactory(is_default=True)
+    subclass = DCATResourceSubclassFactory()
     org = OrganizationFactory(name=organization_name, slug=organization_slug, title=organization_title)
     user = UserFactory(is_staff=True, organization=org)
     app.set_user(user)
-    form = app.get(reverse('dataset-add', kwargs={'pk': org.id})).forms['dataset-form']
+    form = app.get(reverse('dataset-add', kwargs={'pk': org.id, "subclass_uuid": subclass.pk})).forms['dataset-form']
     form['title'] = dataset_title
     if dataset_name is not None:
-        form['name'] = dataset_name 
+        form['name'] = dataset_name
     form['description'] = 'Added new dataset description'
     form['access_rights'] = Dataset.PUBLIC
     response = form.submit()
@@ -3509,42 +3484,43 @@ def test_create_dataset_without_name_generates_automatically(app: DjangoTestApp,
     assert Dataset.objects.count() == 1
     dataset = Dataset.objects.first()
     assert dataset.name == expected_dataset_name
-    
+
 
 @pytest.mark.django_db
 def test_create_dataset_without_name_generate_unique_name(app: DjangoTestApp):
+    subclass = DCATResourceSubclassFactory()
     FrequencyFactory(is_default=True)
     org = OrganizationFactory(name='Test Organization')
     user = UserFactory(is_staff=True, organization=org)
     app.set_user(user)
-    
+
     dataset1 = DatasetFactory(organization=org, title="Test Dataset")
     MetadataFactory(content_type=ContentType.objects.get_for_model(Dataset),
-                    name='datasets/gov/test-organization/test-dataset', 
+                    name='datasets/gov/test-organization/test-dataset',
                     dataset=dataset1,
                     object_id=dataset1.pk
 )
     dataset2 = DatasetFactory(organization=org, title="Second Test Dataset")
     MetadataFactory(content_type=ContentType.objects.get_for_model(Dataset),
-                    name='datasets/gov/test-organization/test-dataset_3', 
+                    name='datasets/gov/test-organization/test-dataset_3',
                     dataset=dataset2,
                     object_id=dataset2.pk
     )
-    
-    form = app.get(reverse('dataset-add', kwargs={'pk': org.id})).forms['dataset-form']
+
+    form = app.get(reverse('dataset-add', kwargs={'pk': org.id, "subclass_uuid": subclass.pk})).forms['dataset-form']
     form['title'] = 'Test Dataset'
     form['description'] = 'Added new dataset description'
     form['access_rights'] = Dataset.PUBLIC
     response = form.submit()
     assert response.status_code == 302
     assert Dataset.objects.count() == 3
-    
+
     dataset1.refresh_from_db()
     assert dataset1.name == "datasets/gov/test-organization/test-dataset"
-    
+
     dataset2.refresh_from_db()
     assert dataset2.name == "datasets/gov/test-organization/test-dataset_3"
-    
+
     dataset3 = Dataset.objects.last()
     assert dataset3.name == "datasets/gov/test-organization/test-dataset_4"
 
@@ -3555,45 +3531,45 @@ def test_update_dateset_generates_name(app: DjangoTestApp):
     org = OrganizationFactory(name='Test Organization')
     user = UserFactory(is_staff=True, organization=org)
     app.set_user(user)
-    
+
     dataset = DatasetFactory(organization=org, title="Test Dataset")
     MetadataFactory(content_type=ContentType.objects.get_for_model(Dataset),
-                    name="", 
+                    name="",
                     dataset=dataset,
                     object_id=dataset.pk
     )
-    
+
     form = app.get(reverse('dataset-change', kwargs={'pk': dataset.id})).forms['dataset-form']
     form['title'] = 'Updated Test Dataset'
     form['description'] = 'Updated dataset description'
     form['access_rights'] = Dataset.PUBLIC
     response = form.submit()
-    
+
     assert response.status_code == 302
     dataset.refresh_from_db()
     assert dataset.name == "datasets/gov/test-organization/updated-test-dataset"
-    
-    
+
+
 @pytest.mark.django_db
 def test_update_dateset_existing_name_cannot_be_removed(app: DjangoTestApp):
     FrequencyFactory(is_default=True)
     org = OrganizationFactory(name='Test Organization')
     user = UserFactory(is_staff=True, organization=org)
     app.set_user(user)
-    
+
     dataset = DatasetFactory(organization=org, title="Test Dataset")
     MetadataFactory(content_type=ContentType.objects.get_for_model(Dataset),
-                    name="test-organization/test-dataset", 
+                    name="test-organization/test-dataset",
                     dataset=dataset,
                     object_id=dataset.pk
     )
-    
+
     form = app.get(reverse('dataset-change', kwargs={'pk': dataset.id})).forms['dataset-form']
     form['title'] = 'Updated Test Dataset'
     form['name'] = ''  # Attempt to remove name
     form['description'] = 'Updated dataset description'
     form['access_rights'] = Dataset.PUBLIC
-    
+
     response = form.submit()
     assert response.status_code == 200
     dataset.refresh_from_db()
@@ -3601,47 +3577,6 @@ def test_update_dateset_existing_name_cannot_be_removed(app: DjangoTestApp):
 
 
 @pytest.mark.django_db
-def test_update_dataset_with_service_and_endpoint_url(app: DjangoTestApp):
-    service_type = TypeFactory(name=Type.SERVICE)
-    organization = OrganizationFactory()
-    dataset = DatasetFactory(organization=organization)
-    user = UserFactory(is_staff=True)
-    app.set_user(user)
-    form = app.get(reverse('dataset-change', kwargs={'pk': dataset.id})).forms['dataset-form']
-    form['type'] = [service_type.pk]
-    form['endpoint_url'] = 'https://example.com'
-    form.submit()
-    dataset.refresh_from_db()
-    assert dataset.service is True
-    assert dataset.endpoint_url == 'https://example.com'
-    assert dataset.status == Dataset.HAS_DATA
-    assert dataset.comments.count() == 1
-    assert dataset.comments.first().type == Comment.STATUS
-    assert dataset.comments.first().status == Comment.OPENED
-
-
-@pytest.mark.django_db
-def test_update_dataset_without_service_and_endpoint_url(app: DjangoTestApp):
-    service_type = TypeFactory(name=Type.SERVICE)
-    organization = OrganizationFactory()
-    dataset = DatasetFactory(organization=organization, service=True)
-    dataset.type.add(service_type)
-    user = UserFactory(is_staff=True)
-    app.set_user(user)
-    form = app.get(reverse('dataset-change', kwargs={'pk': dataset.id})).forms['dataset-form']
-    form['type'] = []
-    form.submit()
-    dataset.refresh_from_db()
-    assert dataset.service is False
-    assert dataset.endpoint_url is None
-    assert dataset.status == Dataset.INVENTORED
-    assert dataset.comments.count() == 1
-    assert dataset.comments.first().type == Comment.STATUS
-    assert dataset.comments.first().status == Comment.INVENTORED
-
-
-@pytest.mark.django_db
->>>>>>> e43e5872 ([1580] Add tests to cover changes)
 def test_dataset_landing_page(app: DjangoTestApp):
     frequency = FrequencyFactory(is_default=True)
     org = OrganizationFactory()

--- a/vitrina/datasets/forms.py
+++ b/vitrina/datasets/forms.py
@@ -288,29 +288,29 @@ class BaseResourceForm(TranslatableModelForm):
 
     def clean_name(self) -> str | None:
         name = self.cleaned_data.get("name")
+        dataset_instance = self.instance
+        existing_metadata = dataset_instance.metadata.first() if dataset_instance and dataset_instance.pk else None
 
-        if not name:
-            return name
+        if name:
+            if not name.isascii():
+                raise ValidationError(_("Kodiniame pavadinime gali būti naudojamos tik lotyniškos raidės."))
 
-        metadata = Metadata.objects.filter(
-            content_type=ContentType.objects.get_for_model(Dataset), name=name
-        )
-        if self.instance and self.instance.pk and self.instance.metadata.first():
-            metadata = metadata.exclude(pk=self.instance.metadata.first().pk)
+            if any(ch.isupper() for ch in name):
+                raise ValidationError(_("Kodiniame pavadinime gali būti naudojamos tik mažosios raidės."))
 
-        if metadata:
-            raise ValidationError(
-                _("Duomenų rinkinys su šiuo kodiniu pavadinimu jau egzistuoja.")
+            metadata_qs = Metadata.objects.filter(
+                content_type=ContentType.objects.get_for_model(Dataset),
+                name=name,
             )
+            if existing_metadata:
+                metadata_qs = metadata_qs.exclude(pk=existing_metadata.pk)
 
-        if not name.isascii():
-            raise ValidationError(
-                _("Kodiniame pavadinime gali būti naudojamos tik lotyniškos raidės.")
-            )
-        if any([ch.isupper() for ch in name]):
-            raise ValidationError(
-                _("Kodiniame pavadinime gali būti naudojamos tik mažosios raidės.")
-            )
+            if metadata_qs.exists():
+                raise ValidationError(_("Duomenų rinkinys su šiuo kodiniu pavadinimu jau egzistuoja."))
+
+        else:
+            if existing_metadata and existing_metadata.name:
+                raise ValidationError(_("Kodinis pavadinimas yra privalomas, jei duomenų rinkinys jau turi kodinį pavadinimą."))
 
         return name
 

--- a/vitrina/datasets/helpers.py
+++ b/vitrina/datasets/helpers.py
@@ -31,7 +31,7 @@ def generate_dataset_name(organization: Organization, dataset_title: str) -> str
         or slugify_ascii_lower(organization.title)
     )    
     dataset_part = slugify_ascii_lower(dataset_title)
-    return f"{organization_part}/{dataset_part}"
+    return f"datasets/gov/{organization_part}/{dataset_part}"
 
 
 def generate_unique_dataset_name(organization: Organization, dataset: Dataset) -> str:

--- a/vitrina/datasets/helpers.py
+++ b/vitrina/datasets/helpers.py
@@ -1,5 +1,71 @@
+import re
+from django.contrib.contenttypes.models import ContentType
+from functools import partial
+
 from django.http import HttpRequest
+from slugify import slugify
+
+from vitrina.orgs.models import Organization
+from vitrina.datasets.models import Dataset, Metadata
 
 
 def is_manager_dataset_list(request: HttpRequest):
     return request.resolver_match.url_name == "manager-dataset-list"
+
+
+def generate_dataset_name(organization: Organization, dataset_title: str) -> str:
+    """
+    Generates a dataset name by combining a slugified organization identifier and a slugified dataset title.
+    The organization identifier is determined by attempting to slugify the organization's name, 
+    then slug, then title (in that order), using ASCII characters and lowercase formatting. 
+    The dataset title is also slugified in the same manner.
+    
+    Returns:
+        str: A string in the format "organization_part/dataset_part", where both parts are slugified.
+    """
+    slugify_ascii_lower = partial(slugify, lowercase=True, allow_unicode=False)
+    
+    organization_part = (
+        slugify_ascii_lower(organization.name) 
+        or slugify_ascii_lower(organization.slug) 
+        or slugify_ascii_lower(organization.title)
+    )    
+    dataset_part = slugify_ascii_lower(dataset_title)
+    return f"{organization_part}/{dataset_part}"
+
+
+def generate_unique_dataset_name(organization: Organization, dataset: Dataset) -> str:
+    """
+    Generates a unique dataset name for the given organization and dataset.
+    The function creates a base name using the organization's information and the dataset's title.
+    It then checks for existing dataset names in the Metadata model that start with the base name.
+    If the base name is not already used, it returns the base name.
+    If the base name exists, it appends an incremented numeric suffix to ensure uniqueness.
+    Args:
+        organization (Organization): The organization to which the dataset belongs.
+        dataset (Dataset): The dataset for which the unique name is to be generated.
+    Returns:
+        str: A unique dataset name in format "organization_part/dataset_part" 
+            or "organization_part/dataset_part_index".
+    """
+    base_name = generate_dataset_name(organization, dataset.title)
+    
+    existing_names = Metadata.objects.filter(
+        content_type=ContentType.objects.get_for_model(Dataset), 
+        name__startswith=base_name
+    ).values_list("name", flat=True)
+
+    if base_name not in existing_names:
+        return base_name
+
+    pattern = re.compile(rf"^{re.escape(base_name)}_(\d+)$")
+
+    max_index = 1
+    for name in existing_names:
+        match = pattern.match(name)
+        if match:
+            index = int(match.group(1))
+            if index >= max_index:
+                max_index = index + 1
+
+    return f"{base_name}_{max_index}"

--- a/vitrina/datasets/helpers.py
+++ b/vitrina/datasets/helpers.py
@@ -24,12 +24,8 @@ def generate_dataset_name(organization: Organization, dataset_title: str) -> str
         str: A string in the format "organization_part/dataset_part", where both parts are slugified.
     """
     slugify_ascii_lower = partial(slugify, lowercase=True, allow_unicode=False)
-
-    organization_part = (
-        slugify_ascii_lower(organization.name)
-        or slugify_ascii_lower(organization.slug)
-        or slugify_ascii_lower(organization.title)
-    )
+    organization_part = organization.name or organization.slug or organization.title 
+    organization_part = slugify_ascii_lower(organization_part)
     dataset_part = slugify_ascii_lower(dataset_title)
     return f"datasets/gov/{organization_part}/{dataset_part}"
 

--- a/vitrina/datasets/helpers.py
+++ b/vitrina/datasets/helpers.py
@@ -16,20 +16,20 @@ def is_manager_dataset_list(request: HttpRequest):
 def generate_dataset_name(organization: Organization, dataset_title: str) -> str:
     """
     Generates a dataset name by combining a slugified organization identifier and a slugified dataset title.
-    The organization identifier is determined by attempting to slugify the organization's name, 
-    then slug, then title (in that order), using ASCII characters and lowercase formatting. 
+    The organization identifier is determined by attempting to slugify the organization's name,
+    then slug, then title (in that order), using ASCII characters and lowercase formatting.
     The dataset title is also slugified in the same manner.
-    
+
     Returns:
         str: A string in the format "organization_part/dataset_part", where both parts are slugified.
     """
     slugify_ascii_lower = partial(slugify, lowercase=True, allow_unicode=False)
-    
+
     organization_part = (
-        slugify_ascii_lower(organization.name) 
-        or slugify_ascii_lower(organization.slug) 
+        slugify_ascii_lower(organization.name)
+        or slugify_ascii_lower(organization.slug)
         or slugify_ascii_lower(organization.title)
-    )    
+    )
     dataset_part = slugify_ascii_lower(dataset_title)
     return f"datasets/gov/{organization_part}/{dataset_part}"
 
@@ -45,13 +45,13 @@ def generate_unique_dataset_name(organization: Organization, dataset: Dataset) -
         organization (Organization): The organization to which the dataset belongs.
         dataset (Dataset): The dataset for which the unique name is to be generated.
     Returns:
-        str: A unique dataset name in format "organization_part/dataset_part" 
+        str: A unique dataset name in format "organization_part/dataset_part"
             or "organization_part/dataset_part_index".
     """
     base_name = generate_dataset_name(organization, dataset.title)
-    
+
     existing_names = Metadata.objects.filter(
-        content_type=ContentType.objects.get_for_model(Dataset), 
+        content_type=ContentType.objects.get_for_model(Dataset),
         name__startswith=base_name
     ).values_list("name", flat=True)
 
@@ -69,3 +69,4 @@ def generate_unique_dataset_name(organization: Organization, dataset: Dataset) -
                 max_index = index + 1
 
     return f"{base_name}_{max_index}"
+

--- a/vitrina/datasets/views.py
+++ b/vitrina/datasets/views.py
@@ -67,7 +67,7 @@ from vitrina.datasets.forms import (
     InformationSystemResourceForm,
     DatasetResourceForm,
 )
-from vitrina.datasets.helpers import is_manager_dataset_list
+from vitrina.datasets.helpers import is_manager_dataset_list, generate_unique_dataset_name
 from vitrina.datasets.models import (
     Dataset,
     DatasetStructure,
@@ -838,13 +838,16 @@ class DatasetCreateView(
                 dataset=self.object,
                 file=file,
             )
-
+        dataset_name = (
+            form.cleaned_data.get("name", "") 
+            or generate_unique_dataset_name(self.object.organization, self.object)
+        )
         Metadata.objects.create(
             uuid=str(uuid.uuid4()),
             dataset=self.object,
             content_type=ContentType.objects.get_for_model(self.object),
             object_id=self.object.pk,
-            name=form.cleaned_data.get("name", ""),
+            name=dataset_name,
             title=self.object.title,
             description=self.object.description,
             prepare_ast={},
@@ -1172,7 +1175,7 @@ class DatasetUpdateView(
                     dataset=self.object,
                     file=file,
                 )
-
+               
         if metadata := self.object.metadata.first():
             metadata.title = self.object.title
             metadata.description = self.object.description
@@ -1183,15 +1186,17 @@ class DatasetUpdateView(
                 dataset=self.object,
                 content_type=ContentType.objects.get_for_model(self.object),
                 object_id=self.object.pk,
-                name=form.cleaned_data.get("name"),
                 title=self.object.title,
                 description=self.object.description,
                 prepare_ast={},
                 version=1,
             )
-
-        if "name" in form.changed_data:
-            metadata.name = form.cleaned_data.get("name")
+        dataset_name = (
+            form.cleaned_data.get("name", "")
+            or generate_unique_dataset_name(self.object.organization, self.object)
+        )
+        if not metadata.name or metadata.name != dataset_name:
+            metadata.name = dataset_name
             metadata.draft = True
             metadata.save()
 

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -687,6 +687,11 @@ msgstr ""
 "This property indicates the web page that is the main page of the catalog. "
 "Corresponds to foaf:homepage."
 
+msgid ""
+"Kodinis pavadinimas yra privalomas, jei duomenų rinkinys jau turi kodinį "
+"pavadinimą."
+msgstr "A code name is required if the dataset already has a code name."
+
 msgid "Failas"
 msgstr "File"
 

--- a/vitrina/locale/lt/LC_MESSAGES/django.po
+++ b/vitrina/locale/lt/LC_MESSAGES/django.po
@@ -336,6 +336,11 @@ msgid ""
 "būtini naudotojo užsakytai paslaugai suteikti."
 msgstr ""
 
+msgid ""
+"Kodinis pavadinimas yra privalomas, jei duomenų rinkinys jau turi kodinį "
+"pavadinimą."
+msgstr ""
+
 msgid "Naujienos"
 msgstr ""
 
@@ -592,14 +597,6 @@ msgid "Detalus informacinės sistemos aprašas"
 msgstr ""
 
 msgid "Informacinės sistemos identifikatorius"
-msgstr ""
-
-msgid "Duomenų rinkinys su šiuo kodiniu pavadinimu jau egzistuoja."
-msgstr ""
-
-msgid ""
-"Kodinis pavadinimas yra privalomas, jei duomenų rinkinys jau turi kodinį "
-"pavadinimą."
 msgstr ""
 
 msgid "Failas"

--- a/vitrina/locale/lt/LC_MESSAGES/django.po
+++ b/vitrina/locale/lt/LC_MESSAGES/django.po
@@ -594,6 +594,14 @@ msgstr ""
 msgid "Informacinės sistemos identifikatorius"
 msgstr ""
 
+msgid "Duomenų rinkinys su šiuo kodiniu pavadinimu jau egzistuoja."
+msgstr ""
+
+msgid ""
+"Kodinis pavadinimas yra privalomas, jei duomenų rinkinys jau turi kodinį "
+"pavadinimą."
+msgstr ""
+
 msgid "Failas"
 msgstr ""
 


### PR DESCRIPTION
Generates dataset code name in format: `datasets/gov/organization[title or slug or name]/dataset_title`.

If code name is not provided while creating or updating dataset - generate it automatically. 
Generated code name is unique.
Do not allow to remove dataset name while updating it - validation error is raised.
Exporting dataset structure with code name works out of the box.
Update translation files to add  the error of validation.

<img width="691" height="113" alt="Screenshot 2025-08-05 at 11 57 37" src="https://github.com/user-attachments/assets/2c1b6044-a077-4687-b9b3-c5bce8e9f901" />
