### PR TITLE
[2040] Agreement tab for assigner organization — List & Detail views

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,8 +6,16 @@ v 1.10 (unreleased)
 
 Bug fixes:
 
+https://github.com/atviriduomenys/katalogas/issues/2196
+
 - Return the mock for translation calling, vertimas.vu.lt is up and running, tests are breaking again, because the mock
   was removed
+
+Improvements:
+
+https://github.com/atviriduomenys/katalogas/issues/2040
+
+- Part 1: Organization-based detail & list agreement pages (previously only available under Projects)
 
 
 v 1.9 (2025-12-04)

--- a/tests/orgs/test_permissions.py
+++ b/tests/orgs/test_permissions.py
@@ -1,0 +1,119 @@
+from django.contrib.auth.models import AnonymousUser
+from django.contrib.contenttypes.models import ContentType
+
+from vitrina.orgs.factories import OrganizationFactory, RepresentativeFactory
+from vitrina.orgs.models import Representative
+from vitrina.orgs.permissions import can_view_organization_agreements, can_view_organization_agreement
+from vitrina.smart_contracts.factories import AgreementFactory
+from vitrina.users.factories import UserFactory
+
+
+class TestCanViewOrganizationAgreements:
+    def test_success_representative(self):
+        organization = OrganizationFactory()
+        user = UserFactory()
+        RepresentativeFactory(
+            user=user,
+            organization=organization,
+            role=Representative.COORDINATOR,
+            can_make_agreements=True,
+            object_id=organization.id,
+            content_type=ContentType.objects.get_for_model(organization)
+        )
+        assert can_view_organization_agreements(user, organization)
+
+
+    def test_success_staff_or_superuser(self):
+        organization = OrganizationFactory()
+        staff_user = UserFactory(is_staff=True)
+        super_user = UserFactory(is_superuser=True)
+
+        assert can_view_organization_agreements(staff_user, organization)
+        assert can_view_organization_agreements(super_user, organization)
+
+    def test_user_unauthenticated(self):
+        organization = OrganizationFactory()
+        user = AnonymousUser()
+        assert not can_view_organization_agreements(user, organization)
+
+    def test_user_not_representative(self):
+        organization = OrganizationFactory()
+        user = UserFactory()
+        other_organization = OrganizationFactory()
+        RepresentativeFactory(
+            user=user,
+            organization=other_organization,
+            role=Representative.COORDINATOR,
+            can_make_agreements=True,
+            object_id=other_organization.id,
+            content_type=ContentType.objects.get_for_model(other_organization)
+        )
+        assert not can_view_organization_agreements(user, organization)
+
+
+class TestCanViewOrganizationAgreement:
+    def test_anonymous_user_cannot_view(self):
+        organization = OrganizationFactory()
+        agreement = AgreementFactory(assignee=organization)
+        user = AnonymousUser()
+        assert not can_view_organization_agreement(user, agreement)
+
+    def test_staff_can_view_any_agreement(self):
+        organization = OrganizationFactory()
+        agreement = AgreementFactory(assignee=organization)
+        staff_user = UserFactory(is_staff=True)
+        super_user = UserFactory(is_superuser=True)
+
+        assert can_view_organization_agreement(staff_user, agreement)
+        assert can_view_organization_agreement(super_user, agreement)
+
+    def test_user_representative_of_assignee_can_view(self):
+        organization = OrganizationFactory()
+        user = UserFactory()
+        agreement = AgreementFactory(assignee=organization)
+
+        RepresentativeFactory(
+            user=user,
+            organization=organization,
+            role=Representative.COORDINATOR,
+            can_make_agreements=True,
+            object_id=organization.id,
+            content_type=ContentType.objects.get_for_model(organization),
+        )
+
+        assert can_view_organization_agreement(user, agreement)
+
+    def test_user_representative_of_assigner_can_view(self):
+        assignee = OrganizationFactory()
+        assigner = OrganizationFactory()
+        user = UserFactory()
+        agreement = AgreementFactory(assignee=assignee, assigner=assigner)
+
+        RepresentativeFactory(
+            user=user,
+            organization=assigner,
+            role=Representative.COORDINATOR,
+            can_make_agreements=True,
+            object_id=assigner.id,
+            content_type=ContentType.objects.get_for_model(assigner),
+        )
+
+        assert can_view_organization_agreement(user, agreement)
+
+    def test_user_not_representative_cannot_view(self):
+        assignee = OrganizationFactory()
+        assigner = OrganizationFactory()
+        user = UserFactory()
+        agreement = AgreementFactory(assignee=assignee, assigner=assigner)
+
+        other_organization = OrganizationFactory()
+        RepresentativeFactory(
+            user=user,
+            organization=other_organization,
+            role=Representative.COORDINATOR,
+            can_make_agreements=True,
+            object_id=other_organization.id,
+            content_type=ContentType.objects.get_for_model(other_organization),
+        )
+
+        assert not can_view_organization_agreement(user, agreement)

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -4963,10 +4963,10 @@ msgid "Komentaras pašalintas"
 msgstr "Comment deleted"
 
 msgid "ištrinta"
-msgstr "Deleted"
+msgstr "deleted"
 
 msgid "redaguotas"
-msgstr "Edited"
+msgstr "edited"
 
 msgid "(neviešinamas komentaras)"
 msgstr "(private comment)"

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-27 14:56+0200\n"
+"POT-Creation-Date: 2025-12-02 07:53+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -448,11 +448,17 @@ msgstr "Comment for object:"
 msgid "Registruoti kaip prašymą"
 msgstr "Register as request"
 
+msgid "Poreikio pavadinimas"
+msgstr "Request title"
+
 msgid "Pageidaujamas duomenų atnaujinimo periodiškumas"
 msgstr "Preferred frequency of data updates"
 
 msgid "Jei komentaras registruojamas kaip prašymas, jis privalo būti viešas"
 msgstr "If the comment is registered as a request, it must be public"
+
+msgid "Įrašykite poreikio pavadinimą."
+msgstr "Please input request title."
 
 msgid "Šis laukas yra privalomas"
 msgstr "This field is required"
