### PR TITLE
1941: changing model_structure to show to property eli field

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,9 @@ Change default status in `RequestCommentForm`.
 https://github.com/atviriduomenys/katalogas/issues/1904
 Export Dataset structure to OpenAPI
 
+https://github.com/atviriduomenys/katalogas/issues/1941
+Fix wrong `eli` value in model_structure on properties
+
 v 1.3 (2025-09-30)
 ==================
 

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -3489,3 +3489,47 @@ def test_manifest_export_openapi(app: DjangoTestApp):
         f"Paths mismatch. Missing: {expected_paths - actual_paths}, "
         f"Extra: {actual_paths - expected_paths}"
     )
+
+
+def test_props_metadata_rendering(app: DjangoTestApp) -> None:
+    model = ModelFactory()
+    dataset = model.dataset
+
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(model),
+        object_id=model.pk,
+        dataset=dataset,
+        name="test/dataset/TestModel",
+    )
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(dataset),
+        object_id=dataset.pk,
+        dataset=dataset,
+        name="test/dataset",
+    )
+
+    prop_1 = PropertyFactory(model=model)
+    prop_2 = PropertyFactory(model=model)
+
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(prop_1),
+        object_id=prop_1.pk,
+        dataset=dataset,
+        name="prop_1",
+        type="string",
+        eli="https://example.com/prop_1",
+    )
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(prop_2),
+        object_id=prop_2.pk,
+        dataset=dataset,
+        name="prop_2",
+        type="integer",
+        eli="https://example.com/prop_2",
+    )
+
+    response = app.get(reverse("model-structure", kwargs={"pk": dataset.pk, "model": model.name}))
+
+    assert response.status_code == 200
+    assert 'href="https://example.com/prop_1"' in response.content.decode()
+    assert 'href="https://example.com/prop_2"' in response.content.decode()

--- a/vitrina/structure/templates/vitrina/structure/model_structure.html
+++ b/vitrina/structure/templates/vitrina/structure/model_structure.html
@@ -270,8 +270,8 @@
                             {% endif %}
                         </div>
                         <div class="column is-1">
-                            {% if metadata.eli %}
-                            <a href="{{ metadata.eli }}"
+                            {% if prop_metadata.eli %}
+                            <a href="{{ prop_metadata.eli }}"
                                class="tag is-white has-tooltip"
                                data-tooltip="{% translate 'ELI nuoroda' %}"
                                target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
Summary:
- Fixing bug in model_structure html, to show correct eli link near property.

Ticket: https://github.com/atviriduomenys/katalogas/issues/1941