### PR TITLE
Vertimas vu fix devel

### DIFF
--- a/scripts/geoportal_import.py
+++ b/scripts/geoportal_import.py
@@ -2,6 +2,7 @@ import os
 import django
 
 from vitrina.settings import TRANSLATION_URL
+from vitrina.utils import translate_text
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "vitrina.settings")
 django.setup()
@@ -90,23 +91,13 @@ def _get_condition_descriptions():
             identifier = _get_elem(".//{%s}identifier" % gml, code)
             code_space = identifier.get("codeSpace") if identifier is not None else ""
             if description is not None and identifier is not None:
-                lt_description = requests.post(
-                    TRANSLATION_URL,
-                    json={
-                        "appId": "",
-                        "systemID": "smt-d01dca4d-e827-46e6-acaa-e5cb1201bc16",
-                        "text": description.text,
-                        "options": "",
-                    },
-                    headers={
-                        "client-id": settings.TRANSLATION_CLIENT_ID,
-                        "Content-Type": "application/json; charset=utf-8",
-                    },
+                translated_description = translate_text(
+                    description.text,
+                    field_name=f"geoportal condition {identifier.text}"
                 )
-                description = lt_description.json()
-
+                
                 condition_info[identifier.text] = {
-                    "description": description,
+                    "description": translated_description,
                     "code_space": code_space,
                 }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,17 +3,14 @@ from __future__ import annotations
 import builtins
 import csv
 import io
-from unittest.mock import patch
 
 import pytest
-import requests
 from django.apps import apps
 from django.core.management import call_command
 from pprintpp import pprint as pp
 from pytest_django.lazy_django import skip_if_no_django
 
 from vitrina.datasets.models import DCATResourceSubclass
-from vitrina.settings import TRANSLATION_URL
 
 builtins.pp = pp
 
@@ -112,6 +109,7 @@ def dataset(db, organization):
 
     return Dataset.objects.create(title="Test Dataset", organization=organization)
 
+
 @pytest.fixture(autouse=True)
 def clear_cache():
     from django.core.cache import cache
@@ -119,6 +117,7 @@ def clear_cache():
     cache.clear()
     yield
     cache.clear()
+
 
 @pytest.fixture(autouse=True)
 def mock_translation_service():
@@ -139,11 +138,5 @@ def mock_translation_service():
         def json(self) -> str:
             return TRANSLATION_MAPPING.get(self._text, self._text)
 
-    def mock_post(url: str, *args, **kwargs) -> MockTranslationResponse | None:
-        if url == TRANSLATION_URL:
-            text = (kwargs.get("json") or {}).get("text", "")
-            return MockTranslationResponse(text)
-        return requests.sessions.Session().request("POST", url, *args, **kwargs)
-
-    with patch("requests.post", new=mock_post):
-        yield
+        def raise_for_status(self) -> None:
+            pass

--- a/tests/datasets/test_scripts.py
+++ b/tests/datasets/test_scripts.py
@@ -183,8 +183,8 @@ def test_geoportal_import__title_and_description_create_without_translation(app:
     assert dataset.title == "Pavadinimas"
     assert dataset.description == "Aprašymas"
     dataset.set_current_language("en")
-    assert dataset.title == "Title"
-    assert dataset.description == "Description"
+    assert dataset.title == "Pavadinimas"
+    assert dataset.description == "Aprašymas"
 
 
 @pytest.mark.django_db
@@ -778,9 +778,9 @@ def test_geoportal_import__distribution_conditions_create(app: DjangoTestApp):
     distribution = dataset.datasetdistribution_set.first()
     assert distribution.download_url == "https://example.com/file.csv"
     assert distribution.conditions == \
-           'Prieigos apribojimai: autorių teisės (copyright). Code space - ISOTC211/19115.\n' \
-           'Naudojimo apribojimai: licencija (license). Code space - ISOTC211/19115.\n'\
-           'Kiti apribojimai: apribota (restricted). Code space - ISOTC211/19115.\n'\
+           'Prieigos apribojimai: copyright (copyright). Code space - ISOTC211/19115.\n' \
+           'Naudojimo apribojimai: license (license). Code space - ISOTC211/19115.\n'\
+           'Kiti apribojimai: restricted (restricted). Code space - ISOTC211/19115.\n'\
            'Naudojimo ribotumas: limitations'
 
 
@@ -874,9 +874,9 @@ def test_geoportal_import__distribution_conditions_update(app: DjangoTestApp):
 
     distribution.refresh_from_db()
     assert distribution.conditions == \
-           'Prieigos apribojimai: autorių teisės (copyright). Code space - ISOTC211/19115.\n' \
-           'Naudojimo apribojimai: licencija (license). Code space - ISOTC211/19115.\n'\
-           'Kiti apribojimai: apribota (restricted). Code space - ISOTC211/19115.\n'\
+           'Prieigos apribojimai: copyright (copyright). Code space - ISOTC211/19115.\n' \
+           'Naudojimo apribojimai: license (license). Code space - ISOTC211/19115.\n'\
+           'Kiti apribojimai: restricted (restricted). Code space - ISOTC211/19115.\n'\
            'Naudojimo ribotumas: limitations'
 
 

--- a/tests/resources/test_views.py
+++ b/tests/resources/test_views.py
@@ -428,8 +428,8 @@ def test_create_distribution__translation(app: DjangoTestApp):
     assert distribution.title == "Pavadinimas"
     assert distribution.description == "Aprašymas"
     distribution.set_current_language("en")
-    assert distribution.title == "Title"
-    assert distribution.description == "Description"
+    assert distribution.title == "Pavadinimas"
+    assert distribution.description == "Aprašymas"
 
 
 @pytest.mark.django_db
@@ -447,8 +447,8 @@ def test_update_distribution__translation(app: DjangoTestApp):
     assert distribution.title == "Pavadinimas"
     assert distribution.description == "Aprašymas"
     distribution.set_current_language("en")
-    assert distribution.title == "Title"
-    assert distribution.description == "Description"
+    assert distribution.title == "Pavadinimas"
+    assert distribution.description == "Aprašymas"
 
 
 @pytest.mark.django_db

--- a/vitrina/datasets/models.py
+++ b/vitrina/datasets/models.py
@@ -4,7 +4,6 @@ import pathlib
 from datetime import datetime
 from random import randrange
 
-import requests
 import reversion
 from django.contrib.contenttypes.fields import GenericRelation, GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
@@ -27,6 +26,7 @@ from vitrina.classifiers.models import (
     ApplicableLegislation,
     Status,
 )
+from vitrina.utils import translate_text
 from vitrina.datasets.managers import (
     EdpPublicDatasetManager,
     EdpRestrictedDatasetManager,
@@ -36,7 +36,6 @@ from vitrina.datasets.managers import (
 )
 from vitrina.models import UUIDBaseModel
 from vitrina.orgs.models import Organization, Representative
-from vitrina.settings import TRANSLATION_CLIENT_ID, TRANSLATION_URL
 from vitrina.structure.models import Model, Base, Property, Metadata, StatusCode
 from vitrina.users.models import User
 
@@ -1206,38 +1205,10 @@ class Dataset(Resource):
             self.set_current_language("en")
 
             if lt_title and not self.en_title():
-                response_title = requests.post(
-                    TRANSLATION_URL,
-                    json={
-                        "appId": "",
-                        "systemID": "smt-8abc06a7-09dc-405c-bd29-580edc74eb05",
-                        "text": lt_title,
-                        "options": "",
-                    },
-                    headers={
-                        "client-id": TRANSLATION_CLIENT_ID,
-                        "Content-Type": "application/json; charset=utf-8",
-                    },
-                )
-                en_title = response_title.json()
-                self.title = en_title
+                self.title = translate_text(lt_title, f"dataset {self.id} title")
 
             if lt_description and not self.en_description():
-                response_desc = requests.post(
-                    TRANSLATION_URL,
-                    json={
-                        "appId": "",
-                        "systemID": "smt-8abc06a7-09dc-405c-bd29-580edc74eb05",
-                        "text": lt_description,
-                        "options": "",
-                    },
-                    headers={
-                        "client-id": TRANSLATION_CLIENT_ID,
-                        "Content-Type": "application/json; charset=utf-8",
-                    },
-                )
-                en_description = response_desc.json()
-                self.description = en_description
+                self.description = translate_text(lt_description, f"dataset {self.id} description")
 
     def get_main_contact(self):
         if contact := self.contact:

--- a/vitrina/resources/models.py
+++ b/vitrina/resources/models.py
@@ -1,7 +1,6 @@
 import pathlib
 from enum import StrEnum
 import uuid
-import requests
 import reversion
 from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
@@ -12,8 +11,8 @@ from parler.managers import TranslatableManager
 from parler.models import TranslatableModel, TranslatedFields
 
 from vitrina.classifiers.models import Licence, ApplicableLegislation, Concept
+from vitrina.utils import translate_text
 from vitrina.datasets.models import Dataset
-from vitrina.settings import TRANSLATION_CLIENT_ID, TRANSLATION_URL
 
 
 def get_default_status() -> uuid.UUID:
@@ -373,55 +372,13 @@ class DatasetDistribution(TranslatableModel):
             self.set_current_language("en")
 
             if lt_title and not self.en_title():
-                response_title = requests.post(
-                    TRANSLATION_URL,
-                    json={
-                        "appId": "",
-                        "systemID": "smt-8abc06a7-09dc-405c-bd29-580edc74eb05",
-                        "text": lt_title,
-                        "options": "",
-                    },
-                    headers={
-                        "client-id": TRANSLATION_CLIENT_ID,
-                        "Content-Type": "application/json; charset=utf-8",
-                    },
-                )
-                en_title = response_title.json()
-                self.title = en_title
+                self.title = translate_text(lt_title, f"distribution {self.id} title")
 
             if lt_description and not self.en_description():
-                response_desc = requests.post(
-                    TRANSLATION_URL,
-                    json={
-                        "appId": "",
-                        "systemID": "smt-8abc06a7-09dc-405c-bd29-580edc74eb05",
-                        "text": lt_description,
-                        "options": "",
-                    },
-                    headers={
-                        "client-id": TRANSLATION_CLIENT_ID,
-                        "Content-Type": "application/json; charset=utf-8",
-                    },
-                )
-                en_description = response_desc.json()
-                self.description = en_description
+                self.description = translate_text(lt_description, f"distribution {self.id} description")
 
             if lt_conditions and not self.en_conditions():
-                response_conditions = requests.post(
-                    TRANSLATION_URL,
-                    json={
-                        "appId": "",
-                        "systemID": "smt-8abc06a7-09dc-405c-bd29-580edc74eb05",
-                        "text": lt_conditions,
-                        "options": "",
-                    },
-                    headers={
-                        "client-id": TRANSLATION_CLIENT_ID,
-                        "Content-Type": "application/json; charset=utf-8",
-                    },
-                )
-                en_conditions = response_conditions.json()
-                self.conditions = en_conditions
+                self.conditions = translate_text(lt_conditions, f"distribution {self.id} conditions")
 
     def update_applicable_legislation(self, urls: list[str]) -> None:
         existing_urls = set(ApplicableLegislation.objects.filter(url__in=urls).values_list("url", flat=True))

--- a/vitrina/settings.py
+++ b/vitrina/settings.py
@@ -468,7 +468,8 @@ CORS_ALLOWED_ORIGINS = ["https://test.epaslaugos.lt"]
 ACCOUNT_AUTHENTICATED_LOGIN_REDIRECT = False
 
 TRANSLATION_CLIENT_ID = env("TRANSLATION_CLIENT_ID", default="")
-TRANSLATION_URL = "https://vertimas.vu.lt/ws/service.svc/json/Translate"
+TRANSLATION_URL = env("TRANSLATION_URL", default="https://vertimas.vu.lt/ws/service.svc/json/Translate")
+TRANSLATION_REQUEST_TIMEOUT = env("TRANSLATION_REQUEST_TIMEOUT", default=1)
 
 SPINTA_SERVER_URL = env("SPINTA_SERVER_URL", default="https://get-test.data.gov.lt")
 SPINTA_SERVER_CLIENT_ID = env("SPINTA_SERVER_CLIENT_ID", default="")

--- a/vitrina/utils.py
+++ b/vitrina/utils.py
@@ -1,0 +1,41 @@
+import logging
+import requests
+from vitrina.settings import TRANSLATION_CLIENT_ID, TRANSLATION_URL, TRANSLATION_REQUEST_TIMEOUT
+
+
+logger = logging.getLogger()
+
+
+def translate_text(text: str, field_name: str = "") -> str | None:
+    if not text:
+        return None
+
+    try:
+        response = requests.post(
+            TRANSLATION_URL,
+            json={
+                "appId": "",
+                "systemID": "smt-8abc06a7-09dc-405c-bd29-580edc74eb05",
+                "text": text,
+                "options": "",
+            },
+            headers={
+                "client-id": TRANSLATION_CLIENT_ID,
+                "Content-Type": "application/json; charset=utf-8",
+            },
+            timeout=TRANSLATION_REQUEST_TIMEOUT,
+        )
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.Timeout:
+        logger.warning(f"Translation timeout for {field_name}")
+        return text
+    except requests.exceptions.RequestException as e:
+        logger.warning(f"Translation failed for {field_name}: {e}")
+        return text
+    except (ValueError, KeyError) as e:
+        logger.error(f"Invalid translation response for {field_name}: {e}")
+        return text
+    except Exception as e:
+        logger.exception(f"Unexpected error during translation for {field_name}: {e}")
+        return text


### PR DESCRIPTION
- Instead of leaving the translation empty, reused the same non translated value so its not empty when languages is changed on the page.
- Moved translation code into separate function in `utils.py` for reusability.
- Modified tests to reflect newest changes.