### PR TITLE
Ft/2028 fake viisp

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,10 @@ https://github.com/atviriduomenys/katalogas/issues/2011
 - Added seperate docker container for celery;
 - Added celery task to run `spinta check` command and save the manifest status to `ManifestValidationEntry`
 
+https://github.com/atviriduomenys/katalogas/issues/2028
+- Added a fake VIISP login feature to simulate authentication via VIISP.
+- The login functionality is available only in test mode and will be hidden in production.
+
 
 v 1.5 (2025-10-27)
 ==================

--- a/tests/viisp/test_forms.py
+++ b/tests/viisp/test_forms.py
@@ -1,0 +1,18 @@
+import pytest
+from vitrina.viisp.forms import FakeViispForm
+from vitrina.users.factories import UserFactory
+
+
+@pytest.mark.django_db
+def test_fake_viisp_form_valid_email():
+    user = UserFactory(email="valid@test.com")
+    form = FakeViispForm(data={"email": user.email})
+    assert form.is_valid()
+
+
+@pytest.mark.django_db
+def test_fake_viisp_form_invalid_email():
+    # Email not in DB
+    form = FakeViispForm(data={"email": "not.existing@test.com"})
+    assert not form.is_valid()
+    assert "Naudotojas su tokiu el. paštu nerastas." in form.errors["email"][0]

--- a/tests/viisp/test_forms.py
+++ b/tests/viisp/test_forms.py
@@ -15,4 +15,4 @@ def test_fake_viisp_form_invalid_email():
     # Email not in DB
     form = FakeViispForm(data={"email": "not.existing@test.com"})
     assert not form.is_valid()
-    assert "Naudotojas su tokiu el. paštu nerastas." in form.errors["email"][0]
+    assert "Naudotojas su tokiu el. paštu neegzistuoja." in form.errors["email"][0]

--- a/tests/viisp/test_views.py
+++ b/tests/viisp/test_views.py
@@ -1,18 +1,11 @@
-from unittest.mock import patch
-
 import pytest
-from django.http import Http404
 from django.urls import reverse
 from django_webtest import DjangoTestApp
 from django.contrib.auth.hashers import make_password
 
 from vitrina.users.factories import UserFactory
 from vitrina.orgs.factories import OrganizationFactory
-from allauth.socialaccount.models import SocialAccount
 from webtest import Upload
-from django.test import override_settings, Client, RequestFactory
-
-from vitrina.viisp.views import FakeVIISPCompleteLoginView
 
 
 @pytest.mark.haystack
