### PR TITLE
Moved fields from ResourceForm to DatasetResourceForm

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,13 +2,13 @@ Changes
 #######
 2025-08-21
 ==========
-https://github.com/atviriduomenys/katalogas/pull/1846
+https://github.com/atviriduomenys/katalogas/issues/642
 Moves `temporal_resolution` and `spatial_resolution` fields to `DatasetResourceForm` form.
 
 
 2025-08-21
 ==========
-https://github.com/atviriduomenys/katalogas/pull/1827
+https://github.com/atviriduomenys/katalogas/issues/642
 Adds `temporal_resolution` and `spatial_resolution` fields to `Dataset` model.
 
 Adds `temporal_resolution` and `spatial_resolution` fields to `ResourceForm` form.
@@ -18,7 +18,7 @@ Adds `temporal_resolution` and `spatial_resolution` fields to the `coretable.htm
 
 2025-08-21
 ==========
-https://github.com/atviriduomenys/katalogas/pull/1821
+https://github.com/atviriduomenys/katalogas/issues/1778
 Adds `temporal_resolution` and `spatial_resolution` fields to `DatasetDistribution` model.
 
 Adds `temporal_resolution` and `spatial_resolution` fields to `DatasetDistribution` form and

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,16 @@ Changes
 #######
 2025-08-21
 ==========
+https://github.com/atviriduomenys/katalogas/pull/1846
+Moves `temporal_resolution` and `spatial_resolution` fields to `DatasetResourceForm` form.
+
+
+2025-08-21
+==========
 https://github.com/atviriduomenys/katalogas/pull/1827
 Adds `temporal_resolution` and `spatial_resolution` fields to `Dataset` model.
 
-Adds `temporal_resolution` and `spatial_resolution` fields to `Dataset` form where its subclass is Dataset.
+Adds `temporal_resolution` and `spatial_resolution` fields to `ResourceForm` form.
 
 Adds `temporal_resolution` and `spatial_resolution` fields to the `coretable.html` page
 

--- a/vitrina/datasets/forms.py
+++ b/vitrina/datasets/forms.py
@@ -500,6 +500,8 @@ class DatasetResourceForm(BaseResourceForm):
             "managed_by_publisher",
             "landing_page",
             "parent",
+            "temporal_resolution",
+            "spatial_resolution",
         )
 
     def __init__(self, request=None, organization=None, *args, **kwargs) -> None:
@@ -514,6 +516,8 @@ class DatasetResourceForm(BaseResourceForm):
                 Field("temporal_start", placeholder=_("Pasirinkite pradžios datą")),
                 Field("temporal_end", placeholder=_("Pasirinkite pabaigos datą")),
             ),
+            Field("temporal_resolution"),
+            Field("spatial_resolution"),
             Field("files"),
             Field("tags", placeholder=_("Surašykite aktualius raktinius žodžius")),
             Field("landing_page"),
@@ -556,8 +560,6 @@ class ResourceForm(BaseResourceForm):
             "managed_by_publisher",
             "landing_page",
             "parent",
-            "temporal_resolution",
-            "spatial_resolution",
         )
 
     def __init__(self, request=None, organization=None, *args, **kwargs):
@@ -569,8 +571,6 @@ class ResourceForm(BaseResourceForm):
             Field("name", placeholder=_("Duomenų rinkinio kodinis pavadinimas")),
             Field("description", placeholder=_("Detalus duomenų rinkinio aprašas")),
             Field("files"),
-            Field("temporal_resolution"),
-            Field("spatial_resolution"),
             Field("tags", placeholder=_("Surašykite aktualius raktinius žodžius")),
             Field("landing_page"),
             Field("catalog"),


### PR DESCRIPTION
The `temporal_resolution` and `spatial_resolution` fields were in the `ResourceForm`, because there was no `DatasetResourceForm` but now `DatasetResourceForm` exists so the fields are moved to it.