### PR TITLE
ft/2124 Secure uploaded contracts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,18 @@ https://github.com/atviriduomenys/katalogas/issues/2075
 v 1.9 (2025-12-04)
 ==================
 
+https://github.com/atviriduomenys/katalogas/issues/2124
+
+- Adds new "internal media" directory for non public uploaded files. It works same way as Django media files, but uses `INTERNAL_MEDIA_ROOT` and `INTERNAL_MEDIA_URL` settings.
+- Adds new endpoint for downloading uploaded smart contract files. In production, file is returned via `X-Accel-Redirect` header
+- Additional Nginx configuration is needed:
+    ```
+    location /internal-static {
+        internal;
+        alias /internal-static;
+    }
+    ```
+
 Security improvements:
 
 - Added HTTP Strict Transport Security (HSTS) with 1-year max-age;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,16 +60,19 @@ def _haystack_marker(request):
 
 
 @pytest.fixture(scope="session", autouse=True)
-def temp_media_root(tmp_path_factory):
-    """Use a temporary directory for MEDIA_ROOT during tests."""
+def set_test_settings(tmp_path_factory):
+    """Change django settings for tests"""
     from django.conf import settings
 
+    # Change MEDIA_ROOT directories to temporary directories
     media_dir = tmp_path_factory.mktemp("media")
     settings.MEDIA_ROOT = str(media_dir)
 
     internal_media_dir = tmp_path_factory.mktemp("internal-media")
     settings.INTERNAL_MEDIA_ROOT = str(internal_media_dir)
-    return media_dir
+
+    # Disable CMS toolbar in tests
+    settings.CMS_TOOLBAR_HIDE = True
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,6 +66,9 @@ def temp_media_root(tmp_path_factory):
 
     media_dir = tmp_path_factory.mktemp("media")
     settings.MEDIA_ROOT = str(media_dir)
+
+    internal_media_dir = tmp_path_factory.mktemp("internal-media")
+    settings.INTERNAL_MEDIA_ROOT = str(internal_media_dir)
     return media_dir
 
 

--- a/tests/smart_contracts/test_permissions.py
+++ b/tests/smart_contracts/test_permissions.py
@@ -1,12 +1,18 @@
 import pytest
 from django.contrib.contenttypes.models import ContentType
+from django_webtest import DjangoTestApp
 
 from vitrina.orgs.factories import RepresentativeFactory, OrganizationFactory
 from vitrina.orgs.models import Organization, Representative
 from vitrina.projects.factories import ProjectFactory
 from vitrina.smart_contracts.factories import AgreementFactory
-from vitrina.smart_contracts.permissions import can_create_agreements, can_submit_agreements, can_approve_agreements, \
-    can_form_agreements
+from vitrina.smart_contracts.permissions import (
+    can_create_agreements,
+    can_submit_agreements,
+    can_approve_agreements,
+    can_form_agreements,
+    can_view_agreement,
+)
 from vitrina.users.factories import UserFactory
 
 
@@ -20,7 +26,7 @@ class TestCanCreateAgreements:
             role=Representative.COORDINATOR,
             can_make_agreements=True,
             object_id=organization.id,
-            content_type=ContentType.objects.get_for_model(organization)
+            content_type=ContentType.objects.get_for_model(organization),
         )
 
         assert can_create_agreements(user, project)
@@ -34,7 +40,7 @@ class TestCanCreateAgreements:
             role=Representative.COORDINATOR,
             can_make_agreements=True,
             object_id=organization.id,
-            content_type=ContentType.objects.get_for_model(organization)
+            content_type=ContentType.objects.get_for_model(organization),
         )
 
         assert not can_create_agreements(user, project)
@@ -48,7 +54,7 @@ class TestCanCreateAgreements:
             role=Representative.COORDINATOR,
             can_make_agreements=True,
             object_id=organization.id,
-            content_type=ContentType.objects.get_for_model(organization)
+            content_type=ContentType.objects.get_for_model(organization),
         )
 
         assert not can_create_agreements(user, project)
@@ -73,7 +79,7 @@ class TestCanSubmitAgreements:
             role=Representative.COORDINATOR,
             can_make_agreements=True,
             object_id=organization.id,
-            content_type=ContentType.objects.get_for_model(organization)
+            content_type=ContentType.objects.get_for_model(organization),
         )
 
         assert can_submit_agreements(user, agreement)
@@ -90,7 +96,7 @@ class TestCanSubmitAgreements:
             role=Representative.COORDINATOR,
             can_make_agreements=True,
             object_id=organization.id,
-            content_type=ContentType.objects.get_for_model(organization)
+            content_type=ContentType.objects.get_for_model(organization),
         )
 
         assert not can_submit_agreements(user, agreement)
@@ -118,7 +124,7 @@ class TestCanApproveAgreements:
             role=Representative.COORDINATOR,
             can_make_agreements=True,
             object_id=organization.id,
