### PR TITLE
[2045] Organizacijos tipo keitimo apribojimai

### DIFF
--- a/tests/orgs/test_views.py
+++ b/tests/orgs/test_views.py
@@ -1243,7 +1243,7 @@ def test_gov_organizaton_cannot_select_different_kind(app: DjangoTestApp):
 
 @pytest.mark.django_db
 def test_create_organization(app: DjangoTestApp):
-    user = UserFactory(is_superuser = True)
+    user = UserFactory(is_superuser=True)
     app.set_user(user)
 
     form = app.get(reverse('organization-create')).forms['organization-form']
@@ -1263,7 +1263,7 @@ def test_create_organization(app: DjangoTestApp):
 
     assert response.status_code == 302
 
-    organization = Organization.objects.get(company_code = "123456789")
+    organization = Organization.objects.get(company_code="123456789")
     assert organization.title == "Imone"
     assert organization.name == "kodinis_pavadinimas"
     assert organization.jurisdiction == jurisdiction

--- a/tests/orgs/test_views.py
+++ b/tests/orgs/test_views.py
@@ -1208,6 +1208,71 @@ def test_contact_delete_no_permission(app, representative_data):
     assert Contact.objects.count() == 1
 
 
+@pytest.mark.django_db
+def test_non_gov_organizaton_no_gov_kind(app: DjangoTestApp):
+    representative = ViispRepresentativeFactory()
+    org = representative.content_object
+
+    user = representative.user
+    app.set_user(user)
+
+    form = app.get(reverse('organization-change', kwargs={'pk': org.id})).forms['organization-form']
+
+    kind_values = [value for value, _, _ in form['kind'].options]
+    
+    assert len(kind_values) == 2
+    assert Organization.GOV not in kind_values
+
+@pytest.mark.django_db
+def test_gov_organizaton_cannot_select_different_kind(app: DjangoTestApp):
+    representative = ViispRepresentativeFactory()
+    org = representative.content_object
+    org.kind = Organization.GOV
+    org.save()
+
+    user = representative.user
+    app.set_user(user)
+
+    form = app.get(reverse('organization-change', kwargs={'pk': org.id})).forms['organization-form']
+
+    kind_values = [value for value, _, _ in form['kind'].options]
+    
+    assert len(kind_values) == 1
+    assert kind_values[0] == Organization.GOV
+
+
+@pytest.mark.django_db
+def test_create_organization(app: DjangoTestApp):
+    user = UserFactory(is_superuser = True)
+    app.set_user(user)
+
+    form = app.get(reverse('organization-create')).forms['organization-form']
+
+    form["company_code"] = "123456789"
+    form["title"] = "Imone"
+    form["name"] = "kodinis_pavadinimas"
+    jurisdiction = AreaOfManagement.objects.first()
+    form["jurisdiction"] = jurisdiction.pk
+    form["email"] = "example@example.com"
+    form["phone"] = "061234567"
+    form["address"] = "Gatve 1"
+    form["description"] = "aprasymas"
+    form["kind"] = Organization.GOV
+
+    response = form.submit()
+
+    assert response.status_code == 302
+
+    organization = Organization.objects.get(company_code = "123456789")
+    assert organization.title == "Imone"
+    assert organization.name == "kodinis_pavadinimas"
+    assert organization.jurisdiction == jurisdiction
+    assert organization.email == "example@example.com"
+    assert organization.phone == "061234567"
+    assert organization.address == "Gatve 1"
+    assert organization.description == "aprasymas"
+    assert organization.kind == Organization.GOV
+
 class TestRepresentativeDeleteView:
     @pytest.mark.django_db
     def test_delete_representative(self, app: DjangoTestApp) -> None:

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -2285,6 +2285,9 @@ msgstr "E-mail address"
 msgid "Adresas"
 msgstr "Address"
 
+msgid "Saugoti"
+msgstr "Save"
+
 msgid "Jurisdikcija"
 msgstr "Jurisdiction"
 
@@ -2377,9 +2380,6 @@ msgstr ""
 
 msgid "Naujas slaptažodis"
 msgstr "New password"
-
-msgid "Saugoti"
-msgstr "Save"
 
 msgid "Objektas"
 msgstr "Object"

--- a/vitrina/orgs/forms.py
+++ b/vitrina/orgs/forms.py
@@ -174,6 +174,8 @@ class OrganizationBaseForm(ModelForm):
     address = CharField(label=_("Adresas"), required=True)
     description = CharField(label=_("Aprašymas"), widget=Textarea(), required=False)
 
