### PR TITLE
[2067] Bugfix: Add `atomic=False` due to migration issues

### DIFF
--- a/vitrina/smart_contracts/migrations/0009_agreement_assignee_representative_and_more.py
+++ b/vitrina/smart_contracts/migrations/0009_agreement_assignee_representative_and_more.py
@@ -15,6 +15,8 @@ def remove_agreements(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
+    atomic = False
+
     dependencies = [
         ('vitrina_datasets', '0031_auto_20251027_0636'),
         ('vitrina_smart_contracts', '0008_remove_agreement_other_assignee_legislations'),


### PR DESCRIPTION
### Changes
- Removing atomicity due to issues caused by this migration:

```python
django.db.utils.OperationalError: cannot CREATE INDEX "vitrina_smart_contracts_agreement" because it has pending trigger events
```

---
### Detailed Explanation

During the migration two things are happening:
- Deletes are made:
```
AgreementScope.objects.all().delete()
AgreementFile.objects.all().delete()
Agreement.objects.all().delete()
```
- Fields are added:
    - `assignee_representative`
    - `assigner_representative`

The delete operations fire triggers, and PostgreSQL can't create new indexes (for FK fields) until all triggers are fully processed. Since Django runs migrations in a single transaction by default, the triggers are still pending.