### PR TITLE
1590 add history for Dataset, DatasetDistribution, DatasetAttribution

### DIFF
--- a/vitrina/classifiers/models.py
+++ b/vitrina/classifiers/models.py
@@ -3,10 +3,12 @@ from django.utils.translation import gettext_lazy as _, get_language
 
 from parler.models import TranslatableModel, TranslatedFields
 from treebeard.mp_tree import MP_Node, MP_NodeManager
+import reversion
 
 from vitrina.models import UUIDBaseModel
 
 
+@reversion.register()
 class Category(MP_Node):
     created = models.DateTimeField(blank=True, null=True, auto_now_add=True)
     modified = models.DateTimeField(blank=True, null=True, auto_now=True)

--- a/vitrina/datasets/models.py
+++ b/vitrina/datasets/models.py
@@ -84,6 +84,7 @@ class Resource(MP_Node, TranslatableModel):
         abstract = True
 
 
+@reversion.register(follow=["category"]) 
 class Dataset(Resource):
     node_order_by = ("organization_id", )
 
@@ -124,6 +125,7 @@ class Dataset(Resource):
     DELETED = "DELETED"
     PROJECT_SET = "PROJECT_SET"
     REQUEST_SET = "REQUEST_SET"
+    CATEGORY_UPDATED = "CATEGORY_UPDATED"
     HISTORY_MESSAGES = {
         CREATED: _("Sukurta"),
         EDITED: _("Redaguota"),
@@ -134,6 +136,7 @@ class Dataset(Resource):
         DELETED: _("Ištrinta"),
         PROJECT_SET: _("Priskirta projektui"),
         REQUEST_SET: _("Priskirta poreikiui"),
+        CATEGORY_UPDATED: _("Pakeista kategrija(-os)"),
     }
 
     PUBLIC = "PUBLIC"

--- a/vitrina/datasets/models.py
+++ b/vitrina/datasets/models.py
@@ -84,7 +84,7 @@ class Resource(MP_Node, TranslatableModel):
         abstract = True
 
 
-@reversion.register(follow=["category"]) 
+@reversion.register(follow=["category", "part_of"]) 
 class Dataset(Resource):
     node_order_by = ("organization_id", )
 
@@ -126,6 +126,8 @@ class Dataset(Resource):
     PROJECT_SET = "PROJECT_SET"
     REQUEST_SET = "REQUEST_SET"
     CATEGORY_UPDATED = "CATEGORY_UPDATED"
+    RELATION_ADDED = "RELATION_ADDED"
+    RELATION_DELETED = "RELATION_DELETED"
     HISTORY_MESSAGES = {
         CREATED: _("Sukurta"),
         EDITED: _("Redaguota"),
@@ -137,6 +139,8 @@ class Dataset(Resource):
         PROJECT_SET: _("Priskirta projektui"),
         REQUEST_SET: _("Priskirta poreikiui"),
         CATEGORY_UPDATED: _("Pakeista kategrija(-os)"),
+        RELATION_ADDED: _("Pridėtas ryšys"),
+        RELATION_DELETED: _("Ištrintas ryšys")
     }
 
     PUBLIC = "PUBLIC"
@@ -1651,6 +1655,7 @@ class Relation(TranslatableModel):
         )
 
 
