### PR TITLE
185: new tables in anonymization script

### DIFF
--- a/scripts/anonymize.py
+++ b/scripts/anonymize.py
@@ -4,42 +4,68 @@ from typing import Set
 
 import bcrypt
 import dataset
-from tqdm import tqdm
-
+from dataset import Database, Table
 from faker import Faker
-from typer import Argument
-from typer import Option
-from typer import confirm
-from typer import run
+from tqdm import tqdm
+from typer import Argument, Option, confirm, run
 
 
 def main(
-    uri: str = Argument(..., help=(
-        "Database URI (postgresql://user:pass@host:port/db)"
-    )),
+    uri: str = Argument(..., help=("Database URI (postgresql://user:pass@host:port/db)")),
     yes: bool = Option(False, help="Do not ask anything, just do it"),
 ):
     """
     Anonymize database.
 
-    WARGNING! This command will modify database data, without possibility to
-    restore it. So before using this command, make sure to pass corect database
+    WARNING! This command will modify database data, without possibility to
+    restore it. So before using this command, make sure to pass correct database
     connection string.
     """
     db = dataset.connect(uri)
 
-    tables = [
-        'user',
-        'representative',
-        'old_password',
-        'password_reset_token',
-        'newsletter_subscription',
-        'partner_application',
-        'sso_token',
-        'suggestion',
-        'comment',
-        'request_event',
-    ]
+    tables = (
+        "organization",
+        "adp_cms_page",
+        "news_item",
+        "djangocms_blog_post_translation",
+        "reversion_version",
+        "api_description",
+        "vitrina_datasets_contact",
+        "open_data_dov_lt",
+        "hitcount_hit",
+        "harvesting_result",
+        "django_session",
+        "dataset_resource_migrate",
+        "dataset_resource",
+        "dataset_migrate",
+        "dataset",
+        "cms_page",
+        "account_emailconfirmation",
+        "socialaccount_socialaccount",
+        "socialaccount_socialtoken",
+        "socialaccount_socialapp",
+        "django_admin_log",
+        "sent_mail",
+        "contact",
+        "vitrina_uapi_agent",
+        "viispkey",
+        "viisptokenkey",
+        "user_email_device",
+        "account_emailaddress",
+        "otp_email_emaildevice",
+        "representative_request",
+        "api_key",
+        "user",
+        "representative",
+        "old_password",
+        "password_reset_token",
+        "newsletter_subscription",
+        "partner_application",
+        "sso_token",
+        "suggestion",
+        "comment",
+        "request_event",
+    )
 
     total = sum([db[t].count() for t in tables])
 
@@ -55,170 +81,576 @@ def main(
     users = {}
     with pbar:
         for table in tables:
-            func = sys.modules[__name__].__dict__[f'_anonymize_{table}']
+            func = sys.modules[__name__].__dict__[f"_anonymize_{table}"]
             func(db, fake, pbar, users)
 
 
-def _anonymize_user(db, fake, pbar, users):
-    emails = {row['email'] for row in db['user'].all()}
-    passwd = _hash_password("secret")
-    for user in db['user'].all():
-        first_name = fake.first_name()
-        last_name = fake.last_name()
-        email = f'{first_name}.{last_name}@example.com'
-        email = _ensure_unique_email(email, emails)
+def _anonymize_organization(db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]) -> None:
+    objects: Table = db["djangocms_blog_post_translation"]
+    pk_name = "id"
+    for record in objects.all():
         data = {
-            'id': user['id'],
-            'first_name': first_name,
-            'last_name': last_name,
-            'email': email,
-            'phone': fake.phone_number(),
-            'password': passwd,
-            'year_of_birth': None,
+            pk_name: record[pk_name],
+            "email": fake.email(),
+            "phone": fake.phone_number(),
+            "address": fake.address(),
         }
-        users[user['email']] = data
-        db['user'].update(data, ['id'])
+        objects.update(data, [pk_name])
         pbar.update(1)
 
 
