### PR TITLE
[1713] Change URL for credentials.cfg in Agents

### DIFF
--- a/vitrina/uapi/templates/agents/agent_detail.html
+++ b/vitrina/uapi/templates/agents/agent_detail.html
@@ -126,7 +126,7 @@
                         <br>
                         {% translate "Užregistravus Agentą būtina sukonfigūruoti jo prisijungimo duomenis, kitaip Agentas negalės pasiekti saugyklos." %}
                         <br><br>
-                        <a href="https://atviriduomenys.readthedocs.io/spinta.html#duomenu-publikavimas-i-saugykla">
+                        <a href="https://atviriduomenys.readthedocs.io/agentas.html#agento-prisijungimas-prie-katalogo-spinta-konfiguracija">
                             📖 {% translate "Daugiau apie credentials.cfg" %}
                         </a>
                     </p>


### PR DESCRIPTION
Changing the URL, since it currently points to an old documentation not related to the Agent implementation.