### PR TITLE
[Spinta#1488] Endpoint adjustments/additions for synchronization

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,6 +66,11 @@ Adjustments from the Catalog side for spinta changes:
 - Add an explicit message for Agent creation form, when the auth server is unavailable/unreachable
 - Define better error messages for Agent creation form
 
+https://github.com/atviriduomenys/spinta/issues/1488
+Add additional changes required by sinchronization from the Agent side:
+- New API endpoint for getting manifest structure (in csv).
+- Add an additional query parameter `parent_id` for retrieving all child datasets of a single dataset.
+
 v 1.2 (2025-09-10)
 ==================
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,17 +1,22 @@
 import builtins
+import csv
+import io
 
 import pytest
-
 from django.apps import apps
 from django.core.management import call_command
-
 from pytest_django.lazy_django import skip_if_no_django
-
 from pprintpp import pprint as pp
 
 from vitrina.datasets.models import DCATResourceSubclass
 
 builtins.pp = pp
+
+
+def _normalize_csv(csv_string: str) -> list[list[str]]:
+    reader = csv.reader(io.StringIO(csv_string))
+    rows = [row for row in reader if any(col.strip() for col in row)]
+    return rows
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/uapi/conftest.py
+++ b/tests/uapi/conftest.py
@@ -158,8 +158,7 @@ def url_dataset_structure(dataset: Dataset) -> str:
 
 @pytest.fixture
 def dsa() -> str:
-    return """
-id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description
+    return """id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description
 ,example70,,,,,,,,,,,,,,,,,
 ,,users,,,,dask/json,,/path,,,,,,,,,,
 ,,,,,,,,,,,,,,,,,,

--- a/tests/uapi/dataset/test_views.py
+++ b/tests/uapi/dataset/test_views.py
@@ -16,6 +16,7 @@ from tests.uapi.conftest import _generate_test_token
 from vitrina import settings
 from vitrina.datasets.factories import DatasetFactory
 from vitrina.datasets.models import Dataset, DatasetStructure, DCATResourceSubclass
+from vitrina.orgs.factories import OrganizationFactory
 from vitrina.orgs.models import Organization
 from vitrina.structure.factories import MetadataFactory
 from vitrina.structure.models import Metadata
@@ -517,7 +518,7 @@ def test_list_no_organization_id_inside_token_payload(
     }
 
 
-def test_list_with_query_parameters(
+def test_list_with_name_query_parameter(
     app: DjangoTestApp,
     organization: Organization,
     dataset: Dataset,
@@ -579,6 +580,37 @@ def test_list_with_query_parameters(
             }
         ]
     }
+
+
+def test_list_with_parent_id_query_parameter(
+    app: DjangoTestApp,
+    organization: Organization,
+    dataset: Dataset,
+    url_dataset: str,
+    domain: str,
+    valid_token: str,
+):
+    dataset_2 = DatasetFactory(organization=organization)
+    dataset_3 = DatasetFactory(organization=organization)
+    dataset_orphan = DatasetFactory(organization=organization)
+    dataset_other_organization = DatasetFactory(organization=OrganizationFactory())
+
+    # Attach children to the Data Service (saved instances).
+    dataset_2.move(dataset, pos='sorted-child')
+    dataset_3.move(dataset, pos='sorted-child')
+
+    response = app.get(
+        url_dataset,
+        params={"parent_id": dataset.pk},
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    child_dataset_ids = {dataset["_id"] for dataset in response.json["_data"]}
+    assert str(dataset_2.pk) in child_dataset_ids
+    assert str(dataset_3.pk) in child_dataset_ids
+    assert str(dataset_orphan.pk) not in child_dataset_ids
+    assert str(dataset_other_organization.pk) not in child_dataset_ids
 
 
 def test_list_no_datasets_exist(

--- a/tests/uapi/dataset/test_views.py
+++ b/tests/uapi/dataset/test_views.py
@@ -6,23 +6,24 @@ import pytest
 import pytz
 from authlib.jose import RSAKey
 from django.contrib.contenttypes.models import ContentType
-from django.core.files.base import ContentFile
 from django.urls import reverse
 from django_webtest import DjangoTestApp
-from filer.models import File
+from factory.django import FileField
 from rest_framework import status
 from rest_framework.exceptions import ErrorDetail
 from reversion.models import Version
 
+from tests.conftest import _normalize_csv
 from tests.uapi.conftest import _generate_test_token, _build_reverse_uapi_url
 from vitrina import settings
-from vitrina.datasets.factories import DatasetFactory
+from vitrina.cms.factories import FilerFileFactory
+from vitrina.datasets.factories import DatasetFactory, DatasetStructureFactory
 from vitrina.datasets.models import Dataset, DatasetStructure, DCATResourceSubclass
 from vitrina.orgs.factories import OrganizationFactory
 from vitrina.orgs.models import Organization
 from vitrina.structure.factories import MetadataFactory
 from vitrina.structure.models import Metadata
-
+from vitrina.structure.services import create_structure_objects
 
 pytestmark = pytest.mark.django_db
 timezone = pytz.timezone(settings.TIME_ZONE)
@@ -967,25 +968,37 @@ def test_action_get_dataset_structure(
     url_dataset_structure: str,
     valid_token: str,
 ):
-    dataset.current_structure = DatasetStructure.objects.create(
+    structure = DatasetStructureFactory(
         dataset=dataset,
-        file=File.objects.create(
-            original_filename=f"dataset_{dataset.id}_structure.csv",
-            file=ContentFile(dsa, name=f"dataset_{dataset.id}_structure.csv"),
-        ),
-        filename=f"dataset_{dataset.id}_structure.csv",
-        mime_type="text/csv",
-        size=len(dsa),
+        file=FilerFileFactory(
+            file=FileField(filename=f"dataset_{dataset.id}_structure.csv", data=dsa)
+        )
     )
+    dataset.current_structure = structure
     dataset.save()
+    create_structure_objects(structure)
 
     response = app.get(
-        url_dataset_structure, extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+        url_dataset_structure,
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
     )
 
     assert response.status_code == status.HTTP_200_OK
     assert response.headers["Content-Type"] == "text/csv"
-    assert response.content.decode("utf-8") == dsa
+
+    metadata_to_id_map = dict(Metadata.objects.all().values_list("name", "uuid"))
+    expected_csv = f"""id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description
+{metadata_to_id_map["example70"]},example70,,,,,,,,,,,,,,,,,,Title of the Dataset,Description of the Dataset.
+{metadata_to_id_map["users"]},,users,,,,dask/json,,/path,,,,,,,,,,,users,
+{metadata_to_id_map["example70/User"]},,,,User,,,id,users,,,,,4,completed,package,open,,,Pavadinimas,
+{metadata_to_id_map["id"]},,,,,id,integer,,id,,,,,,,,,,,,
+{metadata_to_id_map["full_name"]},,,,,full_name,string,,name,,,,,,,,,,,,
+{metadata_to_id_map["email_address"]},,,,,email_address,string,,email,,,,,,,,,,,,
+{metadata_to_id_map["active"]},,,,,active,boolean,,isActive,,,,,,,,,,,,
+"""
+    actual_rows = _normalize_csv(response.content.decode("utf-8"))
+    expected_rows = _normalize_csv(expected_csv)
+    assert actual_rows == expected_rows
 
 
 def test_action_get_dataset_structure_no_dataset(

--- a/tests/uapi/dataset/test_views.py
+++ b/tests/uapi/dataset/test_views.py
@@ -6,13 +6,15 @@ import pytest
 import pytz
 from authlib.jose import RSAKey
 from django.contrib.contenttypes.models import ContentType
+from django.core.files.base import ContentFile
 from django.urls import reverse
 from django_webtest import DjangoTestApp
+from filer.models import File
 from rest_framework import status
 from rest_framework.exceptions import ErrorDetail
 from reversion.models import Version
 
-from tests.uapi.conftest import _generate_test_token
+from tests.uapi.conftest import _generate_test_token, _build_reverse_uapi_url
 from vitrina import settings
 from vitrina.datasets.factories import DatasetFactory
 from vitrina.datasets.models import Dataset, DatasetStructure, DCATResourceSubclass
@@ -956,6 +958,72 @@ def test_action_upload_dataset_structure_transaction_rollback_on_failure(
         "additionalProperties": None,
     }
 
+
+def test_action_get_dataset_structure(
+    app: DjangoTestApp,
+    organization: Organization,
+    dataset: Dataset,
+    dsa: str,
+    url_dataset_structure: str,
+    valid_token: str,
+):
+    dataset.current_structure = DatasetStructure.objects.create(
+        dataset=dataset,
+        file=File.objects.create(
+            original_filename=f"dataset_{dataset.id}_structure.csv",
+            file=ContentFile(dsa, name=f"dataset_{dataset.id}_structure.csv"),
+        ),
+        filename=f"dataset_{dataset.id}_structure.csv",
+        mime_type="text/csv",
+        size=len(dsa),
+    )
+    dataset.save()
+
+    response = app.get(
+        url_dataset_structure, extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.headers["Content-Type"] == "text/csv"
+    assert response.content.decode("utf-8") == dsa
+
+
+def test_action_get_dataset_structure_no_dataset(
+    app: DjangoTestApp,
+    organization: Organization,
+    url_dataset_structure: str,
+    valid_token: str
+):
+    response = app.get(
+        _build_reverse_uapi_url("uapi-dataset-structure", dataset_id=1_000_000),
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+        expect_errors=True,
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json == {
+        "code": "not_found",
+        "type": "NotFound",
+        "template": "The requested resource was not found.",
+        "message": "No Dataset matches the given query.",
+        "additionalProperties": None,
+    }
+
+
+def test_action_get_dataset_structure_no_dataset_structure(
+    app: DjangoTestApp,
+    organization: Organization,
+    dataset: Dataset,
+    dsa: str,
+    url_dataset_structure: str,
+    valid_token: str,
+):
+    response = app.get(
+        url_dataset_structure, extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"}, expect_errors=True,
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json == {"detail": "Dataset structure not found."}
 
 
 def test_action_update_dataset_structure(

--- a/vitrina/uapi/serializers/serializers.py
+++ b/vitrina/uapi/serializers/serializers.py
@@ -50,6 +50,7 @@ class UAPIDistributionSerializer(BaseObjectMixin, DatasetDistributionSerializer)
 
 class DatasetQueryParameterSerializer(serializers.Serializer):
     name = serializers.CharField(required=False, max_length=255)
+    parent_id = serializers.CharField(required=False, max_length=255)
 
 
 class DistributionQueryParameterSerializer(serializers.Serializer):

--- a/vitrina/uapi/urls.py
+++ b/vitrina/uapi/urls.py
@@ -58,6 +58,7 @@ urlpatterns = [
         DatasetViewSet.as_view(
             {
                 "post": "upload_dataset_structure",
+                "get": "get_dataset_structure",
                 "put": "update_dataset_structure",
             }
         ),

--- a/vitrina/uapi/views/views.py
+++ b/vitrina/uapi/views/views.py
@@ -5,7 +5,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.files.base import ContentFile
 from django.db import transaction
 from django.db.models import QuerySet, Q
-from django.http import HttpResponse
+from django.http import StreamingHttpResponse
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.utils.functional import cached_property
@@ -30,7 +30,7 @@ from vitrina.resources.models import DatasetDistribution
 from vitrina.smart_contracts import AgreementStatuses
 from vitrina.smart_contracts.models import Agreement
 from vitrina.structure.models import Metadata
-from vitrina.structure.services import create_structure_objects
+from vitrina.structure.services import create_structure_objects, export_dataset_structure
 from vitrina.uapi.serializers.uapi_serializers import BaseObjectListSerializer
 from vitrina.uapi.serializers.serializers import (
     UAPIDatasetSerializer,
@@ -223,7 +223,7 @@ class DatasetViewSet(UAPIExceptionHandlerMixin, viewsets.ModelViewSet):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     @action(detail=False, methods=["get"], url_path="dsa")
-    def get_dataset_structure(self, request: Request, *args: Any, **kwargs: Any) -> Response | HttpResponse:
+    def get_dataset_structure(self, request: Request, *args: Any, **kwargs: Any) -> Response | StreamingHttpResponse:
         dataset = get_object_or_404(
             Dataset,
             ~Q(deleted=True),
@@ -237,11 +237,10 @@ class DatasetViewSet(UAPIExceptionHandlerMixin, viewsets.ModelViewSet):
                 status=status.HTTP_404_NOT_FOUND,
             )
 
-        csv_content = ""
-        with dataset.current_structure.file.file.open("r") as file:
-            csv_content = file.read()
-
-        return HttpResponse(csv_content, content_type="text/csv", status=200)
+        stream = export_dataset_structure(dataset)
+        response = StreamingHttpResponse(stream, content_type="text/csv")
+        response["Content-Disposition"] = "attachment; filename=manifest.csv"
+        return response
 
     @transaction.atomic
     @action(detail=False, methods=["put"], url_path="dsa")

--- a/vitrina/uapi/views/views.py
+++ b/vitrina/uapi/views/views.py
@@ -5,6 +5,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.files.base import ContentFile
 from django.db import transaction
 from django.db.models import QuerySet, Q
+from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.utils.functional import cached_property
@@ -220,6 +221,27 @@ class DatasetViewSet(UAPIExceptionHandlerMixin, viewsets.ModelViewSet):
         dataset.save()
 
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+    @action(detail=False, methods=["get"], url_path="dsa")
+    def get_dataset_structure(self, request: Request, *args: Any, **kwargs: Any) -> Response | HttpResponse:
+        dataset = get_object_or_404(
+            Dataset,
+            ~Q(deleted=True),
+            id=self.kwargs["dataset_id"],
+            organization=self.request.organization,
+        )
+
+        if not dataset.current_structure or not dataset.current_structure.file:
+            return Response(
+                {"detail": "Dataset structure not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        csv_content = ""
+        with dataset.current_structure.file.file.open("r") as file:
+            csv_content = file.read()
+
+        return HttpResponse(csv_content, content_type="text/csv", status=200)
 
     @transaction.atomic
     @action(detail=False, methods=["put"], url_path="dsa")

--- a/vitrina/uapi/views/views.py
+++ b/vitrina/uapi/views/views.py
@@ -91,6 +91,9 @@ class DatasetViewSet(UAPIExceptionHandlerMixin, viewsets.ModelViewSet):
             if name := query_parameter_serializer.validated_data.get("name"):
                 queryset = queryset.filter(metadata__name=name)
 
+            if parent_id := query_parameter_serializer.validated_data.get("parent_id"):
+                queryset = queryset.filter(id=parent_id).first().get_children()
+
         return queryset
 
     def get_serializer_class(self) -> Serializer:


### PR DESCRIPTION
### Context

Some additional endpoints + adjustments are required for synchronization. Separated by commits will be different endpoints, adjustments.

### Changes

May review by commits:

- Add query parameter to retrieve all child datasets 
   - [4af9e23](https://github.com/atviriduomenys/katalogas/pull/1951/commits/4af9e23319e57bbd63d0ee58d068f40c194c5413)
- Add endpoint for retrieving DSA (in csv) 
   - [2de3733](https://github.com/atviriduomenys/katalogas/pull/1951/commits/2de37332336719365d3ac72aa1b33ab90201e438)
- Adjust DSA retrieve endpoint to follow the logic of DSA export that is already implemented
   - [f06daf8](https://github.com/atviriduomenys/katalogas/pull/1951/commits/f06daf8507bab5a235613733d4c42d997f4fac81)