### PR TITLE
Bugfix: Mock call to vertimas.vu.lt in tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,7 @@ Bugfixes:
 
 <no ticket>
 - Fix form layout, do not add a field that should be removed from the form itself on specific conditions.
+- Fix an issue where if `vertimas.vu.lt` is down, tests are failing on the pipelines and during local development, by introducing mocks for direct external API calls.
 
 
 v 1.5 (2025-10-27)

--- a/scripts/geoportal_import.py
+++ b/scripts/geoportal_import.py
@@ -1,6 +1,8 @@
 import os
 import django
 
+from vitrina.settings import TRANSLATION_URL
+
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "vitrina.settings")
 django.setup()
 
@@ -89,7 +91,7 @@ def _get_condition_descriptions():
             code_space = identifier.get("codeSpace") if identifier is not None else ""
             if description is not None and identifier is not None:
                 lt_description = requests.post(
-                    "https://vertimas.vu.lt/ws/service.svc/json/Translate",
+                    TRANSLATION_URL,
                     json={
                         "appId": "",
                         "systemID": "smt-d01dca4d-e827-46e6-acaa-e5cb1201bc16",

--- a/scripts/translate_datasets.py
+++ b/scripts/translate_datasets.py
@@ -8,7 +8,7 @@ import requests
 from tqdm import tqdm
 from typer import run
 from vitrina.datasets.models import Dataset
-from vitrina.settings import TRANSLATION_CLIENT_ID
+from vitrina.settings import TRANSLATION_CLIENT_ID, TRANSLATION_URL
 
 
 def main():
@@ -36,7 +36,7 @@ def main():
 
             if not dataset.en_title():
                 response_title = requests.post(
-                    "https://vertimas.vu.lt/ws/service.svc/json/Translate",
+                    TRANSLATION_URL,
                     json={
                         "appId": "",
                         "systemID": "smt-8abc06a7-09dc-405c-bd29-580edc74eb05",
@@ -53,7 +53,7 @@ def main():
 
             if not dataset.en_description():
                 response_desc = requests.post(
-                    "https://vertimas.vu.lt/ws/service.svc/json/Translate",
+                    TRANSLATION_URL,
                     json={
                         "appId": "",
                         "systemID": "smt-8abc06a7-09dc-405c-bd29-580edc74eb05",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,18 @@
+from __future__ import annotations
 import builtins
 import csv
 import io
+from unittest.mock import patch
 
 import pytest
+import requests
 from django.apps import apps
 from django.core.management import call_command
 from pytest_django.lazy_django import skip_if_no_django
 from pprintpp import pprint as pp
 
 from vitrina.datasets.models import DCATResourceSubclass
+from vitrina.settings import TRANSLATION_URL
 
 builtins.pp = pp
 
@@ -106,3 +110,32 @@ def dataset(db, organization):
     from vitrina.datasets.models import Dataset
 
     return Dataset.objects.create(title="Test Dataset", organization=organization)
+
+
+@pytest.fixture(autouse=True)
+def mock_translation_service():
+    TRANSLATION_MAPPING = {
+        "Pavadinimas": "Title",
+        "Aprašymas": "Description",
+        "Būsena": "Status",
+        "copyright": "autorių teisės",
+        "license": "licencija",
+        "restricted": "apribota",
+    }
+
+    class MockTranslationResponse:
+        def __init__(self, text: str) -> None:
+            self.status_code = 200
+            self._text = text
+
+        def json(self) -> str:
+            return TRANSLATION_MAPPING.get(self._text, self._text)
+
+    def mock_post(url: str, *args, **kwargs) -> MockTranslationResponse | None:
+        if url == TRANSLATION_URL:
+            text = (kwargs.get("json") or {}).get("text", "")
+            return MockTranslationResponse(text)
+        return requests.sessions.Session().request("POST", url, *args, **kwargs)
+
+    with patch("requests.post", new=mock_post):
+        yield

--- a/tests/uapi/distribution/test_views.py
+++ b/tests/uapi/distribution/test_views.py
@@ -35,7 +35,7 @@ def test_create(
     file_content = b"Sample CSV content"
     data = {
         "dataset": str(dataset.id),
-        "title": "Title of the Distribution",
+        "title": "Title",
     }
 
     response = app.post(
@@ -91,7 +91,7 @@ def test_create_specific_scope(
     file_content = b"Sample CSV content"
     data = {
         "dataset": str(dataset.id),
-        "title": "Title of the Distribution",
+        "title": "Title",
     }
 
     response = app.post(

--- a/vitrina/datasets/models.py
+++ b/vitrina/datasets/models.py
@@ -36,7 +36,7 @@ from vitrina.datasets.managers import (
 )
 from vitrina.models import UUIDBaseModel
 from vitrina.orgs.models import Organization, Representative
-from vitrina.settings import TRANSLATION_CLIENT_ID
+from vitrina.settings import TRANSLATION_CLIENT_ID, TRANSLATION_URL
 from vitrina.structure.models import Model, Base, Property, Metadata, StatusCode
 from vitrina.users.models import User
 
@@ -1200,7 +1200,7 @@ class Dataset(Resource):
 
             if lt_title and not self.en_title():
                 response_title = requests.post(
-                    "https://vertimas.vu.lt/ws/service.svc/json/Translate",
+                    TRANSLATION_URL,
                     json={
                         "appId": "",
                         "systemID": "smt-8abc06a7-09dc-405c-bd29-580edc74eb05",
@@ -1217,7 +1217,7 @@ class Dataset(Resource):
 
             if lt_description and not self.en_description():
                 response_desc = requests.post(
-                    "https://vertimas.vu.lt/ws/service.svc/json/Translate",
+                    TRANSLATION_URL,
                     json={
                         "appId": "",
                         "systemID": "smt-8abc06a7-09dc-405c-bd29-580edc74eb05",

--- a/vitrina/resources/models.py
+++ b/vitrina/resources/models.py
@@ -13,7 +13,7 @@ from parler.models import TranslatableModel, TranslatedFields
 
 from vitrina.classifiers.models import Licence, ApplicableLegislation, Concept
 from vitrina.datasets.models import Dataset
-from vitrina.settings import TRANSLATION_CLIENT_ID
+from vitrina.settings import TRANSLATION_CLIENT_ID, TRANSLATION_URL
 
 
 def get_default_status() -> uuid.UUID:
@@ -374,7 +374,7 @@ class DatasetDistribution(TranslatableModel):
 
             if lt_title and not self.en_title():
                 response_title = requests.post(
-                    "https://vertimas.vu.lt/ws/service.svc/json/Translate",
+                    TRANSLATION_URL,
                     json={
                         "appId": "",
                         "systemID": "smt-8abc06a7-09dc-405c-bd29-580edc74eb05",
@@ -391,7 +391,7 @@ class DatasetDistribution(TranslatableModel):
 
             if lt_description and not self.en_description():
                 response_desc = requests.post(
-                    "https://vertimas.vu.lt/ws/service.svc/json/Translate",
+                    TRANSLATION_URL,
                     json={
                         "appId": "",
                         "systemID": "smt-8abc06a7-09dc-405c-bd29-580edc74eb05",
@@ -408,7 +408,7 @@ class DatasetDistribution(TranslatableModel):
 
             if lt_conditions and not self.en_conditions():
                 response_conditions = requests.post(
-                    "https://vertimas.vu.lt/ws/service.svc/json/Translate",
+                    TRANSLATION_URL,
                     json={
                         "appId": "",
                         "systemID": "smt-8abc06a7-09dc-405c-bd29-580edc74eb05",

--- a/vitrina/settings.py
+++ b/vitrina/settings.py
@@ -463,6 +463,8 @@ CORS_ALLOWED_ORIGINS = ["https://test.epaslaugos.lt"]
 ACCOUNT_AUTHENTICATED_LOGIN_REDIRECT = False
 
 TRANSLATION_CLIENT_ID = env("TRANSLATION_CLIENT_ID", default="")
+TRANSLATION_URL = "https://vertimas.vu.lt/ws/service.svc/json/Translate"
+
 SPINTA_SERVER_URL = env("SPINTA_SERVER_URL", default="https://get-test.data.gov.lt")
 SPINTA_SERVER_CLIENT_ID = env("SPINTA_SERVER_CLIENT_ID", default="")
 SPINTA_SERVER_CLIENT_SECRET = env("SPINTA_SERVER_CLIENT_SECRET", default="")


### PR DESCRIPTION
Couple of issues:

a) External APIs should not be called from tests
b) The external API is down, development if frozen, due to tests failing (tests failing == can't merge functionalities)

---

Changes:

- Moving the translations URL to a single place (this time the `settings.py` file)
- Creating an `autouse` fixture to mock calls to the `vertimas.vu.lt` website

---

Todo In the future:

- Add safeguards for translations (if `vertimas.vu.lt` drops down again)