@@ -1337,6 +1343,14 @@ msgstr "Harvested"
 
 msgid "Atlikto darbo būsena"
 msgstr "Harvesting status"
+
+msgid "Licencija"
+msgstr "License"
+
+msgid "Ši savybė nurodo licenciją, pagal kurią platinama duomenų paslauga"
+msgstr ""
+"This property specifies the license under which the data service is "
+"distributed."
 
 msgid ""
 "Nurodoma konkreti informacinė sistema - valstybės informacinė sistema ar "
@@ -2705,6 +2719,18 @@ msgstr "Search for organization"
 msgid "Nauja organizacija"
 msgstr "New organization"
 
+msgid "Sukūrimo data"
+msgstr "Creation date"
+
+msgid "Duomenis gaunanti organizacija"
+msgstr "Data receiver organization"
+
+msgid "Panaudojimo atvejis"
+msgstr "Use case"
+
+msgid "Paskutinės sinchronizacijos data"
+msgstr "Date of last synchronization"
+
 msgid "Informacija duomenų teikėjo registravimui"
 msgstr "Data provider information for registration"
 
@@ -2777,6 +2803,9 @@ msgstr "Registration is not allowed"
 msgid ""
 "Šios registravimosi nuorodos galiojimas baigėsi arba nuoroda yra klaidinga."
 msgstr "This registration link has expired or the link is incorrect."
+
+msgid "Sutartys"
+msgstr "Agreements"
 
 msgid "Agentai"
 msgstr "Agents"
@@ -3010,9 +3039,6 @@ msgstr "Select a scope"
 msgid "Leidimai"
 msgstr "Permissions"
 
-msgid "Panaudojimo atvejis"
-msgstr "Use case"
-
 msgid "Kliento ID"
 msgstr "Client ID"
 
@@ -3103,9 +3129,6 @@ msgstr "Key title"
 
 msgid "Šiuo metu raktas leidimų neturi"
 msgstr "Currently the key does not have permissions"
-
-msgid "Sutartys"
-msgstr "Agreements"
 
 msgid "Panaudojimo atvejo registracija"
 msgstr "Use case registration"
@@ -3603,9 +3626,6 @@ msgstr "Upload to storage"
 msgid "Importuojamas išorinis metaduomenų katalogas"
 msgstr "Importing external metadata catalog"
 
-msgid "Licencija"
-msgstr "License"
-
 msgid "Statusas"
 msgstr "Status"
 
@@ -3627,11 +3647,6 @@ msgstr "Open dataset distribution"
 
 msgid "Publikuojamas saugykloje"
 msgstr "Published in storage"
-
-msgid "Ši savybė nurodo licenciją, pagal kurią platinama duomenų paslauga"
-msgstr ""
-"This property specifies the license under which the data service is "
-"distributed."
 
 msgid "Modeliai"
 msgstr "Models"
@@ -3754,9 +3769,6 @@ msgstr "Specifies the organization to which the template is assigned."
 msgid "Duomenų teikėjo atstovas"
 msgstr "Data provider representative"
 
-msgid "Duomenis gaunanti organizacija"
-msgstr "Data receiver organization"
-
 msgid "Duomenų gavėjo atstovas"
 msgstr "Data receiver representative"
 
@@ -3765,9 +3777,6 @@ msgstr "Agreement template"
 
 msgid "Agento sinchronizacija įjungta"
 msgstr "Agent synchronization is enabled"
-
-msgid "Paskutinės sinchronizacijos data"
-msgstr "Date of last synchronization"
 
 msgid "Sutarties iniciatorius"
 msgstr "Creator of an agreement"
@@ -3901,14 +3910,8 @@ msgstr "Awaiting for signed document upload by data provider (assigner)"
 msgid "Sutarties identifikatorius"
 msgstr "Agreement id"
 
-msgid "Sukūrimo data"
-msgstr "Creation date"
-
 msgid "Nėra sutarčių dokumentų."
 msgstr "No agreement documents."
-
-msgid "Nėra sutarčių."
-msgstr "No agreements."
 
 msgid "Sutarties derinimo informacija"
 msgstr "Agreement negotation information"
@@ -3965,10 +3968,11 @@ msgstr "Agreement document is created"
 msgid "PDF failas sutarčiai nėra sukurtas."
 msgstr "PDF file for the agreement is not created."
 
-
 msgid ""
 "Rasti keli PDF failai susieti su sutartimi. Susisiekite su administratoriumi."
-msgstr "Multiple PDF files were found related to the agreement. Please contact the administrator."
+msgstr ""
+"Multiple PDF files were found related to the agreement. Please contact the "
+"administrator."
 
 msgid "Įkelti pasirašytą sutartį"
 msgstr "Upload signed document"
@@ -4958,11 +4962,32 @@ msgstr "Answer to"
 msgid "Komentaras pašalintas"
 msgstr "Comment deleted"
 
+msgid "ištrinta"
+msgstr "Deleted"
+
+msgid "redaguotas"
+msgstr "Edited"
+
 msgid "(neviešinamas komentaras)"
 msgstr "(private comment)"
 
 msgid "Atsakyti"
 msgstr "Answer"
+
+msgid "Atsakyti į komentarą"
+msgstr "Submit comment"
+
+msgid "Redaguoti komentarą"
+msgstr "Edit comment"
+
+msgid "Ištrinti komentarą"
+msgstr "Delete comment"
+
+msgid "Ištrinti komentarą?"
+msgstr "Delete comment?"
+
+msgid "Šis veiksmas negrąžinamas."
+msgstr "This action is irreversible."
 
 msgid "Komentarai"
 msgstr "Comments"
@@ -5083,6 +5108,9 @@ msgstr "Register request to open data"
 
 msgid "Statistika"
 msgstr "Statistics"
+
+msgid "Nėra sutarčių."
+msgstr "No agreements."
 
 msgid "Pradinis"
 msgstr "First"
@@ -5698,7 +5726,8 @@ msgid ""
 "Nurodomas įmonės kodas organizacijos, kurios vardu vartotojas yra "
 "prisijungęs per VIISP."
 msgstr ""
-"The company code of the organization the user is logged in on behalf of via VIISP."
+"The company code of the organization the user is logged in on behalf of via "
+"VIISP."
 
 msgid "Visi naudotojai"
 msgstr "All users"
