### PR TITLE
[2067] Agreement negotiation: Part 3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ https://github.com/atviriduomenys/katalogas/issues/2067
 - Part 2.2: Add new field `template` and new statuses for `Agreement`. Adding a few adjustments for field displays & formatting.
 - Part 2.3: Move permissions to dedicated `permisions.py` file.
 - Part 2.4: Adjust queryset to allow selecting contacts without an assigned user as well.
+- Part 3: Add forms for `submit`, `approve`, change the `form` status form. Separate the forms to be independant for each status.
 
 https://github.com/atviriduomenys/katalogas/issues/1955
 - Improved contact form by adding new contact, position, removed dataset field.

--- a/tests/smart_contracts/test_forms.py
+++ b/tests/smart_contracts/test_forms.py
@@ -114,11 +114,7 @@ class TestAgreementSubmitForm:
             project=ProjectFactory(organization=organization)
         )
 
-        user = UserFactory(
-            organization=organization,
-            is_viisp_login=True,
-            viisp_company_code=organization.company_code,
-        )
+        user = UserFactory(organization=organization)
         contact_with_user = ContactFactory(
             contact_name="Vardenis Pavardenis",
             organization=organization,

--- a/tests/smart_contracts/test_forms.py
+++ b/tests/smart_contracts/test_forms.py
@@ -2,17 +2,25 @@ from pathlib import Path
 
 import pytest
 from django.contrib.contenttypes.models import ContentType
+from django.core.files.base import ContentFile
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django_webtest import DjangoTestApp
 
-from vitrina.datasets.factories import DatasetFactory
-from vitrina.datasets.models import Dataset, Contact
-
-from vitrina.orgs.models import Organization
+from tests.conftest import organization
+from vitrina.datasets.factories import DatasetFactory, ContactFactory
+from vitrina.datasets.models import Dataset
 from vitrina.orgs.factories import OrganizationFactory
+from vitrina.orgs.models import Organization
 from vitrina.projects.factories import ProjectFactory
-from vitrina.smart_contracts.factories import AgreementFactory, AgreementPDFFileFactory, AgreementJSONFileFactory
-from vitrina.smart_contracts.forms import SmartContractForm, AgreementUploadForm, AgreementGeneratePdfForm
+from vitrina.smart_contracts.factories import AgreementPDFFileFactory, AgreementFactory
+from vitrina.smart_contracts.forms import (
+    SmartContractForm,
+    AgreementUploadForm,
+    AgreementSubmitForm,
+    AgreementApproveForm,
+    AgreementFormForm,
+)
+from vitrina.smart_contracts.models import SmartContractTemplate
 from vitrina.structure.factories import MetadataFactory
 from vitrina.users.factories import UserFactory
 from vitrina.users.models import User
@@ -72,67 +80,244 @@ class TestSmartContractForm:
             ("uapi:/test/dataset/:select", "uapi:/test/dataset/:select"),
         }
 
-    def test_agreement_generate_pdf_form_representative_querysets(self):
-        assigner_organization = OrganizationFactory(title="Assigner Organization", email="assigner@example.com")
-        assignee_organization = OrganizationFactory(title="Assignee Organization", email="assignee@example.com")
 