-def _anonymize_representative(db, fake, pbar, users):
-    emails = {row['email'] for row in db['representative'].all()}
-    for rep in db['representative'].all():
-        user = users.get(rep['email'])
+def _anonymize_djangocms_blog_post_translation(
+    db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]
+) -> None:
+    objects: Table = db["djangocms_blog_post_translation"]
+    pk_name = "id"
+    for record in objects.all():
+        data = {
+            pk_name: record[pk_name],
+            "title": "example",
+            "slug": f"example-{uuid.uuid4()}",
+            "abstract": "<p>example</p>",
+            "meta_description": "example",
+            "meta_title": "example",
+            "meta_keywords": "example",
+            "subtitle": "<p>example</p>",
+            "post_text": "<p>example</p>",
+        }
+        objects.update(data, [pk_name])
+        pbar.update(1)
+
+
+def _anonymize_news_item(db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]) -> None:
+    objects: Table = db["news_item"]
+    pk_name = "id"
+    for record in objects.all():
+        data = {
+            pk_name: record[pk_name],
+            "body": "<p>example</p>",
+            "title": "example",
+            "slug": f"example-{uuid.uuid4()}",
+            "summary": "example",
+            "author_name": "example, example",
+        }
+        objects.update(data, [pk_name])
+        pbar.update(1)
+
+
+def _anonymize_adp_cms_page(db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]) -> None:
+    objects: Table = db["news_item"]
+    pk_name = "id"
+    for record in objects.all():
+        data = {
+            pk_name: record[pk_name],
+            "body": "<p>example</p>",
+            "title": "example",
+            "description": "example",
+            "slug": f"example-{uuid.uuid4()}",
+        }
+        objects.update(data, [pk_name])
+        pbar.update(1)
+
+
+def _anonymize_reversion_version(
+    db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]
+) -> None:
+    objects: Table = db["reversion_version"]
+    pk_name = "id"
+    for record in objects.all():
+        data = {pk_name: record[pk_name], "serialized_data": ""}
+        objects.update(data, [pk_name])
+        pbar.update(1)
+
+
+def _anonymize_api_description(db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]) -> None:
+    objects: Table = db["api_description"]
+    pk_name = "id"
+    for record in objects.all():
+        data = {
+            pk_name: record[pk_name],
+            "contact_email": fake.email(),
+            "contact_name": fake.first_name(),
+        }
+        objects.update(data, [pk_name])
+        pbar.update(1)
+
+
+def _anonymize_vitrina_datasets_contact(
+    db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]
+) -> None:
+    objects: Table = db["vitrina_datasets_contact"]
+    pk_name = "id"
+    for record in objects.all():
+        data = {
+            pk_name: record[pk_name],
+            "email": fake.email(),
+            "phone": fake.phone_number(),
+        }
+        objects.update(data, [pk_name])
+        pbar.update(1)
+
+
+def _anonymize_open_data_dov_lt(db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]) -> None:
+    objects: Table = db["open_data_dov_lt"]
+    pk_name = "id"
+    for record in objects.all():
+        data = {
+            pk_name: record[pk_name],
+            "contact_info": f"Example, {fake.first_name()}, {fake.last_name()}, {fake.email()}, {fake.phone_number()}",
+        }
+        objects.update(data, [pk_name])
+        pbar.update(1)
+
+
+def _anonymize_hitcount_hit(db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]) -> None:
+    objects: Table = db["hitcount_hit"]
+    pk_name = "id"
+    for record in objects.all():
+        data = {pk_name: record[pk_name], "ip": "127.0.0.1", "session": "example-session-hash"}
+        objects.update(data, [pk_name])
+        pbar.update(1)
+
+
+def _anonymize_harvesting_result(
+    db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]
+) -> None:
+    objects: Table = db["harvesting_result"]
+    pk_name = "id"
+    for record in objects.all():
+        data = {
+            pk_name: record[pk_name],
+            "raw_data": '<?xml version="1.0" encoding="UTF-8"?><root></root>',
+            "remote_id": f"example-{uuid.uuid4()}",
+        }
+        objects.update(data, [pk_name])
+        pbar.update(1)
+
+
+def _anonymize_django_session(db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]) -> None:
+    objects: Table = db["django_session"]
+    no_objects_to_delete = objects.count()
+    objects.delete()  # Keeping not safe, editing will break things.
+    pbar.update(no_objects_to_delete)
+
+
+def _anonymize_dataset_resource(db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]) -> None:
+    objects: Table = db["dataset_resource"]
+    pk_name = "id"
+    for record in objects.all():
+        data = {pk_name: record[pk_name], "url": fake.url()}
+        objects.update(data, [pk_name])
+        pbar.update(1)
+
+
+def _anonymize_dataset_resource_migrate(
+    db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]
+) -> None:
+    objects: Table = db["dataset_resource_migrate"]
+    pk_name = "id"
+    for record in objects.all():
+        data = {pk_name: record[pk_name], "url": fake.url()}
+        objects.update(data, [pk_name])
+        pbar.update(1)
+
+
+def _anonymize_dataset_migrate(db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]) -> None:
+    objects: Table = db["dataset_migrate"]
+    pk_name = "id"
+    for record in objects.all():
+        data = {
+            pk_name: record[pk_name],
+            "meta": json.dumps({}),
+        }
+        objects.update(data, [pk_name])
+        pbar.update(1)
+
+
+def _anonymize_dataset(db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]) -> None:
+    objects: Table = db["dataset"]
+    pk_name = "id"
+    for record in objects.all():
+        data = {
+            pk_name: record[pk_name],
+            "meta": json.dumps({}),
+        }
+        objects.update(data, [pk_name])
+        pbar.update(1)
+
+
+def _anonymize_cms_page(db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]) -> None:
+    objects: Table = db["cms_page"]
+    pk_name = "id"
+    for record in objects.all():
+        data = {pk_name: record[pk_name], "changed_by": fake.first_name(), "created_by": fake.first_name()}
+        objects.update(data, [pk_name])
+        pbar.update(1)
+
+
+def _anonymize_account_emailconfirmation(
+    db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]
+) -> None:
+    objects: Table = db["account_emailconfirmation"]
+    pk_name = "id"
+    for record in objects.all():
+        data = {
+            pk_name: record[pk_name],
+            "key": f"example-key-{uuid.uuid4()}",
+        }
+        objects.update(data, [pk_name])
+        pbar.update(1)
+
+
+def _anonymize_socialaccount_socialtoken(
+    db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]
+) -> None:
+    objects: Table = db["socialaccount_socialtoken"]
+    pk_name = "id"
+    for record in objects.all():
+        data = {
+            pk_name: record[pk_name],
+            "token_secret": f"example-secret-{uuid.uuid4()}",
+            "token": "example-token",
+        }
+        objects.update(data, [pk_name])
+        pbar.update(1)
+
+
+def _anonymize_socialaccount_socialapp(
+    db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]
+) -> None:
+    objects: Table = db["socialaccount_socialapp"]
+    pk_name = "id"
+    for record in objects.all():
+        data = {
+            pk_name: record[pk_name],
+            "secret": f"example-{uuid.uuid4()}",
+            "client_id": "example-client_id",
+        }
+        objects.update(data, [pk_name])
+        pbar.update(1)
+
+
+def _anonymize_socialaccount_socialaccount(
+    db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]
+) -> None:
+    objects: Table = db["socialaccount_socialaccount"]
+    pk_name = "id"
+    for record in objects.all():
+        data = {
+            pk_name: record[pk_name],
+            "extra_data": {
+                "personal_code": "example-hashed-code",
+                "coordinator_phone_number": None,
+                "coordinator_email": fake.email(domain="example.com"),
+                "password_not_set": False,
+            },
+        }
+        objects.update(data, [pk_name])
+        pbar.update(1)
+
+
+def _anonymize_django_admin_log(db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]) -> None:
+    objects: Table = db["django_admin_log"]
+    pk_name = "id"
+    for record in objects.all():
+        data = {
+            pk_name: record[pk_name],
+            "object_repr": f"{fake.first_name()} {fake.last_name()}",
+            "change_message": [],
+        }
+        objects.update(data, [pk_name])
+        pbar.update(1)
+
+
+def _anonymize_sent_mail(db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]) -> None:
+    objects: Table = db["sent_mail"]
+    pk_name = "id"
+    for record in objects.all():
+        data = {
+            pk_name: record[pk_name],
+            "recipient": [_email_plus_uuid(fake)],
+            "email_content": "<p>Email content example</p>",
+            "email_subject": "Example email subject",
+        }
+        objects.update(data, [pk_name])
+        pbar.update(1)
+
+
+def _anonymize_otp_email_emaildevice(
+    db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]
+) -> None:
+    objects: Table = db["otp_email_emaildevice"]
+    pk_name = "id"
+    for record in objects.all():
+        data = {
+            pk_name: record[pk_name],
+            "email": _email_plus_uuid(fake),
+            "name": f"{fake.first_name()} {fake.last_name()}",
+        }
+        objects.update(data, [pk_name])
+        pbar.update(1)
+
+
+def _anonymize_api_key(db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]) -> None:
+    objects: Table = db["api_key"]
+    pk_name = "id"
+    for record in objects.all():
+        data = {
+            pk_name: record[pk_name],
+            "api_key": f"example-{uuid.uuid4()}",
+            "client_id": f"example-{uuid.uuid4()}",
+            "client_name": f"example-{uuid.uuid4()}",
+        }
+        objects.update(data, [pk_name])
+        pbar.update(1)
+
+
+def _anonymize_representative_request(
+    db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]
+) -> None:
+    objects: Table = db["representative_request"]
+    pk_name = "id"
+    for record in objects.all():
+        data = {
+            pk_name: record[pk_name],
+            "email": _email_plus_uuid(fake),
+            "phone": fake.phone_number(),
+            "document": "path/to/example.docx",
+        }
+        objects.update(data, [pk_name])
+        pbar.update(1)
+
+
+def _anonymize_account_emailaddress(
+    db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]
+) -> None:
+    objects: Table = db["account_emailaddress"]
+    pk_name = "id"
+    for record in objects.all():
+        data = {
+            pk_name: record[pk_name],
+            "email": _email_plus_uuid(fake),
+        }
+        objects.update(data, [pk_name])
+        pbar.update(1)
+
+
+def _anonymize_user_email_device(
+    db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]
+) -> None:
+    objects: Table = db["user_email_device"]
+    pk_name = "emaildevice_ptr_id"
+    for record in objects.all():
+        data = {
+            pk_name: record[pk_name],
+            "ip_address": "127.0.0.1",
+        }
+        objects.update(data, [pk_name])
+        pbar.update(1)
+
+
+def _anonymize_viisptokenkey(db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]) -> None:
+    objects: Table = db["viisptokenkey"]
+    pk_name = "id"
+    for record in objects.all():
+        data = {
+            pk_name: record[pk_name],
+            "key_content": f"example-{uuid.uuid4()}",
+        }
+        objects.update(data, [pk_name])
+        pbar.update(1)
+
+
+def _anonymize_viispkey(db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]) -> None:
+    objects: Table = db["viispkey"]
+    pk_name = "id"
+    for record in objects.all():
+        data = {
+            pk_name: record[pk_name],
+            "key_content": f"example-{uuid.uuid4()}",
+        }
+        objects.update(data, [pk_name])
+        pbar.update(1)
+
+
+def _anonymize_vitrina_uapi_agent(
+    db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]
+) -> None:
+    objects: Table = db["vitrina_uapi_agent"]
+    pk_name = "uuid"
+    for agent in objects.all():
+        data = {pk_name: agent[pk_name], "oauth_client_id": uuid.uuid4()}
+        objects.update(data, [pk_name])
+        pbar.update(1)
+
+
+def _anonymize_contact(db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]) -> None:
+    objects: Table = db["contact"]
+    pk_name = "id"
+    for contact in objects.all():
+        data = {
+            pk_name: contact[pk_name],
+            "email": _email_plus_uuid(fake),
+            "phone": fake.phone_number(),
+        }
+        objects.update(data, [pk_name])
+        pbar.update(1)
+
+
+def _anonymize_user(db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]) -> None:
+    passwd = _hash_password("secret")
+    for user in db["user"].all():
+        first_name = fake.first_name()
+        last_name = fake.last_name()
+        email = _email_plus_uuid(fake)
+        data = {
+            "id": user["id"],
+            "first_name": first_name,
+            "last_name": last_name,
+            "email": email,
+            "phone": fake.phone_number(),
+            "password": passwd,
+            "year_of_birth": None,
+        }
+        users[user["email"]] = data
+        db["user"].update(data, ["id"])
+        pbar.update(1)
+
+
+def _anonymize_representative(db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]) -> None:
+    for rep in db["representative"].all():
+        user = users.get(rep["email"])
         if user:
