### PR TITLE
[1415] Adjustments & Bug fixes for the synchronization process

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,13 @@ v 1.2 (unreleased)
 New features:
 
 
+https://github.com/atviriduomenys/spinta/issues/1415
+Some additional improvements for the synchronization:
+    - Added new fields for Dataset API that conforms to the UAPI: `service` & `series`.
+    - Added `parent_id` to the API to be able to add hierarchy via the API.
+    - Fixed a bug where the translations were not setting properly.
+
+
 https://github.com/atviriduomenys/katalogas/issues/1812
 Upgrade Django 3.2 -> Django 4.2:
     - Changed `delete(..)` methods to `form_valid(..)` in all `DeleteView` views.

--- a/tests/uapi/conftest.py
+++ b/tests/uapi/conftest.py
@@ -10,8 +10,8 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.models import Site
 from django.urls import reverse
 
-from vitrina.datasets.factories import DatasetFactory
-from vitrina.datasets.models import Dataset
+from vitrina.datasets.factories import DatasetFactory, DCATResourceSubclassFactory
+from vitrina.datasets.models import Dataset, DCATResourceSubclass
 from vitrina.orgs.factories import OrganizationFactory
 from vitrina.orgs.models import Organization
 from vitrina.projects.factories import ProjectFactory
@@ -57,6 +57,17 @@ def _generate_test_token(
 @pytest.fixture(autouse=True)
 def override_oauth_jwk(settings, test_jwk):
     settings.OAUTH_SERVER_PUBLIC_JWK_JSON = test_jwk.as_dict(is_private=False)
+
+
+# TODO: Remove after https://github.com/atviriduomenys/katalogas/issues/1840 is complete.
+#   These classes should be created via migrations.
+@pytest.fixture
+def create_dcat_resource_subclasses() -> None:
+    DCATResourceSubclassFactory(name=DCATResourceSubclass.DATASET)
+    DCATResourceSubclassFactory(name=DCATResourceSubclass.SERIES)
+    DCATResourceSubclassFactory(name=DCATResourceSubclass.SERVICE)
+    DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
+    DCATResourceSubclassFactory(name=DCATResourceSubclass.CATALOG)
 
 
 @pytest.fixture(scope="session")

--- a/tests/uapi/dataset/test_views.py
+++ b/tests/uapi/dataset/test_views.py
@@ -132,7 +132,7 @@ def test_create(
     ],
 )
 def test_create_specific_resource(
-    subclass: DCATResourceSubclass,
+    subclass: str,
     subclass_additional_data: dict[str, Any],
     is_service: bool,
     is_series: bool,

--- a/tests/uapi/dataset/test_views.py
+++ b/tests/uapi/dataset/test_views.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from typing import Iterable, Any
 from unittest.mock import patch, PropertyMock
 from urllib.parse import quote
 
@@ -32,12 +32,14 @@ def test_create(
     domain: str,
     valid_token: str,
 ):
+    dataset_parent = DatasetFactory()
     data = {
         "name": "/datasets/gov/vssa/isris/dcat/uapi/Model",
         "title": "DataSet 1",
         "description": "DataSet 1 description",
         "service": True,
         "subclass": DCATResourceSubclass.SERVICE,
+        "parent_id": dataset_parent.pk,
     }
     response = app.post(
         url_dataset,
@@ -53,7 +55,11 @@ def test_create(
         access_rights=Dataset.NON_PUBLIC,
         organization=organization,
     ).first()
+
     assert dataset
+    assert dataset.path is not None
+    assert dataset.is_child_of(dataset_parent) is True  # Parent is set.
+
     assert response.json == {
         "@context": "",
         "_type": url_dataset.rstrip("/"),
@@ -79,8 +85,84 @@ def test_create(
         "organization_id": organization.id,
         "organization_title": organization.title,
         "service": True,
+        "series": False,
         "subclass": DCATResourceSubclass.SERVICE,
     }
+
+
+@pytest.mark.parametrize(
+    "subclass, subclass_additional_data, is_service, is_series",
+    [
+        (
+            DCATResourceSubclass.DATASET,
+            {"subclass": DCATResourceSubclass.DATASET},
+            False,
+            False,
+        ),
+        (
+            DCATResourceSubclass.INFORMATION_SYSTEM,
+            {"subclass": DCATResourceSubclass.INFORMATION_SYSTEM},
+            False,
+            False,
+        ),
+        (
+            DCATResourceSubclass.CATALOG,
+            {"subclass": DCATResourceSubclass.CATALOG},
+            False,
+            False,
+        ),
+        (
+            DCATResourceSubclass.SERIES,
+            {
+                "subclass": DCATResourceSubclass.SERIES,
+                "series": True,
+            },
+            False,
+            True,
+        ),
+        (
+            DCATResourceSubclass.SERVICE,
+            {
+                "subclass": DCATResourceSubclass.SERVICE,
+                "service": True,
+            },
+            True,
+            False,
+        ),
+    ],
+)
+def test_create_specific_resource(
+    subclass: DCATResourceSubclass,
+    subclass_additional_data: dict[str, Any],
+    is_service: bool,
+    is_series: bool,
+    app: DjangoTestApp,
+    organization: Organization,
+    url_dataset: str,
+    domain: str,
+    valid_token: str,
+):
+    """Test that a specific resource is created on API call.
+
+    Following DCAT, the Dataset model serves 5 resources: Dataset, Data Service, Catalog, IS & Data Series.
+    We need this API to be able to create any one of these resources.
+    """
+    data = {
+        "name": "/datasets/gov/vssa/isris/dcat/uapi/Model",
+        "title": "Example",
+        "description": "Example description",
+        **subclass_additional_data,
+    }
+    response = app.post(
+        url_dataset,
+        data,
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+    )
+
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.json["subclass"] == subclass
+    assert response.json["series"] == is_series
+    assert response.json["service"] == is_service
 
 
 def test_create_specific_scope(
@@ -140,6 +222,7 @@ def test_create_specific_scope(
         "organization_id": organization.id,
         "organization_title": organization.title,
         "service": False,
+        "series": False,
         "subclass": DCATResourceSubclass.DATASET,
     }
 
@@ -317,6 +400,7 @@ def test_list(
                 "organization_title": organization.title,
                 "id": str(dataset.id),
                 "service": False,
+                "series": False,
                 "subclass": DCATResourceSubclass.DATASET,
             }
         ]
@@ -370,6 +454,7 @@ def test_list_specific_scope(
                 "organization_title": organization.title,
                 "id": str(dataset.id),
                 "service": False,
+                "series": False,
                 "subclass": DCATResourceSubclass.DATASET,
             }
         ]
@@ -481,6 +566,7 @@ def test_list_with_query_parameters(
                 "organization_title": organization.title,
                 "id": str(dataset.id),
                 "service": False,
+                "series": False,
                 "subclass": DCATResourceSubclass.DATASET,
             }
         ]

--- a/tests/uapi/dataset/test_views.py
+++ b/tests/uapi/dataset/test_views.py
@@ -129,6 +129,13 @@ def test_create(
             True,
             False,
         ),
+        # Defaults to Dataset when value is not given.
+        (
+            DCATResourceSubclass.DATASET,
+            {},
+            False,
+            False,
+        ),
     ],
 )
 def test_create_specific_resource(
@@ -141,6 +148,7 @@ def test_create_specific_resource(
     url_dataset: str,
     domain: str,
     valid_token: str,
+    create_dcat_resource_subclasses: None,
 ):
     """Test that a specific resource is created on API call.
 

--- a/vitrina/uapi/serializers/serializers.py
+++ b/vitrina/uapi/serializers/serializers.py
@@ -12,7 +12,15 @@ class UAPIDatasetSerializer(BaseObjectMixin, DatasetSerializer):
     )
 
     class Meta(DatasetSerializer.Meta):
-        fields = DatasetSerializer.Meta.fields + BaseObjectMixin.Meta.fields + ("service", "subclass")
+        fields = (
+            DatasetSerializer.Meta.fields
+            + BaseObjectMixin.Meta.fields
+            + (
+                "subclass",
+                "service",
+                "series",
+            )
+        )
 
 
 class UAPIDatasetCreateSerializer(PostDatasetSerializer):
@@ -21,9 +29,21 @@ class UAPIDatasetCreateSerializer(PostDatasetSerializer):
         queryset=DCATResourceSubclass.objects.all(),
         default=DCATResourceSubclass.DATASET,
     )
+    service = serializers.BooleanField(default=False)
+    series = serializers.BooleanField(default=False)
+    parent_id = serializers.CharField(required=False, allow_null=True)
 
     class Meta(PostDatasetSerializer.Meta):
-        fields = PostDatasetSerializer.Meta.fields + ("name", "service", "subclass")
+        fields = (
+            PostDatasetSerializer.Meta.fields
+            + (
+                "name",
+                "subclass",
+                "parent_id",
+                "service",
+                "series",
+            )
+        )
 
 
 class UAPIDistributionSerializer(BaseObjectMixin, DatasetDistributionSerializer):

--- a/vitrina/uapi/serializers/serializers.py
+++ b/vitrina/uapi/serializers/serializers.py
@@ -34,15 +34,12 @@ class UAPIDatasetCreateSerializer(PostDatasetSerializer):
     parent_id = serializers.CharField(required=False, allow_null=True)
 
     class Meta(PostDatasetSerializer.Meta):
-        fields = (
-            PostDatasetSerializer.Meta.fields
-            + (
-                "name",
-                "subclass",
-                "parent_id",
-                "service",
-                "series",
-            )
+        fields = PostDatasetSerializer.Meta.fields + (
+            "name",
+            "subclass",
+            "parent_id",
+            "service",
+            "series",
         )
 
 

--- a/vitrina/uapi/views/template_views.py
+++ b/vitrina/uapi/views/template_views.py
@@ -207,8 +207,9 @@ class AgentCreateView(CreateView, BaseAgentView):
                     ),
                 )
                 return redirect(reverse("agent-detail", args=[self.organization.pk, self.object.pk]))
-        except Exception:
+        except Exception as e:
             messages.error(self.request, _("Įvyko klaida, nepavyko sukurti agento."))
+            logger.exception(f"Agent creation failed with exception {e}")
             return self.form_invalid(form)
 
     def get_context_data(self, **kwargs: Any) -> dict:

--- a/vitrina/uapi/views/views.py
+++ b/vitrina/uapi/views/views.py
@@ -120,8 +120,26 @@ class DatasetViewSet(UAPIExceptionHandlerMixin, viewsets.ModelViewSet):
                 "access_rights": Dataset.NON_PUBLIC,
                 "organization_id": organization.id,
             }
+
+            title = dataset_data.get("title", None)
+            description = dataset_data.get("description", None)
+            parent_id = dataset_data.pop("parent_id", None)
+
             instance = Dataset(**dataset_data)
-            Dataset.add_root(instance=instance)
+
+            if parent_id:
+                parent = Dataset.objects.filter(id=parent_id).first()
+                parent.add_child(instance=instance)
+            else:
+                Dataset.add_root(instance=instance)
+
+            language = getattr(request, "LANGUAGE_CODE", "lt")
+            instance.set_current_language(language)
+            if title is not None:
+                instance.title = title
+            if description is not None:
+                instance.description = description
+            instance.save()
 
         Metadata.objects.create(
             uuid=str(uuid.uuid4()),
@@ -129,8 +147,8 @@ class DatasetViewSet(UAPIExceptionHandlerMixin, viewsets.ModelViewSet):
             content_type=ContentType.objects.get_for_model(serializer.Meta.model),
             object_id=instance.pk,
             name=self.request.data.get("name", ""),
-            title=serializer.validated_data["title"],
-            description=serializer.validated_data["description"],
+            title=title,
+            description=description,
             prepare_ast={},
             version=1,
         )

--- a/vitrina/uapi/views/views.py
+++ b/vitrina/uapi/views/views.py
@@ -127,8 +127,8 @@ class DatasetViewSet(UAPIExceptionHandlerMixin, viewsets.ModelViewSet):
 
             instance = Dataset(**dataset_data)
 
-            if parent_id:
-                parent = Dataset.objects.filter(id=parent_id).first()
+            parent = Dataset.objects.filter(id=parent_id).first() if parent_id else None
+            if parent:
                 parent.add_child(instance=instance)
             else:
                 Dataset.add_root(instance=instance)

--- a/vitrina/uapi/views/views.py
+++ b/vitrina/uapi/views/views.py
@@ -135,10 +135,8 @@ class DatasetViewSet(UAPIExceptionHandlerMixin, viewsets.ModelViewSet):
 
             language = getattr(request, "LANGUAGE_CODE", "lt")
             instance.set_current_language(language)
-            if title is not None:
-                instance.title = title
-            if description is not None:
-                instance.description = description
+            instance.title = title or instance.title
+            instance.description = description or instance.description
             instance.save()
 
         Metadata.objects.create(


### PR DESCRIPTION
### Context:

Some additional changes had to be made to the implementation of the synchronization process:

1. Added API fields:
   - `service` & `series`: Deprecated but still used attributes, that need to be sent via the API to not break any existing logic.
   
   - `parent_id`: Defines relationships and dependencies of resources (Dataset model).

2. Added logic for `parent_id` setting, if the value is not sent — the object is set to root and has no children.
3. Found a bug:
   - When an object is initially saved via the `Dataset.add_root(instance=instance)`, the translations are not set, following that, ElasticSearch does not index the object and it is not displayed in the list of organizations. To solve that, we explicitly add translations & save the instance.

### Notes:
- Can be reviewed, tests will be added ASAP (in the same PR).

### Dependencies:
- https://github.com/atviriduomenys/spinta/pull/1450