### PR TITLE
[1747] Adjust dataset creation logic following the merge of #1747

### DIFF
--- a/vitrina/datasets/models.py
+++ b/vitrina/datasets/models.py
@@ -75,7 +75,7 @@ class Resource(MP_Node, TranslatableModel):
     """
     Conceptual abstract model.
     Created to have common terminology between code and business language.
-    May become concrete model in the future
+    It May become a concrete model in the future
     """
     steplen = 25  # to set depth max up to 10 with 255 length path varchar (MP_Node default).
     depth = models.PositiveIntegerField(default=1) # Root by default

--- a/vitrina/uapi/views/views.py
+++ b/vitrina/uapi/views/views.py
@@ -106,20 +106,27 @@ class DatasetViewSet(UAPIExceptionHandlerMixin, viewsets.ModelViewSet):
 
     @transaction.atomic
     def create(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        organization = self.request.organization
+
         serializer_context = self.get_serializer_context()
         serializer = self.get_serializer(
             data=request.data,
             context={
                 **serializer_context,
-                "organization": self.request.organization,
+                "organization": organization,
             }
         )
         serializer.is_valid(raise_exception=True)
+
         with create_revision():
-            instance = serializer.save(
-                subclass=self.dcat_resource_subclass,
-                access_rights=Dataset.NON_PUBLIC
-            )
+            dataset_data = serializer.validated_data | {
+                "subclass": self.dcat_resource_subclass,
+                "access_rights": Dataset.NON_PUBLIC,
+                "organization_id": organization.id,
+            }
+            instance = Dataset(**dataset_data)
+            Dataset.add_root(instance=instance)
+
 
         Metadata.objects.create(
             uuid=str(uuid.uuid4()),


### PR DESCRIPTION
### Changes:
- Dataset creation API adjusted to add a parent for the Dataset (otherwise, 500 is raised, breaks on creation).
- Fix typo.

```python
UnexpectedAPIResponse: 
        Unexpected status code received while calling the api for operation 
`Create dataset`. 
        Expected '{201}', Got: '500.
        Due to: {'code': 'server_error', 'type': 'IntegrityError', 'template': 
'An unexpected server error occurred.', 'message': 'duplicate key value violates
unique constraint "dataset_path_e37b7f04_uniq"\nDETAIL:  Key (path)=() already 
exists.', 'additionalProperties': None}
    
  Context:
    operation: Create dataset
    expected_status_code: {201}
    response_status_code: 500
    response_data: {'code': 'server_error', 'type': 'IntegrityError', 
'template': 'An unexpected server error occurred.', 'message': 'duplicate key 
value violates unique constraint "dataset_path_e37b7f04_uniq"\nDETAIL:  Key 
(path)=() already exists.', 'additionalProperties': None}
```

CC: @varzgalys 