-            first_name = user['first_name']
-            last_name = user['last_name']
-            email = user['email']
-            phone = user['phone']
+            first_name = user["first_name"]
+            last_name = user["last_name"]
+            email = user["email"]
+            phone = user["phone"]
         else:
             first_name = fake.first_name()
             last_name = fake.last_name()
-            email = f'{first_name}.{last_name}@example.com'
-            email = _ensure_unique_email(email, emails)
+            email = _email_plus_uuid(fake)
             phone = fake.phone_number()
         data = {
-            'id': rep['id'],
-            'first_name': first_name,
-            'last_name': last_name,
-            'email': email,
-            'phone': phone,
+            "id": rep["id"],
+            "first_name": first_name,
+            "last_name": last_name,
+            "email": email,
+            "phone": phone,
         }
-        db['representative'].update(data, ['id'])
+        db["representative"].update(data, ["id"])
         pbar.update(1)
 
 
-def _anonymize_old_password(db, fake, pbar, users):
+def _anonymize_old_password(db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]) -> None:
     passwd = _hash_password("secret")
-    for user in db['old_password'].all():
+    for user in db["old_password"].all():
         data = {
-            'id': user['id'],
-            'password': passwd,
+            "id": user["id"],
+            "password": passwd,
         }
-        db['old_password'].update(data, ['id'])
+        db["old_password"].update(data, ["id"])
         pbar.update(1)
 
 
