### PR TITLE
Show all metadata in the publishing form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,9 @@ https://github.com/atviriduomenys/katalogas/issues/2123
 https://github.com/atviriduomenys/dvms/issues/346
 - Add password validation for fake VIISP login.
 
+https://github.com/atviriduomenys/katalogas/pull/2115
+- Publish version form now shows and lets the user select all fields that are created.
+
 v 1.7 (2025-11-20)
 ==================
 

--- a/scripts/geoportal_import.py
+++ b/scripts/geoportal_import.py
@@ -95,7 +95,7 @@ def _get_condition_descriptions():
                     description.text,
                     field_name=f"geoportal condition {identifier.text}"
                 )
-                
+
                 condition_info[identifier.text] = {
                     "description": translated_description,
                     "code_space": code_space,

--- a/scripts/translate_datasets.py
+++ b/scripts/translate_datasets.py
@@ -33,47 +33,47 @@ def main():
             if not dataset.has_translation(language_code='en'):
                 dataset.create_translation(language_code='en')
             dataset.set_current_language('en')
-    #
-    #         if not dataset.en_title():
-    #             response_title = requests.post(
-    #                 TRANSLATION_URL,
-    #                 json={
-    #                     "appId": "",
-    #                     "systemID": "smt-8abc06a7-09dc-405c-bd29-580edc74eb05",
-    #                     "text": lt_title,
-    #                     "options": ""
-    #                 },
-    #                 headers={
-    #                     "client-id": TRANSLATION_CLIENT_ID,
-    #                     "Content-Type": "application/json; charset=utf-8"
-    #                 },
-    #             )
-    #             en_title = response_title.json()
-    #             dataset.title = en_title
-    #
-    #         if not dataset.en_description():
-    #             response_desc = requests.post(
-    #                 TRANSLATION_URL,
-    #                 json={
-    #                     "appId": "",
-    #                     "systemID": "smt-8abc06a7-09dc-405c-bd29-580edc74eb05",
-    #                     "text": lt_description,
-    #                     "options": ""
-    #                 },
-    #                 headers={
-    #                     "client-id": TRANSLATION_CLIENT_ID,
-    #                     "Content-Type": "application/json; charset=utf-8"
-    #                 },
-    #             )
-    #             en_description = response_desc.json()
-    #             dataset.description = en_description
-    #
-    #         dataset.save()
-    #         count += 1
-    #
-    #     pbar.update(1)
-    #
-    # print(f'Updated dataset translations: {count}')
+
+            if not dataset.en_title():
+                response_title = requests.post(
+                    TRANSLATION_URL,
+                    json={
+                        "appId": "",
+                        "systemID": "smt-8abc06a7-09dc-405c-bd29-580edc74eb05",
+                        "text": lt_title,
+                        "options": ""
+                    },
+                    headers={
+                        "client-id": TRANSLATION_CLIENT_ID,
+                        "Content-Type": "application/json; charset=utf-8"
+                    },
+                )
+                en_title = response_title.json()
+                dataset.title = en_title
+
+            if not dataset.en_description():
+                response_desc = requests.post(
+                    TRANSLATION_URL,
+                    json={
+                        "appId": "",
+                        "systemID": "smt-8abc06a7-09dc-405c-bd29-580edc74eb05",
+                        "text": lt_description,
+                        "options": ""
+                    },
+                    headers={
+                        "client-id": TRANSLATION_CLIENT_ID,
+                        "Content-Type": "application/json; charset=utf-8"
+                    },
+                )
+                en_description = response_desc.json()
+                dataset.description = en_description
+
+            dataset.save()
+            count += 1
+
+        pbar.update(1)
+
+    print(f'Updated dataset translations: {count}')
 
 
 if __name__ == '__main__':

--- a/scripts/translate_datasets.py
+++ b/scripts/translate_datasets.py
@@ -33,47 +33,47 @@ def main():
             if not dataset.has_translation(language_code='en'):
                 dataset.create_translation(language_code='en')
             dataset.set_current_language('en')
-
-            if not dataset.en_title():
-                response_title = requests.post(
-                    TRANSLATION_URL,
-                    json={
-                        "appId": "",
-                        "systemID": "smt-8abc06a7-09dc-405c-bd29-580edc74eb05",
-                        "text": lt_title,
-                        "options": ""
-                    },
-                    headers={
-                        "client-id": TRANSLATION_CLIENT_ID,
-                        "Content-Type": "application/json; charset=utf-8"
-                    },
-                )
-                en_title = response_title.json()
-                dataset.title = en_title
-
-            if not dataset.en_description():
-                response_desc = requests.post(
-                    TRANSLATION_URL,
-                    json={
-                        "appId": "",
-                        "systemID": "smt-8abc06a7-09dc-405c-bd29-580edc74eb05",
-                        "text": lt_description,
-                        "options": ""
-                    },
-                    headers={
-                        "client-id": TRANSLATION_CLIENT_ID,
-                        "Content-Type": "application/json; charset=utf-8"
-                    },
-                )
-                en_description = response_desc.json()
-                dataset.description = en_description
-
-            dataset.save()
-            count += 1
-
-        pbar.update(1)
-
-    print(f'Updated dataset translations: {count}')
+    #
+    #         if not dataset.en_title():
+    #             response_title = requests.post(
+    #                 TRANSLATION_URL,
+    #                 json={
+    #                     "appId": "",
+    #                     "systemID": "smt-8abc06a7-09dc-405c-bd29-580edc74eb05",
+    #                     "text": lt_title,
+    #                     "options": ""
+    #                 },
+    #                 headers={
+    #                     "client-id": TRANSLATION_CLIENT_ID,
+    #                     "Content-Type": "application/json; charset=utf-8"
+    #                 },
+    #             )
+    #             en_title = response_title.json()
+    #             dataset.title = en_title
+    #
+    #         if not dataset.en_description():
+    #             response_desc = requests.post(
+    #                 TRANSLATION_URL,
+    #                 json={
+    #                     "appId": "",
+    #                     "systemID": "smt-8abc06a7-09dc-405c-bd29-580edc74eb05",
+    #                     "text": lt_description,
+    #                     "options": ""
+    #                 },
+    #                 headers={
+    #                     "client-id": TRANSLATION_CLIENT_ID,
+    #                     "Content-Type": "application/json; charset=utf-8"
+    #                 },
+    #             )
+    #             en_description = response_desc.json()
+    #             dataset.description = en_description
+    #
+    #         dataset.save()
+    #         count += 1
+    #
+    #     pbar.update(1)
+    #
+    # print(f'Updated dataset translations: {count}')
 
 
 if __name__ == '__main__':

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -4449,3 +4449,33 @@ def test_publish_form_shows_all_metadata_rows_multiple_resources(app: DjangoTest
     assert len(form.fields["metadata"]) == 9 # If multiple resources uploaded, only the last gets saved. Might be a bug.
     assert len(dataset_distributions) == 1
     assert dataset_distributions.first().metadata.first().name == "resource"
+
+def test_publish_form_shows_all_metadata_rows_denorm_props(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+    manifest = (
+        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
+        '1,datasets/govsssss/ivpk/adp,,,,,,,,,,,,,,,,,\n'
+        '2,,,,City,,,,,,,,,,,,,,\n'
+        '3,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n'
+        '4,,,,,title,string,,,,5,,,open,dct:title,,,,\n'
+        '5,,,,,country,ref,Country,,,5,,,open,,,,,,\n'
+        '6,,,,,country.id,,,,,5,,,open,,,,,,\n'
+        '7,,,,,country.continent.id,,,,,5,,,open,,,,,,\n'
+        '8,,resource,,,,,,http://www.example.com,,,,,,,,,Title,Description\n'
+        '9,,,,Country,,,,,,4,,,,,,,,,\n'
+        '10,,,,,id,integer,,,,3,,,,,,,,,\n'
+        '11,,,,,title,string,,,,2,,,,,,,,,\n'
+    )
+
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(
+            file=FileField(filename='file.csv', data=manifest)
+        )
+    )
+    structure.dataset.current_structure = structure
+    structure.dataset.save()
+    create_structure_objects(structure)
+
+    form = app.get(reverse("version-create", args=[structure.dataset.pk])).forms["version-form"]
+    assert len(form.fields["metadata"]) == 12 # Denorm props create an additional property country.continent

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -22,6 +22,7 @@ from vitrina.datasets.factories import DatasetStructureFactory, DatasetFactory
 from vitrina.orgs.factories import RepresentativeFactory
 from vitrina.orgs.models import Representative
 from vitrina.resources.factories import DatasetDistributionFactory
+from vitrina.resources.models import DatasetDistribution
 from vitrina.settings import SPINTA_SERVER_URL
 from vitrina.structure.factories import ModelFactory, MetadataFactory, PropertyFactory, EnumFactory, EnumItemFactory, \
     PrefixFactory, ParamItemFactory, ParamFactory, BaseFactory, VersionFactory
@@ -4302,3 +4303,149 @@ def test_multiple_patch_versions_increment_external_version(app: DjangoTestApp):
 
     assert patch_versions[0].external_version == "1.1.1"
     assert patch_versions[1].external_version == "1.1.2"
+
+def test_publish_form_shows_all_metadata_rows_params(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+    manifest = (
+        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
+        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
+        ',,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n'
+        '2,,,,,,param,country,,"lt",,,,,,,,,\n'
+        '3,,,,,,,,,"lv",,,,,,,,,\n'
+        '4,,,,,,,,,"ee",,,,,,,,,\n'
+        '5,,,,City,,,,,,,,,,,,,,\n'
+        '6,,,,,,param,type,,"created",,,,,,,,,\n'
+        '7,,,,,,,,,"modified",,,,,,,,,\n'
+        '8,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
+        '9,,,,,type,string,,,,5,,,open,dct:type,,,,\n'
+    )
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(
+            file=FileField(filename='file.csv', data=manifest)
+        )
+    )
+    structure.dataset.current_structure = structure
+    structure.dataset.save()
+    create_structure_objects(structure)
+
+    form = app.get(reverse("version-create", args=[structure.dataset.pk])).forms["version-form"]
+    assert len(form.fields["metadata"]) == 11 # 10 fields from DSA + 1 for dataset_distribution
+
+def test_publish_form_shows_all_metadata_rows_base(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+    manifest = (
+        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
+        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
+        '1,,,,Base,,,,,,4,,,,,,,,,\n'
+        ',,,Base,,,,,,,4,,,,,,,,,\n'
+        '2,,,,City,,,,,,5,,,,,,,,,\n'
+        ',,,,,id,integer,,,,5,,,,,,,,,\n'
+        ',,,,,title,string,,,,5,,,,,,,,,\n'
+        ',,,,,country,ref,Country,,,4,,,,,,,,,\n'
+        '3,,,,Country,,,,,,4,,,,,,,,,\n'
+        ',,,,,id,integer,,,,3,,,,,,,,,\n'
+        ',,,,,title,string,,,,2,,,,,,,,,\n'
+    )
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(
+            file=FileField(filename='file.csv', data=manifest)
+        )
+    )
+    structure.dataset.current_structure = structure
+    structure.dataset.save()
+    create_structure_objects(structure)
+
+    form = app.get(reverse("version-create", args=[structure.dataset.pk])).forms["version-form"]
+    assert len(form.fields["metadata"]) == 10 # 9 fields from DSA, because Base as City Base is not displayed + 1 for dataset_distribution
+
+def test_publish_form_shows_all_metadata_rows_enum(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+    manifest = (
+        'id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n'
+        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
+        '2,,,,,,prefix,dct,,,,,,,,http://purl.org/dc/terms/,,,\n'
+        '3,,,,,,enum,Size,,SMALL,,,,,,,,,,\n'
+        '4,,,,,,,,,MEDIUM,,,,,,,,,\n'
+        '5,,,,,,,,,BIG,,,,,,,,,\n'
+        '6,,,,City,,,,,,,,,,,,,,\n'
+        '7,,,,,id,integer,,,,,5,,,open,dct:identifier,,Identifikatorius,\n'
+        '8,,,,,size,Size,,,,,5,,,open,dct:size,,,\n'
+        '9,,,,,type,string,,,,,5,,,open,dct:type,,,\n'
+        '10,,,,,,enum,Type,,CREATED,,,,,,,,,\n'
+        '11,,,,,,,,,MODIFIED,,,,,,,,,\n'
+    )
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(
+            file=FileField(filename='file.csv', data=manifest)
+        )
+    )
+    structure.dataset.current_structure = structure
+    structure.dataset.save()
+    create_structure_objects(structure)
+
+    form = app.get(reverse("version-create", args=[structure.dataset.pk])).forms["version-form"]
+    assert len(form.fields["metadata"]) == 12 # 11 DSA rows + 1 dataset_distribution
+
+def test_publish_form_shows_all_metadata_rows_single_defined_resource(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+    manifest = (
+        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
+        '1,datasets/govsssss/ivpk/adp,,,,,,,,,,,,,,,,,\n'
+        '2,,,,City,,,,,,5,,,,,,,,,\n'
+        '3,,,,,id,integer,,,,5,,,,,,,,,\n'
+        '4,,,,,title,string,,,,5,,,,,,,,,\n'
+        '5,,,,,country,ref,Country,,,4,,,,,,,,,\n'
+        '6,,resource,,,,,,http://www.example.com,,,,,,,,,Title,Description\n'
+        '7,,,,Country,,,,,,4,,,,,,,,,\n'
+        '8,,,,,id,integer,,,,3,,,,,,,,,\n'
+        '9,,,,,title,string,,,,2,,,,,,,,,\n'
+    )
+
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(
+            file=FileField(filename='file.csv', data=manifest)
+        )
+    )
+    structure.dataset.current_structure = structure
+    structure.dataset.save()
+    create_structure_objects(structure)
+
+    form = app.get(reverse("version-create", args=[structure.dataset.pk])).forms["version-form"]
+    assert len(form.fields["metadata"]) == 9
+
+def test_publish_form_shows_all_metadata_rows_multiple_resources(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+    manifest = (
+        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
+        '1,datasets/govsssss/ivpk/adp,,,,,,,,,,,,,,,,,\n'
+        '2,,resource1,,,,,,http://www.example.com,,,,,,,,,Title,Description\n'
+        '3,,,,City,,,,,,5,,,,,,,,,\n'
+        '4,,,,,id,integer,,,,5,,,,,,,,,\n'
+        '5,,,,,title,string,,,,5,,,,,,,,,\n'
+        '6,,,,,country,ref,Country,,,4,,,,,,,,,\n'
+        '7,,resource,,,,,,http://www.example.com,,,,,,,,,Title,Description\n'
+        '8,,,,Country,,,,,,4,,,,,,,,,\n'
+        '9,,,,,id,integer,,,,3,,,,,,,,,\n'
+        '10,,,,,title,string,,,,2,,,,,,,,,\n'
+    )
+
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(
+            file=FileField(filename='file.csv', data=manifest)
+        )
+    )
+    structure.dataset.current_structure = structure
+    structure.dataset.save()
+    create_structure_objects(structure)
+
+    dataset_distributions = DatasetDistribution.objects.filter(dataset=structure.dataset)
+
+    form = app.get(reverse("version-create", args=[structure.dataset.pk])).forms["version-form"]
+    assert len(form.fields["metadata"]) == 9 # If multiple resources uploaded, only the last gets saved. Might be a bug.
+    assert len(dataset_distributions) == 1
+    assert dataset_distributions.first().metadata.first().name == "resource"

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -4428,7 +4428,7 @@ def test_publish_form_shows_all_metadata_rows_multiple_resources(app: DjangoTest
         '4,,,,,id,integer,,,,5,,,,,,,,,\n'
         '5,,,,,title,string,,,,5,,,,,,,,,\n'
         '6,,,,,country,ref,Country,,,4,,,,,,,,,\n'
-        '7,,resource,,,,,,http://www.example.com,,,,,,,,,Title,Description\n'
+        '7,,resource,,,,,,http://www.example2.com,,,,,,,,,Title,Description\n'
         '8,,,,Country,,,,,,4,,,,,,,,,\n'
         '9,,,,,id,integer,,,,3,,,,,,,,,\n'
         '10,,,,,title,string,,,,2,,,,,,,,,\n'
@@ -4446,9 +4446,10 @@ def test_publish_form_shows_all_metadata_rows_multiple_resources(app: DjangoTest
     dataset_distributions = DatasetDistribution.objects.filter(dataset=structure.dataset)
 
     form = app.get(reverse("version-create", args=[structure.dataset.pk])).forms["version-form"]
-    assert len(form.fields["metadata"]) == 9 # If multiple resources uploaded, only the last gets saved. Might be a bug.
-    assert len(dataset_distributions) == 1
-    assert dataset_distributions.first().metadata.first().name == "resource"
+    assert len(form.fields["metadata"]) == 10
+    assert len(dataset_distributions) == 2
+    assert dataset_distributions.first().metadata.first().name == "resource1"
+    assert dataset_distributions.last().metadata.first().name == "resource"
 
 def test_publish_form_shows_all_metadata_rows_denorm_props(app: DjangoTestApp):
     user = UserFactory(is_staff=True)

--- a/tests/tasks/test_services.py
+++ b/tests/tasks/test_services.py
@@ -148,20 +148,20 @@ def test_get_active_tasks_with_staff_after_10_days():
         parent_organization_user,
         now=timezone.datetime(2022, 11, 28).date()
     )
-    assert list(active_tasks) == [
+    assert set(active_tasks) == {
         task_for_parent_organization,
         task_for_child_organization1,
         task_for_child_organization2
-    ]
+    }
 
     active_tasks = get_active_tasks(
         child_organization_user,
         now=timezone.datetime(2022, 11, 28).date()
     )
-    assert list(active_tasks) == [
+    assert set(active_tasks) == {
         task_for_child_organization1,
         task_for_child_organization2
-    ]
+    }
 
     active_tasks = get_active_tasks(
         staff,

--- a/vitrina/datasets/models.py
+++ b/vitrina/datasets/models.py
@@ -989,10 +989,15 @@ class Dataset(Resource):
             content_type_id = metadata_instance.content_type.id
             metadata_model = ContentType.objects.get_for_id(content_type_id).model
             if metadata_model == "prefix":
+                prefix_text = (
+                    f"<a href='{metadata_instance.uri_link}'>Prefix</a>"
+                    if metadata_instance.uri_link else "Prefix"
+                )
                 label = mark_safe(
-                    f"<a href={metadata_instance.uri_link}>Prefix</a> name: "
+                    f"{prefix_text} name: "
                     f"<span class='tag is-success is-light is-medium'>{metadata_instance.name}</span>"
                 )
+
                 meta_objects.append((metadata_instance.pk, label))
 
             if metadata_model == "paramitem":
@@ -1001,8 +1006,12 @@ class Dataset(Resource):
                 if param.content_type_id == ContentType.objects.filter(model="dataset").first().pk and metadata_instance.metadata_version.status == VersionStatus.DRAFT:
                     if metadata_instance.ref:
                         dataset_param_item_metadata_ref = metadata_instance.ref
+                    param_text = (
+                        f"<a href='{metadata_instance.uri_link}'>Param</a>: {dataset_param_item_metadata_ref}"
+                        if metadata_instance.uri_link else f"Param: {dataset_param_item_metadata_ref}"
+                    )
                     label = mark_safe(
-                        f"Param: {dataset_param_item_metadata_ref} "
+                        f"{param_text} "
                         f"<span class='tag is-success is-light is-medium'>{metadata_instance.prepare}</span>"
                     )
                     meta_objects.append((metadata_instance.pk, label))
@@ -1020,25 +1029,12 @@ class Dataset(Resource):
                     meta_objects.append((metadata_instance.pk, label))
 
         for model in self.model_set.all():
-            if param := model.params.first():
-                for param_item in param.paramitem_set.all():
-                    metadata = param_item.metadata.first()
-                    if metadata and metadata.metadata_version.status == VersionStatus.DRAFT:
-                        if metadata.ref:
-                            model_param_item_metadata_ref = metadata.ref
-
-                        label = mark_safe(
-                            f"Param: <span class='prop_metadata'>{model_param_item_metadata_ref}</span> "
-                            f"<span class='tag is-success is-light is-medium'>{metadata.prepare}</span>"
-                        )
-                        meta_objects.append((metadata.pk, label))
-
             if dataset_distribution_for_model := model.distribution:
                 if dataset_distribution_metadata := dataset_distribution_for_model.metadata.first():
                     if dataset_distribution_metadata.metadata_version.status == VersionStatus.DRAFT:
                         label = mark_safe(
-                            f"<a href={dataset_distribution_for_model.get_absolute_url()}>{dataset_distribution_for_model.title}</a> name: "
-                            f"<span class='tag is-success is-light is-medium'>{dataset_distribution_for_model.title}</span>"
+                            f"<a href={dataset_distribution_for_model.get_absolute_url()}>{dataset_distribution_metadata.name}</a> name: "
+                            f"<span class='tag is-success is-light is-medium'>{dataset_distribution_metadata.name}</span>"
                         )
 
                         if dataset_distribution_metadata.pk not in dataset_distributions:
@@ -1102,6 +1098,25 @@ class Dataset(Resource):
                         )
                     label = mark_safe(label_str)
                     meta_objects.append((metadata.pk, label))
+
+                if param := model.params.first():
+                    for param_item in param.paramitem_set.all():
+                        metadata = param_item.metadata.first()
+                        if metadata and metadata.metadata_version.status == VersionStatus.DRAFT:
+                            if metadata.ref:
+                                model_param_item_metadata_ref = metadata.ref
+
+                            param_text = (
+                                f"<a href='{metadata.uri_link}'>Param</a>: "
+                                f"<span class='prop_metadata'>{model_param_item_metadata_ref}</span>"
+                                if metadata.uri_link else
+                                f"Param: <span class='prop_metadata'>{model_param_item_metadata_ref}</span>"
+                            )
+                            label = mark_safe(
+                                f"{param_text} "
+                                f"<span class='tag is-success is-light is-medium'>{metadata.prepare}</span>"
+                            )
+                            meta_objects.append((metadata.pk, label))
 
             for prop in model.model_properties.all():
                 metadata = prop.metadata.first()

--- a/vitrina/datasets/models.py
+++ b/vitrina/datasets/models.py
@@ -990,8 +990,7 @@ class Dataset(Resource):
             metadata_model = ContentType.objects.get_for_id(content_type_id).model
             if metadata_model == "prefix":
                 prefix_text = (
-                    f"<a href='{metadata_instance.uri_link}'>Prefix</a>"
-                    if metadata_instance.uri_link else "Prefix"
+                    f"<a href='{metadata_instance.uri_link}'>Prefix</a>" if metadata_instance.uri_link else "Prefix"
                 )
                 label = mark_safe(
                     f"{prefix_text} name: "
@@ -1003,12 +1002,16 @@ class Dataset(Resource):
             if metadata_model == "paramitem":
                 paramitem_instance = ParamItem.objects.filter(metadata=metadata_instance).first()
                 param = paramitem_instance.param
-                if param.content_type_id == ContentType.objects.filter(model="dataset").first().pk and metadata_instance.metadata_version.status == VersionStatus.DRAFT:
+                if (
+                    param.content_type_id == ContentType.objects.filter(model="dataset").first().pk
+                    and metadata_instance.metadata_version.status == VersionStatus.DRAFT
+                ):
                     if metadata_instance.ref:
                         dataset_param_item_metadata_ref = metadata_instance.ref
                     param_text = (
                         f"<a href='{metadata_instance.uri_link}'>Param</a>: {dataset_param_item_metadata_ref}"
-                        if metadata_instance.uri_link else f"Param: {dataset_param_item_metadata_ref}"
+                        if metadata_instance.uri_link
+                        else f"Param: {dataset_param_item_metadata_ref}"
                     )
                     label = mark_safe(
                         f"{param_text} "
@@ -1019,7 +1022,10 @@ class Dataset(Resource):
             if metadata_model == "enumitem":
                 enumitem_instance = EnumItem.objects.filter(metadata=metadata_instance).first()
                 enum = enumitem_instance.enum
-                if enum.content_type_id == ContentType.objects.filter(model="dataset").first().pk and metadata_instance.metadata_version.status == VersionStatus.DRAFT:
+                if (
+                    enum.content_type_id == ContentType.objects.filter(model="dataset").first().pk
+                    and metadata_instance.metadata_version.status == VersionStatus.DRAFT
+                ):
                     if metadata_instance.ref:
                         dataset_enum_item_metadata_ref = metadata_instance.ref
                     label = mark_safe(
@@ -1109,8 +1115,8 @@ class Dataset(Resource):
                             param_text = (
                                 f"<a href='{metadata.uri_link}'>Param</a>: "
                                 f"<span class='prop_metadata'>{model_param_item_metadata_ref}</span>"
-                                if metadata.uri_link else
-                                f"Param: <span class='prop_metadata'>{model_param_item_metadata_ref}</span>"
+                                if metadata.uri_link
+                                else f"Param: <span class='prop_metadata'>{model_param_item_metadata_ref}</span>"
                             )
                             label = mark_safe(
                                 f"{param_text} "

--- a/vitrina/datasets/models.py
+++ b/vitrina/datasets/models.py
@@ -36,10 +36,8 @@ from vitrina.datasets.managers import (
 )
 from vitrina.models import UUIDBaseModel
 from vitrina.orgs.models import Organization, Representative
-from vitrina.settings import TRANSLATION_CLIENT_ID, TRANSLATION_URL
 from vitrina.structure import VersionStatus
 from vitrina.structure.models import Model, Base, Property, Metadata, StatusCode, ParamItem, EnumItem
-from vitrina.structure.models import Model, Base, Property, Metadata, StatusCode
 from vitrina.users.models import User
 
 logger = logging.getLogger(__name__)

--- a/vitrina/datasets/models.py
+++ b/vitrina/datasets/models.py
@@ -966,9 +966,12 @@ class Dataset(Resource):
         dataset_param_item_metadata_ref = None
         dataset_enum_item_metadata_ref = None
         model_param_item_metadata_ref = None
+        dataset_content_type_pk = ContentType.objects.get_for_model(Dataset).pk
 
-        all_metadata_instances = Metadata.objects.filter(dataset=self.pk, draft=True)
-
+        all_metadata_instances = (
+            Metadata.objects.filter(dataset=self.pk, draft=True).order_by("id").select_related("metadata_version")
+        )
+        # TODO optimize by introducing manual collection of all related models.
         if metadata and metadata.draft is True:
             if latest_version := metadata.metadataversion_set.order_by("-version__created").first():
                 if latest_version.name != metadata.name:
@@ -986,66 +989,75 @@ class Dataset(Resource):
                 meta_objects.append((metadata.pk, label))
 
         for metadata_instance in all_metadata_instances:
-            content_type_id = metadata_instance.content_type.id
-            metadata_model = ContentType.objects.get_for_id(content_type_id).model
+            metadata_model = metadata_instance.content_type.model
             if metadata_model == "prefix":
-                prefix_text = (
-                    f"<a href='{metadata_instance.uri_link}'>Prefix</a>" if metadata_instance.uri_link else "Prefix"
-                )
                 label = mark_safe(
-                    f"{prefix_text} name: "
-                    f"<span class='tag is-success is-light is-medium'>{metadata_instance.name}</span>"
+                    f"Prefix ref: "
+                    f"<span class='tag is-success is-light is-medium prop_metadata'>{metadata_instance.name}</span>"
                 )
 
                 meta_objects.append((metadata_instance.pk, label))
 
             if metadata_model == "paramitem":
-                paramitem_instance = ParamItem.objects.filter(metadata=metadata_instance).first()
-                param = paramitem_instance.param
-                if (
-                    param.content_type_id == ContentType.objects.filter(model="dataset").first().pk
-                    and metadata_instance.metadata_version.status == VersionStatus.DRAFT
-                ):
-                    if metadata_instance.ref:
-                        dataset_param_item_metadata_ref = metadata_instance.ref
-                    param_text = (
-                        f"<a href='{metadata_instance.uri_link}'>Param</a>: {dataset_param_item_metadata_ref}"
-                        if metadata_instance.uri_link
-                        else f"Param: {dataset_param_item_metadata_ref}"
-                    )
-                    label = mark_safe(
-                        f"{param_text} "
-                        f"<span class='tag is-success is-light is-medium'>{metadata_instance.prepare}</span>"
-                    )
-                    meta_objects.append((metadata_instance.pk, label))
+                param_item_instance = (
+                    ParamItem.objects.filter(metadata=metadata_instance).select_related("param").first()
+                )
+                if param_item_instance:
+                    if param := param_item_instance.param:
+                        if (
+                            param.content_type_id == dataset_content_type_pk
+                            and metadata_instance.metadata_version.status == VersionStatus.DRAFT
+                        ):
+                            if metadata_instance.ref:
+                                dataset_param_item_metadata_ref = metadata_instance.ref
+                            label = mark_safe(
+                                f"Param ref:  <span class='tag is-success is-light is-medium prop_metadata'>{dataset_param_item_metadata_ref}</span>"
+                                f" prepare: <span class='tag is-success is-light is-medium'>{metadata_instance.prepare}</span>"
+                            )
+                            meta_objects.append((metadata_instance.pk, label))
 
             if metadata_model == "enumitem":
-                enumitem_instance = EnumItem.objects.filter(metadata=metadata_instance).first()
-                enum = enumitem_instance.enum
-                if (
-                    enum.content_type_id == ContentType.objects.filter(model="dataset").first().pk
-                    and metadata_instance.metadata_version.status == VersionStatus.DRAFT
-                ):
-                    if metadata_instance.ref:
-                        dataset_enum_item_metadata_ref = metadata_instance.ref
-                    label = mark_safe(
-                        f"Enum: {dataset_enum_item_metadata_ref} "
-                        f"<span class='tag is-success is-light is-medium'>{metadata_instance.prepare}</span>"
-                    )
-                    meta_objects.append((metadata_instance.pk, label))
+                enum_item_instance = EnumItem.objects.filter(metadata=metadata_instance).select_related("enum").first()
+                if enum_item_instance:
+                    if enum := enum_item_instance.enum:
+                        if (
+                            enum.content_type_id == dataset_content_type_pk
+                            and metadata_instance.metadata_version.status == VersionStatus.DRAFT
+                        ):
+                            if metadata_instance.ref:
+                                dataset_enum_item_metadata_ref = metadata_instance.ref
+                            label = mark_safe(
+                                f"Enum ref:  <span class='tag is-success is-light is-medium prop_metadata'>{dataset_enum_item_metadata_ref}</span> "
+                                f" prepare: <span class='tag is-success is-light is-medium'>{metadata_instance.prepare}</span>"
+                            )
+                            meta_objects.append((metadata_instance.pk, label))
 
         for model in self.model_set.all():
-            if dataset_distribution_for_model := model.distribution:
-                if dataset_distribution_metadata := dataset_distribution_for_model.metadata.first():
-                    if dataset_distribution_metadata.metadata_version.status == VersionStatus.DRAFT:
-                        label = mark_safe(
-                            f"<a href={dataset_distribution_for_model.get_absolute_url()}>{dataset_distribution_metadata.name}</a> name: "
-                            f"<span class='tag is-success is-light is-medium'>{dataset_distribution_metadata.name}</span>"
-                        )
+            dataset_distribution_for_model = model.distribution
+            dataset_distribution_metadata = (
+                dataset_distribution_for_model.metadata.first() if dataset_distribution_for_model else None
+            )
 
-                        if dataset_distribution_metadata.pk not in dataset_distributions:
-                            dataset_distributions.add(dataset_distribution_metadata.pk)
-                            meta_objects.append((dataset_distribution_metadata.pk, label))
+            is_metadata_inside_expected_distributions = False
+            is_version_draft = False
+
+            if dataset_distribution_metadata:
+                is_metadata_inside_expected_distributions = dataset_distribution_metadata.pk in dataset_distributions
+                metadata_version_status = getattr(dataset_distribution_metadata.metadata_version, "status", None)
+                is_version_draft = metadata_version_status == VersionStatus.DRAFT
+
+            if (
+                dataset_distribution_for_model
+                and dataset_distribution_metadata
+                and not is_metadata_inside_expected_distributions
+                and is_version_draft
+            ):
+                label = mark_safe(
+                    f"<a href={dataset_distribution_for_model.get_absolute_url()}>{dataset_distribution_metadata.name}</a> name: "
+                    f"<span class='tag is-success is-light is-medium'>{dataset_distribution_metadata.name}</span>"
+                )
+                dataset_distributions.add(dataset_distribution_metadata.pk)
+                meta_objects.append((dataset_distribution_metadata.pk, label))
 
             metadata = model.metadata.first()
             if metadata and metadata.draft is True:
@@ -1108,21 +1120,13 @@ class Dataset(Resource):
                 if param := model.params.first():
                     for param_item in param.paramitem_set.all():
                         metadata = param_item.metadata.first()
-                        if metadata and metadata.metadata_version.status == VersionStatus.DRAFT:
-                            if metadata.ref:
-                                model_param_item_metadata_ref = metadata.ref
-
-                            param_text = (
-                                f"<a href='{metadata.uri_link}'>Param</a>: "
-                                f"<span class='prop_metadata'>{model_param_item_metadata_ref}</span>"
-                                if metadata.uri_link
-                                else f"Param: <span class='prop_metadata'>{model_param_item_metadata_ref}</span>"
-                            )
-                            label = mark_safe(
-                                f"{param_text} "
-                                f"<span class='tag is-success is-light is-medium'>{metadata.prepare}</span>"
-                            )
-                            meta_objects.append((metadata.pk, label))
+                        if metadata and metadata.metadata_version.status == VersionStatus.DRAFT and metadata.ref:
+                            model_param_item_metadata_ref = metadata.ref
+                        label = mark_safe(
+                            f"Param ref:  <span class='tag is-success is-light is-medium prop_metadata'>{model_param_item_metadata_ref}</span>"
+                            f" prepare: <span class='tag is-success is-light is-medium'>{metadata.prepare}</span>"
+                        )
+                        meta_objects.append((metadata_instance.pk, label))
 
             for prop in model.model_properties.all():
                 metadata = prop.metadata.first()

--- a/vitrina/datasets/models.py
+++ b/vitrina/datasets/models.py
@@ -36,6 +36,9 @@ from vitrina.datasets.managers import (
 )
 from vitrina.models import UUIDBaseModel
 from vitrina.orgs.models import Organization, Representative
+from vitrina.settings import TRANSLATION_CLIENT_ID, TRANSLATION_URL
+from vitrina.structure import VersionStatus
+from vitrina.structure.models import Model, Base, Property, Metadata, StatusCode, ParamItem, EnumItem
 from vitrina.structure.models import Model, Base, Property, Metadata, StatusCode
 from vitrina.users.models import User
 
@@ -958,8 +961,14 @@ class Dataset(Resource):
         meta_objects = []
         models = []
         props = []
-
+        dataset_distributions = set()
         metadata = self.metadata.first()
+        dataset_param_item_metadata_ref = None
+        dataset_enum_item_metadata_ref = None
+        model_param_item_metadata_ref = None
+
+        all_metadata_instances = Metadata.objects.filter(dataset=self.pk, draft=True)
+
         if metadata and metadata.draft is True:
             if latest_version := metadata.metadataversion_set.order_by("-version__created").first():
                 if latest_version.name != metadata.name:
@@ -976,7 +985,66 @@ class Dataset(Resource):
                 )
                 meta_objects.append((metadata.pk, label))
 
+        for metadata_instance in all_metadata_instances:
+            content_type_id = metadata_instance.content_type.id
+            metadata_model = ContentType.objects.get_for_id(content_type_id).model
+            if metadata_model == "prefix":
+                label = mark_safe(
+                    f"<a href={metadata_instance.uri_link}>Prefix</a> name: "
+                    f"<span class='tag is-success is-light is-medium'>{metadata_instance.name}</span>"
+                )
+                meta_objects.append((metadata_instance.pk, label))
+
+            if metadata_model == "paramitem":
+                paramitem_instance = ParamItem.objects.filter(metadata=metadata_instance).first()
+                param = paramitem_instance.param
+                if param.content_type_id == ContentType.objects.filter(model="dataset").first().pk and metadata_instance.metadata_version.status == VersionStatus.DRAFT:
+                    if metadata_instance.ref:
+                        dataset_param_item_metadata_ref = metadata_instance.ref
+                    label = mark_safe(
+                        f"Param: {dataset_param_item_metadata_ref} "
+                        f"<span class='tag is-success is-light is-medium'>{metadata_instance.prepare}</span>"
+                    )
+                    meta_objects.append((metadata_instance.pk, label))
+
+            if metadata_model == "enumitem":
+                enumitem_instance = EnumItem.objects.filter(metadata=metadata_instance).first()
+                enum = enumitem_instance.enum
+                if enum.content_type_id == ContentType.objects.filter(model="dataset").first().pk and metadata_instance.metadata_version.status == VersionStatus.DRAFT:
+                    if metadata_instance.ref:
+                        dataset_enum_item_metadata_ref = metadata_instance.ref
+                    label = mark_safe(
+                        f"Enum: {dataset_enum_item_metadata_ref} "
+                        f"<span class='tag is-success is-light is-medium'>{metadata_instance.prepare}</span>"
+                    )
+                    meta_objects.append((metadata_instance.pk, label))
+
         for model in self.model_set.all():
+            if param := model.params.first():
+                for param_item in param.paramitem_set.all():
+                    metadata = param_item.metadata.first()
+                    if metadata and metadata.metadata_version.status == VersionStatus.DRAFT:
+                        if metadata.ref:
+                            model_param_item_metadata_ref = metadata.ref
+
+                        label = mark_safe(
+                            f"Param: <span class='prop_metadata'>{model_param_item_metadata_ref}</span> "
+                            f"<span class='tag is-success is-light is-medium'>{metadata.prepare}</span>"
+                        )
+                        meta_objects.append((metadata.pk, label))
+
+            if dataset_distribution_for_model := model.distribution:
+                if dataset_distribution_metadata := dataset_distribution_for_model.metadata.first():
+                    if dataset_distribution_metadata.metadata_version.status == VersionStatus.DRAFT:
+                        label = mark_safe(
+                            f"<a href={dataset_distribution_for_model.get_absolute_url()}>{dataset_distribution_for_model.title}</a> name: "
+                            f"<span class='tag is-success is-light is-medium'>{dataset_distribution_for_model.title}</span>"
+                        )
+
+                        if dataset_distribution_metadata.pk not in dataset_distributions:
+                            dataset_distributions.add(dataset_distribution_metadata.pk)
+                            meta_objects.append((dataset_distribution_metadata.pk, label))
+
             metadata = model.metadata.first()
             if metadata and metadata.draft is True:
                 models.append(model)
@@ -1035,7 +1103,7 @@ class Dataset(Resource):
                     label = mark_safe(label_str)
                     meta_objects.append((metadata.pk, label))
 
-            for prop in model.model_properties.filter(given=True):
+            for prop in model.model_properties.all():
                 metadata = prop.metadata.first()
                 if metadata and metadata.draft is True:
                     props.append(prop)

--- a/vitrina/structure/templates/vitrina/structure/version_detail.html
+++ b/vitrina/structure/templates/vitrina/structure/version_detail.html
@@ -14,11 +14,14 @@
 
 {% block head %}
     <style>
+        .model_metadata {
+            padding-left: 1.5em;
+        }
 		.prop_metadata {
-		    padding-left: 1.5em;
+		    padding-left: 3.5em;
 		}
 		.enum_metadata {
-		    padding-left: 3.5em;
+		    padding-left: 5.5em;
 		}
     </style>
 {% endblock %}

--- a/vitrina/structure/templates/vitrina/structure/version_form.html
+++ b/vitrina/structure/templates/vitrina/structure/version_form.html
@@ -17,11 +17,14 @@
         #div_id_metadata div.control {
           margin-bottom: 0.5rem;
        }
-       div.control:has(.prop_metadata) {
+       div.control:has(.model_metadata) {
            padding-left: 1.5em;
        }
-       div.control:has(.enum_metadata) {
+       div.control:has(.prop_metadata) {
            padding-left: 3.5em;
+       }
+       div.control:has(.enum_metadata) {
+           padding-left: 5.5em;
        }
     </style>
 {% endblock %}


### PR DESCRIPTION
The publishing form was not displaying all of the metadata fields that were required. This made it difficult to collect the full version. 
This PR makes the publishing form hold all of the metadata fields as possible selections.