+@reversion.register()
 class DatasetRelation(models.Model):
     relation = models.ForeignKey(
         Relation, verbose_name=_("Ryšio tipas"), on_delete=models.PROTECT

--- a/vitrina/datasets/models.py
+++ b/vitrina/datasets/models.py
@@ -128,6 +128,8 @@ class Dataset(Resource):
     CATEGORY_UPDATED = "CATEGORY_UPDATED"
     RELATION_ADDED = "RELATION_ADDED"
     RELATION_DELETED = "RELATION_DELETED"
+    ATTRIBUTION_ADDED = "ATTRIBUTION_ADDED"
+    ATTRIBUTION_DELETED = "ATTRIBUTION_DELETED"
     HISTORY_MESSAGES = {
         CREATED: _("Sukurta"),
         EDITED: _("Redaguota"),
@@ -140,7 +142,9 @@ class Dataset(Resource):
         REQUEST_SET: _("Priskirta poreikiui"),
         CATEGORY_UPDATED: _("Pakeista kategrija(-os)"),
         RELATION_ADDED: _("Pridėtas ryšys"),
-        RELATION_DELETED: _("Ištrintas ryšys")
+        RELATION_DELETED: _("Ištrintas ryšys"),
+        ATTRIBUTION_ADDED: _("Priskirta organizacijai"),
+        ATTRIBUTION_DELETED: _("Pašalinta iš organizacijos")
     }
 
     PUBLIC = "PUBLIC"
@@ -1536,6 +1540,7 @@ class Attribution(models.Model):
         return self.title if self.title else self.name
 
 
+@reversion.register()
 class DatasetAttribution(models.Model):
     dataset = models.ForeignKey(
         Dataset, on_delete=models.CASCADE, verbose_name=_("Duomenų rinkinys")

--- a/vitrina/datasets/models.py
+++ b/vitrina/datasets/models.py
@@ -140,7 +140,7 @@ class Dataset(Resource):
         DELETED: _("Ištrinta"),
         PROJECT_SET: _("Priskirta projektui"),
         REQUEST_SET: _("Priskirta poreikiui"),
-        CATEGORY_UPDATED: _("Pakeista kategrija(-os)"),
+        CATEGORY_UPDATED: _("Pakeista kategorija(-os)"),
         RELATION_ADDED: _("Pridėtas ryšys"),
         RELATION_DELETED: _("Ištrintas ryšys"),
         ATTRIBUTION_ADDED: _("Priskirta organizacijai"),

--- a/vitrina/datasets/views.py
+++ b/vitrina/datasets/views.py
@@ -3414,7 +3414,6 @@ class DatasetAttributionDeleteView(PermissionRequiredMixin, DeleteView):
     def delete(self, request, *args, **kwargs):
         with create_revision():
             self.object = self.get_object()
-            add_to_revision(self.object)
             set_user(request.user)
             set_comment(Dataset.ATTRIBUTION_DELETED)
             self.object.save()

--- a/vitrina/datasets/views.py
+++ b/vitrina/datasets/views.py
@@ -40,7 +40,7 @@ from parler.views import (
     LanguageChoiceMixin,
     ViewUrlMixin,
 )
-from reversion import set_comment, add_to_revision, create_revision, set_user
+from reversion import set_comment, create_revision, set_user
 from reversion.models import Version
 from reversion.views import RevisionMixin
 

--- a/vitrina/datasets/views.py
+++ b/vitrina/datasets/views.py
@@ -40,7 +40,7 @@ from parler.views import (
     LanguageChoiceMixin,
     ViewUrlMixin,
 )
-from reversion import set_comment, create_revision, set_user
+from reversion import set_comment, create_revision, set_user, add_to_revision
 from reversion.models import Version
 from reversion.views import RevisionMixin
 
@@ -3409,8 +3409,8 @@ class DatasetAttributionDeleteView(PermissionRequiredMixin, DeleteView):
         with create_revision():
             self.object = self.get_object()
             set_user(request.user)
+            add_to_revision(self.object)
             set_comment(Dataset.ATTRIBUTION_DELETED)
-            self.object.save()
 
         return super().delete(request, *args, **kwargs)
 
@@ -3493,7 +3493,7 @@ class DatasetRelationDeleteView(PermissionRequiredMixin, DeleteView):
             self.object = self.get_object()
             set_user(request.user)
             set_comment(Dataset.RELATION_DELETED)
-            self.object.save()
+            add_to_revision(self.object)
         return super().delete(request, *args, **kwargs)
 
     def get_success_url(self):

--- a/vitrina/datasets/views.py
+++ b/vitrina/datasets/views.py
@@ -40,7 +40,7 @@ from parler.views import (
     LanguageChoiceMixin,
     ViewUrlMixin,
 )
-from reversion import set_comment, add_to_revision
+from reversion import set_comment, add_to_revision, create_revision, set_user
 from reversion.models import Version
 from reversion.views import RevisionMixin
 
@@ -1409,6 +1409,11 @@ class DatasetHistoryView(DatasetStructureMixin, PlanMixin, HistoryView):
         dataset_distribution_history_objects = Version.objects.get_for_model(DatasetDistribution).filter(
             object_id__in=list(dataset_distribution_ids)
         )
+        attribution_history_objects_ids = [
+            v.pk for v in Version.objects.get_for_model(DatasetAttribution)
+            if v.field_dict['dataset_id'] == self.object.id
+        ]
+        attribution_history_objects = Version.objects.get_for_model(DatasetAttribution).filter(pk__in=attribution_history_objects_ids)
 
         history_objects = (
             property_history_objects
@@ -1416,6 +1421,7 @@ class DatasetHistoryView(DatasetStructureMixin, PlanMixin, HistoryView):
             | dataset_history_objects
             | plan_history_objects
             | dataset_distribution_history_objects
+            | attribution_history_objects
         )
         return history_objects.order_by("-revision__date_created")
 
@@ -3351,7 +3357,7 @@ class FilterCategoryView(LoginRequiredMixin, View):
         return JsonResponse({"categories": category_data})
 
 
-class DatasetAttributionCreateView(PermissionRequiredMixin, CreateView):
+class DatasetAttributionCreateView(PermissionRequiredMixin, RevisionMixin, CreateView):
     model = DatasetAttribution
     form_class = DatasetAttributionForm
     template_name = "vitrina/datasets/attribution_form.html"
@@ -3379,6 +3385,7 @@ class DatasetAttributionCreateView(PermissionRequiredMixin, CreateView):
         self.object: DatasetAttribution = form.save(commit=False)
         self.object.dataset = self.dataset
         self.object.save()
+        set_comment(Dataset.ATTRIBUTION_ADDED)
         return redirect(self.dataset.get_absolute_url())
 
 
@@ -3396,6 +3403,16 @@ class DatasetAttributionDeleteView(PermissionRequiredMixin, DeleteView):
 
     def get(self, request, *args, **kwargs):
         return self.post(request, *args, **kwargs)
+    
+    def delete(self, request, *args, **kwargs):
+        with create_revision():
+            self.object = self.get_object()
+            add_to_revision(self.object)
+            set_user(request.user)
+            set_comment(Dataset.ATTRIBUTION_DELETED)
+            self.object.save()
+
+        return super().delete(request, *args, **kwargs)
 
     def get_success_url(self):
         return self.dataset.get_absolute_url()

--- a/vitrina/datasets/views.py
+++ b/vitrina/datasets/views.py
@@ -1419,12 +1419,18 @@ class DatasetHistoryView(DatasetStructureMixin, PlanMixin, HistoryView):
         return history_objects.order_by("-revision__date_created")
     
     def _get_history_objects_for_model(self, model: TypingType[models.Model]) -> QuerySet[Version]:
-        version_ids = [
-            version.pk for version in Version.objects.get_for_model(model)
-            if version.field_dict['dataset_id'] == self.object.id
+        all_versions = Version.objects.get_for_model(model)
+        filtered_versions_ids = [
+            version.pk for version in all_versions
+            if version.field_dict.get('dataset_id') == self.object.id
         ]
+        if model == DatasetRelation:
+            filtered_versions_ids += [
+                version.pk for version in all_versions
+                if version.field_dict.get('part_of_id') == self.object.id
+            ]
 
-        return Version.objects.get_for_model(model).filter(pk__in=version_ids)
+        return all_versions.filter(pk__in=filtered_versions_ids)
 
 
 class DatasetStructureImportView(

--- a/vitrina/datasets/views.py
+++ b/vitrina/datasets/views.py
@@ -1418,7 +1418,7 @@ class DatasetHistoryView(DatasetStructureMixin, PlanMixin, HistoryView):
         )
         return history_objects.order_by("-revision__date_created")
     
-    def _get_history_objects_for_model(self, model: TypingType[models.Model]) -> list[int]:
+    def _get_history_objects_for_model(self, model: TypingType[models.Model]) -> QuerySet[Version]:
         version_ids = [
             version.pk for version in Version.objects.get_for_model(model)
             if version.field_dict['dataset_id'] == self.object.id

--- a/vitrina/datasets/views.py
+++ b/vitrina/datasets/views.py
@@ -1415,6 +1415,11 @@ class DatasetHistoryView(DatasetStructureMixin, PlanMixin, HistoryView):
             if v.field_dict['dataset_id'] == self.object.id
         ]
         attribution_history_objects = Version.objects.get_for_model(DatasetAttribution).filter(pk__in=attribution_history_objects_ids)
+        relation_history_objects_ids = [
+            v.pk for v in Version.objects.get_for_model(DatasetRelation)
+            if v.field_dict['dataset_id'] == self.object.id
+        ]
+        relation_history_objects = Version.objects.get_for_model(DatasetRelation).filter(pk__in=relation_history_objects_ids)
 
         history_objects = (
             property_history_objects
@@ -1423,6 +1428,7 @@ class DatasetHistoryView(DatasetStructureMixin, PlanMixin, HistoryView):
             | plan_history_objects
             | dataset_distribution_history_objects
             | attribution_history_objects
+            | relation_history_objects
         )
         return history_objects.order_by("-revision__date_created")
 
@@ -3474,14 +3480,10 @@ class DatasetRelationCreateView(PermissionRequiredMixin, RevisionMixin, CreateVi
         return redirect(self.dataset.get_absolute_url())
 
 
-class DatasetRelationDeleteView(PermissionRequiredMixin, RevisionMixin, DeleteView):
+class DatasetRelationDeleteView(PermissionRequiredMixin, DeleteView):
     model = DatasetRelation
 
     dataset: Dataset
-
-    # Enable reversion tracking for GET (default is POST only)
-    def revision_request_creates_revision(self, request):
-        return request.method in ("GET", "POST")
 
     def dispatch(self, request, *args, **kwargs):
         self.dataset = get_object_or_404(Dataset, pk=kwargs.get("dataset_id"))
@@ -3494,8 +3496,11 @@ class DatasetRelationDeleteView(PermissionRequiredMixin, RevisionMixin, DeleteVi
         return self.post(*args, **kwargs)
     
     def delete(self, request, *args, **kwargs):
-        add_to_revision(self.dataset)
-        set_comment(Dataset.RELATION_DELETED)
+        with create_revision():
+            self.object = self.get_object()
+            set_user(request.user)
+            set_comment(Dataset.RELATION_DELETED)
+            self.object.save()
         return super().delete(request, *args, **kwargs)
 
     def get_success_url(self):

--- a/vitrina/datasets/views.py
+++ b/vitrina/datasets/views.py
@@ -4,7 +4,7 @@ import secrets
 import uuid
 from datetime import datetime, date
 from functools import cached_property
-from typing import List, Any
+from typing import List, Any, Type as TypingType
 from urllib.parse import urlencode
 
 import numpy as np
@@ -1403,23 +1403,9 @@ class DatasetHistoryView(DatasetStructureMixin, PlanMixin, HistoryView):
         plan_history_objects = Version.objects.get_for_model(Plan).filter(
             object_id__in=list(dataset_plan_ids)
         )
-        distribution_history_objects_ids = [
-            v.pk for v in Version.objects.get_for_model(DatasetAttribution)
-            if v.field_dict['dataset_id'] == self.object.id
-        ]
-        dataset_distribution_history_objects = Version.objects.get_for_model(DatasetDistribution).filter(
-            pk__in=list(distribution_history_objects_ids)
-        )
-        attribution_history_objects_ids = [
-            v.pk for v in Version.objects.get_for_model(DatasetAttribution)
-            if v.field_dict['dataset_id'] == self.object.id
-        ]
-        attribution_history_objects = Version.objects.get_for_model(DatasetAttribution).filter(pk__in=attribution_history_objects_ids)
-        relation_history_objects_ids = [
-            v.pk for v in Version.objects.get_for_model(DatasetRelation)
-            if v.field_dict['dataset_id'] == self.object.id
-        ]
-        relation_history_objects = Version.objects.get_for_model(DatasetRelation).filter(pk__in=relation_history_objects_ids)
+        dataset_distribution_history_objects = self._get_history_objects_for_model(DatasetDistribution)
+        attribution_history_objects = self._get_history_objects_for_model(DatasetAttribution)
+        relation_history_objects = self._get_history_objects_for_model(DatasetRelation)
 
         history_objects = (
             property_history_objects
@@ -1431,6 +1417,14 @@ class DatasetHistoryView(DatasetStructureMixin, PlanMixin, HistoryView):
             | relation_history_objects
         )
         return history_objects.order_by("-revision__date_created")
+    
+    def _get_history_objects_for_model(self, model: TypingType[models.Model]) -> list[int]:
+        version_ids = [
+            version.pk for version in Version.objects.get_for_model(model)
+            if version.field_dict['dataset_id'] == self.object.id
+        ]
+
+        return Version.objects.get_for_model(model).filter(pk__in=version_ids)
 
 
 class DatasetStructureImportView(

--- a/vitrina/datasets/views.py
+++ b/vitrina/datasets/views.py
@@ -1403,11 +1403,12 @@ class DatasetHistoryView(DatasetStructureMixin, PlanMixin, HistoryView):
         plan_history_objects = Version.objects.get_for_model(Plan).filter(
             object_id__in=list(dataset_plan_ids)
         )
-        dataset_distribution_ids = DatasetDistribution.objects.filter(dataset=self.object).values_list(
-            "id", flat=True
-        )
+        distribution_history_objects_ids = [
+            v.pk for v in Version.objects.get_for_model(DatasetAttribution)
+            if v.field_dict['dataset_id'] == self.object.id
+        ]
         dataset_distribution_history_objects = Version.objects.get_for_model(DatasetDistribution).filter(
-            object_id__in=list(dataset_distribution_ids)
+            pk__in=list(distribution_history_objects_ids)
         )
         attribution_history_objects_ids = [
             v.pk for v in Version.objects.get_for_model(DatasetAttribution)

--- a/vitrina/datasets/views.py
+++ b/vitrina/datasets/views.py
@@ -19,6 +19,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.paginator import Paginator
 from django.core.serializers.json import DjangoJSONEncoder
+from django.db import models
 from django.db.models import QuerySet, Count, Max, Q, Avg, Sum, Func, F, Value, TextField
 from django.http import JsonResponse, HttpResponseRedirect, HttpResponse
 from django.http.response import HttpResponsePermanentRedirect

--- a/vitrina/datasets/views.py
+++ b/vitrina/datasets/views.py
@@ -40,7 +40,7 @@ from parler.views import (
     LanguageChoiceMixin,
     ViewUrlMixin,
 )
-from reversion import set_comment
+from reversion import set_comment, add_to_revision
 from reversion.models import Version
 from reversion.views import RevisionMixin
 
@@ -3401,7 +3401,7 @@ class DatasetAttributionDeleteView(PermissionRequiredMixin, DeleteView):
         return self.dataset.get_absolute_url()
 
 
-class DatasetRelationCreateView(PermissionRequiredMixin, CreateView):
+class DatasetRelationCreateView(PermissionRequiredMixin, RevisionMixin, CreateView):
     model = DatasetRelation
     form_class = DatasetRelationForm
     template_name = "vitrina/datasets/relation_form.html"
@@ -3451,14 +3451,19 @@ class DatasetRelationCreateView(PermissionRequiredMixin, CreateView):
             # need to save to update search index
             self.object.dataset.save()
             self.object.part_of.save()
+            set_comment(Dataset.RELATION_ADDED)
 
         return redirect(self.dataset.get_absolute_url())
 
 
-class DatasetRelationDeleteView(PermissionRequiredMixin, DeleteView):
+class DatasetRelationDeleteView(PermissionRequiredMixin, RevisionMixin, DeleteView):
     model = DatasetRelation
 
     dataset: Dataset
+
+    # Enable reversion tracking for GET (default is POST only)
+    def revision_request_creates_revision(self, request):
+        return request.method in ("GET", "POST")
 
     def dispatch(self, request, *args, **kwargs):
         self.dataset = get_object_or_404(Dataset, pk=kwargs.get("dataset_id"))
@@ -3469,6 +3474,11 @@ class DatasetRelationDeleteView(PermissionRequiredMixin, DeleteView):
 
     def get(self, *args, **kwargs):
         return self.post(*args, **kwargs)
+    
+    def delete(self, request, *args, **kwargs):
+        add_to_revision(self.dataset)
+        set_comment(Dataset.RELATION_DELETED)
+        return super().delete(request, *args, **kwargs)
 
     def get_success_url(self):
         return self.dataset.get_absolute_url()

--- a/vitrina/datasets/views.py
+++ b/vitrina/datasets/views.py
@@ -1403,12 +1403,19 @@ class DatasetHistoryView(DatasetStructureMixin, PlanMixin, HistoryView):
         plan_history_objects = Version.objects.get_for_model(Plan).filter(
             object_id__in=list(dataset_plan_ids)
         )
+        dataset_distribution_ids = DatasetDistribution.objects.filter(dataset=self.object).values_list(
+            "id", flat=True
+        )
+        dataset_distribution_history_objects = Version.objects.get_for_model(DatasetDistribution).filter(
+            object_id__in=list(dataset_distribution_ids)
+        )
 
         history_objects = (
             property_history_objects
             | model_history_objects
             | dataset_history_objects
             | plan_history_objects
+            | dataset_distribution_history_objects
         )
         return history_objects.order_by("-revision__date_created")
 

--- a/vitrina/datasets/views.py
+++ b/vitrina/datasets/views.py
@@ -3246,7 +3246,7 @@ class QuarterStatsView(DatasetListView):
         return context
 
 
-class DatasetCategoryView(PermissionRequiredMixin, TemplateView):
+class DatasetCategoryView(PermissionRequiredMixin, RevisionMixin, TemplateView):
     template_name = "vitrina/datasets/dataset_categories.html"
 
     dataset: Dataset
@@ -3271,6 +3271,7 @@ class DatasetCategoryView(PermissionRequiredMixin, TemplateView):
             for category in form.cleaned_data.get("category"):
                 self.dataset.category.add(category)
             self.dataset.save()
+            set_comment(Dataset.CATEGORY_UPDATED)
 
             DatasetExcludedGroups.objects.filter(dataset=self.dataset).delete()
             for group in DatasetGroup.objects.filter(

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -788,6 +788,12 @@ msgstr "Added to request"
 msgid "Pakeista kategrija(-os)"
 msgstr "Updated category(-ies)"
 
+msgid "Pridėtas ryšys"
+msgstr "Added relation"
+
+msgid "Ištrintas ryšys"
+msgstr "Deleted relation"
+
 msgid "Atviri duomenys"
 msgstr "Public data"
 

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -785,6 +785,9 @@ msgstr "Added to project"
 msgid "Priskirta poreikiui"
 msgstr "Added to request"
 
+msgid "Pakeista kategrija(-os)"
+msgstr "Updated category(-ies)"
+
 msgid "Atviri duomenys"
 msgstr "Public data"
 

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -785,7 +785,7 @@ msgstr "Added to project"
 msgid "Priskirta poreikiui"
 msgstr "Added to request"
 
-msgid "Pakeista kategrija(-os)"
+msgid "Pakeista kategorija(-os)"
 msgstr "Updated category(-ies)"
 
 msgid "Pridėtas ryšys"
@@ -3173,18 +3173,18 @@ msgstr "New dataset distribution"
 
 #, python-format
 msgid "Pridėtas naujas duomenų šaltinis \"%(title)s\"."
-msgstr "New resource \"%(title)s\" has been added."
+msgstr "New data source \"%(title)s\" has been added."
 
 msgid "Duomenų rinkinio šaltinio redagavimas"
 msgstr "Dataset source edit"
 
 #, python-format
 msgid "Redaguotas duomenų šaltinis \"%(title)s\"."
-msgstr "Resource \"%(title)s\" has been edited."
+msgstr "Data source \"%(title)s\" has been edited."
 
 #, python-format
 msgid "Ištrintas duomenų šaltinis \"%(title)s\"."
-msgstr "Resource \"%(title)s\" has been deleted."
+msgstr "Data source \"%(title)s\" has been deleted."
 
 msgid "Modelio pridėjimas"
 msgstr "Add model"

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -794,6 +794,12 @@ msgstr "Added relation"
 msgid "Ištrintas ryšys"
 msgstr "Deleted relation"
 
+msgid "Priskirta organizacijai"
+msgstr "Added to organization"
+
+msgid "Pašalinta iš organizacijos"
+msgstr "Removed from organization"
+
 msgid "Atviri duomenys"
 msgstr "Public data"
 

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -3159,8 +3159,20 @@ msgstr "New model"
 msgid "Naujas duomenų rinkinio šaltinis"
 msgstr "New dataset distribution"
 
+#, python-format
+msgid "Pridėtas naujas duomenų šaltinis \"%(title)s\"."
+msgstr "New resource \"%(title)s\" has been added."
+
 msgid "Duomenų rinkinio šaltinio redagavimas"
 msgstr "Dataset source edit"
+
+#, python-format
+msgid "Redaguotas duomenų šaltinis \"%(title)s\"."
+msgstr "Resource \"%(title)s\" has been edited."
+
+#, python-format
+msgid "Ištrintas duomenų šaltinis \"%(title)s\"."
+msgstr "Resource \"%(title)s\" has been deleted."
 
 msgid "Modelio pridėjimas"
 msgstr "Add model"

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -3171,20 +3171,8 @@ msgstr "New model"
 msgid "Naujas duomenų rinkinio šaltinis"
 msgstr "New dataset distribution"
 
-#, python-format
-msgid "Pridėtas naujas duomenų šaltinis \"%(title)s\"."
-msgstr "New data source \"%(title)s\" has been added."
-
 msgid "Duomenų rinkinio šaltinio redagavimas"
 msgstr "Dataset source edit"
-
-#, python-format
-msgid "Redaguotas duomenų šaltinis \"%(title)s\"."
-msgstr "Data source \"%(title)s\" has been edited."
-
-#, python-format
-msgid "Ištrintas duomenų šaltinis \"%(title)s\"."
-msgstr "Data source \"%(title)s\" has been deleted."
 
 msgid "Modelio pridėjimas"
 msgstr "Add model"

--- a/vitrina/resources/views.py
+++ b/vitrina/resources/views.py
@@ -175,7 +175,7 @@ class ResourceCreateView(
             self.dataset.status = Dataset.HAS_DATA
             self.dataset.save()
 
-        set_comment(_("Pridėtas naujas duomenų šaltinis \"%(title)s\".") % {"title": resource.title})
+        set_comment(("Pridėtas naujas duomenų šaltinis \"%(title)s\".") % {"title": resource.lt_title()})
         resource.save()
         return redirect(resource.get_absolute_url())
 
@@ -262,7 +262,7 @@ class ResourceUpdateView(
                 level_given=form.cleaned_data.get("level"),
             )
 
-        set_comment(_("Redaguotas duomenų šaltinis \"%(title)s\".") % {"title": resource.title})
+        set_comment(("Redaguotas duomenų šaltinis \"%(title)s\".") % {"title": resource.lt_title()})
         resource.save()
         return redirect(resource.get_absolute_url())
 
@@ -299,7 +299,7 @@ class ResourceDeleteView(LoginRequiredMixin, PermissionRequiredMixin, DeleteView
         with create_revision():
             add_to_revision(resource)
             set_user(request.user)
-            set_comment(_("Ištrintas duomenų šaltinis \"%(title)s\".") % {"title": resource.title})
+            set_comment(("Ištrintas duomenų šaltinis \"%(title)s\".") % {"title": resource.lt_title()})
             resource.delete()
 
             if (

--- a/vitrina/resources/views.py
+++ b/vitrina/resources/views.py
@@ -9,6 +9,8 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import DeleteView, DetailView
 from parler.views import TranslatableCreateView, TranslatableUpdateView
+from reversion.views import RevisionMixin
+from reversion import set_comment
 
 from vitrina import settings
 from vitrina.comments.models import Comment
@@ -70,6 +72,7 @@ class ResourceDetailView(
 class ResourceCreateView(
     LoginRequiredMixin,
     PermissionRequiredMixin,
+    RevisionMixin,
     TranslatableCreateView,
 ):
     model = DatasetDistribution
@@ -106,6 +109,7 @@ class ResourceCreateView(
         resource = form.save(commit=False)
         resource.dataset = self.dataset
         resource.save()
+        set_comment(_("Pridėtas naujas duomenų šaltinis \"%(title)s\".") % {"title": resource.title})
 
         name = form.cleaned_data.get("name")
         if not name:
@@ -182,7 +186,10 @@ class ResourceCreateView(
 
 
 class ResourceUpdateView(
-    LoginRequiredMixin, PermissionRequiredMixin, TranslatableUpdateView
+    LoginRequiredMixin,
+    PermissionRequiredMixin,
+    RevisionMixin,
+    TranslatableUpdateView
 ):
     model = DatasetDistribution
     template_name = "vitrina/resources/form.html"
@@ -255,6 +262,7 @@ class ResourceUpdateView(
                 level_given=form.cleaned_data.get("level"),
             )
         resource.save()
+        set_comment(_("Redaguotas duomenų šaltinis \"%(title)s\".") % {"title": resource.title})
         return redirect(resource.get_absolute_url())
 
     def get_form_kwargs(self):
@@ -264,8 +272,12 @@ class ResourceUpdateView(
         return kwargs
 
 
-class ResourceDeleteView(LoginRequiredMixin, PermissionRequiredMixin, DeleteView):
+class ResourceDeleteView(LoginRequiredMixin, PermissionRequiredMixin, RevisionMixin, DeleteView):
     model = DatasetDistribution
+
+    # Enable reversion tracking for GET (default is POST only)
+    def revision_request_creates_revision(self, request):
+        return request.method in ("GET", "POST")
 
     def has_permission(self):
         resource = get_object_or_404(DatasetDistribution, id=self.kwargs["pk"])
@@ -287,6 +299,7 @@ class ResourceDeleteView(LoginRequiredMixin, PermissionRequiredMixin, DeleteView
     def delete(self, request, *args, **kwargs):
         resource = get_object_or_404(DatasetDistribution, id=self.kwargs["pk"])
         dataset = get_object_or_404(Dataset, id=resource.dataset_id)
+        set_comment(_("Ištrintas duomenų šaltinis \"%(title)s\".") % {"title": resource.title})
         resource.delete()
 
         if (

--- a/vitrina/resources/views.py
+++ b/vitrina/resources/views.py
@@ -9,8 +9,7 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import DeleteView, DetailView
 from parler.views import TranslatableCreateView, TranslatableUpdateView
-from reversion.views import RevisionMixin
-from reversion import set_comment
+from reversion import set_comment, set_user, create_revision
 
 from vitrina import settings
 from vitrina.comments.models import Comment
@@ -72,7 +71,6 @@ class ResourceDetailView(
 class ResourceCreateView(
     LoginRequiredMixin,
     PermissionRequiredMixin,
-    RevisionMixin,
     TranslatableCreateView,
 ):
     model = DatasetDistribution
@@ -109,7 +107,6 @@ class ResourceCreateView(
         resource = form.save(commit=False)
         resource.dataset = self.dataset
         resource.save()
-        set_comment(_("Pridėtas naujas duomenų šaltinis \"%(title)s\".") % {"title": resource.title})
 
         name = form.cleaned_data.get("name")
         if not name:
@@ -176,7 +173,10 @@ class ResourceCreateView(
             self.dataset.status = Dataset.HAS_DATA
             self.dataset.save()
 
-        resource.save()
+        with create_revision():
+            set_user(self.request.user)
+            set_comment(_("Pridėtas naujas duomenų šaltinis \"%(title)s\".") % {"title": resource.title})
+            resource.save()
         return redirect(resource.get_absolute_url())
 
     def get_form_kwargs(self):
@@ -188,7 +188,6 @@ class ResourceCreateView(
 class ResourceUpdateView(
     LoginRequiredMixin,
     PermissionRequiredMixin,
-    RevisionMixin,
     TranslatableUpdateView
 ):
     model = DatasetDistribution
@@ -261,8 +260,10 @@ class ResourceUpdateView(
                 description=form.cleaned_data.get("description"),
                 level_given=form.cleaned_data.get("level"),
             )
-        resource.save()
-        set_comment(_("Redaguotas duomenų šaltinis \"%(title)s\".") % {"title": resource.title})
+        with create_revision():
+            set_user(self.request.user)
+            set_comment(_("Redaguotas duomenų šaltinis \"%(title)s\".") % {"title": resource.title})
+            resource.save()
         return redirect(resource.get_absolute_url())
 
     def get_form_kwargs(self):
@@ -272,12 +273,8 @@ class ResourceUpdateView(
         return kwargs
 
 
-class ResourceDeleteView(LoginRequiredMixin, PermissionRequiredMixin, RevisionMixin, DeleteView):
+class ResourceDeleteView(LoginRequiredMixin, PermissionRequiredMixin, DeleteView):
     model = DatasetDistribution
-
-    # Enable reversion tracking for GET (default is POST only)
-    def revision_request_creates_revision(self, request):
-        return request.method in ("GET", "POST")
 
     def has_permission(self):
         resource = get_object_or_404(DatasetDistribution, id=self.kwargs["pk"])
@@ -299,7 +296,10 @@ class ResourceDeleteView(LoginRequiredMixin, PermissionRequiredMixin, RevisionMi
     def delete(self, request, *args, **kwargs):
         resource = get_object_or_404(DatasetDistribution, id=self.kwargs["pk"])
         dataset = get_object_or_404(Dataset, id=resource.dataset_id)
-        set_comment(_("Ištrintas duomenų šaltinis \"%(title)s\".") % {"title": resource.title})
+        with create_revision():
+            set_user(request.user)
+            set_comment(_("Ištrintas duomenų šaltinis \"%(title)s\".") % {"title": resource.title})
+            resource.save()
         resource.delete()
 
         if (

--- a/vitrina/resources/views.py
+++ b/vitrina/resources/views.py
@@ -175,7 +175,7 @@ class ResourceCreateView(
             self.dataset.status = Dataset.HAS_DATA
             self.dataset.save()
 
-        set_comment(("Pridėtas naujas duomenų šaltinis \"%(title)s\".") % {"title": resource.lt_title()})
+        set_comment((f'Pridėtas naujas duomenų šaltinis "{resource.lt_title()}".'))
         resource.save()
         return redirect(resource.get_absolute_url())
 
@@ -262,7 +262,7 @@ class ResourceUpdateView(
                 level_given=form.cleaned_data.get("level"),
             )
 
-        set_comment(("Redaguotas duomenų šaltinis \"%(title)s\".") % {"title": resource.lt_title()})
+        set_comment((f'Redaguotas duomenų šaltinis "{resource.lt_title()}".'))
         resource.save()
         return redirect(resource.get_absolute_url())
 
@@ -299,7 +299,7 @@ class ResourceDeleteView(LoginRequiredMixin, PermissionRequiredMixin, DeleteView
         with create_revision():
             add_to_revision(resource)
             set_user(request.user)
-            set_comment(("Ištrintas duomenų šaltinis \"%(title)s\".") % {"title": resource.lt_title()})
+            set_comment((f'Ištrintas duomenų šaltinis "{resource.lt_title()}".'))
             resource.delete()
 
             if (

--- a/vitrina/resources/views.py
+++ b/vitrina/resources/views.py
@@ -9,7 +9,8 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import DeleteView, DetailView
 from parler.views import TranslatableCreateView, TranslatableUpdateView
-from reversion import set_comment, set_user, create_revision
+from reversion import set_comment, set_user, create_revision, add_to_revision
+from reversion.views import RevisionMixin
 
 from vitrina import settings
 from vitrina.comments.models import Comment
@@ -71,6 +72,7 @@ class ResourceDetailView(
 class ResourceCreateView(
     LoginRequiredMixin,
     PermissionRequiredMixin,
+    RevisionMixin,
     TranslatableCreateView,
 ):
     model = DatasetDistribution
@@ -173,10 +175,8 @@ class ResourceCreateView(
             self.dataset.status = Dataset.HAS_DATA
             self.dataset.save()
 
-        with create_revision():
-            set_user(self.request.user)
-            set_comment(_("Pridėtas naujas duomenų šaltinis \"%(title)s\".") % {"title": resource.title})
-            resource.save()
+        set_comment(_("Pridėtas naujas duomenų šaltinis \"%(title)s\".") % {"title": resource.title})
+        resource.save()
         return redirect(resource.get_absolute_url())
 
     def get_form_kwargs(self):
@@ -188,6 +188,7 @@ class ResourceCreateView(
 class ResourceUpdateView(
     LoginRequiredMixin,
     PermissionRequiredMixin,
+    RevisionMixin,
     TranslatableUpdateView
 ):
     model = DatasetDistribution
@@ -260,10 +261,9 @@ class ResourceUpdateView(
                 description=form.cleaned_data.get("description"),
                 level_given=form.cleaned_data.get("level"),
             )
-        with create_revision():
-            set_user(self.request.user)
-            set_comment(_("Redaguotas duomenų šaltinis \"%(title)s\".") % {"title": resource.title})
-            resource.save()
+
+        set_comment(_("Redaguotas duomenų šaltinis \"%(title)s\".") % {"title": resource.title})
+        resource.save()
         return redirect(resource.get_absolute_url())
 
     def get_form_kwargs(self):
@@ -297,30 +297,30 @@ class ResourceDeleteView(LoginRequiredMixin, PermissionRequiredMixin, DeleteView
         resource = get_object_or_404(DatasetDistribution, id=self.kwargs["pk"])
         dataset = get_object_or_404(Dataset, id=resource.dataset_id)
         with create_revision():
+            add_to_revision(resource)
             set_user(request.user)
             set_comment(_("Ištrintas duomenų šaltinis \"%(title)s\".") % {"title": resource.title})
-            resource.save()
-        resource.delete()
+            resource.delete()
 
-        if (
-            not DatasetDistribution.objects.filter(dataset=dataset)
-            and dataset.is_public
-        ):
-            if dataset.plandataset_set.exists():
-                dataset.status = Dataset.PLANNED
-                comment_status = Comment.PLANNED
-            else:
-                dataset.status = Dataset.INVENTORED
-                comment_status = Comment.INVENTORED
+            if (
+                not DatasetDistribution.objects.filter(dataset=dataset)
+                and dataset.is_public
+            ):
+                if dataset.plandataset_set.exists():
+                    dataset.status = Dataset.PLANNED
+                    comment_status = Comment.PLANNED
+                else:
+                    dataset.status = Dataset.INVENTORED
+                    comment_status = Comment.INVENTORED
 
-            Comment.objects.create(
-                content_type=ContentType.objects.get_for_model(dataset),
-                object_id=dataset.pk,
-                type=Comment.STATUS,
-                status=comment_status,
-                user=self.request.user,
-            )
-            dataset.save()
+                Comment.objects.create(
+                    content_type=ContentType.objects.get_for_model(dataset),
+                    object_id=dataset.pk,
+                    type=Comment.STATUS,
+                    status=comment_status,
+                    user=self.request.user,
+                )
+                dataset.save()
         return redirect(dataset)
 
 

--- a/vitrina/views.py
+++ b/vitrina/views.py
@@ -159,13 +159,15 @@ class HistoryView(PermissionRequiredMixin, TemplateView):
                 "tabs_template_name": self.tabs_template_name,
             }
         )
-        context["history"] = sorted(
-            [dict(t) for t in {tuple(d.items()) for d in context["history"]}],
-            key=lambda x: x["date"],
-            reverse=True,
-        )
+        context["history"] = self._deduplicate_and_sort_history(context["history"])
 
         return context
+    
+    def _deduplicate_and_sort_history(self, history: list[dict]) -> list[dict]:
+        unique_entries = {tuple(entry.items()) for entry in history}
+        unique_history = [dict(t) for t in unique_entries]
+
+        return sorted(unique_history, key=lambda x: x["date"], reverse=True)
 
     def get_detail_url_name(self):
         return self.detail_url_name

--- a/vitrina/views.py
+++ b/vitrina/views.py
@@ -165,7 +165,7 @@ class HistoryView(PermissionRequiredMixin, TemplateView):
     
     def _deduplicate_and_sort_history(self, history: list[dict]) -> list[dict]:
         unique_entries = {tuple(entry.items()) for entry in history}
-        unique_history = [dict(t) for t in unique_entries]
+        unique_history = [dict(entry) for entry in unique_entries]
 
         return sorted(unique_history, key=lambda x: x["date"], reverse=True)
 

--- a/vitrina/views.py
+++ b/vitrina/views.py
@@ -159,9 +159,12 @@ class HistoryView(PermissionRequiredMixin, TemplateView):
                 "tabs_template_name": self.tabs_template_name,
             }
         )
-        context["history"] = [
-            dict(t) for t in {tuple(d.items()) for d in context["history"]}
-        ]
+        context["history"] = sorted(
+            [dict(t) for t in {tuple(d.items()) for d in context["history"]}],
+            key=lambda x: x["date"],
+            reverse=True,
+        )
+
         return context
 
     def get_detail_url_name(self):


### PR DESCRIPTION
Added history tracking and displaying on dataset history for following changes:

- Adding/deleting DatasetRelation
- Adding/editing/deleting DatasetDistribution (dataset resource)
- Adding/deleting DatasetAttribution (assigning/removing dataset to/from organization)
- Updating Dataset.categories

Fixed sorting of history entries.