@@ -5950,7 +5979,8 @@ msgid ""
 "Elektroninis paštas ir/arba slaptažodis yra neteisingas. Atkreipkite dėmesį, "
 "kad abu laukai yra jautrūs raidžių dydžiui (mažosios ir didžiosios raidės)."
 msgstr ""
-"The email and/or the password is incorrect. Note that both fields are case-sensitive."
+"The email and/or the password is incorrect. Note that both fields are case-"
+"sensitive."
 
 msgid "key_content"
 msgstr "key_content"

--- a/vitrina/orgs/permissions.py
+++ b/vitrina/orgs/permissions.py
@@ -1,0 +1,18 @@
+from django.contrib.auth.models import AnonymousUser
+
+from vitrina.orgs.models import Organization
+from vitrina.users.models import User
+
+
+def can_view_organization_agreements(user: User | AnonymousUser, organization: Organization) -> bool:
+    if not user.is_authenticated:
+        return False
+
+    if user.is_staff or user.is_superuser:
+        return True
+
+    user_represented_organization_ids = user.represented_org_ids
+    if organization.id in user_represented_organization_ids:
+        return True
+
+    return False

--- a/vitrina/orgs/permissions.py
+++ b/vitrina/orgs/permissions.py
@@ -1,6 +1,8 @@
 from django.contrib.auth.models import AnonymousUser
 
 from vitrina.orgs.models import Organization
+from vitrina.smart_contracts.models import Agreement
+from vitrina.smart_contracts.services import get_agreements
 from vitrina.users.models import User
 
 
