### PR TITLE
[Spinta#1488] Adjustments from Catalog side

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,12 @@ Create or update organisation should not require icon.
 https://github.com/atviriduomenys/katalogas/issues/1928
 Add contact tab to Dataset list form.
 
+https://github.com/atviriduomenys/spinta/issues/1488
+Adjustments from the Catalog side for spinta changes:
+- Create Metadata w/ the initial data service that is created during agent creation
+- Assign subclass to the service
+- Add an explicit message for Agent creation form, when the auth server is unavailable/unreachable
+- Define better error messages for Agent creation form
 
 v 1.2 (2025-09-10)
 ==================

--- a/tests/uapi/agents/test_views.py
+++ b/tests/uapi/agents/test_views.py
@@ -7,7 +7,7 @@ from django.urls import reverse
 from django_webtest import DjangoTestApp
 from vitrina.api.models import ApiKey
 from vitrina.datasets.factories import DatasetFactory, AgentFactory
-from vitrina.datasets.models import Dataset
+from vitrina.datasets.models import Dataset, DCATResourceSubclass
 from vitrina.uapi import AgentType
 from vitrina.orgs.factories import OrganizationFactory
 from vitrina.orgs.models import Organization
@@ -95,9 +95,11 @@ def test_create_view(app: DjangoTestApp, representative_user: User, organization
     assert response.status_code == HTTPStatus.FOUND
     assert Agent.objects.count() == 1
     agent = Agent.objects.filter(title=data["title"], organization=organization).first()
+    agent_service = agent.service
     assert agent.oauth_client_id == mocked_id
-    assert agent is not None
-    assert ApiKey.objects.count() == 0 # No longer relying on API keys, using oauth client file instead.
+    assert agent_service.service is True
+    assert agent_service.subclass == DCATResourceSubclass.objects.get(name=DCATResourceSubclass.SERVICE)
+    assert agent_service.metadata.first().name == Agent().get_codename(data["title"])
     assert mock_create_oauth_client.called
 
 

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-08 09:29+0300\n"
+"POT-Creation-Date: 2025-09-23 13:15+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -286,6 +286,19 @@ msgstr "Read more"
 
 msgid "Prie mokymo medžiagos pridėti failai"
 msgstr "Learning material files"
+
+msgid "Įkeltas"
+msgstr "Uploaded"
+
+msgid "Atsisiųsti failą"
+msgstr "Download file"
+
+msgid "Atsisiųsti"
+msgstr "Download"
+
+msgid ""
+"Spustelėkite atsisiųsti mygtuką, kad išsaugotumėte failą savo kompiuteryje"
+msgstr "Press the Download button to save the file to your file system"
 
 msgid "Privatumo politika"
 msgstr "Privacy policy"
@@ -1431,9 +1444,6 @@ msgstr "unassigned name"
 msgid "Peržiūrėti"
 msgstr "Review"
 
-msgid "Atsisiųsti"
-msgstr "Download"
-
 msgid "Atidaryti"
 msgstr "Open"
 
@@ -2060,63 +2070,6 @@ msgstr "Comment subscription"
 msgid "Prenumeratos tipas"
 msgstr "Subscription type"
 
-msgid "Prenumerata patvirtinta"
-msgstr "Subscription confirmed"
-
-msgid "Prenumerata sėkmingai patvirtinta!"
-msgstr "Subscription was successfully confirmed!"
-
-msgid "Ačiū! Jūsų el. pašto adresas sėkmingai užprenumeravo naujienlaiškį."
-msgstr "Thank you! Your email was successfully added to newsletter subscription."
-
-msgid "Gausite naujienlaiškį kai tik bus paskelbtas naujas turinys."
-msgstr "You will receive the newsletter whenever new post will be published."
-
-msgid "Grįžti į pagrindinį puslapį"
-msgstr "Go back to home page"
-
-msgid "Jei kada nors norėsite atšaukti prenumeratą, galėsite tai padaryti paspausdami nuorodą bet kuriame gautame naujienlaiškio laiške."
-msgstr "If you ever decide to cancel your newsletter subscription, you can do so by clicking the unsubscribe link in any newsletter you receive."
-
-msgid "Atšaukti prenumeratą"
-msgstr "Cancel subscription"
-
-msgid "Atšaukti naujienlaiškio prenumeratą"
-msgstr "Cancel newsletter subscription"
-
-msgid "Ar tikrai norite atšaukti prenumeratą el. pašto adresui"
-msgstr "Are you sure you want to cancel subscription for email"
-
-msgid "Po prenumeratos atšaukimo nebegausite mūsų naujienlaiškių."
-msgstr "After canceling subscription you will stop receiving our newsletters."
-
-msgid "Taip, atšaukti prenumeratą"
-msgstr "Yes, cancel subscription"
-
-msgid "Ne, grįžti atgal"
-msgstr "No, go back"
-
-msgid "Jei pakeisite nuomonę, galėsite bet kada prenumeruoti iš naujo mūsų svetainėje."
-msgstr "If you ever change your decision, you can renew your subscription anytime on our website."
-
-msgid "Prenumerata atšaukta"
-msgstr "Subscription cancelled"
-
-msgid "Prenumerata sėkmingai atšaukta"
-msgstr "Subscription was successfully cancelled"
-
-msgid "Jūsų el. pašto adresas daugiau negaus mūsų naujienlaiškio."
-msgstr "Your email address will stop receiving our newsletter."
-
-msgid "Dėkojame, kad buvote su mumis!"
-msgstr "Thank you for being with us!"
-
-msgid "Norėtumėte vėl prenumeruoti?"
-msgstr "Would you like to subscribe again?"
-
-msgid "Jei turite klausimų ar pasiūlymų, susisiekite su mumis:"
-msgstr "If you have any questions or suggestions, contact us:"
-
 msgid "Prenumeratos laiško užsisakymas"
 msgstr "E-mail subscription"
 
@@ -2141,6 +2094,84 @@ msgstr "Project comment subscription"
 msgid "Komentaro atsako prenumerata"
 msgstr "Comment reply subscription"
 
+msgid "Laukiama patvirtinimo"
+msgstr "Waiting for confirmation"
+
+msgid "Prenumeruojama"
+msgstr "Sbuscribed"
+
+msgid "Prenumeracija nutraukta"
+msgstr "Subscription cancelled"
+
+msgid "Prenumerata patvirtinta"
+msgstr "Subscription confirmed"
+
+msgid "Prenumerata sėkmingai patvirtinta!"
+msgstr "Subscription was successfully confirmed!"
+
+msgid "Ačiū! Jūsų el. pašto adresas sėkmingai užprenumeravo naujienlaiškį."
+msgstr ""
+"Thank you! Your email was successfully added to newsletter subscription."
+
+msgid "Gausite naujienlaiškį kai tik bus paskelbtas naujas turinys."
+msgstr "You will receive the newsletter whenever new post will be published."
+
+msgid "Grįžti į pagrindinį puslapį"
+msgstr "Go back to home page"
+
+msgid ""
+"Jei kada nors norėsite atšaukti prenumeratą, galėsite tai padaryti "
+"paspausdami nuorodą bet kuriame gautame naujienlaiškio laiške."
+msgstr ""
+"If you ever decide to cancel your newsletter subscription, you can do so by "
+"clicking the unsubscribe link in any newsletter you receive."
+
+msgid "Atšaukti prenumeratą"
+msgstr "Cancel subscription"
+
+msgid "Atšaukti naujienlaiškio prenumeratą"
+msgstr "Cancel newsletter subscription"
+
+msgid "Ar tikrai norite atšaukti prenumeratą el. pašto adresui"
+msgstr "Are you sure you want to cancel subscription for email"
+
+msgid "Po prenumeratos atšaukimo nebegausite mūsų naujienlaiškių."
+msgstr "After canceling subscription you will stop receiving our newsletters."
+
+msgid "Taip, atšaukti prenumeratą"
+msgstr "Yes, cancel subscription"
+
+msgid "Ne, grįžti atgal"
+msgstr "No, go back"
+
+msgid "Pastaba:"
+msgstr "Notes"
+
+msgid ""
+"Jei pakeisite nuomonę, galėsite bet kada prenumeruoti iš naujo mūsų "
+"svetainėje."
+msgstr ""
+"If you ever change your decision, you can renew your subscription anytime on "
+"our website."
+
+msgid "Prenumerata atšaukta"
+msgstr "Subscription cancelled"
+
+msgid "Prenumerata sėkmingai atšaukta"
+msgstr "Subscription was successfully cancelled"
+
+msgid "Šiuo el. paštu nebegausite naujienlaiškio."
+msgstr "You will not be receiving the newsletter to this email."
+
+msgid "Dėkojame, kad buvote su mumis!"
+msgstr "Thank you for being with us!"
+
+msgid "Norėtumėte vėl prenumeruoti?"
+msgstr "Would you like to subscribe again?"
+
+msgid "Jei turite klausimų ar pasiūlymų, susisiekite su mumis:"
+msgstr "If you have any questions or suggestions, contact us:"
+
 msgid "Jūs neturit teisės sukurti prenumeratos kitam naudotojui."
 msgstr "You don't have permission to create subscription for other user."
 
@@ -2155,6 +2186,30 @@ msgstr "Subscription was created successfully"
 
 msgid "Rasta esama šio objekto prenumerata, ji buvo sėkmingai atnaujinta."
 msgstr "Found existing object subscription. It was updated successfully."
+
+msgid "Prašome įvesti el. pašto adresą."
+msgstr "Please enter your email address."
+
+msgid "Šis el. pašto adresas jau prenumeruoja naujienlaiškį."
+msgstr "This email is already subscribed to the newsletter ."
+
+msgid "Patvirtinimo nuorodą vis dar galiojanti, patikrinkite el. pašto dežutę."
+msgstr "The confirmation url is still valid, please check your email inbox."
+
+msgid ""
+"Patvirtinimo nuoroda išsiųsta į jūsų el. paštą. Nuoroda galioja 24 valandas."
+msgstr ""
+"The cnfirmation url has been sent to your e-mail. It is valid for 24 hours."
+
+msgid ""
+"Patvirtinimo nuoroda nebegalioja. Prašome užsisakyti prenumeratą iš naujo."
+msgstr "The confirmation URL has expired. Please subscribe again."
+
+msgid "Naujienlaiškio prenumerata sėkmingai patvirtinta!"
+msgstr "Newsletter subscription was successfully confirmed!"
+
+msgid "Įvyko klaida patvirtinant prenumeratą."
+msgstr "An error occurred trying to confirm the subscription."
 
 msgid "organizacija"
 msgstr "organization"
@@ -2470,9 +2525,6 @@ msgstr ""
 
 msgid "Taip, esu tikras"
 msgstr "Yes, I am sure"
-
-msgid "Ne, grįžti atgal"
-msgstr "No, go back"
 
 msgid "Šablono redagavimas"
 msgstr "Edit template"
@@ -4998,6 +5050,9 @@ msgstr "No errors"
 msgid "Pridėti Agentą"
 msgstr "Add an Agent"
 
+msgid "Duomenų paslauga automatiškai sukurta kuriant agentą."
+msgstr "Data service automatically created with the agent."
+
 msgid ""
 "Išsisaugokite slaptą raktą rodomą puslapio pabaigoje, jis bus rodomas tik šį "
 "kartą!\n"
@@ -5008,8 +5063,16 @@ msgstr ""
 "only this one time! If you selected the \"Spinta\" type, the key is shown "
 "next to the \"secret\" column in the credentials.cfg file example."
 
-msgid "Įvyko klaida, nepavyko sukurti agento."
-msgstr "An error occurred; the agent could not be created."
+#, python-format
+msgid ""
+"Nepavyko pasiekti autorizacijos serverio (%(url)s), dėl to Agento kūrimas "
+"nepavyko."
+msgstr ""
+"Failed to reach the authorization server (%(url)s), so creating the Agent "
+"failed."
+
+msgid "Įvyko klaida, nepavyko sukurti agento. Klaida: %(exception)s"
+msgstr "An error occurred; the agent could not be created. Error: %(exception)s"
 
 msgid "Redaguoti Agentą"
 msgstr "Edit agent"
@@ -5194,9 +5257,6 @@ msgstr "Confirm"
 msgid "Aktyvus"
 msgstr "Active"
 
-msgid "Laukiama patvirtinimo"
-msgstr "Waiting for confirmation"
-
 msgid "Suspenduotas"
 msgstr "Suspended"
 
@@ -5335,6 +5395,9 @@ msgstr "Logged in for"
 
 msgid "Keisti duomenis"
 msgstr "Change data"
+
+msgid "Prenumeruoti naujienlaiškį"
+msgstr "Subscribe to the newsletter"
 
 msgid "Naudotojo registracija"
 msgstr "User registration"

--- a/vitrina/uapi/views/template_views.py
+++ b/vitrina/uapi/views/template_views.py
@@ -1,9 +1,11 @@
 import codecs
 import logging
+import uuid
 from typing import Any
 
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
+from django.contrib.contenttypes.models import ContentType
 from django.core.handlers.wsgi import WSGIRequest
 from django.core.paginator import Paginator
 from django.db import transaction
@@ -19,14 +21,16 @@ from django.views.generic import (
     TemplateView,
 )
 from django_otp.plugins.otp_email.conf import settings
+from requests.exceptions import ConnectionError as RequestsConnectionError
 
 from vitrina.api.oauth import Secret, OAuthClientManagement
-from vitrina.datasets.models import Dataset, Contact, Type
+from vitrina.datasets.models import Dataset, Contact, Type, DCATResourceSubclass
 from vitrina.orgs.models import Organization, Representative
 from vitrina.orgs.services import (
     has_perm,
     Action,
 )
+from vitrina.structure.models import Metadata
 from vitrina.uapi.models import RequestHistory
 from vitrina.resources.models import Format
 from vitrina.uapi.forms import AgentForm
@@ -176,23 +180,35 @@ class AgentCreateView(CreateView, BaseAgentView):
         try:
             with transaction.atomic():
                 form.instance.organization = self.organization
-                instance = Dataset.add_root(
+                service = Dataset.add_root(
                     title=f'Agento "{title}" Duomenų Paslauga',
                     description="Ši duomenų paslauga buvo automatiškai sukurta kuriant Agentą.",
                     access_rights=Dataset.NON_PUBLIC,
                     organization=self.organization,
                     service=True,
+                    subclass=DCATResourceSubclass.objects.get(name=DCATResourceSubclass.SERVICE),
                     endpoint_url=None,
                     endpoint_type=Format.objects.filter(extension="UAPI").first(),
                     endpoint_description="https://ivpk.github.io/uapi",
                     endpoint_description_type=Format.objects.filter(extension="Open API").first(),
                     is_public=False,
                 )
-                form.instance.service = instance
+                form.instance.service = service
                 form.instance.service.type.set(Type.objects.filter(name=Type.SERVICE).values_list("pk", flat=True))
                 form.instance.service.save_translations()
-
                 self.object = form.save()
+
+                Metadata.objects.create(
+                    uuid=str(uuid.uuid4()),
+                    dataset=service,
+                    content_type=ContentType.objects.get_for_model(Dataset),
+                    object_id=service.pk,
+                    name=self.object.codename,
+                    title=title,
+                    description=_("Duomenų paslauga automatiškai sukurta kuriant agentą."),
+                    prepare_ast={},
+                    version=1,
+                )
 
                 self.request.session["secret"] = self._create_oauth_client(agent=self.object)
                 self.request.session["scopes"] = settings.OAUTH_AGENT_DEFAULT_SCOPES
@@ -207,9 +223,13 @@ class AgentCreateView(CreateView, BaseAgentView):
                     ),
                 )
                 return redirect(reverse("agent-detail", args=[self.organization.pk, self.object.pk]))
-        except Exception as e:
-            messages.error(self.request, _("Įvyko klaida, nepavyko sukurti agento."))
-            logger.exception(f"Agent creation failed with exception {e}")
+        except RequestsConnectionError:
+            error = _("Nepavyko pasiekti autorizacijos serverio (%(url)s), dėl to Agento kūrimas nepavyko.")
+            messages.error(self.request, error % {"url": settings.OAUTH_SERVER_CLIENTS_URL})
+            return self.form_invalid(form)
+        except Exception as general_exception:
+            error = _("Įvyko klaida, nepavyko sukurti agento. Klaida: %(exception)s")
+            messages.error(self.request, error % {"exception": str(general_exception)})
             return self.form_invalid(form)
 
     def get_context_data(self, **kwargs: Any) -> dict:


### PR DESCRIPTION
- Create Metadata w/ the initial data service that is created during agent creation
- Assign subclass to the service
- Add an explicit message for Agent creation form, when the auth server is unavailable/unreachable
- Define better error messages for Agent creation form