-            content_type=ContentType.objects.get_for_model(organization)
+            content_type=ContentType.objects.get_for_model(organization),
         )
 
         assert can_approve_agreements(user, agreement)
@@ -135,7 +141,7 @@ class TestCanApproveAgreements:
             role=Representative.COORDINATOR,
             can_make_agreements=True,
             object_id=organization.id,
-            content_type=ContentType.objects.get_for_model(organization)
+            content_type=ContentType.objects.get_for_model(organization),
         )
 
         assert not can_approve_agreements(user, agreement)
@@ -174,7 +180,7 @@ class TestCanFormAgreements:
             role=Representative.COORDINATOR,
             can_make_agreements=True,
             object_id=assignee.id if is_acting_user_assignee else assigner.id,
-            content_type=ContentType.objects.get_for_model(assignee)
+            content_type=ContentType.objects.get_for_model(assignee),
         )
 
         assert can_form_agreements(user, agreement)
@@ -202,7 +208,7 @@ class TestCanFormAgreements:
             role=Representative.COORDINATOR,
             can_make_agreements=True,
             object_id=assignee.id if is_acting_user_assignee else assigner.id,
-            content_type=ContentType.objects.get_for_model(assignee)
+            content_type=ContentType.objects.get_for_model(assignee),
         )
 
         assert not can_form_agreements(user, agreement)
@@ -225,3 +231,82 @@ class TestCanFormAgreements:
         )
 
         assert not can_form_agreements(user, agreement)
+
+
+class TestCanViewAgreements:
+    def test_not_authenticated(self):
+        assignee = OrganizationFactory()
+        assigner = OrganizationFactory()
+
+        user = UserFactory(organization=assignee)
+
+        agreement = AgreementFactory(
+            assignee=assignee,
+            assigner=assigner,
+            project=ProjectFactory(organization=assignee),
+        )
+
+        assert not can_view_agreement(user, agreement)
+
+    @pytest.mark.parametrize("user_field", ["is_staff", "is_superuser"])
+    def test_superuser_or_staff(self, app: DjangoTestApp, user_field: str):
+        assignee = OrganizationFactory()
+        assigner = OrganizationFactory()
+
+        user = UserFactory(**{user_field: True})
+        app.set_user(user)
+
+        agreement = AgreementFactory(
+            assignee=assignee,
+            assigner=assigner,
+            project=ProjectFactory(organization=assignee),
+        )
+
+        assert can_view_agreement(user, agreement)
+
+    @pytest.mark.parametrize("is_acting_user_assignee", [True, False])
+    def test_user_in_organization(self, app: DjangoTestApp, is_acting_user_assignee: bool):
+        assignee = OrganizationFactory()
+        assigner = OrganizationFactory()
+
+        user = UserFactory()
+        app.set_user(user)
+        RepresentativeFactory(
+            user=user,
+            organization=assignee if is_acting_user_assignee else assigner,
+            role=Representative.COORDINATOR,
+            object_id=assignee.id if is_acting_user_assignee else assigner.id,
+            content_type=ContentType.objects.get_for_model(assignee),
+        )
+
+        agreement = AgreementFactory(
+            assignee=assignee,
+            assigner=assigner,
+            project=ProjectFactory(organization=assignee),
+        )
+
+        assert can_view_agreement(user, agreement)
+
+    @pytest.mark.parametrize("is_acting_user_assignee", [True, False])
+    def test_user_in_different_organization(self, app: DjangoTestApp, is_acting_user_assignee: bool):
+        assignee = OrganizationFactory()
+        assigner = OrganizationFactory()
+        different_organization = OrganizationFactory()
+
+        user = UserFactory()
+        app.set_user(user)
+        RepresentativeFactory(
+            user=user,
+            organization=different_organization,
+            role=Representative.COORDINATOR,
+            object_id=different_organization.id,
+            content_type=ContentType.objects.get_for_model(different_organization),
+        )
+
+        agreement = AgreementFactory(
+            assignee=assignee,
+            assigner=assigner,
+            project=ProjectFactory(organization=assignee),
+        )
+
+        assert not can_view_agreement(user, agreement)

--- a/tests/smart_contracts/test_views.py
+++ b/tests/smart_contracts/test_views.py
@@ -4,17 +4,18 @@ from pathlib import Path
 from uuid import uuid4
 
 import pytest
-from webtest import Upload
+from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.files.base import ContentFile
 from django.urls import reverse
+from django.test import override_settings
 from django_webtest import DjangoTestApp
 from pdfminer.high_level import extract_text
 
 from vitrina.datasets.factories import DatasetFactory, ContactFactory
 from vitrina.datasets.models import Dataset
 from vitrina.orgs.factories import OrganizationFactory, RepresentativeFactory, ViispRepresentativeFactory
-from vitrina.orgs.models import Organization
+from vitrina.orgs.models import Organization, Representative
 from vitrina.projects.factories import ProjectFactory
 from vitrina.smart_contracts import AgreementStatuses
 from vitrina.smart_contracts.factories import AgreementFactory, AgreementPDFFileFactory, AgreementJSONFileFactory