@@ -16,3 +18,7 @@ def can_view_organization_agreements(user: User | AnonymousUser, organization: O
         return True
 
     return False
+
+
+def can_view_organization_agreement(user: User, agreement: Agreement) -> bool:
+    return get_agreements(user).filter(pk=agreement.pk).exists()

--- a/vitrina/orgs/templates/vitrina/orgs/organization_agreements.html
+++ b/vitrina/orgs/templates/vitrina/orgs/organization_agreements.html
@@ -3,23 +3,14 @@
 {% load util_tags %}
 
 {% block agreement_tabs %}
-    {% include 'vitrina/projects/tabs.html' %}
-{% endblock %}
-
-{% block agreement_actions %}
-    {% if can_create_agreements %}
-        <div class="buttons is-right">
-            <a class="button is-primary m-t-xs m-b-lg"
-               href="{% url 'agreement-create' project.pk %}">
-                {% translate "Generuoti sutartis" %}
-            </a>
-        </div>
-    {% endif %}
+    {% include "vitrina/orgs/tabs.html" %}
 {% endblock %}
 
 {% block agreement_table_head %}
     <tr>
-        <th>{% translate "Duomenis teikianti organizacija" %}</th>
+        <th>{% translate "Sukūrimo data" %}</th>
+        <th>{% translate "Duomenis gaunanti organizacija" %}</th>
+        <th>{% translate "Panaudojimo atvejis" %}</th>
         <th>{% translate "Būsena" %}</th>
         <th>{% translate "Paskutinės sinchronizacijos data" %}</th>
         <th>{% translate "Veiksmai" %}</th>
@@ -28,7 +19,14 @@
 
 {% block agreement_table_row %}
     <tr>
-        <td>{{ agreement.assigner }}</td>
+        <td>{{ agreement.created_at|date:"Y-m-d H:i" }}</td>
+        <td>{{ agreement.assignee|truncatechars:50 }}</td>
+
+        <td>
+            <a href="{% url 'project-detail' agreement.project.pk %}">
+                {{ agreement.project|truncatechars:30 }}
+            </a>
+        </td>
 
         <td>
             {{ agreement.get_status_display }}
@@ -47,9 +45,7 @@
         </td>
 
         <td>
-            <a href="{% url 'agreement-detail' project.pk agreement.pk %}">
-                {% translate "Peržiūrėti" %}
-            </a>
+            -
         </td>
     </tr>
 {% endblock %}

--- a/vitrina/orgs/templates/vitrina/orgs/organization_agreements.html
+++ b/vitrina/orgs/templates/vitrina/orgs/organization_agreements.html
@@ -45,7 +45,9 @@
         </td>
 
         <td>
-            -
+            <a href="{% url 'organization-agreement-detail' agreement.assigner.pk agreement.pk %}">
+                {% translate "Peržiūrėti" %}
+            </a>
         </td>
     </tr>
 {% endblock %}

--- a/vitrina/orgs/templates/vitrina/orgs/organization_agreements_detail.html
+++ b/vitrina/orgs/templates/vitrina/orgs/organization_agreements_detail.html
@@ -1,0 +1,40 @@
+{% extends "vitrina/agreements/base_agreement_detail.html" %}
+{% load i18n %}
+
+{% block parent_tabs %}
+    {% include 'vitrina/orgs/tabs.html' %}
+{% endblock %}
+
+{% block back_link_url %}
+    {% url 'organization-agreement-list' organization.pk %}
+{% endblock %}
+
+{% block agreement_buttons %}
+    <div class="buttons is-right">
+        {% if agreement.status == "CREATED" %}
+            <button class="button is-primary m-t-xs m-b-lg" disabled>
+                {% translate "Laukiama gavėjo veiksmų" %}
+            </button>
+        {% elif agreement.status == "SUBMITTED" %}
+            {% if can_approve_agreements %}
+{#                <a href="{% url "organization-agreement-approve" project.pk agreement.pk %}" class="button is-primary m-t-xs m-b-lg">#}
+                    {% translate "Peržiūrėti pateiktą pasiūlymą" %}
+{#                </a>#}
+            {% endif %}
+        {% elif can_form_agreements and agreement.status == "APPROVED" %}
+{#            <a href="{% url "organization-agreement-form" project.pk agreement.pk %}" class="button is-primary m-t-xs m-b-lg">#}
+                {% translate "Formuoti sutartį" %}
+{#            </a>#}
+        {% elif agreement.status == "FORMED" %}
+            <button class="button is-primary m-t-xs m-b-lg" disabled>
+                {% translate "Laukiama kol gavėjas įkels pasirašytą dokumentą" %}
+            </button>
+        {% elif agreement.status == "INITIATED" %}
+            {% if can_sign_agreements %}
+{#                <a href="{% url "organization-agreement-sign" project.pk agreement.pk %}" class="button is-primary m-t-xs m-b-lg">#}
+                    {% translate "Įkelti pasirašytą dokumentą (Teikėjo)" %}
+{#                </a>#}
+            {% endif %}
+        {% endif %}
+    </div>
+{% endblock %}

--- a/vitrina/orgs/templates/vitrina/orgs/tabs.html
+++ b/vitrina/orgs/templates/vitrina/orgs/tabs.html
@@ -30,6 +30,11 @@
                 {% translate "Panaudojimo atvejai" %}
             </a>
         </li>
+        <li class="{%if request.resolver_match.url_name == 'organization-agreements' %} is-active {% endif %}">
+            <a href="{% url 'organization-agreements' organization.id %}">
+                {% translate "Sutartys" %}
+            </a>
+        </li>
         {% if plan_url %}
             <li class="{% if request.resolver_match.url_name == plan_url_name or request.resolver_match.url_name == 'plan-detail' %} is-active {% endif %}">
                 <a href="{{ plan_url }}">

--- a/vitrina/orgs/templates/vitrina/orgs/tabs.html
+++ b/vitrina/orgs/templates/vitrina/orgs/tabs.html
@@ -30,8 +30,8 @@
                 {% translate "Panaudojimo atvejai" %}
             </a>
         </li>
-        <li class="{%if request.resolver_match.url_name == 'organization-agreements' %} is-active {% endif %}">
-            <a href="{% url 'organization-agreements' organization.id %}">
+        <li class="{%if request.resolver_match.url_name == 'organization-agreement-list' %} is-active {% endif %}">
+            <a href="{% url 'organization-agreement-list' organization.id %}">
                 {% translate "Sutartys" %}
             </a>
         </li>

--- a/vitrina/orgs/urls.py
+++ b/vitrina/orgs/urls.py
@@ -29,6 +29,7 @@ from vitrina.orgs.views import (
     ContactDeleteView,
     create_remote_organization,
     check_organization,
+    OrganizationAgreementListView,
 )
 from vitrina.orgs.views import (
     OrganizationDetailView,
@@ -133,6 +134,11 @@ urlpatterns = [
         "orgs/<int:pk>/projects/",
         OrganizationProjectsView.as_view(),
         name="organization-projects",
+    ),
+    path(
+        "orgs/<int:pk>/agreements/",
+        OrganizationAgreementListView.as_view(),
+        name="organization-agreements",
     ),
     path(
         "register/<token>/",

--- a/vitrina/orgs/urls.py
+++ b/vitrina/orgs/urls.py
@@ -30,6 +30,7 @@ from vitrina.orgs.views import (
     create_remote_organization,
     check_organization,
     OrganizationAgreementListView,
+    OrganizationAgreementDetailView,
 )
 from vitrina.orgs.views import (
     OrganizationDetailView,
@@ -138,7 +139,12 @@ urlpatterns = [
     path(
         "orgs/<int:pk>/agreements/",
         OrganizationAgreementListView.as_view(),
-        name="organization-agreements",
+        name="organization-agreement-list",
+    ),
+    path(
+        "orgs/<int:pk>/agreements/<uuid:agreement_id>/",
+        OrganizationAgreementDetailView.as_view(),
+        name="organization-agreement-detail",
     ),
     path(
         "register/<token>/",

--- a/vitrina/orgs/views.py
+++ b/vitrina/orgs/views.py
@@ -3,7 +3,7 @@ import logging
 import secrets
 from datetime import datetime
 from json import JSONDecodeError
-from typing import List
+from typing import List, Any
 
 import pandas as pd
 import requests
@@ -13,7 +13,8 @@ from django.contrib.auth import login
 from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
-from django.db.models import Q, Count
+from django.core.handlers.wsgi import WSGIRequest
+from django.db.models import Q, Count, QuerySet
 from django.forms import BaseForm
 from django.http import HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
@@ -36,6 +37,9 @@ from reversion import set_comment
 from reversion.models import Version
 
 from vitrina.classifiers.models import AreaOfManagement
+from vitrina.orgs.permissions import can_view_organization_agreements
+from vitrina.smart_contracts.services import get_agreements
+from vitrina.smart_contracts.views import BaseAgreementListView
 from vitrina.statistics.helpers import get_start_date_based_on_frequency
 from vitrina.messages.models import SentMail
 from vitrina.orgs.helpers import get_or_create_parent_org
@@ -113,12 +117,7 @@ class OrganizationBaseViewMixin:
     def get_context_data(self, **kwargs):
         context_data = super().get_context_data(**kwargs)
         context_data["can_view_members"] = has_perm(self.request.user, Action.VIEW, Representative, self.organization)
-        context_data["can_view_contacts"] = has_perm(
-            self.request.user,
-            Action.VIEW,
-            Contact,
-            self.organization,
-        )
+        context_data["can_view_contacts"] = has_perm(self.request.user, Action.VIEW, Contact, self.organization)
         context_data["can_update_organization"] = (
             has_perm(self.request.user, Action.UPDATE, Representative, self.organization)
             and self.request.user.viisp_organization == self.organization
@@ -714,6 +713,32 @@ class OrganizationProjectsView(
         )
 
         return context_data
+
+
+class OrganizationAgreementListView(OrganizationBaseViewMixin, BaseAgreementListView):
+    template_name = "vitrina/orgs/organization_agreements.html"
+    parent_type = "organization"
+
+    def setup(self, request: WSGIRequest, *args: Any, **kwargs: Any) -> None:
+        super().setup(request, *args, **kwargs)
+        self.parent: Organization = self.organization
+        return None
+
+    def has_permission(self) -> bool:
+        return can_view_organization_agreements(self.request.user, self.organization)
+
+    def get_queryset(self) -> QuerySet:
+        return get_agreements(self.request.user).filter(assigner=self.organization)
+
+    def get_context_data(self, **kwargs: Any) -> dict:
+        context = super().get_context_data(**kwargs)
+        context["parent_links"] = {
+            reverse("home"): _("Pradžia"),
+            reverse("organization-list"): _("Organizacijos"),
+            reverse("organization-detail", args=[self.organization.pk]): self.organization.title,
+            None: _("Sutartys"),
+        }
+        return context
 
 
 class OrganizationUpdateView(LoginRequiredMixin, PermissionRequiredMixin, RevisionMixin, UpdateView):

--- a/vitrina/orgs/views.py
+++ b/vitrina/orgs/views.py
@@ -37,9 +37,16 @@ from reversion import set_comment
 from reversion.models import Version
 
 from vitrina.classifiers.models import AreaOfManagement
-from vitrina.orgs.permissions import can_view_organization_agreements
+from vitrina.orgs.permissions import can_view_organization_agreements, can_view_organization_agreement
+from vitrina.smart_contracts.models import Agreement
+from vitrina.smart_contracts.permissions import (
+    can_approve_agreements,
+    can_form_agreements,
+    can_sign_agreements,
+    can_upload_agreement_file,
+)
 from vitrina.smart_contracts.services import get_agreements
-from vitrina.smart_contracts.views import BaseAgreementListView
+from vitrina.smart_contracts.views import BaseAgreementListView, BaseAgreementDetailView
 from vitrina.statistics.helpers import get_start_date_based_on_frequency
 from vitrina.messages.models import SentMail
 from vitrina.orgs.helpers import get_or_create_parent_org
@@ -738,6 +745,48 @@ class OrganizationAgreementListView(OrganizationBaseViewMixin, BaseAgreementList
             reverse("organization-detail", args=[self.organization.pk]): self.organization.title,
             None: _("Sutartys"),
         }
+        return context
+
+
+class OrganizationAgreementDetailView(OrganizationBaseViewMixin, BaseAgreementDetailView):
+    template_name = "vitrina/orgs/organization_agreements_detail.html"
+    parent_type = "organization"
+
+    def setup(self, request: WSGIRequest, *args: Any, **kwargs: Any) -> None:
+        super().setup(request, *args, **kwargs)
+        self.parent: Organization = self.organization
+
+        self.agreement = get_object_or_404(
+            Agreement.objects.all().select_related("assigner").prefetch_related("scopes"),
+            assigner=self.organization,
+            pk=self.kwargs["agreement_id"],
+        )
+
+    def has_permission(self) -> bool:
+        return can_view_organization_agreement(self.request.user, self.agreement)
+
+    def get_context_data(self, **kwargs: Any) -> dict:
+        context = super().get_context_data(**kwargs)
+
+        context.update(
+            {
+                "can_create_agreements": False,  # Assignee action, assigner is not able to execute it.
+                "can_submit_agreements": False,  # Assignee action, assigner is not able to execute it.
+                "can_approve_agreements": can_approve_agreements(self.request.user, self.agreement),
+                "can_form_agreements": can_form_agreements(self.request.user, self.agreement),
+                "can_initiate_agreements": False,  # Assignee action, assigner is not able to execute it.
+                "can_sign_agreements": can_sign_agreements(self.request.user, self.agreement),
+                "can_upload_agreement_file": can_upload_agreement_file(self.request.user, self.agreement),
+                "parent_links": {
+                    reverse("home"): _("Pradžia"),
+                    reverse("organization-list"): _("Organizacijos"),
+                    reverse("organization-detail", args=[self.organization.pk]): self.organization.title,
+                    reverse("organization-agreement-list", args=[self.organization.pk]): "Sutartys",
+                    None: _("Sutartys"),
+                },
+            }
+        )
+
         return context
 
 

--- a/vitrina/smart_contracts/templates/smart_contracts/agreement_detail.html
+++ b/vitrina/smart_contracts/templates/smart_contracts/agreement_detail.html
@@ -1,21 +1,15 @@
-{% extends "base.html" %}
+{% extends "vitrina/agreements/base_agreement_detail.html" %}
 {% load i18n %}
-{% load util_tags %}
 
-{% block current_title %}
-    {{ page_title }}
+{% block parent_tabs %}
+    {% include 'vitrina/projects/tabs.html' %}
 {% endblock %}
 
-{% block content %}
-    {% include 'vitrina/projects/tabs.html' %}
+{% block back_link_url %}
+    {% url 'agreement-list' project.pk %}
+{% endblock %}
 
-    <p>
-        <a href="{% url 'agreement-list' project.pk %}">
-            ← {% translate "Grįžti į sutartis" %}
-        </a>
-    </p>
-    <br>
-
+{% block agreement_buttons %}
     <div class="buttons is-right">
         {% if agreement.status == "CREATED" %}
             {% if can_submit_agreements %}
@@ -63,126 +57,4 @@
             {% endif %}
         {% endif %}
     </div>
-
-    <div class="box is-max-desktop has-background-light">
-        <div class="is-flex is-align-items-center mb-4">
-            <div>
-                <p class="is-size-7 has-text-grey">
-                    {% translate "Sukurta" %}: <strong>{{ agreement.created_at|date:"Y-m-d H:i" }}</strong> |
-                    {% translate "Atnaujinta" %}: <strong>{{ agreement.updated_at|date:"Y-m-d H:i" }}</strong>
-                </p>
-            </div>
-        </div>
-
-        <div class="columns is-mobile mb-1">
-            <div class="column is-3 has-text-weight-semibold">{% translate "Sutarties identifikatorius" %}:</div>
-            <div class="column is-7">{{ agreement.pk }}</div>
-        </div>
-
-        <div class="columns is-mobile mb-1">
-            <div class="column is-3 has-text-weight-semibold">{% translate "Panaudojimo atvejis" %}:</div>
-            <div class="column is-7">
-                <a href="{% url 'project-detail' project.pk %}" class="has-text-link" target="_blank">
-                    {{ project }} <span class="icon is-small"><i class="fas fa-external-link-alt"></i></span>
-                </a>
-            </div>
-        </div>
-
-        <div class="columns is-mobile mb-1">
-            <div class="column is-3 has-text-weight-semibold">{% translate "Duomenis teikianti organizacija" %}:</div>
-            <div class="column is-7">
-                <a href="{% url 'organization-detail' agreement.assigner_id %}" class="has-text-link" target="_blank">
-                    {{ agreement.assigner }} <span class="icon is-small"><i class="fas fa-external-link-alt"></i></span>
-                </a>
-            </div>
-        </div>
-
-        <div class="columns is-mobile mb-1">
-            <div class="column is-3 has-text-weight-semibold">{% translate "Duomenų teikėjo atstovas" %}:</div>
-            <div class="column is-7">
-                {% if agreement.assigner_representative %}
-                    {{ agreement.assigner_representative }}
-                {% else %}
-                    -
-                {% endif %}
-            </div>
-        </div>
-
-        <div class="columns is-mobile mb-1">
-            <div class="column is-3 has-text-weight-semibold">{% translate "Duomenis gaunanti organizacija" %}:</div>
-            <div class="column is-7">
-                <a href="{% url 'organization-detail' agreement.assignee.id %}" class="has-text-link" target="_blank">
-                    {{ agreement.assignee }} <span class="icon is-small"><i class="fas fa-external-link-alt"></i></span>
-                </a>
-            </div>
-        </div>
-
-        <div class="columns is-mobile mb-1">
-            <div class="column is-3 has-text-weight-semibold">{% translate "Duomenų gavėjo atstovas" %}:</div>
-            <div class="column is-7">
-                {% if agreement.assignee_representative %}
-                    {{ agreement.assignee_representative }}
-                {% else %}
-                    -
-                {% endif %}
-            </div>
-        </div>
-
-        <div class="columns is-mobile mb-1">
-            <div class="column is-3 has-text-weight-semibold">{% translate "Būsena" %}:</div>
-            <div class="column is-7">
-                {{ agreement.get_status_display }}
-                <span class="icon info-icon has-tooltip-multiline is-middle"
-                    data-tooltip="{{ agreement_status_descriptions|get_item:agreement.status }}">
-                    <i class="fas fa-info-circle"></i>
-                </span>
-            </div>
-        </div>
-
-        <div class="columns is-mobile mb-1">
-            <div class="column is-3 has-text-weight-semibold">{% translate "Sutarties leidimai" %}:</div>
-            <div class="column is-7">
-                {% for scope in agreement.scopes.all %}
-                    {{ scope.scope }}<br>
-                {% empty %}
-                    <span class="has-text-grey">—</span>
-                {% endfor %}
-            </div>
-        </div>
-
-        <div class="columns is-mobile mb-1">
-            <div class="column is-3 has-text-weight-semibold">{% translate "Paskutinės sinchronizacijos data" %}:</div>
-            <div class="column is-7">
-                {% if agreement.last_sync_date %}
-                    {{ agreement.last_sync_date|date:"Y-m-d H:i" }}
-                {% else %}
-                    <span class="has-text-grey">—</span>
-                {% endif %}
-            </div>
-        </div>
-    </div>
-
-    <hr>
-
-    <h6 class="custom-title is-size-6-mobile">{% translate "Sutarties dokumentai" %}</h6>
-    {% if agreement_files %}
-        <table class="table is-fullwidth">
-            <thead>
-                <tr>
-                    <th>{% translate "Sukūrimo data" %}</th>
-                    <th>{% translate "Sutarties dokumentas" %}</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for file in agreement_files %}
-                    <tr>
-                        <td>{{ file.created_at|date:"Y-m-d H:i" }}</td>
-                        <td><a href="{{ file.file.url }}" target="_blank">{{ file.file_name }}</a></td>
-                    </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    {% else %}
-        {% translate "Nėra sutarčių dokumentų." %}
-    {% endif %}
 {% endblock %}

--- a/vitrina/smart_contracts/views.py
+++ b/vitrina/smart_contracts/views.py
@@ -122,13 +122,42 @@ class BaseAgreementListView(LoginRequiredMixin, PermissionRequiredMixin, Templat
         return context
 
 
+class BaseAgreementDetailView(LoginRequiredMixin, PermissionRequiredMixin, TemplateView):
+    template_name = None
+    parent: object = None
+    parent_type: str = None
+
+    agreement: Agreement
+
+    def has_permission(self) -> bool:
+        """Override in subclasses."""
+        return False
+
+    def get_context_data(self, **kwargs: Any) -> dict:
+        context = super().get_context_data(**kwargs)
+
+        context.update(
+            {
+                "agreement": self.agreement,
+                "project": self.agreement.project,
+                "agreement_files": self.agreement.files.all().order_by("-created_at"),
+                "agreement_status_descriptions": AGREEMENT_STATUS_DESCRIPTIONS,
+                "page_title": self.agreement.detail_page_title,
+                "parent": self.parent,
+                "parent_type": self.parent_type,
+            }
+        )
+
+        return context
+
+
 class AgreementListView(BaseProjectMixin, BaseAgreementListView):
     template_name = "smart_contracts/agreement_list.html"
     parent_type = "project"
 
     def setup(self, request, *args: Any, **kwargs: Any) -> None:
         super().setup(request, *args, **kwargs)
-        self.parent: Project = self.project
+        self.parent: Project = self.get_project(kwargs["pk"])
         return None
 
     def dispatch(self, request, *args, **kwargs):
@@ -155,21 +184,13 @@ class AgreementListView(BaseProjectMixin, BaseAgreementListView):
         return context
 
 
-class AgreementDetailView(
-    LoginRequiredMixin,
-    BaseProjectMixin,
-    BaseAgreementMixin,
-    PermissionRequiredMixin,
-    TemplateView,
-):
-    model = Agreement
+class AgreementDetailView(BaseProjectMixin, BaseAgreementMixin, BaseAgreementDetailView):
     template_name = "smart_contracts/agreement_detail.html"
+    parent_type = "project"
 
-    detail_url_name = "project-detail"
-    history_url_name = "project-history"
-
-    project: Project
-    agreement: Agreement
+    def setup(self, request: WSGIRequest, *args: Any, **kwargs: Any) -> None:
+        super().setup(request, *args, **kwargs)
+        self.parent: Project = self.get_project(kwargs["pk"])
 
     def has_permission(self) -> bool:
         return can_view_agreement(self.request.user, self.agreement)
@@ -179,10 +200,6 @@ class AgreementDetailView(
 
         context.update(
             {
-                "agreement": self.agreement,
-                "agreement_files": self.agreement.files.all().order_by("-created_at"),
-                "agreement_status_descriptions": AGREEMENT_STATUS_DESCRIPTIONS,
-                "page_title": self.agreement.detail_page_title,
                 "can_create_agreements": can_create_agreements(self.request.user, self.project),
                 "can_submit_agreements": can_submit_agreements(self.request.user, self.agreement),
                 "can_approve_agreements": can_approve_agreements(self.request.user, self.agreement),
@@ -192,12 +209,9 @@ class AgreementDetailView(
                 "can_upload_agreement_file": can_upload_agreement_file(self.request.user, self.agreement),
             }
         )
-        context["parent_links"].update(
-            {
-                reverse("agreement-list", args=[self.project.pk]): _("Sutartys"),
-                None: self.agreement.detail_page_title,
-            }
-        )
+
+        context["parent_links"].update({reverse("agreement-list", args=[self.project.pk]): _("Sutartys")})
+
         return context
 
 

--- a/vitrina/smart_contracts/views.py
+++ b/vitrina/smart_contracts/views.py
@@ -83,26 +83,58 @@ class BaseAgreementMixin:
         )
 
 
-class AgreementListView(
-    LoginRequiredMixin,
-    BaseProjectMixin,
-    PermissionRequiredMixin,
-    TemplateView,
-):
+class BaseAgreementListView(LoginRequiredMixin, PermissionRequiredMixin, TemplateView):
     model = Agreement
-    template_name = "smart_contracts/agreement_list.html"
+    template_name = None
 
-    detail_url_name = "project-detail"
-    history_url_name = "project-history"
+    paginate_by = 10
 
-    project: Project
+    parent: object
+    parent_type: str
+
+    def get_queryset(self):
+        """Override in subclasses, agreement queryset will be filtered by parent."""
+        raise NotImplementedError
 
     def has_permission(self) -> bool:
-        return can_view_agreements(self.request.user, self.project)
+        """Override in subclasses, permission depends on parent."""
+        return False
+
+    def get_context_data(self, **kwargs: Any):
+        context = super().get_context_data(**kwargs)
+
+        agreements = self.get_queryset()
+        paginator = Paginator(agreements, self.paginate_by)
+        page = paginator.get_page(self.request.GET.get("page"))
+
+        context.update(
+            {
+                "agreements": agreements,
+                "agreement_status_descriptions": AGREEMENT_STATUS_DESCRIPTIONS,
+                "page_obj": page,
+                "paginator": paginator,
+                "can_create_agreements": False,  # Override in subclasses.
+                "parent": self.parent,
+                "parent_type": self.parent_type,
+            }
+        )
+
+        return context
+
+
+class AgreementListView(BaseProjectMixin, BaseAgreementListView):
+    template_name = "smart_contracts/agreement_list.html"
+    parent_type = "project"
+
+    def setup(self, request, *args: Any, **kwargs: Any) -> None:
+        super().setup(request, *args, **kwargs)
+        self.parent: Project = self.project
+        return None
 
     def dispatch(self, request, *args, **kwargs):
         dispatch = super().dispatch(request, *args, **kwargs)
-        if not self.project.organization:
+
+        if not self.parent.organization:
             messages.error(
                 self.request,
                 _("Panaudojimo atvejis registruotas fizinio asmens vardu negali turėti sutarčių."),
@@ -110,30 +142,16 @@ class AgreementListView(
             return HttpResponseRedirect(reverse("project-detail", kwargs={"pk": self.project.pk}))
         return dispatch
 
-    def get_context_data(self, **kwargs: Any) -> dict:
+    def has_permission(self) -> bool:
+        return can_view_agreements(self.request.user, self.project)
+
+    def get_queryset(self):
+        return get_agreements(self.request.user).filter(project=self.project)
+
+    def get_context_data(self, **kwargs: Any):
         context = super().get_context_data(**kwargs)
-
-        project_agreements = get_agreements(self.request.user).filter(project=self.project)
-
-        paginator = Paginator(project_agreements, 10)
-        page_number = self.request.GET.get("page")
-        page = paginator.get_page(page_number)
-
-        context.update(
-            {
-                "project": self.project,
-                "agreements": page.object_list,
-                "agreement_status_descriptions": AGREEMENT_STATUS_DESCRIPTIONS,
-                "page_obj": page,
-                "paginator": paginator,
-                "can_create_agreements": can_create_agreements(self.request.user, self.project),
-            }
-        )
-        context["parent_links"].update(
-            {
-                None: _("Sutartys"),
-            }
-        )
+        context["can_create_agreements"] = can_create_agreements(self.request.user, self.project)
+        context["parent_links"].update({None: _("Sutartys")})
         return context
 
 

--- a/vitrina/templates/vitrina/agreements/base_agreement_detail.html
+++ b/vitrina/templates/vitrina/agreements/base_agreement_detail.html
@@ -1,0 +1,142 @@
+{% extends "base.html" %}
+{% load i18n %}
+{% load util_tags %}
+
+{% block current_title %}
+    {{ page_title }}
+{% endblock %}
+
+{% block content %}
+    {% block parent_tabs %}{% endblock %}
+
+    <p>
+        <a href="{% block back_link_url %}{% endblock %}">
+            ← {% translate "Grįžti į sutartis" %}
+        </a>
+    </p>
+    <br>
+
+    {% block agreement_buttons %}{% endblock %}
+
+    <div class="box is-max-desktop has-background-light">
+        <div class="is-flex is-align-items-center mb-4">
+            <div>
+                <p class="is-size-7 has-text-grey">
+                    {% translate "Sukurta" %}: <strong>{{ agreement.created_at|date:"Y-m-d H:i" }}</strong> |
+                    {% translate "Atnaujinta" %}: <strong>{{ agreement.updated_at|date:"Y-m-d H:i" }}</strong>
+                </p>
+            </div>
+        </div>
+
+        <div class="columns is-mobile mb-1">
+            <div class="column is-3 has-text-weight-semibold">{% translate "Sutarties identifikatorius" %}:</div>
+            <div class="column is-7">{{ agreement.pk }}</div>
+        </div>
+
+        <div class="columns is-mobile mb-1">
+            <div class="column is-3 has-text-weight-semibold">{% translate "Panaudojimo atvejis" %}:</div>
+            <div class="column is-7">
+                <a href="{% url 'project-detail' project.pk %}" class="has-text-link" target="_blank">
+                    {{ project }} <span class="icon is-small"><i class="fas fa-external-link-alt"></i></span>
+                </a>
+            </div>
+        </div>
+
+        <div class="columns is-mobile mb-1">
+            <div class="column is-3 has-text-weight-semibold">{% translate "Duomenis teikianti organizacija" %}:</div>
+            <div class="column is-7">
+                <a href="{% url 'organization-detail' agreement.assigner_id %}" class="has-text-link" target="_blank">
+                    {{ agreement.assigner }} <span class="icon is-small"><i class="fas fa-external-link-alt"></i></span>
+                </a>
+            </div>
+        </div>
+
+        <div class="columns is-mobile mb-1">
+            <div class="column is-3 has-text-weight-semibold">{% translate "Duomenų teikėjo atstovas" %}:</div>
+            <div class="column is-7">
+                {% if agreement.assigner_representative %}
+                    {{ agreement.assigner_representative }}
+                {% else %}
+                    -
+                {% endif %}
+            </div>
+        </div>
+
+        <div class="columns is-mobile mb-1">
+            <div class="column is-3 has-text-weight-semibold">{% translate "Duomenis gaunanti organizacija" %}:</div>
+            <div class="column is-7">
+                <a href="{% url 'organization-detail' agreement.assignee.id %}" class="has-text-link" target="_blank">
+                    {{ agreement.assignee }} <span class="icon is-small"><i class="fas fa-external-link-alt"></i></span>
+                </a>
+            </div>
+        </div>
+
+        <div class="columns is-mobile mb-1">
+            <div class="column is-3 has-text-weight-semibold">{% translate "Duomenų gavėjo atstovas" %}:</div>
+            <div class="column is-7">
+                {% if agreement.assignee_representative %}
+                    {{ agreement.assignee_representative }}
+                {% else %}
+                    -
+                {% endif %}
+            </div>
+        </div>
+
+        <div class="columns is-mobile mb-1">
+            <div class="column is-3 has-text-weight-semibold">{% translate "Būsena" %}:</div>
+            <div class="column is-7">
+                {{ agreement.get_status_display }}
+                <span class="icon info-icon has-tooltip-multiline is-middle"
+                    data-tooltip="{{ agreement_status_descriptions|get_item:agreement.status }}">
+                    <i class="fas fa-info-circle"></i>
+                </span>
+            </div>
+        </div>
+
+        <div class="columns is-mobile mb-1">
+            <div class="column is-3 has-text-weight-semibold">{% translate "Sutarties leidimai" %}:</div>
+            <div class="column is-7">
+                {% for scope in agreement.scopes.all %}
+                    {{ scope.scope }}<br>
+                {% empty %}
+                    <span class="has-text-grey">—</span>
+                {% endfor %}
+            </div>
+        </div>
+
+        <div class="columns is-mobile mb-1">
+            <div class="column is-3 has-text-weight-semibold">{% translate "Paskutinės sinchronizacijos data" %}:</div>
+            <div class="column is-7">
+                {% if agreement.last_sync_date %}
+                    {{ agreement.last_sync_date|date:"Y-m-d H:i" }}
+                {% else %}
+                    <span class="has-text-grey">—</span>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+
+    <hr>
+
+    <h6 class="custom-title is-size-6-mobile">{% translate "Sutarties dokumentai" %}</h6>
+    {% if agreement_files %}
+        <table class="table is-fullwidth">
+            <thead>
+                <tr>
+                    <th>{% translate "Sukūrimo data" %}</th>
+                    <th>{% translate "Sutarties dokumentas" %}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for file in agreement_files %}
+                    <tr>
+                        <td>{{ file.created_at|date:"Y-m-d H:i" }}</td>
+                        <td><a href="{{ file.file.url }}" target="_blank">{{ file.file_name }}</a></td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% else %}
+        {% translate "Nėra sutarčių dokumentų." %}
+    {% endif %}
+{% endblock %}

--- a/vitrina/templates/vitrina/agreements/base_agreement_list.html
+++ b/vitrina/templates/vitrina/agreements/base_agreement_list.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+{% load i18n %}
+{% load util_tags %}
+
+{% block current_title %}
+    {% translate "Sutartys" %}
+{% endblock %}
+
+{% block content %}
+
+    {% block agreement_tabs %}{% endblock %}
+    {% block agreement_actions %}{% endblock %}
+
+    {% if agreements %}
+        <table class="table is-fullwidth">
+            <thead>
+                {% block agreement_table_head %}{% endblock %}
+            </thead>
+            <tbody>
+                {% for agreement in agreements %}
+                    {% block agreement_table_row %}
+                    {% endblock %}
+                {% endfor %}
+            </tbody>
+        </table>
+
+        {% include "vitrina/common/pagination.html" %}
+
+    {% else %}
+        <p>{% translate "Nėra sutarčių." %}</p>
+    {% endif %}
+
+{% endblock %}


### PR DESCRIPTION
This PR introduces the functionality of being able to reach the agreements, where your organization is set as the assigner (data provider).

---

Different commits for easier review, decided to leave list & detail view refactor in one place, due to the low complexity of the changes, just introducing some basic OOP concepts. Other parts will be moved to a separate PR.

- **Part 1:** Extending base agreement LIST form
    - [c3ebcef](https://github.com/atviriduomenys/katalogas/pull/2159/commits/c3ebcef7d4d2ad74c559b4ae7226b00d46319833)
- **Part 2:** Extending base agreement DETAIL form
    - Will be a little botched due to renaming of LIST view & url;
    - [4b13f59](https://github.com/atviriduomenys/katalogas/pull/2159/commits/4b13f59d851571f770ea5b680b37bb872bdb9493)

---

The new permissions are covered by tests, not covering the whole API logic once again since it is practically the same as the project-based agreement logic which is covered extensively.