### PR TITLE
[1415] Adjust Dataset create endpoint [#1]

### DIFF
--- a/tests/uapi/dataset/test_views.py
+++ b/tests/uapi/dataset/test_views.py
@@ -15,7 +15,7 @@ from reversion.models import Version
 from tests.uapi.conftest import _generate_test_token
 from vitrina import settings
 from vitrina.datasets.factories import DatasetFactory
-from vitrina.datasets.models import Dataset, DatasetStructure
+from vitrina.datasets.models import Dataset, DatasetStructure, DCATResourceSubclass
 from vitrina.orgs.models import Organization
 from vitrina.structure.factories import MetadataFactory
 from vitrina.structure.models import Metadata
@@ -36,6 +36,8 @@ def test_create(
         "name": "/datasets/gov/vssa/isris/dcat/uapi/Model",
         "title": "DataSet 1",
         "description": "DataSet 1 description",
+        "service": True,
+        "subclass": DCATResourceSubclass.SERVICE,
     }
     response = app.post(
         url_dataset,
@@ -76,6 +78,8 @@ def test_create(
         "theme": [],
         "organization_id": organization.id,
         "organization_title": organization.title,
+        "service": True,
+        "subclass": DCATResourceSubclass.SERVICE,
     }
 
 
@@ -135,6 +139,8 @@ def test_create_specific_scope(
         "theme": [],
         "organization_id": organization.id,
         "organization_title": organization.title,
+        "service": False,
+        "subclass": DCATResourceSubclass.DATASET,
     }
 
 
@@ -310,6 +316,8 @@ def test_list(
                 "organization_id": organization.id,
                 "organization_title": organization.title,
                 "id": str(dataset.id),
+                "service": False,
+                "subclass": DCATResourceSubclass.DATASET,
             }
         ]
     }
@@ -361,6 +369,8 @@ def test_list_specific_scope(
                 "organization_id": organization.id,
                 "organization_title": organization.title,
                 "id": str(dataset.id),
+                "service": False,
+                "subclass": DCATResourceSubclass.DATASET,
             }
         ]
     }
@@ -470,6 +480,8 @@ def test_list_with_query_parameters(
                 "organization_id": organization.id,
                 "organization_title": organization.title,
                 "id": str(dataset.id),
+                "service": False,
+                "subclass": DCATResourceSubclass.DATASET,
             }
         ]
     }

--- a/vitrina/datasets/models.py
+++ b/vitrina/datasets/models.py
@@ -790,7 +790,7 @@ class Dataset(Resource):
         if metadata := self.metadata.first():
             return metadata.name
         return ""
-    
+
     @property
     def identifier(self) -> str | None:
         return identifier.notation if (identifier := self.identifiers.filter(scheme_agency__code="risr").first()) else None
@@ -1582,7 +1582,9 @@ class Type(TranslatableModel):
 class DCATResourceSubclass(TranslatableModel, UUIDBaseModel):
     SERIES = "series"
     SERVICE = "service"
+    DATASET = "dataset"
     INFORMATION_SYSTEM = "information_system"
+    CATALOG = "catalog"
 
     name = models.CharField(_("Kodinis pavadinimas"), max_length=255, unique=True)
     uri = models.CharField(

--- a/vitrina/uapi/serializers/serializers.py
+++ b/vitrina/uapi/serializers/serializers.py
@@ -1,17 +1,29 @@
 from rest_framework import serializers
 
 from vitrina.api.serializers import DatasetSerializer, DatasetDistributionSerializer, PostDatasetSerializer
+from vitrina.datasets.models import DCATResourceSubclass
 from vitrina.uapi.serializers.uapi_serializers import BaseObjectMixin
 
 
 class UAPIDatasetSerializer(BaseObjectMixin, DatasetSerializer):
+    subclass = serializers.SlugRelatedField(
+        slug_field="name",
+        queryset=DCATResourceSubclass.objects.all(),
+    )
+
     class Meta(DatasetSerializer.Meta):
-        fields = DatasetSerializer.Meta.fields + BaseObjectMixin.Meta.fields
+        fields = DatasetSerializer.Meta.fields + BaseObjectMixin.Meta.fields + ("service", "subclass")
 
 
 class UAPIDatasetCreateSerializer(PostDatasetSerializer):
+    subclass = serializers.SlugRelatedField(
+        slug_field="name",
+        queryset=DCATResourceSubclass.objects.all(),
+        default=DCATResourceSubclass.DATASET,
+    )
+
     class Meta(PostDatasetSerializer.Meta):
-        fields = PostDatasetSerializer.Meta.fields + ("name",)
+        fields = PostDatasetSerializer.Meta.fields + ("name", "service", "subclass")
 
 
 class UAPIDistributionSerializer(BaseObjectMixin, DatasetDistributionSerializer):

--- a/vitrina/uapi/views/views.py
+++ b/vitrina/uapi/views/views.py
@@ -23,7 +23,7 @@ from vitrina.api.oauth import (
     OAuthTokenHasValidOrganizationClaim,
 )
 from vitrina.api.serializers import PostDatasetDistributionSerializer
-from vitrina.datasets.models import Dataset, DatasetStructure
+from vitrina.datasets.models import Dataset, DatasetStructure, DCATResourceSubclass
 from vitrina.exceptions import UAPIException
 from vitrina.resources.models import DatasetDistribution
 from vitrina.smart_contracts import AgreementStatuses
@@ -59,6 +59,11 @@ class DatasetViewSet(UAPIExceptionHandlerMixin, viewsets.ModelViewSet):
     @cached_property
     def dataset_metadata_id(self) -> int:
         return ContentType.objects.get_for_model(Dataset).id
+
+    @cached_property
+    def dcat_resource_subclass(self) -> DCATResourceSubclass:
+        subclass_name = self.request.data.get("subclass", DCATResourceSubclass.DATASET)
+        return get_object_or_404(DCATResourceSubclass, name=subclass_name)
 
     def get_queryset(self) -> QuerySet[Dataset]:
         queryset = Dataset.objects.prefetch_related(
@@ -111,7 +116,10 @@ class DatasetViewSet(UAPIExceptionHandlerMixin, viewsets.ModelViewSet):
         )
         serializer.is_valid(raise_exception=True)
         with create_revision():
-            instance = serializer.save(access_rights=Dataset.NON_PUBLIC)
+            instance = serializer.save(
+                subclass=self.dcat_resource_subclass,
+                access_rights=Dataset.NON_PUBLIC
+            )
 
         Metadata.objects.create(
             uuid=str(uuid.uuid4()),


### PR DESCRIPTION
- Allow sending `service` & `subclass` attribute so the Dataset could be created as a Data Service.
- Also return those attributes in GET requests.