-def _anonymize_password_reset_token(db, fake, pbar, users):
+def _anonymize_password_reset_token(
+    db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]
+) -> None:
     token = str(uuid.uuid4())
-    for user in db['password_reset_token'].all():
+    for user in db["password_reset_token"].all():
         data = {
-            'id': user['id'],
-            'token': token,
+            "id": user["id"],
+            "token": token,
         }
-        db['password_reset_token'].update(data, ['id'])
+        db["password_reset_token"].update(data, ["id"])
         pbar.update(1)
 
 
-def _anonymize_newsletter_subscription(db, fake, pbar, users):
-    emails = {row['email'] for row in db['newsletter_subscription'].all()}
-    for row in db['newsletter_subscription'].all():
-        if row['email'] and '@' in row['email']:
-            first_name = fake.first_name()
-            last_name = fake.last_name()
-            email = f'{first_name}.{last_name}@example.com'
-            email = _ensure_unique_email(email, emails)
+def _anonymize_newsletter_subscription(
+    db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]
+) -> None:
+    for row in db["newsletter_subscription"].all():
+        if row["email"] and "@" in row["email"]:
+            email = _email_plus_uuid(fake)
         else:
-            email = row['email']
+            email = row["email"]
         data = {
-            'id': row['id'],
-            'email': email,
+            "id": row["id"],
+            "email": email,
         }
