### PR TITLE
336: better Rest API error messages and status codes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,12 @@ v 1.8 (unreleased)
 
 New features:
 
+https://github.com/atviriduomenys/dvms/issues/336
+- new OAUTH_SERVER_PUBLIC_JWK_DOWNLOAD_PATH setting for .well-known/jwks.json (and env variable) which if specified will automatically jwks from specified endpoint and store it inside of a cache.
+- add support for multiple public keys picked dynamically for each access token by kid value. If not found, then by
+  algorithm (`alg` & `kty`).
+- these features unlock using auth servers with public key rotation, like gravitee.
+
 https://github.com/atviriduomenys/katalogas/issues/2123
 - Update partner registration permissions: validate that user is in active VIISP session.
 - Update fake VIISP login to work with new partner registration.

--- a/tests/uapi/dataset/test_views.py
+++ b/tests/uapi/dataset/test_views.py
@@ -1021,6 +1021,28 @@ def test_action_get_dataset_structure_no_dataset(
         "message": "No Dataset matches the given query.",
         "additionalProperties": None,
     }
+def test_action_cant_get_dataset_invalid_token(
+    app: DjangoTestApp,
+    organization: Organization,
+    url_dataset_structure: str,
+    valid_token: str
+):
+    token_parts = valid_token.split(".")
+    invalid_token = f"{token_parts[0]}.{token_parts[1]}"
+    response = app.get(
+        _build_reverse_uapi_url("uapi-dataset-structure", dataset_id=1_000_000),
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {invalid_token}"},
+        expect_errors=True,
+    )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.json == {
+        "additionalProperties": None,
+        "code": "authentication_failed",
+        "message": "Invalid input segments length",
+        "template": "Invalid input segments length",
+        "type": "system",
+    }
 
 
 def test_action_get_dataset_structure_no_dataset_structure(

--- a/vitrina/uapi/utils/views.py
+++ b/vitrina/uapi/utils/views.py
@@ -1,7 +1,7 @@
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from rest_framework import status
-from rest_framework.exceptions import NotFound, ValidationError, PermissionDenied as RestPermissionDenied
+from rest_framework.exceptions import NotFound, ValidationError, PermissionDenied as RestPermissionDenied, APIException
 from rest_framework.response import Response
 
 from vitrina.exceptions import UAPIException
@@ -60,7 +60,18 @@ class UAPIExceptionHandlerMixin:
             )
             serializer.is_valid(raise_exception=True)
             return Response(serializer.data, status=status.HTTP_403_FORBIDDEN)
-
+        if isinstance(exc, APIException):
+            serializer = BaseErrorSerializer(
+                data={
+                    "code": exc.default_code,
+                    "type": "system",
+                    "template": exc.detail,
+                    "message": str(exc),
+                    "additional_properties": None,
+                }
+            )
+            serializer.is_valid(raise_exception=True)
+            return Response(serializer.data, status=exc.status_code)
         error_data = BaseErrorSerializer.from_exception(exc)
         serializer = BaseErrorSerializer(data=error_data)
         serializer.is_valid(raise_exception=True)


### PR DESCRIPTION
Su šia užduotimi bus tik pataisomas klaidos status kodas ir pranešimas Kataloge Auth klaidos atveju, bei kitu DRF klaidu atveju

<img width="897" height="394" alt="Image" src="https://github.com/user-attachments/assets/f46ef4bb-0c25-4339-86ca-6f5907d09bd0" />

taps:

<img width="820" height="328" alt="Image" src="https://github.com/user-attachments/assets/12abe33d-17b3-4a06-80fa-2e46a0d921ed" />