-        assigner_user = UserFactory(organization=assigner_organization, email="assigner@test.com")
-        assignee_user = UserFactory(organization=assignee_organization, email="assignee@test.com")
-
-        content_type_user = ContentType.objects.get_for_model(User)
-
-        dataset_a, dataset_b, dataset_c, dataset_d, dataset_e, dataset_f = [
-            DatasetFactory(organization=assigner_organization) for _ in range(6)
-        ]
-
-        assigner_contact_user = Contact.objects.create(
-            organization=assigner_organization,
-            content_type=content_type_user,
-            object_id=assigner_user.pk,
-            email=assigner_user.email,
+class TestAgreementSubmitForm:
+    def test_success(self, organization: Organization):
+        # Arrange
+        agreement = AgreementFactory(
+            assignee=organization,
+            project=ProjectFactory(organization=organization),
         )
-        assigner_contact = Contact.objects.create(
-            organization=assigner_organization,
-            content_type=None,
+        contact = ContactFactory(
+            contact_name="Vardenis Pavardenis",
+            organization=organization,
             object_id=None,
-            email=assigner_organization.email,
-        )
-
-        assignee_contact_user = Contact.objects.create(
-            organization=assignee_organization,
-            content_type=content_type_user,
-            object_id=assignee_user.pk,
-            email=assignee_user.email,
-        )
-        assignee_contact = Contact.objects.create(
-            organization=assignee_organization,
             content_type=None,
-            object_id=None,
-            email=assignee_organization.email,
-        )
-
-        random_contact_user = Contact.objects.create(
-            organization=assigner_organization,
-            content_type=content_type_user,
-            object_id=OrganizationFactory().pk,
             email="example@example.com",
+            phone="+37060000000"
         )
 
-        project = ProjectFactory(organization=assignee_organization, datasets=[dataset_a, dataset_b, dataset_c, dataset_d])
-        agreement = AgreementFactory(project=project, assigner=assigner_organization, assignee=assignee_organization)
+        # Act
+        form = AgreementSubmitForm(
+            data={"assignee_representative": contact.pk},
+            agreement=agreement
+        )
 
-        form = AgreementGeneratePdfForm(agreement=agreement)
+        # Assert
+        assert form.is_valid(), form.errors
 
-        assigner_queryset = list(form.fields["assigner_representative"].queryset)
-        assignee_queryset = list(form.fields["assignee_representative"].queryset)
+    def test_assignee_representative_queryset(self, organization: Organization):
+        # Arrange
+        unrelated_organization = OrganizationFactory()
+        agreement = AgreementFactory(
+            assignee=organization,
+            project=ProjectFactory(organization=organization)
+        )
 
-        assert assigner_contact_user in assigner_queryset
-        assert assigner_contact in assigner_queryset
-        assert assignee_contact_user in assignee_queryset
-        assert assignee_contact in assignee_queryset
+        user = UserFactory(
+            organization=organization,
+            is_viisp_login=True,
+            viisp_company_code=organization.company_code,
+        )
+        contact_with_user = ContactFactory(
+            contact_name="Vardenis Pavardenis",
+            organization=organization,
+            object_id=user.id,
+            content_type=ContentType.objects.get_for_model(User),
+            email="example@example.com",
+            phone="+37060000000"
+        )
+        contact_no_user = ContactFactory(
+            contact_name="Petras Petrauskas",
+            organization=organization,
+            content_object=user,
+            email="example2@example.com",
+            phone="+37060000000"
+        )
+        contact_unrelated_organization = ContactFactory(
+            contact_name="Jonas Jonauskas",
+            organization=unrelated_organization,
+            object_id=None,
+            content_type=None,
+            email="example3@example.com",
+            phone="+37060000000"
+        )
 
-        assert random_contact_user not in assigner_queryset
-        assert random_contact_user not in assignee_queryset
+        # Act
+        form = AgreementSubmitForm(agreement=agreement)
+
+        # Assert
+        contacts_selectable_in_form = list(form.fields["assignee_representative"].queryset)
+        assert contact_unrelated_organization not in contacts_selectable_in_form
+        assert all(contact in contacts_selectable_in_form for contact in {contact_with_user, contact_no_user})
+
+    def test_failure_required_fields_unfilled(self, organization: Organization):
+        agreement = AgreementFactory(
+            assignee=organization,
+            project=ProjectFactory(organization=organization)
+        )
+        form = AgreementSubmitForm(data={}, agreement=agreement)
+
+        assert not form.is_valid()
+        assert form.errors == {"assignee_representative": ["Šis laukas yra privalomas."]}
+
+
+class TestAgreementApproveForm:
+    def test_success(self, organization: Organization):
+        # Arrange
+        template = SmartContractTemplate.objects.create(
+            file=ContentFile(
+                open(Path(__file__).parent / "files" / "contract_template.md").read(),
+                name="contract_template.md",
+            )
+        )
+        organization = OrganizationFactory()
+        agreement = AgreementFactory(
+            assigner=organization,
+            project=ProjectFactory(organization=organization),
+        )
+
+        contact = ContactFactory(
+            contact_name="Vardenis Pavardenis",
+            organization=organization,
+            object_id=None,
+            content_type=None,
+            email="example@example.com",
+            phone="+37060000000"
+        )
+
+        # Act
+        form = AgreementApproveForm(
+            data={
+                "template": template.pk,
+                "assigner_representative": contact.pk,
+                "other_assigner_legislations": "Legislation A; Legislation B; Legislation C."
+            },
+            agreement=agreement
+        )
+
+        # Assert
+        assert form.is_valid(), form.errors
+
+    def test_assigner_representative_queryset(self, organization: Organization):
+        # Arrange
+        unrelated_organization = OrganizationFactory()
+        agreement = AgreementFactory(
+            assigner=organization,
+            project=ProjectFactory(organization=organization),
+        )
+
+        user = UserFactory(
+            organization=organization,
+            is_viisp_login=True,
+            viisp_company_code=organization.company_code,
+        )
+        contact_with_user = ContactFactory(
+            contact_name="Vardenis Pavardenis",
+            organization=organization,
+            object_id=user.id,
+            content_type=ContentType.objects.get_for_model(User),
+            email="example@example.com",
+            phone="+37060000000"
+        )
+        contact_no_user = ContactFactory(
+            contact_name="Petras Petrauskas",
+            organization=organization,
+            content_object=user,
+            email="example2@example.com",
+            phone="+37060000000"
+        )
+        contact_unrelated_organization = ContactFactory(
+            contact_name="Jonas Jonauskas",
+            organization=unrelated_organization,
+            object_id=None,
+            content_type=None,
+            email="example3@example.com",
+            phone="+37060000000"
+        )
+
+        # Act
+        form = AgreementApproveForm(agreement=agreement)
+
+        # Assert
+        contacts_selectable_in_form = list(form.fields["assigner_representative"].queryset)
+        assert contact_unrelated_organization not in contacts_selectable_in_form
+        assert all(contact in contacts_selectable_in_form for contact in (contact_with_user, contact_no_user))
+
+    def test_template_queryset(self, organization: Organization):
+        # Arrange
+        unrelated_organization = OrganizationFactory()
+        agreement = AgreementFactory(
+            assigner=organization,
+            project=ProjectFactory(organization=organization),
+        )
+
+        template_no_organization = SmartContractTemplate.objects.create(
+            file=ContentFile(
+                open(Path(__file__).parent / "files" / "contract_template.md").read(),
+                name="contract_template.md",
+            )
+        )
+        template_current_organization = SmartContractTemplate.objects.create(
+            file=ContentFile(
+                open(Path(__file__).parent / "files" / "contract_template.md").read(),
+                name="contract_template.md",
+            ),
+            organization=organization,
+        )
+        template_unrelated_organization = SmartContractTemplate.objects.create(
+            file=ContentFile(
+                open(Path(__file__).parent / "files" / "contract_template.md").read(),
+                name="contract_template.md",
+            ),
+            organization=unrelated_organization,
+        )
+
+        # Act
+        form = AgreementApproveForm(agreement=agreement)
+
+        # Assert
+        agreements_selectable_in_form = list(form.fields["template"].queryset)
+        assert template_unrelated_organization not in agreements_selectable_in_form
+        assert all(
+            template in agreements_selectable_in_form for template in (
+                template_no_organization,
+                template_current_organization,
+            )
+        )
+
+    def test_failure_required_fields_unfilled(self, organization: Organization):
+        # Arrange
+        agreement = AgreementFactory(
+            assignee=organization,
+            project=ProjectFactory(organization=organization)
+        )
+
+        # Act
+        form = AgreementApproveForm(data={}, agreement=agreement)
+
+        # Assert
+        assert not form.is_valid()
+        assert form.errors == {
+            "template": ["Šis laukas yra privalomas."],
+            "assigner_representative": ["Šis laukas yra privalomas."],
+            "other_assigner_legislations": ["Šis laukas yra privalomas."],
+        }
+
+
+class TestAgreementFormForm:
+    def test_success(self, organization: Organization):
+        # Arrange
+        agreement = AgreementFactory(
+            assignee=organization,
+            project=ProjectFactory(organization=organization)
+        )
+
+        # Act
+        form = AgreementFormForm(data={}, agreement=agreement)
+
+        # Assert
+        assert form.is_valid(), form.errors
 
 
 class TestAgreementUploadForm:

--- a/tests/smart_contracts/test_permissions.py
+++ b/tests/smart_contracts/test_permissions.py
@@ -1,0 +1,227 @@
+import pytest
+from django.contrib.contenttypes.models import ContentType
+
+from vitrina.orgs.factories import RepresentativeFactory, OrganizationFactory
+from vitrina.orgs.models import Organization, Representative
+from vitrina.projects.factories import ProjectFactory
+from vitrina.smart_contracts.factories import AgreementFactory
+from vitrina.smart_contracts.permissions import can_create_agreements, can_submit_agreements, can_approve_agreements, \
+    can_form_agreements
+from vitrina.users.factories import UserFactory
+
+
+class TestCanCreateAgreements:
+    def test_success(self, organization: Organization):
+        user = UserFactory(is_viisp_login=True, viisp_company_code=organization.company_code)
+        project = ProjectFactory(organization=organization)
+        RepresentativeFactory(
+            user=user,
+            organization=organization,
+            role=Representative.COORDINATOR,
+            can_make_agreements=True,
+            object_id=organization.id,
+            content_type=ContentType.objects.get_for_model(organization)
+        )
+
+        assert can_create_agreements(user, project)
+
+    def test_no_organization_provided(self, organization: Organization):
+        user = UserFactory()
+        project = ProjectFactory(organization=None)
+        RepresentativeFactory(
+            user=user,
+            organization=organization,
+            role=Representative.COORDINATOR,
+            can_make_agreements=True,
+            object_id=organization.id,
+            content_type=ContentType.objects.get_for_model(organization)
+        )
+
+        assert not can_create_agreements(user, project)
+
+    def test_not_viisp_authenticated(self, organization: Organization):
+        user = UserFactory(is_viisp_login=False, viisp_company_code="invalid_company_code")
+        project = ProjectFactory(organization=organization)
+        RepresentativeFactory(
+            user=user,
+            organization=organization,
+            role=Representative.COORDINATOR,
+            can_make_agreements=True,
+            object_id=organization.id,
+            content_type=ContentType.objects.get_for_model(organization)
+        )
+
+        assert not can_create_agreements(user, project)
+
+    def test_not_representative(self, organization: Organization):
+        user = UserFactory(is_viisp_login=False, viisp_company_code="invalid_company_code")
+        project = ProjectFactory(organization=organization)
+
+        assert not can_create_agreements(user, project)
+
+
+class TestCanSubmitAgreements:
+    def test_success(self, organization: Organization):
+        user = UserFactory(is_viisp_login=True, viisp_company_code=organization.company_code)
+        agreement = AgreementFactory(
+            assignee=organization,
+            project=ProjectFactory(organization=organization),
+        )
+        RepresentativeFactory(
+            user=user,
+            organization=organization,
+            role=Representative.COORDINATOR,
+            can_make_agreements=True,
+            object_id=organization.id,
+            content_type=ContentType.objects.get_for_model(organization)
+        )
+
+        assert can_submit_agreements(user, agreement)
+
+    def test_not_viisp_authenticated(self, organization: Organization):
+        user = UserFactory(is_viisp_login=False, viisp_company_code="invalid_company_code")
+        agreement = AgreementFactory(
+            assignee=organization,
+            project=ProjectFactory(organization=organization),
+        )
+        RepresentativeFactory(
+            user=user,
+            organization=organization,
+            role=Representative.COORDINATOR,
+            can_make_agreements=True,
+            object_id=organization.id,
+            content_type=ContentType.objects.get_for_model(organization)
+        )
+
+        assert not can_submit_agreements(user, agreement)
+
+    def test_not_representative(self, organization: Organization):
+        user = UserFactory(is_viisp_login=True, viisp_company_code=organization.company_code)
+        agreement = AgreementFactory(
+            assignee=organization,
+            project=ProjectFactory(organization=organization),
+        )
+
+        assert not can_submit_agreements(user, agreement)
+
+
+class TestCanApproveAgreements:
+    def test_success(self, organization: Organization):
+        user = UserFactory(is_viisp_login=True, viisp_company_code=organization.company_code)
+        agreement = AgreementFactory(
+            assigner=organization,
+            project=ProjectFactory(organization=organization),
+        )
+        RepresentativeFactory(
+            user=user,
+            organization=organization,
+            role=Representative.COORDINATOR,
+            can_make_agreements=True,
+            object_id=organization.id,
+            content_type=ContentType.objects.get_for_model(organization)
+        )
+
+        assert can_approve_agreements(user, agreement)
+
+    def test_not_viisp_authenticated(self, organization: Organization):
+        user = UserFactory(is_viisp_login=False, viisp_company_code="invalid_company_code")
+        agreement = AgreementFactory(
+            assignee=organization,
+            project=ProjectFactory(organization=organization),
+        )
+        RepresentativeFactory(
+            user=user,
+            organization=organization,
+            role=Representative.COORDINATOR,
+            can_make_agreements=True,
+            object_id=organization.id,
+            content_type=ContentType.objects.get_for_model(organization)
+        )
+
+        assert not can_approve_agreements(user, agreement)
+
+    def test_not_representative(self, organization: Organization):
+        user = UserFactory(is_viisp_login=True, viisp_company_code=organization.company_code)
+        agreement = AgreementFactory(
+            assigner=organization,
+            project=ProjectFactory(organization=organization),
+        )
+
+        assert not can_approve_agreements(user, agreement)
+
+
+class TestCanFormAgreements:
+    @pytest.mark.parametrize("is_acting_user_assignee", [True, False])
+    def test_success(self, is_acting_user_assignee: bool):
+        assignee = OrganizationFactory()
+        assigner = OrganizationFactory()
+
+        user = UserFactory(
+            is_viisp_login=True,
+            organization=assignee if is_acting_user_assignee else assigner,
+            viisp_company_code=assignee.company_code if is_acting_user_assignee else assigner.company_code,
+        )
+
+        agreement = AgreementFactory(
+            assignee=assignee,
+            assigner=assigner,
+            project=ProjectFactory(organization=assignee),
+        )
+
+        RepresentativeFactory(
+            user=user,
+            organization=assignee if is_acting_user_assignee else assigner,
+            role=Representative.COORDINATOR,
+            can_make_agreements=True,
+            object_id=assignee.id if is_acting_user_assignee else assigner.id,
+            content_type=ContentType.objects.get_for_model(assignee)
+        )
+
+        assert can_form_agreements(user, agreement)
+
+    @pytest.mark.parametrize("is_acting_user_assignee", [True, False])
+    def test_not_viisp_authenticated(self, is_acting_user_assignee: bool):
+        assignee = OrganizationFactory()
+        assigner = OrganizationFactory()
+
+        user = UserFactory(
+            is_viisp_login=True,
+            organization=assignee if is_acting_user_assignee else assigner,
+            viisp_company_code="invalid_company_code",
+        )
+
+        agreement = AgreementFactory(
+            assignee=assignee,
+            assigner=assigner,
+            project=ProjectFactory(organization=assignee),
+        )
+
+        RepresentativeFactory(
+            user=user,
+            organization=assignee if is_acting_user_assignee else assigner,
+            role=Representative.COORDINATOR,
+            can_make_agreements=True,
+            object_id=assignee.id if is_acting_user_assignee else assigner.id,
+            content_type=ContentType.objects.get_for_model(assignee)
+        )
+
+        assert not can_form_agreements(user, agreement)
+
+    @pytest.mark.parametrize("is_acting_user_assignee", [True, False])
+    def test_not_representative(self, is_acting_user_assignee: bool):
+        assignee = OrganizationFactory()
+        assigner = OrganizationFactory()
+
+        user = UserFactory(
+            is_viisp_login=True,
+            organization=assignee if is_acting_user_assignee else assigner,
+            viisp_company_code=assignee.company_code if is_acting_user_assignee else assigner.company_code,
+        )
+
+        agreement = AgreementFactory(
+            assignee=assignee,
+            assigner=assigner,
+            project=ProjectFactory(organization=assignee),
+        )
+
+        assert not can_form_agreements(user, agreement)

--- a/tests/smart_contracts/test_views.py
+++ b/tests/smart_contracts/test_views.py
@@ -21,7 +21,6 @@ from vitrina.smart_contracts.factories import AgreementFactory, AgreementPDFFile
 from vitrina.smart_contracts.models import (
     Agreement,
     AgreementScope,
-    AgreementFile,
     SmartContractTemplate,
 )
 from vitrina.structure.factories import MetadataFactory
@@ -327,63 +326,1051 @@ class TestAgreementCreateView:
         assert response.status_code == 403
 
 
-
-class TestAgreementGeneratePdf:
-    def test_cannot_generate_pdf_without_permission(self, app: DjangoTestApp) -> None:
-        representative = ViispRepresentativeFactory(can_make_agreements=False)
-        user = representative.user
-        organization = representative.content_object
+class TestAgreementSubmit:
+    def test_success(self, app: DjangoTestApp, dataset: Dataset):
+        # Arrange
+        assignee_organization, assigner_organization = OrganizationFactory.create_batch(2)
+        user = UserFactory(
+            organization=assignee_organization,
+            is_viisp_login=True,
+            viisp_company_code=assignee_organization.company_code,
+        )
         app.set_user(user)
-        project = ProjectFactory(organization=organization)
-        agreement = AgreementFactory(project=project, assigner=organization)
+        RepresentativeFactory(user=user, content_object=assignee_organization, can_make_agreements=True)
+        contact = ContactFactory(
+            organization=assignee_organization,
+            object_id=user.pk,
+            content_type=ContentType.objects.get_for_model(User),
+            email=user.email,
+            phone=user.phone
+        )
 
-        response = app.get(
-            reverse("agreement-generate-pdf", args=[project.pk, agreement.pk]),
+        project = ProjectFactory(
+            organization=assignee_organization,
+            datasets=[dataset],
+            other_assignee_legislations="Test",
+        )
+        agreement = AgreementFactory(
+            project=project,
+            assignee=assignee_organization,
+            assignee_representative=None,
+            assigner=assigner_organization,
+            created_by=user,
+            status=AgreementStatuses.CREATED
+        )
+
+        # Act
+        response = app.post(
+            reverse("agreement-submit", args=[project.pk, agreement.pk]),
+            {
+                "assignee_representative": contact.pk
+            }
+        )
+
+        # Assert
+        assert response.status_code == 302
+        agreement.refresh_from_db()
+        assert agreement.status == AgreementStatuses.SUBMITTED
+        assert agreement.assignee_representative == contact
+
+    def test_unauthorized_not_representative(self, app: DjangoTestApp, dataset: Dataset):
+        # Arrange
+        assignee_organization, assigner_organization = OrganizationFactory.create_batch(2)
+        user = UserFactory(
+            organization=assignee_organization,
+            is_viisp_login=True,
+            viisp_company_code=assignee_organization.company_code,
+        )
+        app.set_user(user)
+        contact = ContactFactory(
+            organization=assignee_organization,
+            object_id=user.pk,
+            content_type=ContentType.objects.get_for_model(User),
+            email=user.email,
+            phone=user.phone
+        )
+
+        project = ProjectFactory(
+            organization=assignee_organization,
+            datasets=[dataset],
+            other_assignee_legislations="Test",
+        )
+        agreement = AgreementFactory(
+            project=project,
+            assignee=assignee_organization,
+            assignee_representative=None,
+            assigner=assigner_organization,
+            created_by=user,
+            status=AgreementStatuses.CREATED
+        )
+
+        # Act
+        response = app.post(
+            reverse("agreement-submit", args=[project.pk, agreement.pk]),
+            {
+                "assignee_representative": contact.pk,
+            },
             expect_errors=True,
         )
+
+        # Assert
         assert response.status_code == 403
+        agreement.refresh_from_db()
+        assert agreement.status == AgreementStatuses.CREATED
+        assert not agreement.assignee_representative
 
-    def test_page_loads_without_error(
-        self, app: DjangoTestApp, organization: Organization, dataset: Dataset,
-    ) -> None:
-        representative = ViispRepresentativeFactory(content_object=organization, can_make_agreements=True)
-        user = representative.user
+    def test_unauthorized_not_viisp_authorized(self, app: DjangoTestApp, dataset: Dataset):
+        # Arrange
+        assignee_organization, assigner_organization = OrganizationFactory.create_batch(2)
+        user = UserFactory(
+            organization=assignee_organization,
+            is_viisp_login=False,
+            viisp_company_code="invalid_company_code",
+        )
         app.set_user(user)
-        project = ProjectFactory(organization=organization, datasets=[dataset])
+        RepresentativeFactory(user=user, content_object=assignee_organization, can_make_agreements=True)
+        contact = ContactFactory(
+            organization=assignee_organization,
+            object_id=user.pk,
+            content_type=ContentType.objects.get_for_model(User),
+            email=user.email,
+            phone=user.phone
+        )
+
+        project = ProjectFactory(
+            organization=assignee_organization,
+            datasets=[dataset],
+            other_assignee_legislations="Test",
+        )
         agreement = AgreementFactory(
-            project=project, assigner=organization, status=AgreementStatuses.CREATED,
+            project=project,
+            assignee=assignee_organization,
+            assignee_representative=None,
+            assigner=assigner_organization,
+            created_by=user,
+            status=AgreementStatuses.CREATED
         )
 
-        response = app.get(
-            reverse("agreement-generate-pdf", args=[project.pk, agreement.pk]),
+        # Act
+        response = app.post(
+            reverse("agreement-submit", args=[project.pk, agreement.pk]),
+            {
+                "assignee_representative": contact.pk
+            },
+            expect_errors=True,
         )
 
-        assert response.status_code == 200
+        # Assert
+        assert response.status_code == 403
+        agreement.refresh_from_db()
+        assert agreement.status == AgreementStatuses.CREATED
+        assert not agreement.assignee_representative
 
-    @pytest.mark.parametrize(
-        "status",
-        [
-            AgreementStatuses.FORMED,
-            AgreementStatuses.INITIATED,
-            AgreementStatuses.SIGNED,
-            AgreementStatuses.ACTIVE,
-            AgreementStatuses.TERMINATED,
-        ],
-    )
-    def test_cannot_generate_pdf_for_agreement_with_status_other_than_created(
+    def test_unauthorized_not_granted_agreement_signing_rights(self, app: DjangoTestApp, dataset: Dataset):
+        # Arrange
+        assignee_organization, assigner_organization = OrganizationFactory.create_batch(2)
+        user = UserFactory(
+            organization=assignee_organization,
+            is_viisp_login=True,
+            viisp_company_code=assignee_organization.company_code,
+        )
+        app.set_user(user)
+        RepresentativeFactory(user=user, content_object=assignee_organization, can_make_agreements=False)
+        contact = ContactFactory(
+            organization=assignee_organization,
+            object_id=user.pk,
+            content_type=ContentType.objects.get_for_model(User),
+            email=user.email,
+            phone=user.phone
+        )
+
+        project = ProjectFactory(
+            organization=assignee_organization,
+            datasets=[dataset],
+            other_assignee_legislations="Test",
+        )
+        agreement = AgreementFactory(
+            project=project,
+            assignee=assignee_organization,
+            assignee_representative=None,
+            assigner=assigner_organization,
+            created_by=user,
+            status=AgreementStatuses.CREATED
+        )
+
+        # Act
+        response = app.post(
+            reverse("agreement-submit", args=[project.pk, agreement.pk]),
+            {
+                "assignee_representative": contact.pk
+            },
+            expect_errors=True,
+        )
+
+        # Assert
+        assert response.status_code == 403
+        agreement.refresh_from_db()
+        assert agreement.status == AgreementStatuses.CREATED
+        assert not agreement.assignee_representative
+
+    @pytest.mark.parametrize("initial_agreement_status", [
+        AgreementStatuses.SUBMITTED,
+        AgreementStatuses.APPROVED,
+        AgreementStatuses.FORMED,
+        AgreementStatuses.INITIATED,
+        AgreementStatuses.SIGNED,
+        AgreementStatuses.ACTIVE,
+        AgreementStatuses.TERMINATED,
+    ])
+    def test_incorrect_agreement_status(
         self,
+        initial_agreement_status: AgreementStatuses,
         app: DjangoTestApp,
-        organization: Organization,
         dataset: Dataset,
-        status: AgreementStatuses,
-    ) -> None:
+    ):
+        # Arrange
+        assignee_organization, assigner_organization = OrganizationFactory.create_batch(2)
+        user = UserFactory(
+            organization=assignee_organization,
+            is_viisp_login=True,
+            viisp_company_code=assignee_organization.company_code,
+        )
+        app.set_user(user)
+        RepresentativeFactory(user=user, content_object=assignee_organization, can_make_agreements=True)
+        contact = ContactFactory(
+            organization=assignee_organization,
+            object_id=user.pk,
+            content_type=ContentType.objects.get_for_model(User),
+            email=user.email,
+            phone=user.phone
+        )
+
+        project = ProjectFactory(
+            organization=assignee_organization,
+            datasets=[dataset],
+            other_assignee_legislations="Test",
+        )
+        agreement = AgreementFactory(
+            project=project,
+            assignee=assignee_organization,
+            assignee_representative=None,
+            assigner=assigner_organization,
+            created_by=user,
+            status=initial_agreement_status
+        )
+
+        # Act
+        response = app.post(
+            reverse("agreement-submit", args=[project.pk, agreement.pk]),
+            {
+                "assignee_representative": contact.pk
+            }
+        )
+
+        # Assert
+        assert response.status_code == 302  # Still redirects to the success page, just with an error message.
+        agreement.refresh_from_db()
+        assert not agreement.assignee_representative
+        assert agreement.status == initial_agreement_status
+
+
+class TestAgreementApprove:
+    def test_success(self, app: DjangoTestApp, dataset: Dataset):
+        # Arrange
         template = SmartContractTemplate.objects.create(
             file=ContentFile(
                 open(Path(__file__).parent / "files" / "contract_template.md").read(),
                 name="contract_template.md",
             )
         )
+
         assignee_organization, assigner_organization = OrganizationFactory.create_batch(2)
+        assignee_user = UserFactory(
+            organization=assignee_organization,
+            is_viisp_login=True,
+            viisp_company_code=assignee_organization.company_code,
+        )
+        assigner_user = UserFactory(
+            organization=assigner_organization,
+            is_viisp_login=True,
+            viisp_company_code=assigner_organization.company_code,
+        )
+        app.set_user(assigner_user)
+
+        RepresentativeFactory(user=assignee_user, content_object=assignee_organization, can_make_agreements=True)
+        RepresentativeFactory(user=assigner_user, content_object=assigner_organization, can_make_agreements=True)
+
+        assignee_contact = ContactFactory(
+            organization=assignee_organization,
+            object_id=assignee_user.pk,
+            content_type=ContentType.objects.get_for_model(User),
+            email=assignee_user.email,
+            phone=assignee_user.phone
+        )
+        assigner_contact = ContactFactory(
+            organization=assigner_organization,
+            object_id=assigner_user.pk,
+            content_type=ContentType.objects.get_for_model(User),
+            email=assigner_user.email,
+            phone=assigner_user.phone
+        )
+
+        project = ProjectFactory(
+            organization=assignee_organization,
+            datasets=[dataset],
+            other_assignee_legislations="Test",
+        )
+
+        agreement = AgreementFactory(
+            project=project,
+            assignee=assignee_organization,
+            assignee_representative=assignee_contact,
+            assigner_representative=None,
+            assigner=assigner_organization,
+            created_by=assignee_user,
+            status=AgreementStatuses.SUBMITTED
+        )
+        other_assigner_legislations = "Legislation A; Legislation B; Legislation C."
+
+        # Act
+        response = app.post(
+            reverse("agreement-approve", args=[project.pk, agreement.pk]),
+            {
+                "template": template.pk,
+                "assigner_representative": assigner_contact.pk,
+                "other_assigner_legislations": other_assigner_legislations
+            }
+        )
+
+        # Assert
+        assert response.status_code == 302
+        agreement.refresh_from_db()
+        assert agreement.status == AgreementStatuses.APPROVED
+        assert agreement.template == template
+        assert agreement.assigner_representative == assigner_contact
+        assert agreement.other_assigner_legislations == other_assigner_legislations
+
+
+    def test_unauthorized_not_representative(self, app: DjangoTestApp, dataset: Dataset):
+        # Arrange
+        template = SmartContractTemplate.objects.create(
+            file=ContentFile(
+                open(Path(__file__).parent / "files" / "contract_template.md").read(),
+                name="contract_template.md",
+            )
+        )
+
+        assignee_organization, assigner_organization = OrganizationFactory.create_batch(2)
+        assignee_user = UserFactory(
+            organization=assignee_organization,
+            is_viisp_login=True,
+            viisp_company_code=assignee_organization.company_code,
+        )
+        assigner_user = UserFactory(
+            organization=assigner_organization,
+            is_viisp_login=True,
+            viisp_company_code=assigner_organization.company_code,
+        )
+        app.set_user(assigner_user)
+
+        RepresentativeFactory(user=assignee_user, content_object=assignee_organization, can_make_agreements=True)
+
+        assignee_contact = ContactFactory(
+            organization=assignee_organization,
+            object_id=assignee_user.pk,
+            content_type=ContentType.objects.get_for_model(User),
+            email=assignee_user.email,
+            phone=assignee_user.phone
+        )
+        assigner_contact = ContactFactory(
+            organization=assigner_organization,
+            object_id=assigner_user.pk,
+            content_type=ContentType.objects.get_for_model(User),
+            email=assigner_user.email,
+            phone=assigner_user.phone
+        )
+
+        project = ProjectFactory(
+            organization=assignee_organization,
+            datasets=[dataset],
+            other_assignee_legislations="Test",
+        )
+
+        agreement = AgreementFactory(
+            project=project,
+            assignee=assignee_organization,
+            assignee_representative=assignee_contact,
+            assigner_representative=None,
+            assigner=assigner_organization,
+            created_by=assignee_user,
+            status=AgreementStatuses.SUBMITTED
+        )
+        other_assigner_legislations = "Legislation A; Legislation B; Legislation C."
+
+        # Act
+        response = app.post(
+            reverse("agreement-approve", args=[project.pk, agreement.pk]),
+            {
+                "template": template.pk,
+                "assigner_representative": assigner_contact.pk,
+                "other_assigner_legislations": other_assigner_legislations
+            },
+            expect_errors=True,
+        )
+
+        # Assert
+        assert response.status_code == 403
+        agreement.refresh_from_db()
+        assert agreement.status == AgreementStatuses.SUBMITTED
+        assert not agreement.template
+        assert not agreement.assigner_representative
+        assert not agreement.other_assigner_legislations
+
+    def test_unauthorized_not_viisp_authorized(self, app: DjangoTestApp, dataset: Dataset):
+        # Arrange
+        template = SmartContractTemplate.objects.create(
+            file=ContentFile(
+                open(Path(__file__).parent / "files" / "contract_template.md").read(),
+                name="contract_template.md",
+            )
+        )
+
+        assignee_organization, assigner_organization = OrganizationFactory.create_batch(2)
+        assignee_user = UserFactory(
+            organization=assignee_organization,
+            is_viisp_login=True,
+            viisp_company_code=assignee_organization.company_code,
+        )
+        assigner_user = UserFactory(
+            organization=assigner_organization,
+            is_viisp_login=False,
+            viisp_company_code="invalid_company_code",
+        )
+        app.set_user(assigner_user)
+
+        RepresentativeFactory(user=assignee_user, content_object=assignee_organization, can_make_agreements=True)
+        RepresentativeFactory(user=assigner_user, content_object=assigner_organization, can_make_agreements=True)
+
+        assignee_contact = ContactFactory(
+            organization=assignee_organization,
+            object_id=assignee_user.pk,
+            content_type=ContentType.objects.get_for_model(User),
+            email=assignee_user.email,
+            phone=assignee_user.phone
+        )
+        assigner_contact = ContactFactory(
+            organization=assigner_organization,
+            object_id=assigner_user.pk,
+            content_type=ContentType.objects.get_for_model(User),
+            email=assigner_user.email,
+            phone=assigner_user.phone
+        )
+
+        project = ProjectFactory(
+            organization=assignee_organization,
+            datasets=[dataset],
+            other_assignee_legislations="Test",
+        )
+
+        agreement = AgreementFactory(
+            project=project,
+            assignee=assignee_organization,
+            assignee_representative=assignee_contact,
+            assigner_representative=None,
+            assigner=assigner_organization,
+            created_by=assignee_user,
+            status=AgreementStatuses.SUBMITTED
+        )
+        other_assigner_legislations = "Legislation A; Legislation B; Legislation C."
+
+        # Act
+        response = app.post(
+            reverse("agreement-approve", args=[project.pk, agreement.pk]),
+            {
+                "template": template.pk,
+                "assigner_representative": assigner_contact.pk,
+                "other_assigner_legislations": other_assigner_legislations
+            },
+            expect_errors=True,
+        )
+
+        # Assert
+        assert response.status_code == 403
+        agreement.refresh_from_db()
+        assert agreement.status == AgreementStatuses.SUBMITTED
+        assert not agreement.template
+        assert not agreement.assigner_representative
+        assert not agreement.other_assigner_legislations
+
+    def test_unauthorized_not_granted_agreement_signing_rights(self, app: DjangoTestApp, dataset: Dataset):
+        # Arrange
+        template = SmartContractTemplate.objects.create(
+            file=ContentFile(
+                open(Path(__file__).parent / "files" / "contract_template.md").read(),
+                name="contract_template.md",
+            )
+        )
+
+        assignee_organization, assigner_organization = OrganizationFactory.create_batch(2)
+        assignee_user = UserFactory(
+            organization=assignee_organization,
+            is_viisp_login=True,
+            viisp_company_code=assignee_organization.company_code,
+        )
+        assigner_user = UserFactory(
+            organization=assigner_organization,
+            is_viisp_login=True,
+            viisp_company_code=assigner_organization.company_code,
+        )
+        app.set_user(assigner_user)
+
+        RepresentativeFactory(user=assignee_user, content_object=assignee_organization, can_make_agreements=True)
+        RepresentativeFactory(user=assigner_user, content_object=assigner_organization, can_make_agreements=False)
+
+        assignee_contact = ContactFactory(
+            organization=assignee_organization,
+            object_id=assignee_user.pk,
+            content_type=ContentType.objects.get_for_model(User),
+            email=assignee_user.email,
+            phone=assignee_user.phone
+        )
+        assigner_contact = ContactFactory(
+            organization=assigner_organization,
+            object_id=assigner_user.pk,
+            content_type=ContentType.objects.get_for_model(User),
+            email=assigner_user.email,
+            phone=assigner_user.phone
+        )
+
+        project = ProjectFactory(
+            organization=assignee_organization,
+            datasets=[dataset],
+            other_assignee_legislations="Test",
+        )
+
+        agreement = AgreementFactory(
+            project=project,
+            assignee=assignee_organization,
+            assignee_representative=assignee_contact,
+            assigner_representative=None,
+            assigner=assigner_organization,
+            created_by=assignee_user,
+            status=AgreementStatuses.SUBMITTED
+        )
+        other_assigner_legislations = "Legislation A; Legislation B; Legislation C."
+
+        # Act
+        response = app.post(
+            reverse("agreement-approve", args=[project.pk, agreement.pk]),
+            {
+                "template": template.pk,
+                "assigner_representative": assigner_contact.pk,
+                "other_assigner_legislations": other_assigner_legislations
+            },
+            expect_errors=True,
+        )
+
+        # Assert
+        assert response.status_code == 403
+        agreement.refresh_from_db()
+        assert agreement.status == AgreementStatuses.SUBMITTED
+        assert not agreement.template
+        assert not agreement.assigner_representative
+        assert not agreement.other_assigner_legislations
+
+    @pytest.mark.parametrize("initial_agreement_status", [
+        AgreementStatuses.CREATED,
+        AgreementStatuses.APPROVED,
+        AgreementStatuses.FORMED,
+        AgreementStatuses.INITIATED,
+        AgreementStatuses.SIGNED,
+        AgreementStatuses.ACTIVE,
+        AgreementStatuses.TERMINATED,
+    ])
+    def test_incorrect_agreement_status(
+        self,
+        initial_agreement_status: AgreementStatuses,
+        app: DjangoTestApp,
+        dataset: Dataset
+    ):
+        # Arrange
+        template = SmartContractTemplate.objects.create(
+            file=ContentFile(
+                open(Path(__file__).parent / "files" / "contract_template.md").read(),
+                name="contract_template.md",
+            )
+        )
+
+        assignee_organization, assigner_organization = OrganizationFactory.create_batch(2)
+        assignee_user = UserFactory(
+            organization=assignee_organization,
+            is_viisp_login=True,
+            viisp_company_code=assignee_organization.company_code,
+        )
+        assigner_user = UserFactory(
+            organization=assigner_organization,
+            is_viisp_login=True,
+            viisp_company_code=assigner_organization.company_code,
+        )
+        app.set_user(assigner_user)
+
+        RepresentativeFactory(user=assignee_user, content_object=assignee_organization, can_make_agreements=True)
+        RepresentativeFactory(user=assigner_user, content_object=assigner_organization, can_make_agreements=True)
+
+        assignee_contact = ContactFactory(
+            organization=assignee_organization,
+            object_id=assignee_user.pk,
+            content_type=ContentType.objects.get_for_model(User),
+            email=assignee_user.email,
+            phone=assignee_user.phone
+        )
+        assigner_contact = ContactFactory(
+            organization=assigner_organization,
+            object_id=assigner_user.pk,
+            content_type=ContentType.objects.get_for_model(User),
+            email=assigner_user.email,
+            phone=assigner_user.phone
+        )
+
+        project = ProjectFactory(
+            organization=assignee_organization,
+            datasets=[dataset],
+            other_assignee_legislations="Test",
+        )
+
+        agreement = AgreementFactory(
+            project=project,
+            assignee=assignee_organization,
+            assignee_representative=assignee_contact,
+            assigner_representative=None,
+            assigner=assigner_organization,
+            created_by=assignee_user,
+            status=initial_agreement_status
+        )
+        other_assigner_legislations = "Legislation A; Legislation B; Legislation C."
+
+        # Act
+        response = app.post(
+            reverse("agreement-approve", args=[project.pk, agreement.pk]),
+            {
+                "template": template.pk,
+                "assigner_representative": assigner_contact.pk,
+                "other_assigner_legislations": other_assigner_legislations
+            }
+        )
+
+        # Assert
+        assert response.status_code == 302  # Still redirects to the success page, just with an error message.
+        agreement.refresh_from_db()
+        assert agreement.status == initial_agreement_status
+        assert not agreement.template
+        assert not agreement.assigner_representative
+        assert not agreement.other_assigner_legislations
+
+
+class TestAgreementForm:
+    @pytest.mark.parametrize("is_acting_user_assignee", [True, False])
+    def test_success(self, is_acting_user_assignee: bool, app: DjangoTestApp, dataset: Dataset):
+        # Arrange
+        template = SmartContractTemplate.objects.create(
+            file=ContentFile(
+                open(Path(__file__).parent / "files" / "contract_template.md").read(),
+                name="contract_template.md",
+            )
+        )
+
+        assignee_organization, assigner_organization = OrganizationFactory.create_batch(2)
+        dataset.organization = assigner_organization
+        dataset.save()
+        assignee_user = UserFactory(
+            organization=assignee_organization,
+            is_viisp_login=True,
+            viisp_company_code=assignee_organization.company_code,
+        )
+        assigner_user = UserFactory(
+            organization=assigner_organization,
+            is_viisp_login=True,
+            viisp_company_code=assigner_organization.company_code,
+        )
+        app.set_user(assignee_user if is_acting_user_assignee else assigner_user)
+
+        RepresentativeFactory(user=assignee_user, content_object=assignee_organization, can_make_agreements=True)
+        RepresentativeFactory(user=assigner_user, content_object=assigner_organization, can_make_agreements=True)
+
+        assignee_contact = ContactFactory(
+            organization=assignee_organization,
+            object_id=assignee_user.pk,
+            content_type=ContentType.objects.get_for_model(User),
+            email=assignee_user.email,
+            phone=assignee_user.phone
+        )
+        assigner_contact = ContactFactory(
+            organization=assigner_organization,
+            object_id=assigner_user.pk,
+            content_type=ContentType.objects.get_for_model(User),
+            email=assigner_user.email,
+            phone=assigner_user.phone,
+        )
+
+        project = ProjectFactory(
+            organization=assignee_organization,
+            datasets=[dataset],
+            other_assignee_legislations="Test",
+        )
+
+        agreement = AgreementFactory(
+            template=template,
+            project=project,
+            assignee=assignee_organization,
+            assignee_representative=assignee_contact,
+            assigner=assigner_organization,
+            assigner_representative=assigner_contact,
+            other_assigner_legislations="Legislation D; Legislation E; Legislation F.",
+            payment_terms="Payment term A; Payment term B.",
+            created_by=assignee_user,
+            status=AgreementStatuses.APPROVED,
+        )
+
+        # Act
+        response = app.post(
+            reverse("agreement-form", args=[project.pk, agreement.pk]),
+            {}
+        )
+
+        # Assert
+        assert response.status_code == 302
+        agreement.refresh_from_db()
+        assert agreement.status == AgreementStatuses.FORMED
+
+        odrl_file, contract, template_copy = list(agreement.files.order_by("is_template", "created_at"))
+
+        assert odrl_file.file_name.endswith(".json")
+        odrl_content = json.loads(odrl_file.file.read())
+        assert odrl_content == {
+            "@context": {
+                "@vocab": "http://www.w3.org/ns/odrl.jsonld",
+                "ex": "http://example.org/vocab#",
+            },
+            "uid": f"https://data.gov.lt/ID/datasets/gov/vssa/isris/dcat/Agreement/{agreement.pk}",
+            "type": "Agreement",
+            "profile": "http://www.w3.org/ns/odrl/profile/core",
+            "issued": odrl_content["issued"],
+            "assigner": [
+                {
+                    "uid": str(assigner_organization.pk),
+                    "ex:companyName": assigner_organization.title,
+                    "ex:companyCode": assigner_organization.company_code,
+                    "ex:address": assigner_organization.address,
+                    "ex:representative": agreement.assigner_representative_full_name,
+                    "ex:email": assigner_organization.email,
+                    "ex:phone": assigner_organization.phone,
+                    "ex:personalCode": " - ",
+                }
+            ],
+            "assignee": [
+                {
+                    "uid": str(assignee_organization.pk),
+                    "ex:companyName": assignee_organization.title,
+                    "ex:companyCode": assignee_organization.company_code,
+                    "ex:address": assignee_organization.address,
+                    "ex:representative": agreement.assignee_representative_full_name,
+                    "ex:email": assignee_organization.email,
+                    "ex:phone": assignee_organization.phone,
+                    "ex:personalCode": " - ",
+                }
+            ],
+            "permission": [
+                {
+                    "target": {
+                        "uid": dataset.pk,
+                        "ex:name": dataset.title,
+                        "ex:scopes": [],
+                    }
+                }
+            ],
+            "ex:paymentTerms": agreement.payment_terms,
+            "ex:otherAssignerLegislations": agreement.other_assigner_legislations,
+            "ex:otherAssigneeLegislations": project.other_assignee_legislations,
+        }
+
+        assert not contract.is_template
+        assert contract.checksum
+        contract.file.seek(0)
+        contract_content = extract_text(BytesIO(contract.file.read()))
+        expected_contract_values = [
+            odrl_content["issued"],
+            odrl_content["assigner"][0]["ex:companyName"],
+            odrl_content["assigner"][0]["ex:companyCode"],
+            odrl_content["assigner"][0]["ex:address"].split("\n")[0],
+            odrl_content["assigner"][0]["ex:email"],
+            odrl_content["assigner"][0]["ex:phone"],
+            odrl_content["assigner"][0]["ex:representative"],
+            odrl_content["assigner"][0]["ex:personalCode"],
+            odrl_content["assignee"][0]["ex:companyName"],
+            odrl_content["assignee"][0]["ex:companyCode"],
+            odrl_content["assignee"][0]["ex:address"].split("\n")[0],
+            odrl_content["assignee"][0]["ex:email"],
+            odrl_content["assignee"][0]["ex:phone"],
+            odrl_content["assignee"][0]["ex:representative"],
+            odrl_content["assignee"][0]["ex:personalCode"],
+            odrl_content["permission"][0]["target"]["ex:name"],
+            *odrl_content["permission"][0]["target"].get("ex:scopes", []),
+            odrl_content["ex:paymentTerms"],
+            odrl_content["ex:otherAssignerLegislations"],
+            odrl_content["ex:otherAssigneeLegislations"],
+        ]
+        # Ensure all required values from odrl were transferred to the contract.
+        for index, value in enumerate(expected_contract_values):
+            if value := str(value).strip():
+                assert value in contract_content, f"Expected '{value}' (index={index}) not found in PDF."
+
+        assert template_copy.is_template
+        assert template_copy.file.path != template.file.path
+        assert template_copy.file.read() == template.file.read()
+        assert template_copy.checksum
+
+    @pytest.mark.parametrize("is_acting_user_assignee", [True, False])
+    def test_unauthorized_not_representative(self, is_acting_user_assignee: bool, app: DjangoTestApp, dataset: Dataset):
+        # Arrange
+        template = SmartContractTemplate.objects.create(
+            file=ContentFile(
+                open(Path(__file__).parent / "files" / "contract_template.md").read(),
+                name="contract_template.md",
+            )
+        )
+
+        assignee_organization, assigner_organization = OrganizationFactory.create_batch(2)
+        dataset.organization = assigner_organization
+        dataset.save()
+        assignee_user = UserFactory(
+            organization=assignee_organization,
+            is_viisp_login=True,
+            viisp_company_code=assignee_organization.company_code,
+        )
+        assigner_user = UserFactory(
+            organization=assigner_organization,
+            is_viisp_login=True,
+            viisp_company_code=assigner_organization.company_code,
+        )
+        app.set_user(assignee_user if is_acting_user_assignee else assigner_user)
+
+        assignee_contact = ContactFactory(
+            organization=assignee_organization,
+            object_id=assignee_user.pk,
+            content_type=ContentType.objects.get_for_model(User),
+            email=assignee_user.email,
+            phone=assignee_user.phone
+        )
+        assigner_contact = ContactFactory(
+            organization=assigner_organization,
+            object_id=assigner_user.pk,
+            content_type=ContentType.objects.get_for_model(User),
+            email=assigner_user.email,
+            phone=assigner_user.phone,
+        )
+
+        project = ProjectFactory(
+            organization=assignee_organization,
+            datasets=[dataset],
+            other_assignee_legislations="Test",
+        )
+
+        agreement = AgreementFactory(
+            template=template,
+            project=project,
+            assignee=assignee_organization,
+            assignee_representative=assignee_contact,
+            assigner=assigner_organization,
+            assigner_representative=assigner_contact,
+            other_assigner_legislations="Legislation D; Legislation E; Legislation F.",
+            payment_terms="Payment term A; Payment term B.",
+            created_by=assignee_user,
+            status=AgreementStatuses.APPROVED,
+        )
+
+        # Act
+        response = app.post(
+            reverse("agreement-form", args=[project.pk, agreement.pk]),
+            {},
+            expect_errors=True,
+        )
+
+        # Assert
+        assert response.status_code == 403
+        agreement.refresh_from_db()
+        assert agreement.status == AgreementStatuses.APPROVED  # Unchanged.
+        assert not agreement.files.exists()
+
+    @pytest.mark.parametrize("is_acting_user_assignee", [True, False])
+    def test_unauthorized_not_viisp_authorized(self, is_acting_user_assignee: bool, app: DjangoTestApp, dataset: Dataset):
+        # Arrange
+        template = SmartContractTemplate.objects.create(
+            file=ContentFile(
+                open(Path(__file__).parent / "files" / "contract_template.md").read(),
+                name="contract_template.md",
+            )
+        )
+
+        assignee_organization, assigner_organization = OrganizationFactory.create_batch(2)
+        dataset.organization = assigner_organization
+        dataset.save()
+        assignee_user = UserFactory(
+            organization=assignee_organization,
+            is_viisp_login=False,
+            viisp_company_code="invalid_company_code",
+        )
+        assigner_user = UserFactory(
+            organization=assigner_organization,
+            is_viisp_login=False,
+            viisp_company_code="invalid_company_code",
+        )
+        app.set_user(assignee_user if is_acting_user_assignee else assigner_user)
+
+        RepresentativeFactory(user=assignee_user, content_object=assignee_organization, can_make_agreements=True)
+        RepresentativeFactory(user=assigner_user, content_object=assigner_organization, can_make_agreements=True)
+
+        assignee_contact = ContactFactory(
+            organization=assignee_organization,
+            object_id=assignee_user.pk,
+            content_type=ContentType.objects.get_for_model(User),
+            email=assignee_user.email,
+            phone=assignee_user.phone
+        )
+        assigner_contact = ContactFactory(
+            organization=assigner_organization,
+            object_id=assigner_user.pk,
+            content_type=ContentType.objects.get_for_model(User),
+            email=assigner_user.email,
+            phone=assigner_user.phone,
+        )
+
+        project = ProjectFactory(
+            organization=assignee_organization,
+            datasets=[dataset],
+            other_assignee_legislations="Test",
+        )
+
+        agreement = AgreementFactory(
+            template=template,
+            project=project,
+            assignee=assignee_organization,
+            assignee_representative=assignee_contact,
+            assigner=assigner_organization,
+            assigner_representative=assigner_contact,
+            other_assigner_legislations="Legislation D; Legislation E; Legislation F.",
+            payment_terms="Payment term A; Payment term B.",
+            created_by=assignee_user,
+            status=AgreementStatuses.APPROVED,
+        )
+
+        # Act
+        response = app.post(
+            reverse("agreement-form", args=[project.pk, agreement.pk]),
+            {},
+            expect_errors=True,
+        )
+
+        # Assert
+        assert response.status_code == 403
+        agreement.refresh_from_db()
+        assert agreement.status == AgreementStatuses.APPROVED  # Unchanged.
+        assert not agreement.files.exists()
+
+    @pytest.mark.parametrize("is_acting_user_assignee", [True, False])
+    def test_unauthorized_not_granted_agreement_signing_rights(self, is_acting_user_assignee: bool, app: DjangoTestApp, dataset: Dataset):
+        # Arrange
+        template = SmartContractTemplate.objects.create(
+            file=ContentFile(
+                open(Path(__file__).parent / "files" / "contract_template.md").read(),
+                name="contract_template.md",
+            )
+        )
+
+        assignee_organization, assigner_organization = OrganizationFactory.create_batch(2)
+        dataset.organization = assigner_organization
+        dataset.save()
+        assignee_user = UserFactory(
+            organization=assignee_organization,
+            is_viisp_login=True,
+            viisp_company_code=assignee_organization.company_code,
+        )
+        assigner_user = UserFactory(
+            organization=assigner_organization,
+            is_viisp_login=True,
+            viisp_company_code=assigner_organization.company_code,
+        )
+        app.set_user(assignee_user if is_acting_user_assignee else assigner_user)
+
+        RepresentativeFactory(user=assignee_user, content_object=assignee_organization, can_make_agreements=False)
+        RepresentativeFactory(user=assigner_user, content_object=assigner_organization, can_make_agreements=False)
+
+        assignee_contact = ContactFactory(
+            organization=assignee_organization,
+            object_id=assignee_user.pk,
+            content_type=ContentType.objects.get_for_model(User),
+            email=assignee_user.email,
+            phone=assignee_user.phone
+        )
+        assigner_contact = ContactFactory(
+            organization=assigner_organization,
+            object_id=assigner_user.pk,
+            content_type=ContentType.objects.get_for_model(User),
+            email=assigner_user.email,
+            phone=assigner_user.phone,
+        )
+
+        project = ProjectFactory(
+            organization=assignee_organization,
+            datasets=[dataset],
+            other_assignee_legislations="Test",
+        )
+
+        agreement = AgreementFactory(
+            template=template,
+            project=project,
+            assignee=assignee_organization,
+            assignee_representative=assignee_contact,
+            assigner=assigner_organization,
+            assigner_representative=assigner_contact,
+            other_assigner_legislations="Legislation D; Legislation E; Legislation F.",
+            payment_terms="Payment term A; Payment term B.",
+            created_by=assignee_user,
+            status=AgreementStatuses.APPROVED,
+        )
+
+        # Act
+        response = app.post(
+            reverse("agreement-form", args=[project.pk, agreement.pk]),
+            {},
+            expect_errors=True,
+        )
+
+        # Assert
+        assert response.status_code == 403
+        agreement.refresh_from_db()
+        assert agreement.status == AgreementStatuses.APPROVED  # Unchanged.
+        assert not agreement.files.exists()
+
+    @pytest.mark.parametrize("initial_agreement_status", [
+        AgreementStatuses.CREATED,
+        AgreementStatuses.SUBMITTED,
+        AgreementStatuses.FORMED,
+        AgreementStatuses.INITIATED,
+        AgreementStatuses.SIGNED,
+        AgreementStatuses.ACTIVE,
+        AgreementStatuses.TERMINATED,
+    ])
+    def test_incorrect_agreement_status(self, initial_agreement_status: AgreementStatuses, app: DjangoTestApp, dataset: Dataset):
+        template = SmartContractTemplate.objects.create(
+            file=ContentFile(
+                open(Path(__file__).parent / "files" / "contract_template.md").read(),
+                name="contract_template.md",
+            )
+        )
+
+        assignee_organization, assigner_organization = OrganizationFactory.create_batch(2)
+        dataset.organization = assigner_organization
+        dataset.save()
         assignee_user = UserFactory(
             organization=assignee_organization,
             is_viisp_login=True,
@@ -404,7 +1391,7 @@ class TestAgreementGeneratePdf:
             object_id=assignee_user.pk,
             content_type=ContentType.objects.get_for_model(User),
             email=assignee_user.email,
-            phone=assignee_user.phone,
+            phone=assignee_user.phone
         )
         assigner_contact = ContactFactory(
             organization=assigner_organization,
@@ -417,221 +1404,34 @@ class TestAgreementGeneratePdf:
         project = ProjectFactory(
             organization=assignee_organization,
             datasets=[dataset],
-            other_assignee_legislations="Test"
+            other_assignee_legislations="Test",
         )
 
         agreement = AgreementFactory(
+            template=template,
             project=project,
             assignee=assignee_organization,
+            assignee_representative=assignee_contact,
             assigner=assigner_organization,
+            assigner_representative=assigner_contact,
+            other_assigner_legislations="Legislation D; Legislation E; Legislation F.",
+            payment_terms="Payment term A; Payment term B.",
             created_by=assignee_user,
-            status=status,
+            status=initial_agreement_status,
         )
 
+        # Act
         response = app.post(
-            reverse("agreement-generate-pdf", args=[project.pk, agreement.pk]),
-            {
-                "template": template.pk,
-                "assigner_representative": assigner_contact.pk,
-                "other_assigner_legislations": "",
-                "assignee_representative": assignee_contact.pk,
-                "other_assignee_legislations": "",
-                "payment_terms": "",
-            },
+            reverse("agreement-form", args=[project.pk, agreement.pk]),
+            {},
+            expect_errors=True,
         )
 
+        # Assert
+        assert response.status_code == 302  # Still redirects to the success page, just with an error message.
         agreement.refresh_from_db()
-        assert response.status_code == 302
-        assert agreement.status == status
-
-    def test_generate_pdf_changes_agreement_status_to_formed(
-        self, app: DjangoTestApp, organization: Organization, dataset: Dataset
-    ) -> None:
-        template = SmartContractTemplate.objects.create(
-            file=ContentFile(
-                open(Path(__file__).parent / "files" / "contract_template.md").read(),
-                name="contract_template.md",
-            )
-        )
-
-        organization.title = "Gonzalez Group"
-        organization.company_code = "LWGYU0W8S"
-        organization.address = "206 Weaver Trace\nNorth Danny, VA 96120"
-        organization.email = "lwolf@example.com"
-        organization.phone = "456.631.4059"
-        organization.save()
-
-        dataset.title = "Odit nostrum."
-        dataset.save()
-
-        user = UserFactory(
-            organization=organization,
-            email="bethgarcia@example.net",
-            is_viisp_login=True,
-            viisp_company_code=organization.company_code
-        )
-        RepresentativeFactory(user=user, content_object=organization, can_make_agreements=True)
-
-        app.set_user(user)
-        assigner_user = UserFactory(organization=organization)
-
-        other_assigner_legislations = "Bought data"
-        other_assignee_legislations = "Sold data"
-        project = ProjectFactory(
-            organization=organization,
-            datasets=[dataset],
-            other_assignee_legislations=other_assignee_legislations
-        )
-
-        assigner_representative = ContactFactory(
-            organization=organization,
-            object_id=assigner_user.pk,
-            content_type=ContentType.objects.get_for_model(User),
-            email=assigner_user.email,
-            phone=assigner_user.phone,
-        )
-        assignee_representative = ContactFactory(
-            organization=organization,
-            object_id=user.pk,
-            content_type=ContentType.objects.get_for_model(User),
-            email=user.email,
-            phone=user.phone,
-        )
-
-        agreement = AgreementFactory(
-            project=project,
-            assigner=organization,
-            assignee=organization,
-            created_by=user,
-            status=AgreementStatuses.CREATED,
-        )
-
-        assert agreement.files.count() == 0
-        payment_terms = "Cash only"
-        response = app.post(
-            reverse("agreement-generate-pdf", args=[project.pk, agreement.pk]),
-            {
-                "template": template.pk,
-                "assigner_representative": assigner_representative.pk,
-                "other_assigner_legislations": other_assigner_legislations,
-                "assignee_representative": assignee_representative.pk,
-                "payment_terms": payment_terms,
-            },
-        )
-        agreement.refresh_from_db()
-        assert response.status_code == 302
-        assert agreement.status == AgreementStatuses.FORMED
-        agreement_files = list(agreement.files.order_by("is_template", "created_at"))
-        assert len(agreement_files) == 3
-        contract: AgreementFile = agreement_files[1]
-        template_copy: AgreementFile = agreement_files[2]
-        odlr_file: AgreementFile = agreement_files[0]
-
-
-        assert template_copy.is_template
-        assert template_copy.file_name
-        for name_part in ("_copy.md", "contract_template"):
-            assert name_part in template_copy.file_name
-        assert "/" not in template_copy.file_name
-        assert template_copy.file.path != template.file.path  # check if is an hard copy
-        assert template_copy.file.read() == template.file.read()
-        assert template_copy.checksum
-
-        assert odlr_file.file_name.endswith(".json")
-
-        assert not contract.is_template
-        assert contract.checksum
-
-        odrl :dict= json.loads(odlr_file.file.read())
-
-        expected_odrl = {
-            "@context": {
-                "@vocab": "http://www.w3.org/ns/odrl.jsonld",
-                "ex": "http://example.org/vocab#",
-            },
-            "uid": f"https://data.gov.lt/ID/datasets/gov/vssa/isris/dcat/Agreement/{agreement.pk}",
-            "type": "Agreement",
-            "profile": "http://www.w3.org/ns/odrl/profile/core",
-            "issued": odrl[
-                "issued"
-            ],  # Use actual value from file to avoid time mismatch
-            "assigner": [
-                {
-                    "uid": str(organization.pk),
-                    "ex:companyName": "Gonzalez Group",
-                    "ex:companyCode": "LWGYU0W8S",
-                    "ex:address": "206 Weaver Trace\nNorth Danny, VA 96120",
-                    "ex:representative": agreement.assigner_representative_full_name,
-                    "ex:email": "lwolf@example.com",
-                    "ex:phone": "456.631.4059",
-                    "ex:personalCode": " - ",
-                }
-            ],
-            "assignee": [
-                {
-                    "uid": str(organization.pk),
-                    "ex:companyName": "Gonzalez Group",
-                    "ex:companyCode": "LWGYU0W8S",
-                    "ex:address": "206 Weaver Trace\nNorth Danny, VA 96120",
-                    "ex:representative": agreement.assignee_representative_full_name,
-                    "ex:email": "lwolf@example.com",
-                    "ex:phone": "456.631.4059",
-                    "ex:personalCode": " - ",
-                }
-            ],
-            "permission": [
-                {
-                    "target": {
-                        "uid": dataset.pk,
-                        "ex:name": "Odit nostrum.",
-                        "ex:scopes": [],
-                    }
-                }
-            ],
-            "ex:paymentTerms": payment_terms,
-            "ex:otherAssignerLegislations": other_assigner_legislations,
-            "ex:otherAssigneeLegislations": other_assignee_legislations,
-        }
-        assert odrl == expected_odrl
-        assert contract.file
-        assert contract.file_name
-        contract.file.seek(0)
-        pdf_text = extract_text(BytesIO(contract.file.read()))
-
-        # Pull specific expected values directly from the odrl JSON
-        expected_values = [
-            # Dates
-            odrl["issued"],  # Check only a date portion to avoid microsecond mismatches
-            # Assigner
-            odrl["assigner"][0]["ex:companyName"],
-            odrl["assigner"][0]["ex:companyCode"],
-            odrl["assigner"][0]["ex:address"].split("\n")[0],  # Just street line
-            odrl["assigner"][0]["ex:email"],
-            odrl["assigner"][0]["ex:phone"],
-            odrl["assigner"][0]["ex:representative"],
-            odrl["assigner"][0]["ex:personalCode"],
-            # Assignee
-            odrl["assignee"][0]["ex:companyName"],
-            odrl["assignee"][0]["ex:companyCode"],
-            odrl["assignee"][0]["ex:address"].split("\n")[0],
-            odrl["assignee"][0]["ex:email"],
-            odrl["assignee"][0]["ex:phone"],
-            odrl["assignee"][0]["ex:representative"],
-            odrl["assignee"][0]["ex:personalCode"],
-            # Permission target
-            odrl["permission"][0]["target"]["ex:name"],
-            *odrl["permission"][0]["target"].get("ex:scopes", []),
-            # Misc fields
-            odrl["ex:paymentTerms"],
-            odrl["ex:otherAssignerLegislations"],
-            odrl["ex:otherAssigneeLegislations"],
-        ]
-
-        # Validate that each expected value appears in the PDF text
-        for i, value in enumerate(expected_values):
-            value = str(value).strip()
-            if value:
-                assert value in pdf_text, f"Expected '{value}' (index={i}) not found in PDF"
+        assert agreement.status == initial_agreement_status  # Unchanged.
+        assert not agreement.files.exists()
 
 
 class TestAgreementUploadSignedFile:

--- a/vitrina/datasets/models.py
+++ b/vitrina/datasets/models.py
@@ -1857,7 +1857,7 @@ class Contact(models.Model):
             if self.content_type.model == "organization":
                 return self.content_object.title
             return self.content_object.get_full_name()
-        return self.contact_name
+        return f"{self.contact_name} ({self.position})"
 
     def get_email(self):
         if self.email:

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -3714,10 +3714,10 @@ msgid "Išmaniųjų sutarčių numatytieji šablonai"
 msgstr "Smart contracts default templates"
 
 msgid "Pateikti"
-msgstr "Propose"
+msgstr "Submit"
 
 msgid "Pateikti pasiūlymą"
-msgstr "Propose"
+msgstr "Submit proposal"
 
 msgid "Patvirtinti pasiūlymą"
 msgstr "Confirm proposal"

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-19 12:59+0200\n"
+"POT-Creation-Date: 2025-11-19 15:10+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3713,6 +3713,18 @@ msgstr "Smart contracts default template"
 msgid "Išmaniųjų sutarčių numatytieji šablonai"
 msgstr "Smart contracts default templates"
 
+msgid "Pateikti"
+msgstr "Propose"
+
+msgid "Pateikti pasiūlymą"
+msgstr "Propose"
+
+msgid "Patvirtinti pasiūlymą"
+msgstr "Confirm proposal"
+
+msgid "Formuoti sutartį"
+msgstr "Form agreement"
+
 msgid "Dokumentas turi būti adoc formato."
 msgstr "The document must be in adoc format."
 
@@ -3870,6 +3882,9 @@ msgstr "Generate agreements"
 msgid "Grįžti į sutartis"
 msgstr "Go back to agreements"
 
+msgid "Peržiūrėti pateiktą pasiūlymą"
+msgstr "Review proposal"
+
 msgid "Įkelti pasirašytą dokumentą"
 msgstr "Upload document signed by data receiver"
 
@@ -3884,6 +3899,27 @@ msgstr "No agreement documents."
 
 msgid "Nėra sutarčių."
 msgstr "No agreements."
+
+msgid "Sutarties derinimo informacija"
+msgstr "Agreement negotation information"
+
+msgid "Nėra susietų duomenų išteklių."
+msgstr "No related datasets found."
+
+msgid "Duomenų gavimo tikslas"
+msgstr "Purpose of data acquisition"
+
+msgid "Nėra pasirinktas duomenų gavėjo atstovas."
+msgstr "Data receiver representative is not selected."
+
+msgid "Nėra pasirinktas duomenų teikėjo atstovas."
+msgstr "Data provider representative is not selected."
+
+msgid "Duomenų teikimo teisinis pagrindas (prievolė)"
+msgstr "Legal basis for data provision (obligation)"
+
+msgid "Šablono failas nepridėtas."
+msgstr "Template file is not added."
 
 msgid ""
 "Panaudojimo atvejis registruotas fizinio asmens vardu negali turėti sutarčių."
@@ -3902,6 +3938,22 @@ msgstr "Agreements generated successfully"
 msgid "Sutarčių generavime kilo klaidų"
 msgstr "Errors occurred while generating agreements"
 
+msgid ""
+"Veiksmas gali būti atliekamas tik sutarčiai esant būsenoje "
+"{expected_status}.Dabartinė būsena: {current_status}."
+msgstr ""
+"The action can only be executed when the agreement has the status "
+"{expected_status}. Current status: {current_status}"
+
+msgid "Pasiūlymas sėkmingai pateiktas duomenų teikėjui."
+msgstr "The proposal has been successfully submitted to the data provider."
+
+msgid "Pasiūlymas sėkmingai patvirtintas."
+msgstr "Proposal was successfully confirmed."
+
+msgid "Sutarties dokumentas sukurtas"
+msgstr "Agreement document is created"
+
 #, python-brace-format
 msgid ""
 "Sutarties dokumentas gali būti generuojamas sutarčiai su būsena "
@@ -3909,9 +3961,6 @@ msgid ""
 msgstr ""
 "Agreement document can only be generated for agreement with "
 "status{accepted_status}. Current status: {current_status}"
-
-msgid "Sutarties dokumentas sukurtas"
-msgstr "Agreement document is created"
 
 #, python-brace-format
 msgid ""

--- a/vitrina/smart_contracts/forms.py
+++ b/vitrina/smart_contracts/forms.py
@@ -1,4 +1,4 @@
-from functools import cached_property
+from typing import Any
 
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Submit
@@ -6,9 +6,10 @@ from django import forms
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.core.validators import FileExtensionValidator
-from django.db.models import Q, QuerySet
+from django.db.models import Q, QuerySet, Subquery
 from django.core.files.uploadedfile import UploadedFile
 from django.forms import CheckboxSelectMultiple
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 import zipfile
 
@@ -65,6 +66,78 @@ class SmartContractForm(forms.ModelForm):
         return choices
 
 
+class BaseAgreementForm(forms.ModelForm):
+    label = _("Pateikti")
+
+    def __init__(self, *args, **kwargs):
+        self.agreement = kwargs.pop("agreement")
+        super().__init__(*args, **kwargs)
+
+        self.helper = FormHelper()
+        self.helper.add_input(Submit("submit", self.label, css_class="button is-primary"))
+
+    @cached_property
+    def content_type_user(self) -> ContentType:
+        return ContentType.objects.get_for_model(User)
+
+    @staticmethod
+    def get_smart_contract_templates_by_organization(organization_id: int) -> QuerySet:
+        return SmartContractTemplate.objects.filter(
+            Q(organization__isnull=True) | Q(organization=organization_id),
+        ).order_by(
+            "organization",
+            "file",
+        )
+
+    def get_contacts_by_organization(self, organization_id: int) -> QuerySet:
+        user_ids = User.objects.filter(organization=organization_id).exclude(deleted=True).values("pk")
+
+        return Contact.objects.filter(
+            Q(organization=organization_id),
+            Q(content_type=self.content_type_user, object_id__in=Subquery(user_ids))
+            | Q(content_type__isnull=True, object_id__isnull=True),
+        )
+
+
+class AgreementSubmitForm(BaseAgreementForm):
+    label = _("Pateikti pasiūlymą")
+
+    class Meta:
+        model = Agreement
+        fields = ("assignee_representative",)
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+        self.fields["assignee_representative"].required = True
+        self.fields["assignee_representative"].queryset = self.get_contacts_by_organization(self.agreement.assignee_id)
+
+
+class AgreementApproveForm(BaseAgreementForm):
+    label = _("Patvirtinti pasiūlymą")
+
+    class Meta:
+        model = Agreement
+        fields = ("template", "assigner_representative", "other_assigner_legislations")
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+        for field in self.Meta.fields:
+            self.fields[field].required = True
+
+        self.fields["template"].queryset = self.get_smart_contract_templates_by_organization(self.agreement.assigner_id)
+        self.fields["assigner_representative"].queryset = self.get_contacts_by_organization(self.agreement.assigner_id)
+
+
+class AgreementFormForm(BaseAgreementForm):
+    label = _("Formuoti sutartį")
+
+    class Meta:
+        model = Agreement
+        fields = tuple()
+
+
 class SmartContractFormSetHelper(FormHelper):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -106,56 +179,3 @@ class AgreementUploadForm(forms.ModelForm):
             raise ValidationError(error)
 
         return file
-
-
-class AgreementGeneratePdfForm(forms.Form):
-    template = forms.ModelChoiceField(
-        label=_("Pasirinkite šabloną (privaloma)"),
-        queryset=SmartContractTemplate.objects.none(),  # will be dynamically set in __init__
-        required=True,
-    )
-    other_assigner_legislations = forms.CharField(
-        label=_("Papildomi teikėjo teisės aktai"),
-        required=False,
-        widget=forms.Textarea(),
-    )
-    payment_terms = forms.CharField(label=_("Mokėjimo sąlygos"), required=False, widget=forms.Textarea())
-    assigner_representative = forms.ModelChoiceField(
-        label=_("Duomenų teikėjo atstovas"),
-        queryset=Contact.objects.none(),
-        required=True,
-    )
-    assignee_representative = forms.ModelChoiceField(
-        label=_("Duomenų gavėjo atstovas"), queryset=Contact.objects.none(), required=True
-    )
-
-    @cached_property
-    def content_type_user(self) -> QuerySet[ContentType]:
-        return ContentType.objects.get_for_model(User)
-
-    def __init__(self, *args, **kwargs):
-        agreement: Agreement = kwargs.pop("agreement")
-        super().__init__(*args, **kwargs)
-
-        self.fields["template"].queryset = SmartContractTemplate.objects.filter(
-            Q(organization__isnull=True) | Q(organization=agreement.assigner)
-        ).order_by("organization", "file")
-
-        self.fields["assigner_representative"].queryset = self.get_contact_queryset(agreement.assigner)
-        self.fields["assignee_representative"].queryset = self.get_contact_queryset(agreement.assignee)
-
-        self.helper = FormHelper()
-        self.helper.add_input(Submit("submit", _("Generuoti sutarties dokumentą"), css_class="button is-primary"))
-
-    def get_contact_queryset(self, organization: Organization) -> QuerySet[Contact]:
-        user_ids = User.objects.filter(Q(organization=organization.pk), Q(deleted=False) | Q(deleted="")).values_list(
-            "pk", flat=True
-        )
-
-        return Contact.objects.filter(
-            Q(organization=organization),
-            (
-                Q(content_type=self.content_type_user, object_id__in=user_ids)
-                | Q(content_type__isnull=True, object_id__isnull=True)
-            ),
-        )

--- a/vitrina/smart_contracts/forms.py
+++ b/vitrina/smart_contracts/forms.py
@@ -82,11 +82,15 @@ class BaseAgreementForm(forms.ModelForm):
 
     @staticmethod
     def get_smart_contract_templates_by_organization(organization_id: int) -> QuerySet:
-        return SmartContractTemplate.objects.filter(
-            Q(organization__isnull=True) | Q(organization=organization_id),
-        ).order_by(
-            "organization",
-            "file",
+        return (
+            SmartContractTemplate.objects.filter(
+                Q(organization__isnull=True) | Q(organization_id=organization_id),
+            )
+            .select_related("organization")
+            .order_by(
+                "organization",
+                "file",
+            )
         )
 
     def get_contacts_by_organization(self, organization_id: int) -> QuerySet:

--- a/vitrina/smart_contracts/models.py
+++ b/vitrina/smart_contracts/models.py
@@ -156,7 +156,7 @@ class Agreement(UUIDBaseModel):
             "issued": format_lithuanian_datetime(),
             "assigner": [
                 {
-                    "uid": f"{self.assigner.pk}",
+                    "uid": str(self.assigner.pk),
                     "ex:companyName": self.assigner.title,
                     "ex:companyCode": self.assigner.company_code,
                     "ex:address": self.assigner.address,

--- a/vitrina/smart_contracts/permissions.py
+++ b/vitrina/smart_contracts/permissions.py
@@ -12,9 +12,7 @@ def _is_viisp_authenticated_and_representative(user: User, organization: Organiz
         return False
 
     is_viisp_authenticated = organization == user.viisp_organization
-    is_representative = user.is_representative_of(organization, True)
-
-    return is_viisp_authenticated and is_representative
+    return is_viisp_authenticated and user.is_representative_of(organization, True)
 
 
 def can_view_agreements(user: User | AnonymousUser, project: Project) -> bool:

--- a/vitrina/smart_contracts/permissions.py
+++ b/vitrina/smart_contracts/permissions.py
@@ -1,3 +1,4 @@
+from vitrina.orgs.models import Organization
 from vitrina.smart_contracts.services import get_agreements
 from vitrina.users.models import User
 from vitrina.smart_contracts.models import Agreement
@@ -5,11 +6,15 @@ from vitrina.projects.models import Project
 from django.contrib.auth.models import AnonymousUser
 
 
-def can_create_agreements(user: User, project: Project) -> bool:
-    if project.organization:
-        return project.organization == user.viisp_organization and user.is_representative_of(project.organization, True)
+def _is_viisp_authenticated_and_representative(user: User, organization: Organization | None) -> bool:
+    """Helper to find out if a user is VIISP authenticated and a representative of an organization."""
+    if not organization:
+        return False
 
-    return False
+    is_viisp_authenticated = organization == user.viisp_organization
+    is_representative = user.is_representative_of(organization, True)
+
+    return is_viisp_authenticated and is_representative
 
 
 def can_view_agreements(user: User | AnonymousUser, project: Project) -> bool:
@@ -35,3 +40,26 @@ def can_upload_agreement_file(user: User, agreement: Agreement) -> bool:
     parties = [agreement.assignee, agreement.assigner]
 
     return any(user.viisp_organization == party and user.is_representative_of(party, True) for party in parties)
+
+
+def can_create_agreements(user: User, project: Project) -> bool:
+    return _is_viisp_authenticated_and_representative(user, project.organization)
+
+
+def can_submit_agreements(user: User, agreement: Agreement) -> bool:
+    return _is_viisp_authenticated_and_representative(user, agreement.assignee)
+
+
+def can_approve_agreements(user: User, agreement: Agreement) -> bool:
+    return _is_viisp_authenticated_and_representative(user, agreement.assigner)
+
+
+def can_form_agreements(user: User, agreement: Agreement) -> bool:
+    is_viisp_authenticated = (
+        user.organization in {agreement.assignee, agreement.assigner} and user.organization == user.viisp_organization
+    )
+    is_representative = user.is_representative_of(agreement.assignee, True) or user.is_representative_of(
+        agreement.assigner, True
+    )
+
+    return is_viisp_authenticated and is_representative

--- a/vitrina/smart_contracts/templates/smart_contracts/agreement_detail.html
+++ b/vitrina/smart_contracts/templates/smart_contracts/agreement_detail.html
@@ -17,9 +17,17 @@
     <br>
 
     <div class="buttons is-right">
-        {% if can_create_agreements and agreement.status == "CREATED" %}
-            <a href="{% url "agreement-generate-pdf" project.pk agreement.pk %}" class="button is-primary m-t-xs m-b-lg">
-                {% translate "Generuoti sutarties dokumentą" %}
+        {% if can_submit_agreements and agreement.status == "CREATED" %}
+            <a href="{% url "agreement-submit" project.pk agreement.pk %}" class="button is-primary m-t-xs m-b-lg">
+                {% translate "Pateikti pasiūlymą" %}
+            </a>
+        {% elif can_approve_agreements and agreement.status == "SUBMITTED" %}
+            <a href="{% url "agreement-approve" project.pk agreement.pk %}" class="button is-primary m-t-xs m-b-lg">
+                {% translate "Peržiūrėti pateiktą pasiūlymą" %}
+            </a>
+        {% elif can_form_agreements and agreement.status == "APPROVED" %}
+            <a href="{% url "agreement-form" project.pk agreement.pk %}" class="button is-primary m-t-xs m-b-lg">
+                {% translate "Formuoti sutartį" %}
             </a>
         {% elif can_upload_agreement_file and agreement.status == "FORMED" or agreement.status == "INITIATED" %}
             <a class="button is-primary m-t-xs m-b-lg" href="{% url "agreement-upload-signed-adoc" project.pk agreement.pk %}">

--- a/vitrina/smart_contracts/templates/smart_contracts/agreement_negotiate.html
+++ b/vitrina/smart_contracts/templates/smart_contracts/agreement_negotiate.html
@@ -1,0 +1,130 @@
+{% extends "base_form.html" %}
+{% load i18n %}
+{% load markdown_tags %}
+
+{% block content %}
+    {% include 'vitrina/projects/tabs.html' %}
+    <div class="columns is-centered">
+        <div class="column is-half has-background-white-ter p-4">
+            <h3 class="title is-3 has-text-weight-semibold mb-5">
+                {% trans "Sutarties derinimo informacija" %}
+            </h3>
+
+            <h3 class="title is-5 has-text-weight-semibold mb-3">
+                {% trans "Duomenų ištekliai" %}:
+            </h3>
+            <div class="ml-5 mb-4">
+                {% if project.datasets.all %}
+                    <ul>
+                        {% for dataset in project.datasets.all %}
+                            <li class="mb-2">
+                                <a href="{% url 'dataset-detail' dataset.pk %}" target="_blank" class="has-text-link is-inline-flex is-align-items-center">
+                                    <span>{{ dataset.title }}</span>
+                                    <span class="icon is-small ml-1 is-inline-flex is-align-items-center">
+                                        <i class="fas fa-external-link-alt"></i>
+                                    </span>
+                                </a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% else %}
+                    <p class="has-text-grey">
+                        {% trans "Nėra susietų duomenų išteklių." %}
+                    </p>
+                {% endif %}
+            </div>
+
+            <h3 class="title is-5 has-text-weight-semibold mb-3">
+                {% trans "Duomenų gavimo tikslas" %}:
+            </h3>
+            <div class="content ml-5 mb-4">
+                {% block description %}
+                    {{ project.description|markdown|safe }}
+                {% endblock %}
+            </div>
+
+            <h3 class="title is-5 has-text-weight-semibold mb-3">
+                {% trans "Duomenų gavimo teisinis pagrindas" %}:
+            </h3>
+            <div class="content ml-5 mb-4">
+                {% block other_legislation %}
+                    {{ project.other_assignee_legislations|markdown|safe }}
+                {% endblock %}
+            </div>
+
+            {% if agreement.status == "SUBMITTED" or agreement.status == "APPROVED" or agreement.status == "FORMED" or agreement.status == "INITIATED" %}
+                <h3 class="title is-5 has-text-weight-semibold mb-3">
+                    {% trans "Duomenų gavėjo atstovas" %}:
+                </h3>
+                <div class="ml-5 mb-4">
+                    {% block agreement.assignee_representative %}
+                        {% if agreement.assignee_representative %}
+                            <ul>
+                                <li class="mb-2">
+                                    <span>{{ agreement.assignee_representative }}</span>
+                                </li>
+                            </ul>
+                        {% else %}
+                            <p class="has-text-grey">
+                                {% trans "Nėra pasirinktas duomenų gavėjo atstovas." %}
+                            </p>
+                        {% endif %}
+                    {% endblock %}
+                </div>
+
+                {% if agreement.status == "APPROVED"  or agreement.status == "FORMED" or agreement.status == "INITIATED" %}
+                    <h3 class="title is-5 has-text-weight-semibold mb-3">
+                        {% trans "Duomenų teikėjo atstovas" %}:
+                    </h3>
+                    <div class="ml-5 mb-4">
+                        {% block agreement.assigner_representative %}
+                            {% if agreement.assigner_representative %}
+                                <ul>
+                                    <li class="mb-2">
+                                        <span>{{ agreement.assigner_representative }}</span>
+                                    </li>
+                                </ul>
+                            {% else %}
+                                <p class="has-text-grey">
+                                    {% trans "Nėra pasirinktas duomenų teikėjo atstovas." %}
+                                </p>
+                            {% endif %}
+                        {% endblock %}
+                    </div>
+
+                    <h3 class="title is-5 has-text-weight-semibold mb-3">
+                        {% trans "Duomenų teikimo teisinis pagrindas (prievolė)" %}:
+                    </h3>
+                    <div class="content ml-5 mb-4">
+                        {% block agreement.other_assigner_legislations %}
+                            {{ agreement.other_assigner_legislations|markdown|safe }}
+                        {% endblock %}
+                    </div>
+
+                    <h3 class="title is-5 has-text-weight-semibold mb-3">
+                        {% trans "Sutarties šablonas" %}:
+                    </h3>
+                    <div class="ml-5 mb-4">
+                        {% if agreement.template and agreement.template.file %}
+                            <ul>
+                                <li class="mb-2">
+                                    <a href="{{ agreement.template.file.url }}" target="_blank" class="has-text-link">
+                                        {{ agreement.template.file.name }}
+                                    </a>
+                                </li>
+                            </ul>
+                        {% else %}
+                            <p class="has-text-grey">
+                                {% trans "Šablono failas nepridėtas." %}
+                            </p>
+                        {% endif %}
+                    </div>
+                {% endif %}
+
+            {% endif %}
+
+        </div>
+    </div>
+
+    {{ block.super }}
+{% endblock %}

--- a/vitrina/smart_contracts/urls.py
+++ b/vitrina/smart_contracts/urls.py
@@ -4,8 +4,10 @@ from vitrina.smart_contracts.views import (
     AgreementCreateView,
     AgreementListView,
     AgreementDetailView,
-    AgreementGeneratePdf,
     AgreementUploadSignedFile,
+    AgreementSubmitView,
+    AgreementApproveView,
+    AgreementFormView,
 )
 
 urlpatterns = [
@@ -25,9 +27,19 @@ urlpatterns = [
         name="agreement-detail",
     ),
     path(
-        "projects/<int:pk>/agreement/<uuid:agreement_id>/generate-pdf/",
-        AgreementGeneratePdf.as_view(),
-        name="agreement-generate-pdf",
+        "projects/<int:pk>/agreement/<uuid:agreement_id>/submit/",
+        AgreementSubmitView.as_view(),
+        name="agreement-submit",
+    ),
+    path(
+        "projects/<int:pk>/agreement/<uuid:agreement_id>/approve/",
+        AgreementApproveView.as_view(),
+        name="agreement-approve",
+    ),
+    path(
+        "projects/<int:pk>/agreement/<uuid:agreement_id>/form",
+        AgreementFormView.as_view(),
+        name="agreement-form",
     ),
     path(
         "projects/<int:pk>/agreement/<uuid:agreement_id>/upload-signed/",

--- a/vitrina/smart_contracts/views.py
+++ b/vitrina/smart_contracts/views.py
@@ -11,6 +11,7 @@ from django.core.paginator import Paginator
 from django.db import transaction
 from django.db.models import Prefetch, Q
 from django.forms import modelformset_factory, BaseFormSet
+from django.forms.models import ModelForm
 from django.http import HttpResponseRedirect
 from django.http.response import HttpResponseBase, HttpResponse
 from django.shortcuts import get_object_or_404
@@ -27,13 +28,14 @@ from vitrina.smart_contracts.forms import (
     SmartContractForm,
     SmartContractFormSetHelper,
     AgreementUploadForm,
-    AgreementGeneratePdfForm,
+    AgreementSubmitForm,
+    AgreementApproveForm,
+    AgreementFormForm,
 )
 from vitrina.smart_contracts.models import (
     Agreement,
     AgreementScope,
     AgreementFile,
-    SmartContractTemplate,
 )
 from vitrina.users.models import User
 from vitrina.structure.models import Metadata
@@ -44,6 +46,9 @@ from vitrina.smart_contracts.permissions import (
     can_create_agreements,
     can_view_agreement,
     can_upload_agreement_file,
+    can_submit_agreements,
+    can_approve_agreements,
+    can_form_agreements,
 )
 from vitrina.projects.views import ProjectViewBaseMixin
 
@@ -157,6 +162,9 @@ class AgreementDetailView(
                 "agreement_status_descriptions": AGREEMENT_STATUS_DESCRIPTIONS,
                 "page_title": self.agreement.detail_page_title,
                 "can_create_agreements": can_create_agreements(self.request.user, self.project),
+                "can_submit_agreements": can_submit_agreements(self.request.user, self.agreement),
+                "can_approve_agreements": can_approve_agreements(self.request.user, self.agreement),
+                "can_form_agreements": can_form_agreements(self.request.user, self.agreement),
                 "can_upload_agreement_file": can_upload_agreement_file(self.request.user, self.agreement),
             }
         )
@@ -301,84 +309,139 @@ class AgreementCreateView(
         return super().formset_invalid(formset)
 
 
-class AgreementGeneratePdf(
-    LoginRequiredMixin,
-    BaseProjectMixin,
-    BaseAgreementMixin,
-    PermissionRequiredMixin,
-    FormView,
+class BaseAgreementNegotiateView(
+    LoginRequiredMixin, BaseProjectMixin, BaseAgreementMixin, PermissionRequiredMixin, FormView
 ):
-    form_class = AgreementGeneratePdfForm
-    template_name = "base_form.html"
+    template_name = "smart_contracts/agreement_negotiate.html"
+    form_class = None
+    title = ""
+
     detail_url_name = "project-detail"
     history_url_name = "project-history"
 
-    def setup(self, request, *args, **kwargs):
+    def setup(self, request: WSGIRequest, *args, **kwargs) -> None:
         self.object = self.get_project(kwargs["pk"])
+        self.agreement = get_object_or_404(Agreement, pk=kwargs["agreement_id"])
         return super().setup(request, *args, **kwargs)
 
-    def has_permission(self) -> bool:
-        return can_create_agreements(self.request.user, self.object)
+    def has_permission(self) -> None:
+        raise NotImplementedError
 
-    def get_success_url(self) -> str:
-        return reverse("agreement-detail", args=[self.object.pk, self.agreement.pk])
-
-    @transaction.atomic
-    def form_valid(self, form: AgreementGeneratePdfForm) -> HttpResponse:
-        if self.agreement.status != AgreementStatuses.CREATED:
-            error_msg = _(
-                "Sutarties dokumentas gali būti generuojamas sutarčiai su "
-                "būsena {accepted_status}. Dabartinė būsena: {current_status}"
-            ).format(
-                accepted_status=AgreementStatuses.CREATED,
-                current_status=self.agreement.status,
-            )
-            messages.error(self.request, error_msg)
-            return HttpResponseRedirect(self.get_success_url())
-
-        contract_template: SmartContractTemplate = form.cleaned_data["template"]
-        self.agreement.status = AgreementStatuses.FORMED
-        self.agreement.other_assigner_legislations = form.cleaned_data["other_assigner_legislations"]
-        self.agreement.payment_terms = form.cleaned_data["payment_terms"]
-        self.agreement.assigner_representative = form.cleaned_data["assigner_representative"]
-        self.agreement.assignee_representative = form.cleaned_data["assignee_representative"]
-        self.agreement.save()
-        self.agreement.generate_contract_pdf_file(template=contract_template)
-        name_without_ext, ext = os.path.splitext(os.path.basename(contract_template.file.name))
-
-        copy_filename = f"{name_without_ext}_copy{ext}"
-        with contract_template.file.open() as f:
-            self.agreement.files.create(
-                file=ContentFile(content=f.read(), name=copy_filename),
-                is_template=True,
-                file_name=copy_filename,
-            )
-
-        messages.success(self.request, _("Sutarties dokumentas sukurtas"))
-        return HttpResponseRedirect(self.get_success_url())
-
-    def get_form_kwargs(self):
+    def get_form_kwargs(self) -> Any:
         kwargs = super().get_form_kwargs()
         kwargs["agreement"] = self.agreement
         return kwargs
 
-    def get_context_data(self, **kwargs) -> dict:
+    def get_success_url(self) -> str:
+        return reverse("agreement-detail", args=[self.object.pk, self.agreement.pk])
+
+    def get_context_data(self, **kwargs: Any) -> dict:
         context = super().get_context_data(**kwargs)
         context.update(
             {
-                "tabs": "vitrina/projects/tabs.html",
-                "current_title": _("Generuoti sutarties dokumentą"),
+                "current_title": self.title,
+                "parent_links": self.get_parent_links(self.title),
+                "agreement": self.agreement,
+                "project": self.agreement.project,
             }
         )
-        context["parent_links"].update(
-            {
-                reverse("agreement-list", args=[self.object.pk]): _("Sutartys"),
-                reverse("agreement-detail", args=[self.object.pk, self.agreement.pk]): self.agreement.detail_page_title,
-                None: _("Generuoti sutarties dokumentą"),
-            }
-        )
-
         return context
+
+    def validate_status(self, expected_status: str) -> bool:
+        if self.agreement.status != expected_status:
+            error_message = _(
+                "Veiksmas gali būti atliekamas tik sutarčiai esant būsenoje {expected_status}."
+                "Dabartinė būsena: {current_status}."
+            ).format(
+                expected_status=expected_status,
+                current_status=self.agreement.status,
+            )
+            messages.error(self.request, error_message)
+            return False
+        return True
+
+    def get_parent_links(self, current_action_name: str) -> dict[str | None, str]:
+        return {
+            reverse("home"): _("Pradžia"),
+            reverse("project-list"): _("Panaudojimo atvejai"),
+            reverse("project-detail", args=[self.project.pk]): self.project,
+            reverse("agreement-list", args=[self.object.pk]): _("Sutartys"),
+            reverse("agreement-detail", args=[self.object.pk, self.agreement.pk]): self.agreement.detail_page_title,
+            None: current_action_name,
+        }
+
+
+class AgreementSubmitView(BaseAgreementNegotiateView):
+    form_class = AgreementSubmitForm
+    title = _("Pateikti pasiūlymą")
+
+    def has_permission(self) -> bool:
+        return can_submit_agreements(self.request.user, self.agreement)
+
+    @transaction.atomic
+    def form_valid(self, form: ModelForm) -> HttpResponseRedirect:
+        if not self.validate_status(AgreementStatuses.CREATED):
+            return HttpResponseRedirect(self.get_success_url())
+
+        self.agreement.status = AgreementStatuses.SUBMITTED
+        self.agreement.assignee_representative = form.cleaned_data["assignee_representative"]
+        self.agreement.save()
+
+        messages.success(self.request, _("Pasiūlymas sėkmingai pateiktas duomenų teikėjui."))
+        return HttpResponseRedirect(self.get_success_url())
+
+
+class AgreementApproveView(BaseAgreementNegotiateView):
+    form_class = AgreementApproveForm
+    title = _("Patvirtinti pasiūlymą")
+
+    def has_permission(self) -> bool:
+        return can_approve_agreements(self.request.user, self.agreement)
+
+    @transaction.atomic
+    def form_valid(self, form: ModelForm) -> HttpResponseRedirect:
+        if not self.validate_status(AgreementStatuses.SUBMITTED):
+            return HttpResponseRedirect(self.get_success_url())
+
+        self.agreement.status = AgreementStatuses.APPROVED
+        self.agreement.template = form.cleaned_data["template"]
+        self.agreement.assigner_representative = form.cleaned_data["assigner_representative"]
+        self.agreement.other_assigner_legislations = form.cleaned_data["other_assigner_legislations"]
+        self.agreement.save()
+
+        messages.success(self.request, _("Pasiūlymas sėkmingai patvirtintas."))
+        return HttpResponseRedirect(self.get_success_url())
+
+
+class AgreementFormView(BaseAgreementNegotiateView):
+    form_class = AgreementFormForm
+    title = _("Formuoti sutartį")
+
+    def has_permission(self):
+        return can_form_agreements(self.request.user, self.agreement)
+
+    @transaction.atomic
+    def form_valid(self, form: ModelForm) -> HttpResponseRedirect:
+        if not self.validate_status(AgreementStatuses.APPROVED):
+            return HttpResponseRedirect(self.get_success_url())
+
+        template = self.agreement.template
+
+        self.agreement.status = AgreementStatuses.FORMED
+        self.agreement.save()
+
+        self.agreement.generate_contract_pdf_file(template=template)
+        file_name, extension = os.path.splitext(os.path.basename(template.file.name))
+        copy_file_name = f"{file_name}_copy{extension}"
+        with template.file.open() as file:
+            self.agreement.files.create(
+                file=ContentFile(content=file.read(), name=copy_file_name),
+                is_template=True,
+                file_name=copy_file_name,
+            )
+
+        messages.success(self.request, _("Sutarties dokumentas sukurtas"))
+        return HttpResponseRedirect(self.get_success_url())
 
 
 class AgreementUploadSignedFile(


### PR DESCRIPTION
### Part 3:

- Introduced logic and forms for statuses:
    - Submit
    - Approve
    - Form
- Added explicit permissions
- Old forms & views have been removed (sadly Github does not display that well for reviewing)

**Part 4 will contain all the changes needed for statuses Initiated & Signed.**

---

# Notes:

- `1440/1876` Changed lines are from added tests for uncovered & new cases.
    - As the PR author I suggest you not taking the time to look through them thoroughly, but do as you please.
- Things that could have been separated, were separated into 2.X parts (2.1 - 2.4) and merged already, without any breaking changes. This PR contains what can only be deployed together, nothing else, and is separated in two parts, since `INITIATED` & `SIGNED` statuses will have a number of changes as well.