-        db['newsletter_subscription'].update(data, ['id'])
+        db["newsletter_subscription"].update(data, ["id"])
         pbar.update(1)
 
 
-def _anonymize_partner_application(db, fake, pbar, users):
-    emails = {row['email'] for row in db['partner_application'].all()}
-    for row in db['partner_application'].all():
+def _anonymize_partner_application(
+    db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]
+) -> None:
+    for row in db["partner_application"].all():
         first_name = fake.first_name()
         last_name = fake.last_name()
-        email = f'{first_name}.{last_name}@example.com'
-        email = _ensure_unique_email(email, emails)
+        email = _email_plus_uuid(fake)
         data = {
-            'id': row['id'],
-            'email': email,
-            'phone': fake.phone_number(),
-            'viisp_first_name': first_name,
-            'viisp_last_name': last_name,
-            'viisp_email': email,
-            'viisp_phone': fake.phone_number() if row['viisp_phone'] else None,
-            'viisp_dob': None,
+            "id": row["id"],
+            "email": email,
+            "phone": fake.phone_number(),
+            "viisp_first_name": first_name,
+            "viisp_last_name": last_name,
+            "viisp_email": email,
+            "viisp_phone": fake.phone_number() if row["viisp_phone"] else None,
+            "viisp_dob": None,
         }