@@ -26,7 +27,7 @@ from vitrina.smart_contracts.models import (
 from vitrina.structure.factories import MetadataFactory
 from vitrina.users.factories import UserFactory
 from vitrina.users.models import User
-from tests.smart_contracts.constants import SIGNER1_FULL_NAME, SIGNER2_FULL_NAME
+from tests.smart_contracts.constants import SIGNER1_FULL_NAME
 
 pytestmark = pytest.mark.django_db
 test_contracts_dir = Path(__file__).parent / "files" / "test_contracts"
@@ -1995,3 +1996,171 @@ class TestAgreementSign:
 
         agreement.refresh_from_db()
         assert agreement.status == AgreementStatuses.INITIATED
+
+
+class TestAgreementFileDownload:
+    def test_cannot_download_file_if_unauthorized(
+        self, app: DjangoTestApp, agreement_pdf: Path,
+    ):
+        assignee = OrganizationFactory()
+        assigner = OrganizationFactory()
+
+        agreement = AgreementFactory(
+            assignee=assignee,
+            assigner=assigner,
+            project=ProjectFactory(organization=assignee),
+        )
+        agreement_file = AgreementPDFFileFactory(agreement=agreement, pdf_path=agreement_pdf)
+        url = reverse("agreement-file-download", args=[agreement.pk, agreement_file.pk])
+        response = app.get(url)
+
+        assert response.status_code == 302
+        assert response.location == f'{reverse("login")}?next={url}'
+
+    @pytest.mark.parametrize("user_field", ["is_staff", "is_superuser"])
+    def test_can_download_file_if_staff_or_superuser(
+        self, app: DjangoTestApp, agreement_pdf: Path, user_field: str,
+    ):
+        assignee = OrganizationFactory()
+        assigner = OrganizationFactory()
+
+        user = UserFactory(**{user_field: True})
+        app.set_user(user)
+
+        agreement = AgreementFactory(
+            assignee=assignee,
+            assigner=assigner,
+            project=ProjectFactory(organization=assignee),
+        )
+        agreement_file = AgreementPDFFileFactory(agreement=agreement, pdf_path=agreement_pdf)
+        response = app.get(
+            reverse("agreement-file-download", args=[agreement.pk, agreement_file.pk])
+        )
+
+        assert response.status_code == 200
+
+    @pytest.mark.parametrize("is_acting_user_assignee", [True, False])
+    def test_can_download_file_if_assignee_or_assigner_organization_representative(
+       self, app: DjangoTestApp, agreement_pdf: Path, is_acting_user_assignee: bool,
+    ):
+        assignee = OrganizationFactory()
+        assigner = OrganizationFactory()
+
+        user = UserFactory()
+        app.set_user(user)
+        RepresentativeFactory(
+            user=user,
+            organization=assignee if is_acting_user_assignee else assigner,
+            role=Representative.COORDINATOR,
+            object_id=assignee.id if is_acting_user_assignee else assigner.id,
+            content_type=ContentType.objects.get_for_model(assignee),
+        )
+        agreement = AgreementFactory(
+            assignee=assignee,
+            assigner=assigner,
+            project=ProjectFactory(organization=assignee),
+        )
+        agreement_file = AgreementPDFFileFactory(agreement=agreement, pdf_path=agreement_pdf)
+
+        response = app.get(
+            reverse("agreement-file-download", args=[agreement.pk, agreement_file.pk])
+        )
+
+        assert response.status_code == 200
+
+    def test_raise_404_if_agreement_file_does_not_exist(self, app: DjangoTestApp):
+        assignee = OrganizationFactory()
+        assigner = OrganizationFactory()
+
+        user = UserFactory()
+        app.set_user(user)
+        RepresentativeFactory(
+            user=user,
+            organization=assignee,
+            role=Representative.COORDINATOR,
+            object_id=assignee.id,
+            content_type=ContentType.objects.get_for_model(assignee),
+        )
+        agreement = AgreementFactory(
+            assignee=assignee,
+            assigner=assigner,
+            project=ProjectFactory(organization=assignee),
+        )
+
+        response = app.get(
+            reverse("agreement-file-download", args=[agreement.pk, uuid4()]),
+            expect_errors=True,
+        )
+
+        assert response.status_code == 404
+
+    def test_return_file_as_attachment_if_debug_true(
+        self, app: DjangoTestApp, agreement_pdf: Path
+    ):
+        debug = settings.DEBUG
+        settings.DEBUG = True
+        assignee = OrganizationFactory()
+        assigner = OrganizationFactory()
+
+        user = UserFactory()
+        app.set_user(user)
+        RepresentativeFactory(
+            user=user,
+            organization=assignee,
+            role=Representative.COORDINATOR,
+            object_id=assignee.id,
+            content_type=ContentType.objects.get_for_model(assignee),
+        )
+        agreement = AgreementFactory(
+            assignee=assignee,
+            assigner=assigner,
+            project=ProjectFactory(organization=assignee),
+        )
+        agreement_file = AgreementPDFFileFactory(agreement=agreement, pdf_path=agreement_pdf)
+
+        response = app.get(
+            reverse("agreement-file-download", args=[agreement.pk, agreement_file.pk]),
+            expect_errors=True,
+        )
+
+        assert response.status_code == 200
+        assert "attachment" in response.headers.get("Content-Disposition")
+        assert response.headers.get("Content-Type") == "application/pdf"
+        assert not response.headers.get("X-Accel-Redirect")
+
+        settings.DEBUG = debug
+
+    def test_return_file_path_as_x_accel_redirect_header_if_debug_false(
+        self, app: DjangoTestApp, agreement_pdf: Path
+    ):
+        debug = settings.DEBUG
+        settings.DEBUG = False
+        assignee = OrganizationFactory()
+        assigner = OrganizationFactory()
+
+        user = UserFactory()
+        app.set_user(user)
+        RepresentativeFactory(
+            user=user,
+            organization=assignee,
+            role=Representative.COORDINATOR,
+            object_id=assignee.id,
+            content_type=ContentType.objects.get_for_model(assignee),
+        )
+        agreement = AgreementFactory(
+            assignee=assignee,
+            assigner=assigner,
+            project=ProjectFactory(organization=assignee),
+        )
+        agreement_file = AgreementPDFFileFactory(agreement=agreement, pdf_path=agreement_pdf)
+
+        response = app.get(
+            reverse("agreement-file-download", args=[agreement.pk, agreement_file.pk]),
+            expect_errors=True,
+        )
+
+        assert response.status_code == 200
+        assert "attachment" in response.headers.get("Content-Disposition")
+        assert response.headers.get("X-Accel-Redirect")
+
+        settings.DEBUG = debug

--- a/tests/smart_contracts/test_views.py
+++ b/tests/smart_contracts/test_views.py
@@ -2094,11 +2094,10 @@ class TestAgreementFileDownload:
 
         assert response.status_code == 404
 
+    @override_settings(DEBUG=True)
     def test_return_file_as_attachment_if_debug_true(
         self, app: DjangoTestApp, agreement_pdf: Path
     ):
-        debug = settings.DEBUG
-        settings.DEBUG = True
         assignee = OrganizationFactory()
         assigner = OrganizationFactory()
 
@@ -2128,13 +2127,10 @@ class TestAgreementFileDownload:
         assert response.headers.get("Content-Type") == "application/pdf"
         assert not response.headers.get("X-Accel-Redirect")
 
-        settings.DEBUG = debug
-
+    @override_settings(DEBUG=False)
     def test_return_file_path_as_x_accel_redirect_header_if_debug_false(
         self, app: DjangoTestApp, agreement_pdf: Path
     ):
-        debug = settings.DEBUG
-        settings.DEBUG = False
         assignee = OrganizationFactory()
         assigner = OrganizationFactory()
 
@@ -2162,5 +2158,3 @@ class TestAgreementFileDownload:
         assert response.status_code == 200
         assert "attachment" in response.headers.get("Content-Disposition")
         assert response.headers.get("X-Accel-Redirect")
-
-        settings.DEBUG = debug

--- a/tests/smart_contracts/test_views.py
+++ b/tests/smart_contracts/test_views.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from uuid import uuid4
 
 import pytest
-from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.files.base import ContentFile
 from django.urls import reverse

--- a/vitrina/datasets/templates/vitrina/datasets/coretable.html
+++ b/vitrina/datasets/templates/vitrina/datasets/coretable.html
@@ -542,7 +542,8 @@
                 <i class="fas fa-info-circle"></i>
             </span>
         </th>
-        <td>{% if harvested %}
+        <td>
+            {% if harvested %}
                 {% if dataset.useLimitation %}
                     {% translate "Naudojimo limitas" %}: {{ dataset.useLimitation }}<br>
                 {% endif %}
@@ -555,8 +556,6 @@
                 {% if dataset.otherConstraints %}
                     {% translate "Kiti apribojimai" %}: {{ dataset.otherConstraints }}
                 {% endif %}
-            {% else %}
-                {{ dataset.distributionConditions }}
             {% endif %}
         </td>
     </tr>

--- a/vitrina/datasets/templates/vitrina/datasets/coretable.html
+++ b/vitrina/datasets/templates/vitrina/datasets/coretable.html
@@ -15,7 +15,7 @@
             {% like obj=dataset user=request.user %}
         </td>
     </tr>
-    <tr title="{{ rating.description }}">
+    <tr>
         <th>
             {% translate "Brandos lygis" %}
             <span class="icon info-icon has-tooltip-multiline is-middle"

--- a/vitrina/datasets/templates/vitrina/datasets/detail.html
+++ b/vitrina/datasets/templates/vitrina/datasets/detail.html
@@ -6,7 +6,9 @@
 {% load comment_tags %}
 {% block pageTitle %}| {{ dataset.title }}{% endblock %}
 {% block pageDescription %}{{ dataset.description | escape }}{% endblock %}
-{% block pageAuthor %}{{ organization.title }}{% endblock %}
+{% if dataset.organization %}
+    {% block pageAuthor %}{{ dataset.organization.title }}{% endblock %}
+{% endif %}
 {% block pageOgTitle %}| {{ dataset.title }}{% endblock %}
 {% block pageOgDescription %}{{ dataset.description | escape }}{% endblock %}
 {% block parent_links %}

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -3218,10 +3218,9 @@ msgstr "API key will be shown only one time, so you must copy it. Created key:"
 msgid "Kurti klientą"
 msgstr "Create client"
 
-#, fuzzy, python-brace-format
-#| msgid "Klientas \"{0}\" sukurtas sėkmingai"
+#, python-brace-format
 msgid "Klientas \"{0}\" sukurtas sėkmingai."
-msgstr "Client \"{0}\" created successfully"
+msgstr "Client \"{0}\" created successfully."
 
 #, python-brace-format
 msgid "Kliento raktas - {0}. Butinai išsisaugokite raktą, jis nebebus rodomas!"
@@ -4944,6 +4943,9 @@ msgstr "All tasks"
 
 msgid "Užduoties uždarymas"
 msgstr "Close task"
+
+msgid "Užduoties priskyrimas"
+msgstr "Assign task"
 
 msgid "VIISP API Klaida"
 msgstr "VIISP API error"

--- a/vitrina/settings.py
+++ b/vitrina/settings.py
@@ -305,6 +305,9 @@ MEDIA_ROOT = env.path("MEDIA_ROOT", default=BASE_DIR / "var/media/")
 STATIC_URL = "static/"
 STATIC_ROOT = env.path("STATIC_ROOT", default=BASE_DIR / "var/static/")
 
+INTERNAL_MEDIA_URL = "internal-media/"
+INTERNAL_MEDIA_ROOT = env.path("INTERNAL_MEDIA_ROOT", default=BASE_DIR / "var/internal-media/")
+
 SASS_PROCESSOR_ROOT = STATIC_ROOT
 
 # Default primary key field type

--- a/vitrina/smart_contracts/models.py
+++ b/vitrina/smart_contracts/models.py
@@ -18,6 +18,7 @@ from vitrina.smart_contracts.utils import (
     format_lithuanian_datetime,
     generate_checksum,
 )
+from vitrina.storages import internal_media_storage
 from vitrina.users.models import User
 
 
@@ -280,6 +281,7 @@ class AgreementFile(UUIDBaseModel):
     )
     file_name = models.CharField(max_length=255)
     file = models.FileField(
+        storage=internal_media_storage,
         upload_to="data/files/agreements",
         verbose_name=_("Sutarties dokumentas"),
         validators=[

--- a/vitrina/smart_contracts/urls.py
+++ b/vitrina/smart_contracts/urls.py
@@ -9,6 +9,7 @@ from vitrina.smart_contracts.views import (
     ProjectBasedAgreementFormView,
     ProjectBasedAgreementInitiateView,
     ProjectBasedAgreementSignView,
+    AgreementFileDownloadView,
 )
 
 urlpatterns = [
@@ -51,5 +52,10 @@ urlpatterns = [
         "projects/<int:pk>/agreement/<uuid:agreement_id>/sign/",
         ProjectBasedAgreementSignView.as_view(),
         name="project-agreement-sign",
+    ),
+    path(
+        "agreement/<uuid:agreement_id>/file/<uuid:agreement_file_id>/",
+        AgreementFileDownloadView.as_view(),
+        name="agreement-file-download",
     ),
 ]

--- a/vitrina/smart_contracts/views.py
+++ b/vitrina/smart_contracts/views.py
@@ -353,9 +353,9 @@ class AgreementFileDownloadView(
 
         if settings.DEBUG:
             return FileResponse(open(agreement_file.file.path, "rb"), as_attachment=True)
-        else:
-            response = HttpResponse()
-            response["X-Accel-Redirect"] = f"/{agreement_file.file.url}"
-            response["Content-Disposition"] = f'attachment; filename="{agreement_file.file_name}"'
 
-            return response
+        response = HttpResponse()
+        response["X-Accel-Redirect"] = f"/{agreement_file.file.url}"
+        response["Content-Disposition"] = f'attachment; filename="{agreement_file.file_name}"'
+
+        return response

--- a/vitrina/smart_contracts/views.py
+++ b/vitrina/smart_contracts/views.py
@@ -1,6 +1,7 @@
 from itertools import groupby
 from typing import Any
 
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
 from django.contrib.contenttypes.models import ContentType
@@ -10,10 +11,12 @@ from django.db import transaction
 from django.db.models import Q, QuerySet
 from django.forms import modelformset_factory, BaseFormSet
 from django.http import HttpResponseRedirect
-from django.http.response import HttpResponseBase, HttpResponse
+from django.http.response import HttpResponseBase, HttpResponse, FileResponse
+from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
+from django.views import View
 from django.views.generic import TemplateView
 
 from vitrina.datasets.models import Dataset
@@ -31,7 +34,7 @@ from vitrina.smart_contracts.mixins import (
     AgreementInitiateMixin,
     AgreementSignMixin,
 )
-from vitrina.smart_contracts.models import Agreement, AgreementScope
+from vitrina.smart_contracts.models import Agreement, AgreementScope, AgreementFile
 from vitrina.users.models import User
 from vitrina.structure.models import Metadata
 from vitrina.views import FormsetView
@@ -334,3 +337,25 @@ class ProjectBasedAgreementInitiateView(AgreementInitiateMixin, ProjectBasedAgre
 
 class ProjectBasedAgreementSignView(AgreementSignMixin, ProjectBasedAgreementNegotiateMixin):
     """Project-based agreement form view responsible for moving the agreement to status `SIGNED`"""
+
+
+class AgreementFileDownloadView(
+    LoginRequiredMixin,
+    BaseAgreementMixin,
+    PermissionRequiredMixin,
+    View,
+):
+    def has_permission(self) -> bool:
+        return can_view_agreement(self.request.user, self.agreement)
+
+    def get(self, request: WSGIRequest, *args, **kwargs) -> HttpResponse | FileResponse:
+        agreement_file = get_object_or_404(AgreementFile, pk=self.kwargs["agreement_file_id"])
+
+        if settings.DEBUG:
+            return FileResponse(open(agreement_file.file.path, "rb"), as_attachment=True)
+        else:
+            response = HttpResponse()
+            response["X-Accel-Redirect"] = f"/{agreement_file.file.url}"
+            response["Content-Disposition"] = f'attachment; filename="{agreement_file.file_name}"'
+
+            return response

--- a/vitrina/storages.py
+++ b/vitrina/storages.py
@@ -1,0 +1,4 @@
+from django.conf import settings
+from django.core.files.storage import FileSystemStorage
+
+internal_media_storage = FileSystemStorage(location=settings.INTERNAL_MEDIA_ROOT, base_url=settings.INTERNAL_MEDIA_URL)

--- a/vitrina/storages.py
+++ b/vitrina/storages.py
@@ -4,11 +4,11 @@ from django.core.files.storage import FileSystemStorage
 
 class InternalFileSystemStorage(FileSystemStorage):
     @property
-    def location(self):
+    def location(self) -> str:
         return settings.INTERNAL_MEDIA_ROOT
 
     @property
-    def base_url(self):
+    def base_url(self) -> str:
         return settings.INTERNAL_MEDIA_URL
 
 

--- a/vitrina/storages.py
+++ b/vitrina/storages.py
@@ -1,4 +1,15 @@
 from django.conf import settings
 from django.core.files.storage import FileSystemStorage
 
-internal_media_storage = FileSystemStorage(location=settings.INTERNAL_MEDIA_ROOT, base_url=settings.INTERNAL_MEDIA_URL)
+
+class InternalFileSystemStorage(FileSystemStorage):
+    @property
+    def location(self):
+        return settings.INTERNAL_MEDIA_ROOT
+
+    @property
+    def base_url(self):
+        return settings.INTERNAL_MEDIA_URL
+
+
+internal_media_storage = InternalFileSystemStorage()

--- a/vitrina/structure/templates/vitrina/structure/model_data_table.html
+++ b/vitrina/structure/templates/vitrina/structure/model_data_table.html
@@ -106,7 +106,7 @@
     </div>
 
     <div class="mt-5 mb-2">
-        <p id="total_count_id">{{ total_count }}</p>
+        <p id="total_count_id"></p>
     </div>
 
     <div class="filter-table">

--- a/vitrina/structure/templates/vitrina/structure/model_data_table.html
+++ b/vitrina/structure/templates/vitrina/structure/model_data_table.html
@@ -133,7 +133,7 @@
                                 <small class="has-text-weight-normal is-italic">
                                     {% if prop.ref_model %}
                                         <a href="{{ prop.ref_model.get_data_url }}">{{ prop.ref_model.name }}</a>
-                                    {% else %}
+                                    {% elif prop %}
                                         {{ prop.metadata.first.type }}
                                     {% endif %}
                                 </small>
@@ -189,11 +189,13 @@
                                             {% translate "Slėpti" %}
                                         </button>
                                     </div>
-                                    <div class="buttons is-right">
-                                        <button id="{{ col }}_filter_id" class="button is-primary is-small is-fixed-length" onclick="filter('{{ col }}', '{{ prop.metadata.first.type }}')">
-                                            {% translate "Filtruoti" %}
-                                        </button>
-                                    </div>
+                                    {% if prop %}
+                                        <div class="buttons is-right">
+                                            <button id="{{ col }}_filter_id" class="button is-primary is-small is-fixed-length" onclick="filter('{{ col }}', '{{ prop.metadata.first.type }}')">
+                                                {% translate "Filtruoti" %}
+                                            </button>
+                                        </div>
+                                    {% endif %}
                                 </div>
                             </div>
 

--- a/vitrina/structure/templates/vitrina/structure/object_data_table.html
+++ b/vitrina/structure/templates/vitrina/structure/object_data_table.html
@@ -40,7 +40,7 @@
                                     <small class="has-text-weight-normal is-italic">
                                         {% if prop.ref_model %}
                                             <a href="{{ prop.ref_model.get_data_url }}">{{ prop.ref_model.name }}</a>
-                                        {% else %}
+                                        {% elif prop %}
                                             {{ prop.metadata.first.type }}
                                         {% endif %}
                                     </small>

--- a/vitrina/tasks/views.py
+++ b/vitrina/tasks/views.py
@@ -238,6 +238,7 @@ class AssignTaskView(LoginRequiredMixin, PermissionRequiredMixin, TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["task"] = self.task
+        context["current_title"] = _("Užduoties priskyrimas")
         return context
 
     def post(self, request, *args, **kwargs):

--- a/vitrina/templates/component/navbar.html
+++ b/vitrina/templates/component/navbar.html
@@ -2,7 +2,6 @@
 {% load i18n parler_tags %}
 {% load navigation_tags %}
 {% load util_tags %}
-{% logged_in_user user logged_in_user as LOGGED_IN_USER %}
 
 <nav class="navbar is-link" role="navigation" aria-label="main navigation">
 <div class="container">
@@ -55,38 +54,38 @@
                     {% endif %}
                 {% endfor %}
                 <div class="navbar-item">
-                    {% if LOGGED_IN_USER.is_authenticated %}
+                    {% if user.is_authenticated %}
                         <div class="navbar-item has-dropdown is-hoverable">
-                            <a class="navbar-link"><strong>{{ LOGGED_IN_USER }}</strong></a>
+                            <a class="navbar-link"><strong>{{ user }}</strong></a>
                             <div class="navbar-dropdown">
-                                <a href="{% url 'user-profile' pk=LOGGED_IN_USER.pk %}" class="navbar-item">
+                                <a href="{% url 'user-profile' pk=user.pk %}" class="navbar-item">
                                     {% translate "Profilis" %}
                                 </a>
-                                <a href="{% url 'user-task-list' pk=LOGGED_IN_USER.pk %}" class="navbar-item">
+                                <a href="{% url 'user-task-list' pk=user.pk %}" class="navbar-item">
                                     {% translate "Užduotys" %}
                                 </a>
-                                {% if LOGGED_IN_USER.organization %}
-                                 <a href="{% url 'organization-plans' LOGGED_IN_USER.organization.pk %}" class="navbar-item">
+                                {% if user.organization %}
+                                 <a href="{% url 'organization-plans' user.organization.pk %}" class="navbar-item">
                                     {% translate "Planas" %}
                                 </a>
-                                <a href="{% url 'organization-datasets' LOGGED_IN_USER.organization.pk %}?selected_facets=organization_exact:{{ LOGGED_IN_USER.organization.pk }}" class="navbar-item">
+                                <a href="{% url 'organization-datasets' user.organization.pk %}?selected_facets=organization_exact:{{ user.organization.pk }}" class="navbar-item">
                                     {% translate "Mano organizacijos duomenų ištekliai" %}
                                 </a>
-                                <a href="{% url 'request-list' %}?selected_facets=organization_exact:{{ LOGGED_IN_USER.organization.pk }}" class="navbar-item">
+                                <a href="{% url 'request-list' %}?selected_facets=organization_exact:{{ user.organization.pk }}" class="navbar-item">
                                     {% translate "Mano poreikiai" %}
                                 </a>
                                 {% endif %}
-                                {% if LOGGED_IN_USER.can_see_manager_dataset_list_url %}
+                                {% if user.can_see_manager_dataset_list_url %}
                                 <a href="{% url 'manager-dataset-list' %}" class="navbar-item">
                                     {% translate "Mano tvarkomi rinkiniai" %}
                                 </a>
                                 {% endif %}
-                                {% if LOGGED_IN_USER.is_staff or LOGGED_IN_USER.is_superuser %}
+                                {% if user.is_staff or user.is_superuser %}
                                 <a href="{% url 'admin:index' %}" class="navbar-item" target="_blank">
                                     {% translate "Administravimas" %}
                                 </a>
                                 {% endif %}
-                                {% if LOGGED_IN_USER.is_superuser or LOGGED_IN_USER.is_supervisor %}
+                                {% if user.is_superuser or user.is_supervisor %}
                                 <a href="/coordinator-admin/vitrina_orgs/representativerequest/" class="navbar-item" target="_blank">
                                     {% translate "Teikėjų prašymai" %}
                                 </a>

--- a/vitrina/templates/component/navbar.html
+++ b/vitrina/templates/component/navbar.html
@@ -111,7 +111,6 @@
                             {% for language in languages %}
                                 <form action="{% url 'set_language' %}" method="post" id="languageChange{{ language.code }}">
                                     {% csrf_token %}
-                                    <input name="next" type="hidden" value="{{ redirect_to }}">
                                     <input name="language" type="hidden" value="{{ language.code }}">
                                 </form>
                                 <a href="#" rel="nofollow" class="navbar-item" onclick="document.getElementById('languageChange{{ language.code }}').submit();">

--- a/vitrina/templates/vitrina/agreements/base_agreement_detail.html
+++ b/vitrina/templates/vitrina/agreements/base_agreement_detail.html
@@ -131,7 +131,7 @@
                 {% for file in agreement_files %}
                     <tr>
                         <td>{{ file.created_at|date:"Y-m-d H:i" }}</td>
-                        <td><a href="{{ file.file.url }}" target="_blank">{{ file.file_name }}</a></td>
+                        <td><a href="{% url "agreement-file-download" project.pk agreement.pk file.pk %}" target="_blank">{{ file.file_name }}</a></td>
                     </tr>
                 {% endfor %}
             </tbody>

--- a/vitrina/templatetags/util_tags.py
+++ b/vitrina/templatetags/util_tags.py
@@ -75,14 +75,6 @@ def get_google_analytics_id():
 
 
 @assignment_tag
-def logged_in_user(_user, _logged_in_user):
-    if _logged_in_user != "":
-        return _logged_in_user
-    else:
-        return _user
-
-
-@assignment_tag
 def convert_coordinates(
     geometry_obj: str,
     source_srid: int,

--- a/vitrina/urls.py
+++ b/vitrina/urls.py
@@ -84,6 +84,7 @@ urlpatterns = [
 ]
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+urlpatterns += static(settings.INTERNAL_MEDIA_URL, document_root=settings.INTERNAL_MEDIA_ROOT)
 urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
 
 urlpatterns += [

--- a/vitrina/users/views.py
+++ b/vitrina/users/views.py
@@ -228,7 +228,6 @@ class ProfileView(LoginRequiredMixin, PermissionRequiredMixin, DetailView):
     def get_context_data(self, **kwargs):
         context_data = super().get_context_data(**kwargs)
         user = context_data.get("user")
-        context_data["logged_in_user"] = self.request.user
 
         subscriptions = (
             Subscription.objects.filter(user=user, object_id__isnull=False)


### PR DESCRIPTION
For reviewers:
  - 8402d67676956b9c0905b218a2dad54b97df3f8c - adds missing tests for `can_view_agreement`.
  - 83109e815aad6900598f78b128c42c094dc8b2c3 - introduce new logic for uploading private files: new settings, new storage, etc.
  - e20736d29f238b874917ee2c6132625a21f378ca - adds `AgreementFileDownloadView`.
  - e7d67de9b4fe16ae9de0985fcab83bcd3f12c82c - fix test file uploading to `INTERNAL_MEDIA_ROOT`.
  - 156a1eaa3737940c55d1b64193727e00d060c725 - switch to using `@override_settings(DEBUG=...)` in tests.
  - 2f636fe902f286987eaf559a9a9038633718c2e0, 973978e5f68b71f55b30286ae7b08121ba3d452b, 82d0a710c80896441790e366d989aaefcaf1cdaa, f5b35be9e968070cd415c647692263ea2fdca5a4, 4bfeb6bb174704012d5bb17e523bc62b97d5b233, d76b0d7a4e70b0f1353438c1af282495e9e166e9, 66abbc10addc04d03304d8a01d762c3b7d837b2f, dbdb4ea763bdd2800e373bbf5f98eaf10479e325 - fixes for missing template variables that started failing random tests after introducing `@override_settings(DEBUG=...)`.
  - 7a7929ee3bdaaf561f7a2ae3aa95b9848b575868 - small PR fixes, added CHANGES.rst

**Summary:**
* Add a way to upload files to another directory, that should not be publicly available, using `INTERNAL_MEDIA_URL`, `INTERNAL_MEDIA_ROOT` and `internal_media_storage`. Changed `SmartContractFile` uploads to this directory.
* Add endpoint `AgreementFileDownloadView` to download uploaded contract files:
  * If `DEBUG=True` - file is downloaded same way as before.
  * If `DEBUG=False` - file path is returned via `X-Accel-Redirect`. This header tells Nginx to do redirect to file and hides file path.
* `AgreementFileDownloadView` has `can_view_agreement` permissions.

**Note:**
Nginx must be configured to serve  `INTERNAL_MEDIA_URL` files internally:
```
    location /internal-media {
        internal;
        alias local/path/to/internal-media/dir;
    }
```

**Ticket:**
https://github.com/atviriduomenys/katalogas/issues/2124