+    submit_label = _("Saugoti")
+
     class Meta:
         model = Organization
         fields = (
@@ -195,7 +197,7 @@ class OrganizationBaseForm(ModelForm):
         user = kwargs.pop("user")
         super().__init__(*args, **kwargs)
 
-        parent = getattr(self.instance, "get_parent", lambda: None)()
+        parent = self.instance.get_parent() if hasattr(self.instance, "get_parent") else None
         if parent:
             self.fields["jurisdiction"].initial = parent
 
@@ -203,7 +205,7 @@ class OrganizationBaseForm(ModelForm):
         self.helper.attrs["novalidate"] = ""
         self.helper.form_id = "organization-form"
         self.fields["kind"].choices = get_kind_choices(
-            user, self.instance if getattr(self.instance, "pk", None) else None
+            user=user, organization=self.instance if getattr(self.instance, "pk", None) else None
         )
         self.helper.layout = Layout(
             Field("company_code", placeholder=_("Registracijos numeris")),
@@ -218,7 +220,7 @@ class OrganizationBaseForm(ModelForm):
             Field("address", placeholder=_("Adresas")),
             Field("publisher", placeholder=_("Duomenų atvėrimo paslaugų teikėjas")),
             Field("description", placeholder=_("Aprašymas")),
-            Submit("submit", self.get_submit_label(), css_class="button is-primary"),
+            Submit("submit", self.submit_label, css_class="button is-primary"),
         )
 
     def clean_name(self):
@@ -246,11 +248,12 @@ class OrganizationBaseForm(ModelForm):
 
 
 class OrganizationUpdateForm(OrganizationBaseForm):
-    def get_submit_label(self) -> str:
-        return _("Redaguoti")
+    submit_label = _("Redaguoti")
 
 
 class OrganizationCreateForm(OrganizationBaseForm):
+    submit_label = _("Sukurti")
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         initial = kwargs.get("initial")
@@ -258,9 +261,6 @@ class OrganizationCreateForm(OrganizationBaseForm):
             self.fields["title"].widget.attrs["readonly"] = True
             self.fields["company_code"].widget.attrs["readonly"] = True
             self.fields["address"].widget.attrs["readonly"] = True
-
-    def get_submit_label(self) -> str:
-        return _("Sukurti")
 
 
 class OrganizationSearchForm(FacetedSearchForm):

--- a/vitrina/orgs/forms.py
+++ b/vitrina/orgs/forms.py
@@ -228,7 +228,7 @@ class OrganizationBaseForm(ModelForm):
         if name:
             if not name.islower():
                 raise ValidationError(_("Pirmas kodinio pavadinimo simbolis turi būti mažoji raidė."))
-            if any((not c.isalnum() and c != "_") for c in name):
+            if any((not character.isalnum() and character != "_") for character in name):
                 raise ValidationError(
                     _(
                         "Pavadinime gali būti didžiosos/mažosios raidės ir skaičiai, "

--- a/vitrina/orgs/forms.py
+++ b/vitrina/orgs/forms.py
@@ -47,6 +47,7 @@ from vitrina.orgs.models import (
     Template,
 )
 from vitrina.orgs.services import get_coordinators_count
+from vitrina.orgs.helpers import get_kind_choices
 from vitrina.plans.models import Plan
 from vitrina.structure.services import get_data_from_spinta
 from vitrina.structure.models import Metadata
@@ -191,6 +192,7 @@ class OrganizationBaseForm(ModelForm):
         )
 
     def __init__(self, *args, **kwargs):
+        user = kwargs.pop("user")
         super().__init__(*args, **kwargs)
 
         parent = getattr(self.instance, "get_parent", lambda: None)()
@@ -200,6 +202,9 @@ class OrganizationBaseForm(ModelForm):
         self.helper = FormHelper()
         self.helper.attrs["novalidate"] = ""
         self.helper.form_id = "organization-form"
+        self.fields["kind"].choices = get_kind_choices(
+            user, self.instance if getattr(self.instance, "pk", None) else None
+        )
         self.helper.layout = Layout(
             Field("company_code", placeholder=_("Registracijos numeris")),
             Field("title", placeholder=_("Pavadinimas")),

--- a/vitrina/orgs/forms.py
+++ b/vitrina/orgs/forms.py
@@ -158,7 +158,7 @@ class OrganizationWidget(ModelSelect2Widget):
         return groups
 
 
-class OrganizationUpdateForm(ModelForm):
+class OrganizationBaseForm(ModelForm):
     company_code = CharField(label=_("Registracijos numeris"), required=True)
     title = CharField(label=_("Pavadinimas"), required=True)
     name = CharField(label=_("Kodinis pavadinimas"), required=True)
@@ -171,7 +171,7 @@ class OrganizationUpdateForm(ModelForm):
     email = CharField(label=_("Elektroninis paštas"), required=True)
     phone = CharField(label=_("Telefono numeris"), required=True)
     address = CharField(label=_("Adresas"), required=True)
-    description = CharField(label=_("Aprašymas"), widget=Textarea, required=False)
+    description = CharField(label=_("Aprašymas"), widget=Textarea(), required=False)
 
     class Meta:
         model = Organization
@@ -192,11 +192,11 @@ class OrganizationUpdateForm(ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        org_instance = self.instance if self.instance and self.instance.pk else None
-        button = _("Redaguoti") if org_instance else _("Sukurti")
-        parent = self.instance.get_parent()
+
+        parent = getattr(self.instance, "get_parent", lambda: None)()
         if parent:
             self.fields["jurisdiction"].initial = parent
+
         self.helper = FormHelper()
         self.helper.attrs["novalidate"] = ""
         self.helper.form_id = "organization-form"
@@ -213,7 +213,7 @@ class OrganizationUpdateForm(ModelForm):
             Field("address", placeholder=_("Adresas")),
             Field("publisher", placeholder=_("Duomenų atvėrimo paslaugų teikėjas")),
             Field("description", placeholder=_("Aprašymas")),
-            Submit("submit", button, css_class="button is-primary"),
+            Submit("submit", self.get_submit_label(), css_class="button is-primary"),
         )
 
     def clean_name(self):
@@ -221,7 +221,7 @@ class OrganizationUpdateForm(ModelForm):
         if name:
             if not name.islower():
                 raise ValidationError(_("Pirmas kodinio pavadinimo simbolis turi būti mažoji raidė."))
-            elif any((not c.isalnum() and c != "_") for c in name):
+            if any((not c.isalnum() and c != "_") for c in name):
                 raise ValidationError(
                     _(
                         "Pavadinime gali būti didžiosos/mažosios raidės ir skaičiai, "
@@ -229,103 +229,33 @@ class OrganizationUpdateForm(ModelForm):
                         "jokie kiti simboliai negalimi."
                     )
                 )
-            elif not name.isascii():
+            if not name.isascii():
                 raise ValidationError(_("Kodiniame pavadinime gali būti naudojamos tik lotyniškos raidės."))
         return name
 
     def clean_image(self):
         image = self.cleaned_data.get("image")
-        if image:
-            if image.width < 256 or image.height < 256:
-                raise ValidationError(_("Nuotraukos dydis turi būti ne mažesnis už 256x256."))
+        if image and (image.width < 256 or image.height < 256):
+            raise ValidationError(_("Nuotraukos dydis turi būti ne mažesnis už 256x256."))
         return image
 
 
-class OrganizationCreateForm(ModelForm):
-    title = CharField(label=_("Pavadinimas"), required=True)
-    company_code = CharField(label=_("Registracijos numeris"), required=True)
-    name = CharField(label=_("Kodinis pavadinimas"), required=True)
-    jurisdiction = ModelChoiceField(
-        queryset=AreaOfManagement.objects.all(),
-        label=_("Valdymo sritis"),
-        required=True,
-    )
-    image = FilerImageField(label=_("Paveiksliukas"), upload_to=Organization.UPLOAD_TO, required=False)
-    email = CharField(label=_("Elektroninis paštas"), required=True)
-    phone = CharField(label=_("Telefono numeris"), required=True)
-    address = CharField(label=_("Adresas"), required=True)
-    description = CharField(label=_("Aprašymas"), widget=Textarea, required=False)
+class OrganizationUpdateForm(OrganizationBaseForm):
+    def get_submit_label(self) -> str:
+        return _("Redaguoti")
 
-    class Meta:
-        model = Organization
-        fields = (
-            "company_code",
-            "title",
-            "name",
-            "kind",
-            "jurisdiction",
-            "image",
-            "website",
-            "email",
-            "phone",
-            "address",
-            "publisher",
-            "description",
-        )
 
+class OrganizationCreateForm(OrganizationBaseForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         initial = kwargs.get("initial")
-        button = "Sukurti"
-        parent = self.instance.get_parent()
-        if parent:
-            self.fields["jurisdiction"].initial = parent
-        self.helper = FormHelper()
-        self.helper.attrs["novalidate"] = ""
-        self.helper.form_id = "organization-form"
-        self.helper.layout = Layout(
-            Field("title", placeholder=_("Pavadinimas")),
-            Field("company_code", placeholder=_("Registracijos numeris")),
-            Field("name", placeholder=_("Kodinis pavadinimas")),
-            Field("kind", placeholder=_("Tipas")),
-            Field("jurisdiction", placeholder=_("Jurisdikcija")),
-            Field("image", placeholder=_("Logotipas")),
-            Field("website", placeholder=_("Tinklalapis")),
-            Field("email", placeholder=_("Elektroninis paštas")),
-            Field("phone", placeholder=_("Telefono numeris")),
-            Field("address", placeholder=_("Adresas")),
-            Field("publisher", placeholder=_("Duomenų atvėrimo paslaugų teikėjas")),
-            Field("description", placeholder=_("Aprašymas")),
-            Submit("submit", button, css_class="button is-primary"),
-        )
         if initial:
             self.fields["title"].widget.attrs["readonly"] = True
             self.fields["company_code"].widget.attrs["readonly"] = True
             self.fields["address"].widget.attrs["readonly"] = True
 
-    def clean_name(self):
-        name = self.cleaned_data.get("name")
-        if name:
-            if not name.islower():
-                raise ValidationError(_("Pirmas kodinio pavadinimo simbolis turi būti mažoji raidė."))
-            elif any((not c.isalnum() and c != "_") for c in name):
-                raise ValidationError(
-                    _(
-                        "Pavadinime gali būti didžiosos/mažosios raidės ir skaičiai, "
-                        "žodžiai gali būti atskirti _ simboliu,"
-                        "jokie kiti simboliai negalimi."
-                    )
-                )
-            elif not name.isascii():
-                raise ValidationError(_("Kodiniame pavadinime gali būti naudojamos tik lotyniškos raidės."))
-        return name
-
-    def clean_image(self):
-        image = self.cleaned_data.get("image")
-        if image:
-            if image.width < 256 or image.height < 256:
-                raise ValidationError(_("Nuotraukos dydis turi būti ne mažesnis už 256x256."))
-        return image
+    def get_submit_label(self) -> str:
+        return _("Sukurti")
 
 
 class OrganizationSearchForm(FacetedSearchForm):

--- a/vitrina/orgs/helpers.py
+++ b/vitrina/orgs/helpers.py
@@ -5,6 +5,7 @@ from rest_framework.request import Request
 
 from vitrina.classifiers.models import AreaOfManagement
 from vitrina.orgs.models import Organization
+from vitrina.users.models import User
 
 
 def is_org_dataset_list(request: Request):
@@ -30,3 +31,13 @@ def get_or_create_parent_org(obj: Union[AreaOfManagement, int]) -> Organization:
         )
         parent_org.save()
     return parent_org
+
+
+def get_kind_choices(user: User, organization: Organization | None = None) -> tuple[tuple[str, str]]:
+    if user.is_staff or user.is_superuser:
+        return Organization.ORGANIZATION_KINDS
+
+    if organization and organization.kind == Organization.GOV:
+        return tuple(kind for kind in Organization.ORGANIZATION_KINDS if kind[0] == Organization.GOV)
+
+    return tuple(kind for kind in Organization.ORGANIZATION_KINDS if kind[0] != Organization.GOV)

--- a/vitrina/orgs/views.py
+++ b/vitrina/orgs/views.py
@@ -744,6 +744,7 @@ class OrganizationUpdateView(LoginRequiredMixin, PermissionRequiredMixin, Revisi
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
         organization = self.get_object()
+        kwargs["user"] = self.request.user
         if organization.jurisdiction_id:
             kwargs["initial"] = {"jurisdiction": organization.jurisdiction_id}
         return kwargs
@@ -840,6 +841,7 @@ class OrganizationCreateView(LoginRequiredMixin, PermissionRequiredMixin, Create
                 "address": self.data[0].get("pilnas_adresas"),
             }
             kwargs["initial"] = initial_dict
+        kwargs["user"] = self.request.user
         return kwargs
 
     def form_valid(self, form):
@@ -854,6 +856,7 @@ class OrganizationCreateView(LoginRequiredMixin, PermissionRequiredMixin, Create
                 email=form.cleaned_data.get("email"),
                 phone=form.cleaned_data.get("phone"),
                 description=form.cleaned_data.get("description"),
+                kind=form.cleaned_data.get("kind"),
                 publisher=False,
                 is_public=True,
                 jurisdiction=jurisdiction,
@@ -871,6 +874,7 @@ class OrganizationCreateView(LoginRequiredMixin, PermissionRequiredMixin, Create
                 email=form.cleaned_data.get("email"),
                 phone=form.cleaned_data.get("phone"),
                 description=form.cleaned_data.get("description"),
+                kind=form.cleaned_data.get("kind"),
                 publisher=False,
                 is_public=True,
             )


### PR DESCRIPTION
Updated `Organization.kind` selection permissions.
Now when updating `Organization` that has `kind=="gov"`, it won't be possible to change it for non admin users.
When updating Organization other than `kind=="gov"`, it won't be possible to change `kind` to `gov`
Same logic applies to when creating new `Organization`, non admin users won't be able to select `gov` as `Organization.kind`

Also fixed a bug, where 'kind' selection wasn't saved when creating new `Organization`.

TBD: translations