-        db['partner_application'].update(data, ['id'])
+        db["partner_application"].update(data, ["id"])
         pbar.update(1)
 
 
-def _anonymize_sso_token(db, fake, pbar, users):
-    for user in db['sso_token'].all():
+def _anonymize_sso_token(db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]) -> None:
+    for user in db["sso_token"].all():
         data = {
-            'id': user['id'],
-            'ip': '127.0.0.1',
-            'token': str(uuid.uuid4()),
+            "id": user["id"],
+            "ip": "127.0.0.1",
+            "token": str(uuid.uuid4()),
         }
-        db['sso_token'].update(data, ['id'])
+        db["sso_token"].update(data, ["id"])
         pbar.update(1)
 
 
-def _anonymize_suggestion(db, fake, pbar, users):
-    emails = {row['email'] for row in db['suggestion'].all()}
-    for row in db['suggestion'].all():
+def _anonymize_suggestion(db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]) -> None:
+    for row in db["suggestion"].all():
         first_name = fake.first_name()
         last_name = fake.last_name()
-        email = f'{first_name}.{last_name}@example.com'
-        email = _ensure_unique_email(email, emails)
+        email = _email_plus_uuid(fake)
         data = {
-            'id': row['id'],
-            'email': email,
-            'name': f'{first_name} {last_name}',
-            'body': fake.sentence(12),
+            "id": row["id"],
+            "email": email,
+            "name": f"{first_name} {last_name}",
+            "body": fake.sentence(12),
         }
-        db['suggestion'].update(data, ['id'])
+        db["suggestion"].update(data, ["id"])
         pbar.update(1)
 
 
-def _anonymize_comment(db, fake, pbar, users):
-    for row in db['comment'].all():
-        first_name = fake.first_name()
-        last_name = fake.last_name()
-        data = {
-            'id': row['id'],
-            'author_name': f"{first_name} {last_name}",
-            'ip_address': '127.0.0.1',
-            'body': fake.sentence(12),
-        }
-        db['comment'].update(data, ['id'])
-        pbar.update(1)
-
-
-def _anonymize_request_event(db, fake, pbar, users):
-    for row in db['request_event'].all():
+def _anonymize_comment(db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]) -> None:
+    for row in db["comment"].all():
         first_name = fake.first_name()
         last_name = fake.last_name()
         data = {
-            'id': row['id'],
-            'meta': f"{first_name} {last_name}",
+            "id": row["id"],
+            "author_name": f"{first_name} {last_name}",
+            "ip_address": "127.0.0.1",
+            "body": fake.sentence(12),
         }
