### PR TITLE
Fix Dockerfile location in docker compose yaml

### DIFF
--- a/docker-compose.template.yml
+++ b/docker-compose.template.yml
@@ -6,7 +6,7 @@ services:
   katalogas-${BRANCH}:
     build:
       context: .
-      dockerfile: Dockerfile
+      dockerfile: docker/Dockerfile
     command:
       - ./auto-entrypoint.sh
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       - ".:/app"
     build:
       context: .
-      dockerfile: Dockerfile
+      dockerfile: docker/Dockerfile
     command:
       - ./entrypoint.sh
     environment:


### PR DESCRIPTION
Fix docker compose config:
```
docker compose up vitrina
[+] Building 0.2s (2/2) FINISHED
 => [internal] load local bake definitions                                                                                                                                                                                                                                                                                              0.0s
 => => reading from stdin 547B                                                                                                                                                                                                                                                                                                          0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                                                                    0.0s
 => => transferring dockerfile: 2B                                                                                                                                                                                                                                                                                                      0.0s
failed to solve: failed to read dockerfile: open Dockerfile: no such file or directory

View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/j05wd6z733onormo9hyl91mtg
```