@@ -32,7 +25,6 @@ def test_logged_in_not_unverified_user_accesses_data_provider_form(app: DjangoTe
 @pytest.mark.haystack
 def test_logged_in_verified_user_accesses_data_provider_form(app: DjangoTestApp):
     user = UserFactory(email="test@test.lt", password="123")
-    temp_user_account = SocialAccount.objects.create(user=user)
     app.set_user(user)
     resp = app.get(reverse("partner-register"))
     assert resp.html.find(id="partner-register-form")
@@ -41,8 +33,6 @@ def test_logged_in_verified_user_accesses_data_provider_form(app: DjangoTestApp)
 @pytest.mark.haystack
 def test_logged_in_coordinator_user_accesses_data_provider_form(app: DjangoTestApp):
     user = UserFactory(email="test@test.lt", password="123")
-    extra_data = {"company_code": "1234-5678", "company_name": "test_company"}
-    temp_user_account = SocialAccount.objects.create(user=user, extra_data=extra_data)
     app.set_user(user)
     resp = app.get(reverse("partner-register"))
     assert resp.html.find(id="partner-register-form")
@@ -51,9 +41,7 @@ def test_logged_in_coordinator_user_accesses_data_provider_form(app: DjangoTestA
 @pytest.mark.haystack
 def test_form_submit_with_correct_data(app: DjangoTestApp):
     user = UserFactory(email="test@testesttesttest.lt", password=make_password("123"))
-    extra_data = {"phone_number": "+37000000000", "email": "test@testesttesttest.lt"}
     org = OrganizationFactory()
-    temp_user_account = SocialAccount.objects.create(user=user, extra_data=extra_data)
     app.set_user(user)
     resp = app.get(reverse("partner-register"))
     form = resp.forms["partner-register-form"]
@@ -69,11 +57,11 @@ def test_form_submit_with_correct_data(app: DjangoTestApp):
 def test_fake_viisp_logs_in_existing_user(app: DjangoTestApp):
     user = UserFactory(email="existing@test.com", is_viisp_login=False)
     url = reverse("fake-viisp-complete-login")
-    data = {"email": user.email, "lt_company_code": "", "proxy_type": ""}
+    data = {"email": user.email, "lt_company_code": 12345678, "proxy_type": ""}
     resp = app.post(url, params=data, expect_errors=True)
 
     user.refresh_from_db()
     assert user.is_viisp_login is True
+    assert user.viisp_company_code == 12345678
     assert resp.status_code == 302
     assert resp.url == reverse("home")
-

--- a/tests/viisp/test_views.py
+++ b/tests/viisp/test_views.py
@@ -1,65 +1,79 @@
+from unittest.mock import patch
+
 import pytest
+from django.http import Http404
 from django.urls import reverse
 from django_webtest import DjangoTestApp
 from django.contrib.auth.hashers import make_password
+
 from vitrina.users.factories import UserFactory
 from vitrina.orgs.factories import OrganizationFactory
-from vitrina.orgs.models import Organization
 from allauth.socialaccount.models import SocialAccount
 from webtest import Upload
+from django.test import override_settings, Client, RequestFactory
+
+from vitrina.viisp.views import FakeVIISPCompleteLoginView
 
 
 @pytest.mark.haystack
 def test_anonymous_user_accesses_data_provider_form(app: DjangoTestApp):
-    resp = app.get(reverse('partner-register'))
-    assert resp.url == '/login/?next=/accounts/viisp/partner-register/'
+    resp = app.get(reverse("partner-register"))
+    assert resp.url == "/login/?next=/accounts/viisp/partner-register/"
+
 
 @pytest.mark.haystack
 def test_logged_in_not_unverified_user_accesses_data_provider_form(app: DjangoTestApp):
     user = UserFactory()
     app.set_user(user)
-    resp = app.get(reverse('partner-register'))
-    assert resp.url == '/accounts/viisp/login'
+    resp = app.get(reverse("partner-register"))
+    assert resp.url == "/accounts/viisp/login"
+
 
 @pytest.mark.haystack
 def test_logged_in_verified_user_accesses_data_provider_form(app: DjangoTestApp):
     user = UserFactory(email="test@test.lt", password="123")
     temp_user_account = SocialAccount.objects.create(user=user)
     app.set_user(user)
-    resp = app.get(reverse('partner-register'))
-    assert resp.html.find(id='partner-register-form')
+    resp = app.get(reverse("partner-register"))
+    assert resp.html.find(id="partner-register-form")
+
 
 @pytest.mark.haystack
 def test_logged_in_coordinator_user_accesses_data_provider_form(app: DjangoTestApp):
     user = UserFactory(email="test@test.lt", password="123")
-    extra_data = {
-        'company_code': '1234-5678',
-        'company_name': 'test_company'
-    }
+    extra_data = {"company_code": "1234-5678", "company_name": "test_company"}
     temp_user_account = SocialAccount.objects.create(user=user, extra_data=extra_data)
     app.set_user(user)
-    resp = app.get(reverse('partner-register'))
-    assert resp.html.find(id='partner-register-form')
+    resp = app.get(reverse("partner-register"))
+    assert resp.html.find(id="partner-register-form")
 
 
 @pytest.mark.haystack
 def test_form_submit_with_correct_data(app: DjangoTestApp):
-    user = UserFactory(
-        email="test@testesttesttest.lt",
-        password=make_password("123")
-    )
-    extra_data = {
-        'phone_number': '+37000000000',
-        'email': "test@testesttesttest.lt"
-    }
+    user = UserFactory(email="test@testesttesttest.lt", password=make_password("123"))
+    extra_data = {"phone_number": "+37000000000", "email": "test@testesttesttest.lt"}
     org = OrganizationFactory()
     temp_user_account = SocialAccount.objects.create(user=user, extra_data=extra_data)
     app.set_user(user)
-    resp = app.get(reverse('partner-register'))
-    form = resp.forms['partner-register-form']
+    resp = app.get(reverse("partner-register"))
+    form = resp.forms["partner-register-form"]
 
-    form['organization'].force_value(org.pk)
-    form['request_form'] = Upload('test.doc', b"Test")
-    form['coordinator_phone_number'] = '+37000000000'
+    form["organization"].force_value(org.pk)
+    form["request_form"] = Upload("test.doc", b"Test")
+    form["coordinator_phone_number"] = "+37000000000"
     resp = form.submit()
-    assert resp.url == '/partner/register-complete/'
+    assert resp.url == "/partner/register-complete/"
+
+
+@pytest.mark.django_db
+def test_fake_viisp_logs_in_existing_user(app: DjangoTestApp):
+    user = UserFactory(email="existing@test.com", is_viisp_login=False)
+    url = reverse("fake-viisp-complete-login")
+    data = {"email": user.email, "lt_company_code": "", "proxy_type": ""}
+    resp = app.post(url, params=data, expect_errors=True)
+
+    user.refresh_from_db()
+    assert user.is_viisp_login is True
+    assert resp.status_code == 302
+    assert resp.url == reverse("home")
+

--- a/tests/viisp/test_views.py
+++ b/tests/viisp/test_views.py
@@ -5,6 +5,7 @@ from django.contrib.auth.hashers import make_password
 
 from vitrina.users.factories import UserFactory
 from vitrina.orgs.factories import OrganizationFactory
+from allauth.socialaccount.models import SocialAccount
 from webtest import Upload
 
 
@@ -25,6 +26,7 @@ def test_logged_in_not_unverified_user_accesses_data_provider_form(app: DjangoTe
 @pytest.mark.haystack
 def test_logged_in_verified_user_accesses_data_provider_form(app: DjangoTestApp):
     user = UserFactory(email="test@test.lt", password="123")
+    SocialAccount.objects.create(user=user)
     app.set_user(user)
     resp = app.get(reverse("partner-register"))
     assert resp.html.find(id="partner-register-form")
@@ -33,6 +35,7 @@ def test_logged_in_verified_user_accesses_data_provider_form(app: DjangoTestApp)
 @pytest.mark.haystack
 def test_logged_in_coordinator_user_accesses_data_provider_form(app: DjangoTestApp):
     user = UserFactory(email="test@test.lt", password="123")
+    SocialAccount.objects.create(user=user, extra_data={"company_code": "1234-5678", "company_name": "test_company"})
     app.set_user(user)
     resp = app.get(reverse("partner-register"))
     assert resp.html.find(id="partner-register-form")
@@ -42,6 +45,9 @@ def test_logged_in_coordinator_user_accesses_data_provider_form(app: DjangoTestA
 def test_form_submit_with_correct_data(app: DjangoTestApp):
     user = UserFactory(email="test@testesttesttest.lt", password=make_password("123"))
     org = OrganizationFactory()
+    SocialAccount.objects.create(
+        user=user, extra_data={"phone_number": "+37000000000", "email": "test@testesttesttest.lt"}
+    )
     app.set_user(user)
     resp = app.get(reverse("partner-register"))
     form = resp.forms["partner-register-form"]
@@ -62,6 +68,6 @@ def test_fake_viisp_logs_in_existing_user(app: DjangoTestApp):
 
     user.refresh_from_db()
     assert user.is_viisp_login is True
-    assert user.viisp_company_code == 12345678
+    assert user.viisp_company_code == "12345678"
     assert resp.status_code == 302
     assert resp.url == reverse("home")

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -5632,6 +5632,13 @@ msgstr ""
 "The password is too weak. Try using more characters, uppercase letters, "
 "digits, and special characters."
 
+
+msgid "JA atstovavimo tipas"
+msgstr "Type of representation of a legal entity"
+
+msgid "Naudotojas su tokiu el. paštu neegzistuoja."
+msgstr "User with this e-mail does not exist."
+
 msgid "key_content"
 msgstr "key_content"
 
@@ -5668,6 +5675,9 @@ msgid ""
 msgstr ""
 "A confirmation has been sent to your e-mail address. Click a link in the e-"
 "mail."
+
+msgid "Testinis VIISP Prisijungimas"
+msgstr "Test VIISP Login"
 
 msgid ""
 "Viisp autentifikacija pavyko, tačiau el.paštas, grįžtantis iš viisp "

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -5632,6 +5632,8 @@ msgstr ""
 "The password is too weak. Try using more characters, uppercase letters, "
 "digits, and special characters."
 
+msgid "Įveskite Lietuvoje registruotos įmonės kodą."
+msgstr "Enter the code of a company registered in Lithuania."
 
 msgid "JA atstovavimo tipas"
 msgstr "Type of representation of a legal entity"

--- a/vitrina/users/templates/vitrina/users/login.html
+++ b/vitrina/users/templates/vitrina/users/login.html
@@ -37,6 +37,13 @@
                 <a id="viisp-login" href="{% url 'viisp_login' %}" class="button is-small is-primary">{% translate "Prisijungti su VIISP" %}</a>
             </p>
         </div>
+        {% if debug %}
+        <div class="content is-small">
+          <p>
+            <a id="fake-viisp-complete-login" href="{% url 'fake-viisp-complete-login' %}" class="button is-small is-primary">{% translate "Testinis Prisijungimas su VIISP" %}</a>
+          </p>
+        </div>
+        {% endif %}
     </div>
     <div class="column is-half">
         <div class="content">

--- a/vitrina/users/templates/vitrina/users/login.html
+++ b/vitrina/users/templates/vitrina/users/login.html
@@ -40,7 +40,7 @@
         {% if debug %}
         <div class="content is-small">
           <p>
-            <a id="fake-viisp-complete-login" href="{% url 'fake-viisp-complete-login' %}" class="button is-small is-primary">{% translate "Testinis Prisijungimas su VIISP" %}</a>
+            <a id="fake-viisp-complete-login" href="{% url 'fake-viisp-complete-login' %}" class="button is-small is-primary">{% translate "Testinis VIISP Prisijungimas" %}</a>
           </p>
         </div>
         {% endif %}

--- a/vitrina/users/views.py
+++ b/vitrina/users/views.py
@@ -70,6 +70,7 @@ class LoginView(BaseLoginView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["current_title"] = _("Prisijungimas")
+        context["debug"] = settings.DEBUG
         return context
 
 

--- a/vitrina/viisp/forms.py
+++ b/vitrina/viisp/forms.py
@@ -1,0 +1,37 @@
+from django import forms
+from crispy_forms.helper import FormHelper
+from crispy_forms.layout import Layout, Field, Submit
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
+
+from vitrina.users.models import User
+
+PROXY_TYPE_CHOICES = [
+
+    ("generic", "Generic"),
+    ("service", "Service"),
+    ("external", "External"),
+    ("legal", "Legal"),
+]
+
+class FakeViispForm(forms.Form):
+    email = forms.EmailField(label="El. paštas", required=True)
+    lt_company_code = forms.CharField(label="Įmonės kodas (LT)", required=False)
+    proxy_type = forms.ChoiceField(label="JA atstovavimo tipas", choices=PROXY_TYPE_CHOICES, required=False)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper = FormHelper()
+        self.helper.form_id = "fake-viisp-form"
+        self.helper.layout = Layout(
+            Field("email", placeholder="El. paštas"),
+            Field("lt_company_code", placeholder="Įmonės kodas (LT)"),
+            Field("proxy_type"),
+            Submit("submit", "Prisijungti", css_class="button is-primary"),
+        )
+
+    def clean_email(self):
+        email = self.cleaned_data.get("email")
+        if not User.objects.filter(email=email).exists():
+            raise ValidationError(_("Naudotojas su tokiu el. paštu nerastas."))
+        return email

--- a/vitrina/viisp/forms.py
+++ b/vitrina/viisp/forms.py
@@ -7,12 +7,12 @@ from django.utils.translation import gettext_lazy as _
 from vitrina.users.models import User
 
 PROXY_TYPE_CHOICES = [
-
     ("generic", "Generic"),
     ("service", "Service"),
     ("external", "External"),
     ("legal", "Legal"),
 ]
+
 
 class FakeViispForm(forms.Form):
     email = forms.EmailField(label="El. paštas", required=True)

--- a/vitrina/viisp/forms.py
+++ b/vitrina/viisp/forms.py
@@ -16,8 +16,11 @@ PROXY_TYPE_CHOICES = [
 
 class FakeViispForm(forms.Form):
     email = forms.EmailField(label=_("El. paštas"), required=True)
-    lt_company_code = forms.CharField(
-        label=_("Įmonės kodas"), help_text=_("Įveskite Lietuvoje registruotos įmonės kodą."), required=False
+    lt_company_code = forms.IntegerField(
+        label=_("Įmonės kodas"),
+        help_text=_("Įveskite Lietuvoje registruotos įmonės kodą."),
+        required=False,
+        min_value=1,
     )
     proxy_type = forms.ChoiceField(label=_("JA atstovavimo tipas"), choices=PROXY_TYPE_CHOICES, required=False)
 

--- a/vitrina/viisp/forms.py
+++ b/vitrina/viisp/forms.py
@@ -15,23 +15,23 @@ PROXY_TYPE_CHOICES = [
 
 
 class FakeViispForm(forms.Form):
-    email = forms.EmailField(label="El. paštas", required=True)
-    lt_company_code = forms.CharField(label="Įmonės kodas (LT)", required=False)
-    proxy_type = forms.ChoiceField(label="JA atstovavimo tipas", choices=PROXY_TYPE_CHOICES, required=False)
+    email = forms.EmailField(label=_("El. paštas"), required=True)
+    lt_company_code = forms.CharField(label=_("Įmonės kodas"), required=False)
+    proxy_type = forms.ChoiceField(label=_("JA atstovavimo tipas"), choices=PROXY_TYPE_CHOICES, required=False)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.helper = FormHelper()
         self.helper.form_id = "fake-viisp-form"
         self.helper.layout = Layout(
-            Field("email", placeholder="El. paštas"),
-            Field("lt_company_code", placeholder="Įmonės kodas (LT)"),
+            Field("email"),
+            Field("lt_company_code"),
             Field("proxy_type"),
-            Submit("submit", "Prisijungti", css_class="button is-primary"),
+            Submit("submit", _("Prisijungti"), css_class="button is-primary"),
         )
 
     def clean_email(self):
         email = self.cleaned_data.get("email")
         if not User.objects.filter(email=email).exists():
-            raise ValidationError(_("Naudotojas su tokiu el. paštu nerastas."))
+            raise ValidationError(_("Naudotojas su tokiu el. paštu neegzistuoja."))
         return email

--- a/vitrina/viisp/forms.py
+++ b/vitrina/viisp/forms.py
@@ -16,7 +16,9 @@ PROXY_TYPE_CHOICES = [
 
 class FakeViispForm(forms.Form):
     email = forms.EmailField(label=_("El. paštas"), required=True)
-    lt_company_code = forms.CharField(label=_("Įmonės kodas"), required=False)
+    lt_company_code = forms.CharField(
+        label=_("Įmonės kodas"), help_text=_("Įveskite Lietuvoje registruotos įmonės kodą."), required=False
+    )
     proxy_type = forms.ChoiceField(label=_("JA atstovavimo tipas"), choices=PROXY_TYPE_CHOICES, required=False)
 
     def __init__(self, *args, **kwargs):
@@ -30,7 +32,7 @@ class FakeViispForm(forms.Form):
             Submit("submit", _("Prisijungti"), css_class="button is-primary"),
         )
 
-    def clean_email(self):
+    def clean_email(self) -> str:
         email = self.cleaned_data.get("email")
         if not User.objects.filter(email=email).exists():
             raise ValidationError(_("Naudotojas su tokiu el. paštu neegzistuoja."))

--- a/vitrina/viisp/templates/vitrina/viisp/fake_viisp_form.html
+++ b/vitrina/viisp/templates/vitrina/viisp/fake_viisp_form.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+{% load i18n %}
+{% load static %}
+
+{% block current_title %}{% translate "Testinis VIISP Prisijungimas" %}{% endblock %}
+
+{% block content %}
+<div class="columns">
+    <div class="column is-one-quarter"></div>
+    <div class="column is-half">
+        {% include "component/form.html" with form=form %}
+        <br/>
+    </div>
+    <div class="column is-one-quarter"></div>
+</div>
+{% endblock %}

--- a/vitrina/viisp/urls.py
+++ b/vitrina/viisp/urls.py
@@ -8,7 +8,8 @@ from vitrina.viisp.views import (
     LoginFirstView,
     VIISPAccountMergeView,
     ConfirmEmailView,
-    AccoutnInactiveView, FakeVIISPCompleteLoginView,
+    AccoutnInactiveView,
+    FakeVIISPCompleteLoginView,
 )
 from vitrina.orgs.views import PartnerRegisterView
 from allauth.socialaccount.views import SignupView, ConnectionsView
@@ -56,8 +57,10 @@ urlpatterns = [
 ]
 
 if settings.DEBUG:
-    urlpatterns.append(path(
-        "fake-viisp/complete-login/",
-        FakeVIISPCompleteLoginView.as_view(),
-        name="fake-viisp-complete-login",
-    ),)
+    urlpatterns.append(
+        path(
+            "fake-viisp/complete-login/",
+            FakeVIISPCompleteLoginView.as_view(),
+            name="fake-viisp-complete-login",
+        ),
+    )

--- a/vitrina/viisp/urls.py
+++ b/vitrina/viisp/urls.py
@@ -1,4 +1,6 @@
 from django.urls import path
+
+from vitrina import settings
 from vitrina.viisp.views import (
     VIISPLoginView,
     VIISPCompleteLoginView,
@@ -6,7 +8,7 @@ from vitrina.viisp.views import (
     LoginFirstView,
     VIISPAccountMergeView,
     ConfirmEmailView,
-    AccoutnInactiveView,
+    AccoutnInactiveView, FakeVIISPCompleteLoginView,
 )
 from vitrina.orgs.views import PartnerRegisterView
 from allauth.socialaccount.views import SignupView, ConnectionsView
@@ -52,3 +54,10 @@ urlpatterns = [
         name="account_inactive",
     ),
 ]
+
+if settings.DEBUG:
+    urlpatterns.append(path(
+        "fake-viisp/complete-login/",
+        FakeVIISPCompleteLoginView.as_view(),
+        name="fake-viisp-complete-login",
+    ),)

--- a/vitrina/viisp/views.py
+++ b/vitrina/viisp/views.py
@@ -165,10 +165,10 @@ class FakeVIISPCompleteLoginView(View):
             company_code: int = form.cleaned_data.get("lt_company_code")
             user, _ = User.objects.get_or_create(email=email)
             user.is_viisp_login = True
-if company_code:
-    user.viisp_company_code = company_code
-else:
-    user.viisp_company_code = None
+            if company_code:
+                user.viisp_company_code = company_code
+            else:
+                user.viisp_company_code = None
             user.save()
             django_login(request, user, backend="django.contrib.auth.backends.ModelBackend")
             return redirect("home")

--- a/vitrina/viisp/views.py
+++ b/vitrina/viisp/views.py
@@ -149,6 +149,8 @@ class VIISPCompleteLoginView(View):
 
 class FakeVIISPCompleteLoginView(View):
     """Fake VIISP login for debug/testing purposes only."""
+    form_class = FakeViispForm
+    cleaned_data = None
 
     def get(self, request):
         if not settings.DEBUG:
@@ -159,16 +161,19 @@ class FakeVIISPCompleteLoginView(View):
     def post(self, request):
         if not settings.DEBUG:
             return redirect("home")
-        form = FakeViispForm(request.POST)
-        if not form.is_valid():
-            return render(request, "vitrina/viisp/fake_viisp_form.html", {"form": form})
+        form = self.form_class(request.POST)
 
-        email = form.cleaned_data["email"]
-        user, _ = User.objects.get_or_create(email=email)
-        user.is_viisp_login = True
-        user.save()
-        django_login(request, user, backend="django.contrib.auth.backends.ModelBackend")
-        return redirect("home")
+        if form.is_valid():
+            email = form.cleaned_data["email"]
+            user, _ = User.objects.get_or_create(email=email)
+            user.is_viisp_login = True
+            user.save()
+            django_login(request, user, backend="django.contrib.auth.backends.ModelBackend")
+            return redirect("home")
+
+        return render(request, "vitrina/viisp/fake_viisp_form.html", {
+            "form": form,
+        })
 
 
 def _confirm_viisp_email(

--- a/vitrina/viisp/views.py
+++ b/vitrina/viisp/views.py
@@ -165,8 +165,10 @@ class FakeVIISPCompleteLoginView(View):
             company_code: int = form.cleaned_data.get("lt_company_code")
             user, _ = User.objects.get_or_create(email=email)
             user.is_viisp_login = True
-            if company_code:
-                user.viisp_company_code = company_code
+if company_code:
+    user.viisp_company_code = company_code
+else:
+    user.viisp_company_code = None
             user.save()
             django_login(request, user, backend="django.contrib.auth.backends.ModelBackend")
             return redirect("home")

--- a/vitrina/viisp/views.py
+++ b/vitrina/viisp/views.py
@@ -149,6 +149,7 @@ class VIISPCompleteLoginView(View):
 
 class FakeVIISPCompleteLoginView(View):
     """Fake VIISP login for debug/testing purposes only."""
+
     form_class = FakeViispForm
     cleaned_data = None
 
@@ -171,9 +172,13 @@ class FakeVIISPCompleteLoginView(View):
             django_login(request, user, backend="django.contrib.auth.backends.ModelBackend")
             return redirect("home")
 
-        return render(request, "vitrina/viisp/fake_viisp_form.html", {
-            "form": form,
-        })
+        return render(
+            request,
+            "vitrina/viisp/fake_viisp_form.html",
+            {
+                "form": form,
+            },
+        )
 
 
 def _confirm_viisp_email(

--- a/vitrina/viisp/views.py
+++ b/vitrina/viisp/views.py
@@ -1,3 +1,4 @@
+from django.http import HttpRequest, HttpResponse
 from django.views import View
 from django.views.generic import TemplateView
 from django.urls import reverse
@@ -10,7 +11,6 @@ from allauth.socialaccount.providers.oauth2.views import (
 )
 from allauth.socialaccount.helpers import complete_social_login
 
-from vitrina import settings
 from vitrina.orgs.models import Representative
 from vitrina.viisp.forms import FakeViispForm
 from vitrina.viisp.models import ViispKey, ViispTokenKey
@@ -153,19 +153,15 @@ class FakeVIISPCompleteLoginView(View):
     form_class = FakeViispForm
     cleaned_data = None
 
-    def get(self, request):
-        if not settings.DEBUG:
-            return redirect("home")
+    def get(self, request: HttpRequest) -> HttpResponse:
         form = FakeViispForm()
         return render(request, "vitrina/viisp/fake_viisp_form.html", {"form": form})
 
-    def post(self, request):
-        if not settings.DEBUG:
-            return redirect("home")
-        form = self.form_class(request.POST)
+    def post(self, request: HttpRequest) -> HttpResponse:
+        form: FakeViispForm = self.form_class(request.POST)
 
         if form.is_valid():
-            email = form.cleaned_data["email"]
+            email: str = form.cleaned_data["email"]
             user, _ = User.objects.get_or_create(email=email)
             user.is_viisp_login = True
             user.save()
@@ -175,9 +171,7 @@ class FakeVIISPCompleteLoginView(View):
         return render(
             request,
             "vitrina/viisp/fake_viisp_form.html",
-            {
-                "form": form,
-            },
+            {"form": form},
         )
 
 

--- a/vitrina/viisp/views.py
+++ b/vitrina/viisp/views.py
@@ -2,6 +2,7 @@ from django.views import View
 from django.views.generic import TemplateView
 from django.urls import reverse
 from django.shortcuts import render, redirect
+from django.contrib.auth import login as django_login
 from allauth.socialaccount import providers
 from allauth.socialaccount.providers.oauth2.views import (
     OAuth2LoginView,
@@ -9,7 +10,9 @@ from allauth.socialaccount.providers.oauth2.views import (
 )
 from allauth.socialaccount.helpers import complete_social_login
 
+from vitrina import settings
 from vitrina.orgs.models import Representative
+from vitrina.viisp.forms import FakeViispForm
 from vitrina.viisp.models import ViispKey, ViispTokenKey
 from vitrina.viisp.adapter import VIISPOAuth2Adapter
 from vitrina.viisp.provider import VIISPProvider
@@ -142,6 +145,30 @@ class VIISPCompleteLoginView(View):
             login.user.save()
 
         return response
+
+
+class FakeVIISPCompleteLoginView(View):
+    """Fake VIISP login for debug/testing purposes only."""
+
+    def get(self, request):
+        if not settings.DEBUG:
+            return redirect("home")
+        form = FakeViispForm()
+        return render(request, "vitrina/viisp/fake_viisp_form.html", {"form": form})
+
+    def post(self, request):
+        if not settings.DEBUG:
+            return redirect("home")
+        form = FakeViispForm(request.POST)
+        if not form.is_valid():
+            return render(request, "vitrina/viisp/fake_viisp_form.html", {"form": form})
+
+        email = form.cleaned_data["email"]
+        user, _ = User.objects.get_or_create(email=email)
+        user.is_viisp_login = True
+        user.save()
+        django_login(request, user, backend="django.contrib.auth.backends.ModelBackend")
+        return redirect("home")
 
 
 def _confirm_viisp_email(

--- a/vitrina/viisp/views.py
+++ b/vitrina/viisp/views.py
@@ -162,8 +162,11 @@ class FakeVIISPCompleteLoginView(View):
 
         if form.is_valid():
             email: str = form.cleaned_data["email"]
+            company_code: int = form.cleaned_data.get("lt_company_code")
             user, _ = User.objects.get_or_create(email=email)
             user.is_viisp_login = True
+            if company_code:
+                user.viisp_company_code = company_code
             user.save()
             django_login(request, user, backend="django.contrib.auth.backends.ModelBackend")
             return redirect("home")


### PR DESCRIPTION
Summary:

- Added button `Testinis prisijungimas su VIISP` to let developers/testers to login with their emails, and get the viisp_login flag = True
- Added the form, so the developer can put existing email, proxy_type, and company_code
- Added checks to not let these view and form be available on production.

Ticket: https://github.com/atviriduomenys/katalogas/issues/2028