### PR TITLE
[Bugfix] Bugfix on project form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ v 1.7 (unreleased)
 v 1.6 (2025-11-06)
 ==================
 
+New features:
+
 https://github.com/atviriduomenys/katalogas/pull/2050
 - Made the status field of structure versionable.
 - Added automatic handling of status values and hid them from the user.
@@ -28,6 +30,11 @@ https://github.com/atviriduomenys/katalogas/issues/2011
 https://github.com/atviriduomenys/katalogas/issues/2028
 - Added a fake VIISP login feature to simulate authentication via VIISP.
 - The login functionality is available only in test mode and will be hidden in production.
+
+Bugfixes:
+
+<no ticket>
+- Fix form layout, do not add a field that should be removed from the form itself on specific conditions.
 
 
 v 1.5 (2025-10-27)

--- a/tests/projects/test_views.py
+++ b/tests/projects/test_views.py
@@ -1,6 +1,5 @@
 import io
 import uuid
-from unittest.mock import patch, Mock
 from urllib.parse import parse_qs
 
 import pytest
@@ -8,9 +7,7 @@ import requests_mock
 from PIL import Image
 from django.urls import reverse
 from django_webtest import DjangoTestApp
-from pyasn1.debug import scope
 from reversion.models import Version
-from shapely.speedups import available
 from webtest import Upload
 
 from vitrina.datasets.factories import DatasetFactory

--- a/vitrina/projects/forms.py
+++ b/vitrina/projects/forms.py
@@ -54,11 +54,14 @@ class ProjectForm(ModelForm):
     def __init__(self, *args, **kwargs):
         self.user: User = kwargs.pop("user")
         super().__init__(*args, **kwargs)
-        project_instance = self.instance if self.instance and self.instance.pk else None
+
+        project_instance = getattr(self.instance, "pk", None)
         button = _("Redaguoti") if project_instance else _("Sukurti")
+
         self.helper = FormHelper()
         self.helper.attrs["novalidate"] = ""
         self.helper.form_id = "project-form"
+
         if (
             not project_instance
             and (organization := self.user.viisp_organization)
@@ -71,13 +74,18 @@ class ProjectForm(ModelForm):
         else:
             self.fields.pop("organization", None)
 
-        self.helper.layout = Layout(
+        layout_fields = [
             Field("is_public"),
             Field("title", placeholder=_("Pavadinimas")),
             Field("description", placeholder=_("Aprašymas")),
-            Field("organization"),
             Field("url", placeholder=_("Nuoroda į panaudojimo atvejį")),
             Field("image"),
+        ]
+        if "organization" in self.fields:
+            layout_fields.insert(3, Field("organization"))
+
+        self.helper.layout = Layout(
+            *layout_fields,
             Submit("submit", button, css_class="button is-primary"),
         )
 


### PR DESCRIPTION
### Problem:

On form load for projects:
- http://localhost:8001/projects/add/

An exception is caught and handled:

<details>

#### Trace:

```python
/Library/Caches/pypoetry/virtualenvs/vitrina-iOmyzedb-py3.12/lib/python3.12/site-packages/cms/cms_toolbars.py:122: UserWarning: This API function will be removed in django CMS 4. For publishing functionality use a package that adds publishing, such as: djangocms-versioning.
  self.page = get_page_draft(self.request.current_page)
/Library/Caches/pypoetry/virtualenvs/vitrina-iOmyzedb-py3.12/lib/python3.12/site-packages/cms/cms_toolbars.py:67: UserWarning: This API function will be removed in django CMS 4. For publishing functionality use a package that adds publishing, such as: djangocms-versioning.
  self.page = get_page_draft(self.request.current_page)
/Library/Caches/pypoetry/virtualenvs/vitrina-iOmyzedb-py3.12/lib/python3.12/site-packages/cms/cms_toolbars.py:396: UserWarning: This API function will be removed in django CMS 4. For publishing functionality use a package that adds publishing, such as: djangocms-versioning.
  self.page = get_page_draft(self.request.current_page)
Could not resolve form field 'organization'.
Traceback (most recent call last):
  File "/Library/Caches/pypoetry/virtualenvs/vitrina-iOmyzedb-py3.12/lib/python3.12/site-packages/django/forms/forms.py", line 178, in __getitem__
    field = self.fields[name]
            ~~~~~~~~~~~^^^^^^
KeyError: 'organization'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Library/Caches/pypoetry/virtualenvs/vitrina-iOmyzedb-py3.12/lib/python3.12/site-packages/crispy_forms/utils.py", line 70, in render_field
    bound_field = form[field]
                  ~~~~^^^^^^^
  File "/Library/Caches/pypoetry/virtualenvs/vitrina-iOmyzedb-py3.12/lib/python3.12/site-packages/django/forms/forms.py", line 180, in __getitem__
    raise KeyError(
KeyError: "Key 'organization' not found in 'ProjectForm'. Choices are: description, image, is_public, title, url."
/Library/Caches/pypoetry/virtualenvs/vitrina-iOmyzedb-py3.12/lib/python3.12/site-packages/cms/toolbar/toolbar.py:39: UserWarning: This API function will be removed in django CMS 4. For publishing functionality use a package that adds publishing, such as: djangocms-versioning.
  cms_page = get_page_draft(self.request.current_page)
[07/Nov/2025 13:04:30] "GET /projects/add/ HTTP/1.1" 200 31848
[07/Nov/2025 13:04:30] "GET /jsi18n/ HTTP/1.1" 200 8431
```

</details>

This was caused by this code block:

```python
    if (
        not project_instance
        and (organization := self.user.viisp_organization)
        and self.user.is_representative_of(organization, True)
    ):
        self.fields["organization"].empty_label = f"{_('Fizinis asmuo')} ({self.user})"
        self.fields["organization"].queryset = Organization.objects.filter(pk=organization.pk)
        self.fields["organization"].label_from_instance = lambda org: _("Organizacija") + f" ({org})"
        self.fields["organization"].initial = organization
    else:
        self.fields.pop("organization", None)
```

Organization is removed from fields and later down the line, while loading the form it is still being searched for because it is added to the layout:

```python
self.helper.layout = Layout(
        Field("is_public"),
        Field("title", placeholder=_("Pavadinimas")),
        Field("description", placeholder=_("Aprašymas")),
        Field("organization"),
        Field("url", placeholder=_("Nuoroda į panaudojimo atvejį")),
        Field("image"),
        Submit("submit", button, css_class="button is-primary"),
    )
```

Even though the form is loaded successfully, because the exception is handled inside of `crispy-forms`, solving the problem to avoid any issues that might be caused later down the line due to this problem.

### Solution:

A simple solution is to add the field to the layout only when the `self.fields` has it (it has not been removed (`pop`))

### Notes:

- No tests due to this not changing the logic itself (since the form was loaded successfully) and the tests would be checking the internals (crispy-forms) which should be handled by the lib itself.