-        db['request_event'].update(data, ['id'])
+        db["comment"].update(data, ["id"])
+        pbar.update(1)
+
+
+def _anonymize_request_event(db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]) -> None:
+    for row in db["request_event"].all():
+        first_name = fake.first_name()
+        last_name = fake.last_name()
+        data = {
+            "id": row["id"],
+            "meta": f"{first_name} {last_name}",
+        }
+        db["request_event"].update(data, ["id"])
         pbar.update(1)
 
 
@@ -230,15 +662,19 @@ def _ensure_unique_email(
     unique = email
     while unique in emails:
         num += 1
-        unique = email.replace('@', f'{num}@')
+        unique = email.replace("@", f"{num}@")
     emails.add(unique)
     return unique
 
 
+def _email_plus_uuid(fake) -> str:
+    return f"{fake.user_name()}.{uuid.uuid4().hex[:10]}@example.com"
+
+
 def _hash_password(password: str) -> str:
     salt = bcrypt.gensalt(10)
-    return bcrypt.hashpw('test'.encode(), salt).decode('ascii')
+    return bcrypt.hashpw("test".encode(), salt).decode("ascii")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     run(main)

--- a/scripts/anonymize.py
+++ b/scripts/anonymize.py
@@ -1,8 +1,8 @@
+import json
 import sys
 import uuid
 from typing import Set
 
-import bcrypt
 import dataset
 from dataset import Database, Table
 from faker import Faker
@@ -338,12 +338,14 @@ def _anonymize_socialaccount_socialaccount(
     for record in objects.all():
         data = {
             pk_name: record[pk_name],
-            "extra_data": {
-                "personal_code": "example-hashed-code",
-                "coordinator_phone_number": None,
-                "coordinator_email": fake.email(domain="example.com"),
-                "password_not_set": False,
-            },
+            "extra_data": json.dumps(
+                {
+                    "personal_code": "example-hashed-code",
+                    "coordinator_phone_number": None,
+                    "coordinator_email": fake.email(domain="example.com"),
+                    "password_not_set": False,
+                }
+            ),
         }
         objects.update(data, [pk_name])
         pbar.update(1)
@@ -498,7 +500,7 @@ def _anonymize_contact(db: Database, fake: Faker, pbar: tqdm, users: dict[str, d
 
 
 def _anonymize_user(db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]) -> None:
-    passwd = _hash_password("secret")
+    passwd = _get_unusable_password()
     for user in db["user"].all():
         first_name = fake.first_name()
         last_name = fake.last_name()
@@ -542,7 +544,7 @@ def _anonymize_representative(db: Database, fake: Faker, pbar: tqdm, users: dict
 
 
 def _anonymize_old_password(db: Database, fake: Faker, pbar: tqdm, users: dict[str, dict[str, str | None]]) -> None:
-    passwd = _hash_password("secret")
+    passwd = _get_unusable_password()
     for user in db["old_password"].all():
         data = {
             "id": user["id"],
@@ -671,9 +673,9 @@ def _email_plus_uuid(fake) -> str:
     return f"{fake.user_name()}.{uuid.uuid4().hex[:10]}@example.com"
 
 
-def _hash_password(password: str) -> str:
-    salt = bcrypt.gensalt(10)
-    return bcrypt.hashpw("test".encode(), salt).decode("ascii")
+def _get_unusable_password() -> str:
+    UNUSABLE_PASSWORD_PREFIX = "!"  # This will never be a valid encoded hash
+    return f"{UNUSABLE_PASSWORD_PREFIX}{uuid.uuid4()}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Update database anonymization script.
Anonymizing additionally these tables:
- "django_admin_log"
- "sent_mail"
- "contact"
- "vitrina_uapi_agent"
- "viispkey"
- "viisptokenkey"
- "user_email_device"
- "account_emailaddress"
- "otp_email_emaildevice"
- "representative_request"
- "api_key"
 
 Introducing type hints
 Fixing file formatting with black and ruff.