### PR TITLE
fix fakeviisp companycode field type

### DIFF
--- a/vitrina/viisp/forms.py
+++ b/vitrina/viisp/forms.py
@@ -16,11 +16,10 @@ PROXY_TYPE_CHOICES = [
 
 class FakeViispForm(forms.Form):
     email = forms.EmailField(label=_("El. paštas"), required=True)
-    lt_company_code = forms.IntegerField(
+    lt_company_code = forms.CharField(
         label=_("Įmonės kodas"),
         help_text=_("Įveskite Lietuvoje registruotos įmonės kodą."),
         required=False,
-        min_value=1,
     )
     proxy_type = forms.ChoiceField(label=_("JA atstovavimo tipas"), choices=PROXY_TYPE_CHOICES, required=False)
 


### PR DESCRIPTION
updated `FakeViispForm` `lt_company_code` field type, because there was issue when trying codes that start with zero, and zero(s) are stripped.