### PR TITLE
[2040] Agreement tab for assigner organization — Introduce API & Views

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,7 @@ https://github.com/atviriduomenys/katalogas/issues/2040
 
 - Part 1-2: Organization-based detail & list agreement pages (previously only available under Projects).
 - Part 3: Refactor agreements to be easily extendable to other pages.
+- Part 4: Add separate agreement-negotiation views that are organization-based (reachable from organization tabs).
 
 https://github.com/atviriduomenys/katalogas/issues/2075
 

--- a/tests/orgs/conftest.py
+++ b/tests/orgs/conftest.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+import pytest
+from django.conf import settings
+
+from tests.smart_contracts.conftest import AGREEMENT_PDF, AGREEMENT_TWO_SIGNERS, ODRL_JSON
+
+
+@pytest.fixture
+def test_files_dir() -> Path:
+    return settings.BASE_DIR / "tests/smart_contracts/files"
+
+
+@pytest.fixture
+def odrl_json(test_files_dir: Path) -> Path:
+    return test_files_dir / ODRL_JSON
+
+
+@pytest.fixture
+def agreement_pdf(agreements_dir: Path) -> Path:
+    return agreements_dir / AGREEMENT_PDF
+
+
+@pytest.fixture
+def agreements_dir(test_files_dir: Path) -> Path:
+    return test_files_dir / "test_contracts"
+
+
+@pytest.fixture
+def agreement_two_signers(agreements_dir: Path) -> Path:
+    return agreements_dir / AGREEMENT_TWO_SIGNERS

--- a/tests/orgs/test_views.py
+++ b/tests/orgs/test_views.py
@@ -1,20 +1,23 @@
 import io
+import json
+from pathlib import Path
 from unittest.mock import patch, Mock
 from bs4 import BeautifulSoup
-
 import pytest
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from PIL import Image
+from django.conf import settings
+from django.core.files.base import ContentFile
 from django_recaptcha.client import RecaptchaResponse
 from freezegun import freeze_time
 import pytz
 from django.contrib.contenttypes.models import ContentType
 from django.core import mail
 from django.urls import reverse
-
 from django_webtest import DjangoTestApp
 from itsdangerous import URLSafeSerializer
+from pdfminer.high_level import extract_text
 from webtest import Upload
 
 from vitrina import settings
@@ -22,21 +25,26 @@ from vitrina.api.factories import APIKeyFactory
 from vitrina.api.models import ApiKey
 from vitrina.classifiers.factories import AreaOfManagementFactory
 from vitrina.classifiers.models import AreaOfManagement
-from vitrina.datasets.factories import DatasetFactory
-from vitrina.datasets.models import Contact
+from vitrina.datasets.factories import DatasetFactory, ContactFactory
+from vitrina.datasets.models import Contact, Dataset
 from vitrina.messages.models import Subscription
 from vitrina.orgs.factories import OrganizationFactory, RepresentativeFactory, ViispRepresentativeFactory
 from vitrina.orgs.models import Representative, Organization
 from vitrina.plans.factories import PlanFactory
 from vitrina.plans.models import Plan
+from vitrina.projects.factories import ProjectFactory
 from vitrina.requests.factories import RequestFactory
+from vitrina.smart_contracts import AgreementStatuses
+from vitrina.smart_contracts.factories import AgreementFactory, AgreementPDFFileFactory, AgreementJSONFileFactory
+from vitrina.smart_contracts.models import SmartContractTemplate, Agreement, AgreementFile
 from vitrina.users.factories import UserFactory
 from vitrina.users.models import User
 
+
+pytestmark = pytest.mark.django_db
 timezone = pytz.timezone(settings.TIME_ZONE)
 
 
-@pytest.mark.django_db
 def test_organization_detail_tab(app: DjangoTestApp):
     parent_organization = OrganizationFactory()
     organization = parent_organization.add_child(instance=OrganizationFactory.build())
@@ -45,7 +53,6 @@ def test_organization_detail_tab(app: DjangoTestApp):
     assert list(resp.html.find("li", class_="is-active").a.stripped_strings) == ["Informacija"]
 
 
-@pytest.mark.django_db
 def test_organization_members_tab(app: DjangoTestApp):
     organization1 = OrganizationFactory()
     organization2 = OrganizationFactory()
@@ -108,7 +115,6 @@ def test_search_without_query(app: DjangoTestApp, organizations):
     assert [int(obj.pk) for obj in resp.context['object_list']] == [organizations[0].pk, organizations[1].pk, organizations[2].pk]
 
 
-@pytest.mark.django_db
 def test_search_with_query_that_doesnt_match(app: DjangoTestApp, organizations):
     resp = app.get("%s?q=%s" % (reverse('organization-list'), "doesnt-match"))
     assert [int(obj.pk) for obj in resp.context['object_list']] == []
@@ -275,7 +281,6 @@ def representative_data():
     }
 
 
-@pytest.mark.django_db
 def test_representative_create_without_permission(app: DjangoTestApp, representative_data):
     app.set_user(representative_data['manager'])
     resp = app.get(reverse('representative-create', kwargs={
@@ -284,7 +289,6 @@ def test_representative_create_without_permission(app: DjangoTestApp, representa
     assert resp.status_code == 403
 
 
-@pytest.mark.django_db
 def test_representative_create_with_existing_user(app: DjangoTestApp, representative_data):
     app.set_user(representative_data['coordinator'])
     form = app.get(reverse('representative-create', kwargs={
@@ -304,7 +308,6 @@ def test_representative_create_with_existing_user(app: DjangoTestApp, representa
     ).first().user.organization == representative_data['organization']
 
 
-@pytest.mark.django_db
 def test_representative_create_can_make_agreements_disabled(app: DjangoTestApp, representative_data):
     app.set_user(representative_data['coordinator'])
     form = app.get(reverse('representative-create', kwargs={
@@ -325,7 +328,7 @@ def test_representative_create_can_make_agreements_disabled(app: DjangoTestApp, 
     assert representative.user.organization == representative_data['organization']
     assert not representative.can_make_agreements
 
-@pytest.mark.django_db
+
 def test_representative_create_with_can_make_agreements_rights(app: DjangoTestApp, representative_data):
     app.set_user(representative_data['viisp_coordinator'])
     form = app.get(reverse('representative-create', kwargs={
@@ -345,7 +348,7 @@ def test_representative_create_with_can_make_agreements_rights(app: DjangoTestAp
     assert representative.user.organization == representative_data['organization']
     assert representative.can_make_agreements
 
-@pytest.mark.django_db
+
 def test_representative_create_without_user(app: DjangoTestApp, representative_data):
     app.set_user(representative_data['coordinator'])
     form = app.get(reverse('representative-create', kwargs={
@@ -364,7 +367,6 @@ def test_representative_create_without_user(app: DjangoTestApp, representative_d
     assert mail.outbox[0].to == ["new@gmail.com"]
 
 
-@pytest.mark.django_db
 def test_representative_create_without_user_for_two_organizations(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     organization1 = OrganizationFactory()
@@ -390,7 +392,6 @@ def test_representative_create_without_user_for_two_organizations(app: DjangoTes
     assert mail.outbox[0].to == ["new@gmail.com"]
 
 
-@pytest.mark.django_db
 def test_representative_create_invalid_phone(app: DjangoTestApp, representative_data):
     app.set_user(representative_data['coordinator'])
     form = app.get(reverse('representative-create', kwargs={
@@ -405,7 +406,6 @@ def test_representative_create_invalid_phone(app: DjangoTestApp, representative_
     assert Representative.objects.filter(email="new@gmail.com").count() == 0
 
 
-@pytest.mark.django_db
 def test_representative_create_valid_phone(app: DjangoTestApp, representative_data):
     app.set_user(representative_data['coordinator'])
 
@@ -434,7 +434,6 @@ def test_representative_create_valid_phone(app: DjangoTestApp, representative_da
     assert rep_queryset.first().phone == "061234567"
 
 
-@pytest.mark.django_db
 @pytest.mark.parametrize("can_write", [True, False])
 def test_representative_create_with_can_write_flag(app: DjangoTestApp, representative_data: dict, can_write: bool):
     app.set_user(representative_data["coordinator"])
@@ -451,7 +450,6 @@ def test_representative_create_with_can_write_flag(app: DjangoTestApp, represent
     assert representative.can_write == can_write
 
 
-@pytest.mark.django_db
 def test_representative_update_phone(app: DjangoTestApp, representative_data):
     representative_data['representative_manager'].user = representative_data['manager']
     representative_data['representative_manager'].save()
@@ -467,7 +465,6 @@ def test_representative_update_phone(app: DjangoTestApp, representative_data):
     assert representative_data['representative_manager'].phone == "061234567"
 
 
-@pytest.mark.django_db
 def test_representative_subscription(app: DjangoTestApp, representative_data):
     subscriptions_before = Subscription.objects.all()
     assert len(subscriptions_before) == 0
@@ -495,7 +492,6 @@ def test_representative_subscription(app: DjangoTestApp, representative_data):
     assert subscription.sub_type == Subscription.ORGANIZATION
 
 
-@pytest.mark.django_db
 def test_register_after_adding_representative(app: DjangoTestApp, representative_data):
     new_representative = RepresentativeFactory(
         email="new@gmail.com",
@@ -525,7 +521,6 @@ def test_register_after_adding_representative(app: DjangoTestApp, representative
         assert new_representative.user.organization == representative_data['organization']
 
 
-@pytest.mark.django_db
 def test_representative_update_without_permission(app: DjangoTestApp, representative_data):
     app.set_user(representative_data['manager'])
     resp = app.get(reverse('representative-create', kwargs={
@@ -534,7 +529,6 @@ def test_representative_update_without_permission(app: DjangoTestApp, representa
     assert resp.status_code == 403
 
 
-@pytest.mark.django_db
 def test_representative_update_no_coordinators(app: DjangoTestApp, representative_data):
     app.set_user(representative_data['coordinator'])
     representative_data['representative_viisp_coordinator'].role = 'manager'
@@ -548,7 +542,6 @@ def test_representative_update_no_coordinators(app: DjangoTestApp, representativ
     assert len(resp.context['form'].errors) == 1
 
 
-@pytest.mark.django_db
 def test_representative_update_with_correct_data(app: DjangoTestApp, representative_data):
     representative_data['representative_manager'].user = representative_data['manager']
     representative_data['representative_manager'].save()
@@ -566,7 +559,6 @@ def test_representative_update_with_correct_data(app: DjangoTestApp, representat
     assert representative_data['representative_manager'].user.organization == representative_data['organization']
 
 
-@pytest.mark.django_db
 def test_representative_update_can_make_agreements(app: DjangoTestApp, representative_data):
     app.set_user(representative_data['viisp_coordinator'])
     form = app.get(reverse('representative-update', kwargs={
@@ -581,7 +573,6 @@ def test_representative_update_can_make_agreements(app: DjangoTestApp, represent
     assert representative_data['representative_manager'].can_make_agreements
 
 
-@pytest.mark.django_db
 @pytest.mark.parametrize("can_write", [True, False])
 def test_representative_update_can_write_flag(app: DjangoTestApp, representative_data: dict, can_write: bool):
     representative = RepresentativeFactory(
@@ -605,7 +596,6 @@ def test_representative_update_can_write_flag(app: DjangoTestApp, representative
     assert representative.can_write == (not can_write)
 
 
-@pytest.mark.django_db
 def test_organization_plan_create_with_no_publisher(app: DjangoTestApp):
     organization = OrganizationFactory()
     ct = ContentType.objects.get_for_model(organization)
@@ -627,7 +617,6 @@ def test_organization_plan_create_with_no_publisher(app: DjangoTestApp):
     ]]
 
 
-@pytest.mark.django_db
 def test_organization_plan_create_with_multiple_publishers(app: DjangoTestApp):
     organization = OrganizationFactory()
     ct = ContentType.objects.get_for_model(organization)
@@ -650,7 +639,6 @@ def test_organization_plan_create_with_multiple_publishers(app: DjangoTestApp):
     ]]
 
 
-@pytest.mark.django_db
 def test_organization_plan_create(app: DjangoTestApp):
     organization = OrganizationFactory()
     ct = ContentType.objects.get_for_model(organization)
@@ -675,7 +663,6 @@ def test_organization_plan_create(app: DjangoTestApp):
     assert Plan.objects.first().receiver == organization
 
 
-@pytest.mark.django_db
 def test_organization_plan_update(app: DjangoTestApp):
     plan = PlanFactory()
     ct = ContentType.objects.get_for_model(plan.receiver)
@@ -697,7 +684,6 @@ def test_organization_plan_update(app: DjangoTestApp):
     assert Plan.objects.first().publisher == plan.receiver
 
 
-@pytest.mark.django_db
 def test_organization_merge_without_permission(app: DjangoTestApp):
     user = UserFactory()
     app.set_user(user)
@@ -708,7 +694,6 @@ def test_organization_merge_without_permission(app: DjangoTestApp):
     assert resp.status_code == 403
 
 
-@pytest.mark.django_db
 def test_organization_merge(app: DjangoTestApp):
     user = UserFactory(is_superuser=True)
     app.set_user(user)
@@ -741,7 +726,6 @@ def test_organization_merge(app: DjangoTestApp):
     )) == [representative]
 
 
-@pytest.mark.django_db
 def test_organization_open_plans(app: DjangoTestApp):
     organization = OrganizationFactory()
     PlanFactory(is_closed=True, receiver=organization)
@@ -752,7 +736,6 @@ def test_organization_open_plans(app: DjangoTestApp):
     assert len(resp.context['plans']) == 2
 
 
-@pytest.mark.django_db
 def test_organization_closed_plans(app: DjangoTestApp):
     organization = OrganizationFactory()
     PlanFactory(is_closed=True, receiver=organization)
@@ -763,7 +746,6 @@ def test_organization_closed_plans(app: DjangoTestApp):
     assert len(resp.context['plans']) == 1
 
 
-@pytest.mark.django_db
 def test_change_form_no_login(app: DjangoTestApp):
     org = OrganizationFactory()
     response = app.get(reverse('organization-change', kwargs={'pk': org.id}))
@@ -771,7 +753,6 @@ def test_change_form_no_login(app: DjangoTestApp):
     assert settings.LOGIN_URL in response.location
 
 
-@pytest.mark.django_db
 def test_change_form_wrong_login(app: DjangoTestApp):
     org = OrganizationFactory()
     user = User.objects.create_user(email="test@test.com", password="test123")
@@ -789,7 +770,6 @@ def generate_photo_file(height, length) -> bytes:
     return file.getvalue()
 
 
-@pytest.mark.django_db
 def test_change_form_correct_login(app: DjangoTestApp):
     representative = ViispRepresentativeFactory()
     org = representative.content_object
@@ -814,7 +794,6 @@ def test_change_form_correct_login(app: DjangoTestApp):
     assert org.description == 'edited org description'
 
 
-@pytest.mark.django_db
 def test_click_edit_button(app: DjangoTestApp):
     representative = ViispRepresentativeFactory()
     org = representative.content_object
@@ -825,7 +804,6 @@ def test_click_edit_button(app: DjangoTestApp):
     assert response.status_code == 200
 
 
-@pytest.mark.django_db
 def test_contact_tab_access_coordinator(app, representative_data):
     app.set_user(representative_data['coordinator'])
 
@@ -838,7 +816,6 @@ def test_contact_tab_access_coordinator(app, representative_data):
     assert 'contacts/add' in resp.text
 
 
-@pytest.mark.django_db
 def test_contact_tab_access_denied_for_manager(app, representative_data):
     app.set_user(representative_data['manager'])
 
@@ -849,7 +826,6 @@ def test_contact_tab_access_denied_for_manager(app, representative_data):
     assert resp.status_code == 403
 
 
-@pytest.mark.django_db
 def test_contact_tab_display_org_contacts(app, representative_data):
     app.set_user(representative_data['coordinator'])
     organization = representative_data['organization']
@@ -872,7 +848,6 @@ def test_contact_tab_display_org_contacts(app, representative_data):
     assert organization.title in resp.text
 
 
-@pytest.mark.django_db
 def test_contact_tab_display_user_contacts(app, representative_data):
     app.set_user(representative_data['coordinator'])
     organization = representative_data['organization']
@@ -896,7 +871,6 @@ def test_contact_tab_display_user_contacts(app, representative_data):
     assert user.get_full_name() in resp.text
 
 
-@pytest.mark.django_db
 def test_contact_tab_display_multiple_contacts(app, representative_data):
     app.set_user(representative_data['coordinator'])
     organization = representative_data['organization']
@@ -942,7 +916,6 @@ def test_contact_tab_display_multiple_contacts(app, representative_data):
     assert user2.get_full_name() in resp.text
 
 
-@pytest.mark.django_db
 def test_contact_tab_pagination(app, representative_data):
     app.set_user(representative_data['coordinator'])
     organization = representative_data['organization']
@@ -968,7 +941,6 @@ def test_contact_tab_pagination(app, representative_data):
     assert len(rows) == 10
 
 
-@pytest.mark.django_db
 def test_contact_tab_empty_state(app, representative_data):
     app.set_user(representative_data['coordinator'])
 
@@ -982,7 +954,6 @@ def test_contact_tab_empty_state(app, representative_data):
     assert rows is None
 
 
-@pytest.mark.django_db
 def test_contact_tab_actions_coordinator(app, representative_data):
     app.set_user(representative_data['coordinator'])
     organization = representative_data['organization']
@@ -1003,7 +974,6 @@ def test_contact_tab_actions_coordinator(app, representative_data):
     assert f'contacts/{contact.pk}/delete' in resp.text
 
 
-@pytest.mark.django_db
 def test_contact_create_for_org(app, representative_data):
     org = representative_data['organization']
     app.set_user(representative_data['coordinator'])
@@ -1035,7 +1005,6 @@ def test_contact_create_for_org(app, representative_data):
     assert org.title in resp.text
 
 
-@pytest.mark.django_db
 def test_contact_create_for_user_valid_data(app, representative_data):
     org = representative_data['organization']
     app.set_user(representative_data['coordinator'])
@@ -1065,8 +1034,7 @@ def test_contact_create_for_user_valid_data(app, representative_data):
     assert contact.phone in resp.text
     assert coordinator.get_full_name() in resp.text
     
-    
-@pytest.mark.django_db
+
 def test_contact_create_for_non_registered_contact(app, representative_data):
     org = representative_data['organization']
     app.set_user(representative_data['coordinator'])
@@ -1102,7 +1070,6 @@ def test_contact_create_for_non_registered_contact(app, representative_data):
     assert contact.phone in resp.text
 
 
-@pytest.mark.django_db
 def test_contact_create_no_permission(app, representative_data):
     app.set_user(representative_data['manager'])
     resp = app.get(reverse('contact-create', kwargs={
@@ -1111,7 +1078,6 @@ def test_contact_create_no_permission(app, representative_data):
     assert resp.status_code == 403
 
 
-@pytest.mark.django_db
 def test_contact_update_org(app, representative_data):
     app.set_user(representative_data['coordinator'])
     org = representative_data['organization']
@@ -1139,7 +1105,6 @@ def test_contact_update_org(app, representative_data):
     assert contact.phone == "+37067654321"
 
 
-@pytest.mark.django_db
 def test_contact_update_user(app, representative_data):
     coordinator = representative_data['coordinator']
     app.set_user(coordinator)
@@ -1166,7 +1131,6 @@ def test_contact_update_user(app, representative_data):
     assert contact.email == "updated@test.com"
 
 
-@pytest.mark.django_db
 def test_contact_delete(app, representative_data):
     app.set_user(representative_data['coordinator'])
     org = representative_data['organization']
@@ -1189,7 +1153,6 @@ def test_contact_delete(app, representative_data):
     assert not c.exists()
 
 
-@pytest.mark.django_db
 def test_contact_delete_no_permission(app, representative_data):
     app.set_user(representative_data['manager'])  # Manager shouldn't have permission
     org = representative_data['organization']
@@ -1208,7 +1171,6 @@ def test_contact_delete_no_permission(app, representative_data):
     assert Contact.objects.count() == 1
 
 
-@pytest.mark.django_db
 def test_non_gov_organizaton_no_gov_kind(app: DjangoTestApp):
     representative = ViispRepresentativeFactory()
     org = representative.content_object
@@ -1223,7 +1185,7 @@ def test_non_gov_organizaton_no_gov_kind(app: DjangoTestApp):
     assert len(kind_values) == 2
     assert Organization.GOV not in kind_values
 
-@pytest.mark.django_db
+
 def test_gov_organizaton_cannot_select_different_kind(app: DjangoTestApp):
     representative = ViispRepresentativeFactory()
     org = representative.content_object
@@ -1241,7 +1203,6 @@ def test_gov_organizaton_cannot_select_different_kind(app: DjangoTestApp):
     assert kind_values[0] == Organization.GOV
 
 
-@pytest.mark.django_db
 def test_create_organization(app: DjangoTestApp):
     user = UserFactory(is_superuser=True)
     app.set_user(user)
@@ -1274,7 +1235,6 @@ def test_create_organization(app: DjangoTestApp):
     assert organization.kind == Organization.GOV
 
 
-@pytest.mark.django_db
 def test_partner_register_no_permission(app: DjangoTestApp):
     user = UserFactory()
     app.set_user(user)
@@ -1284,7 +1244,7 @@ def test_partner_register_no_permission(app: DjangoTestApp):
     assert response.status_code == 302
     assert response.url == reverse("viisp-login")
 
-@pytest.mark.django_db
+
 def test_partner_register_access_with_permission(app: DjangoTestApp):
     user = UserFactory(is_viisp_login=True)
     app.set_user(user)
@@ -1293,8 +1253,8 @@ def test_partner_register_access_with_permission(app: DjangoTestApp):
 
     assert response.status_code == 200
 
+
 class TestRepresentativeDeleteView:
-    @pytest.mark.django_db
     def test_delete_representative(self, app: DjangoTestApp) -> None:
         user = UserFactory(is_staff=True)
         app.set_user(user)
@@ -1311,7 +1271,7 @@ class TestRepresentativeDeleteView:
 
         assert not Representative.objects.filter(pk=representative.pk).exists()
 
-    @pytest.mark.django_db
+    
     def test_remove_publisher_from_all_representative_organization_datasets(
         self, app: DjangoTestApp
     ) -> None:
@@ -1335,7 +1295,6 @@ class TestRepresentativeDeleteView:
 
 
 class TestOrganizationApiKeysDeleteView:
-    @pytest.mark.django_db
     def test_delete_api_client_if_spinta_request_successful(
         self, app: DjangoTestApp
     ) -> None:
@@ -1355,7 +1314,6 @@ class TestOrganizationApiKeysDeleteView:
             assert not ApiKey.objects.exists()
             api_delete_request_mock.assert_called_once()
 
-    @pytest.mark.django_db
     def test_do_not_delete_api_client_if_spinta_request_unsuccessful(
         self, app: DjangoTestApp
     ) -> None:
@@ -1374,3 +1332,1035 @@ class TestOrganizationApiKeysDeleteView:
 
             assert ApiKey.objects.exists()
             api_delete_request_mock.assert_called_once()
+
+
+
+class TestOrganizationBasedAgreementList:
+    def test_success(self, app: DjangoTestApp, organization: Organization):
+        # Arrange
+        status_priority = {
+            AgreementStatuses.SUBMITTED: 0,
+            AgreementStatuses.APPROVED: 1,
+            AgreementStatuses.INITIATED: 2,
+            AgreementStatuses.ACTIVE: 3,
+            AgreementStatuses.SIGNED: 4,
+            AgreementStatuses.CREATED: 5,
+            AgreementStatuses.FORMED: 6,
+            AgreementStatuses.TERMINATED: 7,
+        }
+
+        representative = RepresentativeFactory(content_object=organization)
+        user = representative.user
+        app.set_user(user)
+
+        now = datetime.now(tz=timezone)
+
+        agreements = [
+            AgreementFactory(assigner=organization, status=status, created_at=now)
+            for status in AgreementStatuses
+        ]
+        older_agreement = AgreementFactory(
+            assigner=organization,
+            status=AgreementStatuses.CREATED,
+            created_at=now - timedelta(days=1),
+        )
+        newer_agreement = AgreementFactory(
+            assigner=organization,
+            status=AgreementStatuses.CREATED,
+            created_at=now,
+        )
+        agreements.extend([older_agreement, newer_agreement])
+
+        expected_agreement_order = sorted(
+            agreements, key=lambda agreement: (status_priority.get(agreement.status, 8), agreement.created_at),
+        )
+        ordered_expected_agreement_ids = [agreement.uuid for agreement in expected_agreement_order]
+
+        # Act
+        response = app.get(reverse("organization-agreement-list", args=[organization.pk]))
+
+        # Assert
+        assert response.status_code == 200
+        response_agreement_ids = [item.uuid for item in response.context["agreements"]]
+        assert response_agreement_ids == ordered_expected_agreement_ids
+
+    def test_list_agreements_as_superuser(self, app: DjangoTestApp, organization: Organization):
+        user = UserFactory(is_superuser=True)
+        app.set_user(user)
+
+        AgreementFactory.create_batch(3, assigner=organization)
+
+        url = reverse("organization-agreement-list", args=[organization.pk])
+        response = app.get(url)
+
+        assert response.status_code == 200
+        assert response.context["agreements"].count() == 3
+
+    def test_cannot_list_unauthenticated(self, app: DjangoTestApp, organization: Organization):
+        # AnonymousUser is used, since no user is set.
+        url = reverse("organization-agreement-list", args=[organization.pk])
+        response = app.get(url, expect_errors=True)
+        assert response.status_code == 302  # login redirect
+
+    def test_cannot_list_if_not_representative(self, app: DjangoTestApp, organization: Organization):
+        user = UserFactory()
+        app.set_user(user)
+
+        url = reverse("organization-agreement-list", args=[organization.pk])
+        response = app.get(url, expect_errors=True)
+
+        assert response.status_code == 403
+
+    def test_cannot_list_if_representative_of_another_organization(
+        self,
+        app: DjangoTestApp,
+        organization: Organization
+    ):
+        other_organization = OrganizationFactory()
+
+        representative = RepresentativeFactory(content_object=other_organization)
+        user = representative.user
+
+        AgreementFactory(assigner=organization)
+        app.set_user(user)
+
+        url = reverse("organization-agreement-list", args=[organization.pk])
+        response = app.get(url, expect_errors=True)
+
+        assert response.status_code == 403
+
+
+class TestOrganizationBasedAgreementDetail:
+    def test_success(self, app, organization: Organization):
+        representative = RepresentativeFactory(content_object=organization)
+        user = representative.user
+        app.set_user(user)
+
+        agreement = AgreementFactory(assigner=organization)
+
+        url = reverse(
+            "organization-agreement-detail",
+            args=[organization.pk, agreement.uuid],
+        )
+        response = app.get(url)
+        assert response.status_code == 200
+
+        context_agreement = response.context["agreement"]
+        assert context_agreement == agreement
+
+        assert response.context["can_create_agreements"] is False
+        assert response.context["can_submit_agreements"] is False
+        assert "can_approve_agreements" in response.context
+        assert "can_form_agreements" in response.context
+        assert "can_sign_agreements" in response.context
+        assert "can_upload_agreement_file" in response.context
+
+    def test_permission_denied_for_unrelated_user(self, app, organization: Organization):
+        unrelated_user = UserFactory()
+        app.set_user(unrelated_user)
+
+        agreement = AgreementFactory(assigner=organization)
+
+        url = reverse(
+            "organization-agreement-detail",
+            args=[organization.pk, agreement.uuid],
+        )
+        response = app.get(url, expect_errors=True)
+        assert response.status_code == 403  # Permission denied
+
+    def test_not_found_for_wrong_organization(self, app, organization: Organization):
+        representative = RepresentativeFactory(content_object=organization)
+        app.set_user(representative.user)
+
+        other_organization = OrganizationFactory(title="Other Org")
+        agreement = AgreementFactory(assigner=other_organization)
+
+        url = reverse(
+            "organization-agreement-detail",
+            args=[organization.pk, agreement.uuid],
+        )
+        response = app.get(url, expect_errors=True)
+        assert response.status_code == 404
+
+
+class TestOrganizationBasedAgreementNegotiateApprove:
+    def test_success(self, app: DjangoTestApp, dataset):
+        # Arrange
+        template = SmartContractTemplate.objects.create(
+            file=ContentFile(
+                open(settings.BASE_DIR / "tests/smart_contracts/files/contract_template.md").read(),
+                name="contract_template.md",
+            )
+        )
+
+        assigner_organization, assignee_organization = OrganizationFactory.create_batch(2)
+        assigner_user = UserFactory(
+            organization=assigner_organization,
+            is_viisp_login=True,
+            viisp_company_code=assigner_organization.company_code,
+        )
+        assignee_user = UserFactory(
+            organization=assignee_organization,
+            is_viisp_login=True,
+            viisp_company_code=assignee_organization.company_code,
+        )
+
+        app.set_user(assigner_user)
+
+        RepresentativeFactory(user=assigner_user, content_object=assigner_organization, can_make_agreements=True)
+        RepresentativeFactory(user=assignee_user, content_object=assignee_organization, can_make_agreements=True)
+
+        project = ProjectFactory(organization=assignee_organization, datasets=[dataset], other_assignee_legislations="Test")
+
+        assignee_contact = ContactFactory(
+            organization=assignee_organization,
+            object_id=assignee_user.pk,
+            content_type=ContentType.objects.get_for_model(assignee_user),
+            email=assignee_user.email,
+            phone=assignee_user.phone
+        )
+        assigner_contact = ContactFactory(
+            organization=assigner_organization,
+            object_id=assigner_user.pk,
+            content_type=ContentType.objects.get_for_model(assigner_user),
+            email=assigner_user.email,
+            phone=assigner_user.phone
+        )
+
+        agreement = AgreementFactory(
+            project=project,
+            assignee=assignee_organization,
+            assignee_representative=assignee_contact,
+            assigner=assigner_organization,
+            assigner_representative=None,
+            created_by=assignee_user,
+            status=AgreementStatuses.SUBMITTED,
+        )
+
+        # Act
+        response = app.post(
+            reverse("organization-agreement-approve", args=[assigner_organization.pk, agreement.pk]),
+            {
+                "template": template.pk,
+                "assigner_representative": assigner_contact.pk,
+                "other_assigner_legislations": "Legislation A; Legislation B"
+            }
+        )
+
+        # Assert
+        assert response.status_code == 302
+        agreement.refresh_from_db()
+        assert agreement.status == AgreementStatuses.APPROVED
+        assert agreement.template == template
+        assert agreement.assigner_representative == assigner_contact
+        assert agreement.other_assigner_legislations == "Legislation A; Legislation B"
+
+    def test_unauthorized_not_representative(self, app: DjangoTestApp, dataset):
+        # Arrange
+        assigner_organization, assignee_organization = OrganizationFactory.create_batch(2)
+        unauthorized_user = UserFactory(
+            organization=assigner_organization,
+            is_viisp_login=True,
+            viisp_company_code=assigner_organization.company_code,
+        )
+        app.set_user(unauthorized_user)
+
+        project = ProjectFactory(organization=assignee_organization, datasets=[dataset])
+        agreement = AgreementFactory(
+            project=project,
+            assignee=assignee_organization,
+            assigner=assigner_organization,
+            assigner_representative=None,
+            status=AgreementStatuses.SUBMITTED,
+        )
+
+        template_file = ContentFile(b"test", name="template.md")
+
+        # Act
+        response = app.post(
+            reverse("organization-agreement-approve", args=[assigner_organization.pk, agreement.pk]),
+            {
+                "template": template_file,
+                "assigner_representative": None,
+                "other_assigner_legislations": "",
+            },
+            expect_errors=True
+        )
+
+        # Assert
+        assert response.status_code == 403
+        agreement.refresh_from_db()
+        assert agreement.status == AgreementStatuses.SUBMITTED
+        assert not agreement.template
+        assert not agreement.assigner_representative
+        assert not agreement.other_assigner_legislations
+
+    def test_unauthorized_no_approval_rights(self, app: DjangoTestApp, dataset):
+        # Arrange
+        assigner_organization, assignee_organization = OrganizationFactory.create_batch(2)
+        assigner_user = UserFactory(
+            organization=assigner_organization,
+            is_viisp_login=True,
+            viisp_company_code=assigner_organization.company_code,
+        )
+        app.set_user(assigner_user)
+
+        RepresentativeFactory(user=assigner_user, content_object=assigner_organization, can_make_agreements=False)
+
+        project = ProjectFactory(organization=assignee_organization, datasets=[dataset])
+        agreement = AgreementFactory(
+            project=project,
+            assignee=assignee_organization,
+            assigner=assigner_organization,
+            status=AgreementStatuses.SUBMITTED,
+        )
+
+        template_file = ContentFile(b"test", name="template.md")
+
+        # Act
+        response = app.post(
+            reverse("organization-agreement-approve", args=[assigner_organization.pk, agreement.pk]),
+            {
+                "template": template_file,
+                "assigner_representative": None,
+                "other_assigner_legislations": "",
+            },
+            expect_errors=True
+        )
+
+        # Assert
+        assert response.status_code == 403
+        agreement.refresh_from_db()
+        assert agreement.status == AgreementStatuses.SUBMITTED
+
+    @pytest.mark.parametrize("status", [
+        AgreementStatuses.CREATED,
+        AgreementStatuses.APPROVED,
+        AgreementStatuses.FORMED,
+        AgreementStatuses.INITIATED,
+        AgreementStatuses.SIGNED,
+        AgreementStatuses.ACTIVE,
+        AgreementStatuses.TERMINATED,
+    ])
+    def test_incorrect_agreement_status(self, app: DjangoTestApp, dataset, status):
+        # Arrange
+        template = SmartContractTemplate.objects.create(
+            file=ContentFile(
+                open(settings.BASE_DIR / "tests/smart_contracts/files/contract_template.md").read(),
+                name="contract_template.md",
+            )
+        )
+
+        assigner_organization, assignee_organization = OrganizationFactory.create_batch(2)
+        assigner_user = UserFactory(
+            organization=assigner_organization,
+            is_viisp_login=True,
+            viisp_company_code=assigner_organization.company_code,
+        )
+        assignee_user = UserFactory(
+            organization=assignee_organization,
+            is_viisp_login=True,
+            viisp_company_code=assignee_organization.company_code,
+        )
+
+        app.set_user(assigner_user)
+
+        RepresentativeFactory(user=assigner_user, content_object=assigner_organization, can_make_agreements=True)
+        RepresentativeFactory(user=assignee_user, content_object=assignee_organization, can_make_agreements=True)
+
+        project = ProjectFactory(organization=assignee_organization, datasets=[dataset],
+                                 other_assignee_legislations="Test")
+
+        assignee_contact = ContactFactory(
+            organization=assignee_organization,
+            object_id=assignee_user.pk,
+            content_type=ContentType.objects.get_for_model(assignee_user),
+            email=assignee_user.email,
+            phone=assignee_user.phone
+        )
+        assigner_contact = ContactFactory(
+            organization=assigner_organization,
+            object_id=assigner_user.pk,
+            content_type=ContentType.objects.get_for_model(assigner_user),
+            email=assigner_user.email,
+            phone=assigner_user.phone
+        )
+
+        agreement = AgreementFactory(
+            project=project,
+            assignee=assignee_organization,
+            assignee_representative=assignee_contact,
+            assigner=assigner_organization,
+            assigner_representative=None,
+            created_by=assignee_user,
+            status=status,
+        )
+
+        # Act
+        response = app.post(
+            reverse("organization-agreement-approve", args=[assigner_organization.pk, agreement.pk]),
+            {"template": template.pk, "assigner_representative": assigner_contact.pk, "other_assigner_legislations": ""}
+        )
+
+        # Assert
+        assert response.status_code == 302
+        agreement.refresh_from_db()
+        assert agreement.status == status
+        assert not agreement.template
+        assert not agreement.assigner_representative
+        assert not agreement.other_assigner_legislations
+
+
+class TestOrganizationBasedAgreementNegotiateForm:
+    def test_success(self, app, dataset: Dataset):
+        """Test successful organization-based agreement form submission by the assigner."""
+        # Arrange
+        template = SmartContractTemplate.objects.create(
+            file=ContentFile(
+                open(settings.BASE_DIR / "tests/smart_contracts/files/contract_template.md").read(),
+                name="contract_template.md",
+            )
+        )
+
+        assignee_organization, assigner_organization = OrganizationFactory.create_batch(2)
+        dataset.organization = assigner_organization
+        dataset.save()
+
+        assignee_user = UserFactory(
+            organization=assignee_organization,
+            is_viisp_login=True,
+            viisp_company_code=assignee_organization.company_code,
+        )
+        assigner_user = UserFactory(
+            organization=assigner_organization,
+            is_viisp_login=True,
+            viisp_company_code=assigner_organization.company_code,
+        )
+        app.set_user(assigner_user)
+
+        RepresentativeFactory(user=assignee_user, content_object=assignee_organization, can_make_agreements=True)
+        RepresentativeFactory(user=assigner_user, content_object=assigner_organization, can_make_agreements=True)
+
+        assignee_contact = ContactFactory(
+            organization=assignee_organization,
+            object_id=assignee_user.pk,
+            content_type=ContentType.objects.get_for_model(User),
+            email=assignee_user.email,
+            phone=assignee_user.phone,
+        )
+        assigner_contact = ContactFactory(
+            organization=assigner_organization,
+            object_id=assigner_user.pk,
+            content_type=ContentType.objects.get_for_model(User),
+            email=assigner_user.email,
+            phone=assigner_user.phone,
+        )
+
+        project = ProjectFactory(
+            organization=assignee_organization,
+            datasets=[dataset],
+            other_assignee_legislations="Test",
+        )
+
+        agreement = AgreementFactory(
+            template=template,
+            project=project,
+            assignee=assignee_organization,
+            assignee_representative=assignee_contact,
+            assigner=assigner_organization,
+            assigner_representative=assigner_contact,
+            other_assigner_legislations="Legislation D; Legislation E; Legislation F.",
+            payment_terms="Payment term A; Payment term B.",
+            created_by=assignee_user,
+            status=AgreementStatuses.APPROVED,
+        )
+
+        # Act
+        response = app.post(
+            reverse("organization-agreement-form", args=[assigner_organization.pk, agreement.pk]),
+            {}
+        )
+
+        # Assert
+        assert response.status_code == 302
+        agreement.refresh_from_db()
+        assert agreement.status == AgreementStatuses.FORMED
+
+        odrl_file, contract, template_copy = list(agreement.files.order_by("is_template", "created_at"))
+
+        assert odrl_file.file_name.endswith(".json")
+        odrl_content = json.loads(odrl_file.file.read())
+        assert odrl_content == {
+            "@context": {
+                "@vocab": "http://www.w3.org/ns/odrl.jsonld",
+                "ex": "http://example.org/vocab#",
+            },
+            "uid": f"https://data.gov.lt/ID/datasets/gov/vssa/isris/dcat/Agreement/{agreement.pk}",
+            "type": "Agreement",
+            "profile": "http://www.w3.org/ns/odrl/profile/core",
+            "issued": odrl_content["issued"],
+            "assigner": [
+                {
+                    "uid": str(assigner_organization.pk),
+                    "ex:companyName": assigner_organization.title,
+                    "ex:companyCode": assigner_organization.company_code,
+                    "ex:address": assigner_organization.address,
+                    "ex:representative": agreement.assigner_representative_full_name,
+                    "ex:email": assigner_organization.email,
+                    "ex:phone": assigner_organization.phone,
+                    "ex:personalCode": " - ",
+                }
+            ],
+            "assignee": [
+                {
+                    "uid": str(assignee_organization.pk),
+                    "ex:companyName": assignee_organization.title,
+                    "ex:companyCode": assignee_organization.company_code,
+                    "ex:address": assignee_organization.address,
+                    "ex:representative": agreement.assignee_representative_full_name,
+                    "ex:email": assignee_organization.email,
+                    "ex:phone": assignee_organization.phone,
+                    "ex:personalCode": " - ",
+                }
+            ],
+            "permission": [
+                {
+                    "target": {
+                        "uid": dataset.pk,
+                        "ex:name": dataset.title,
+                        "ex:scopes": [],
+                    }
+                }
+            ],
+            "ex:paymentTerms": agreement.payment_terms,
+            "ex:otherAssignerLegislations": agreement.other_assigner_legislations,
+            "ex:otherAssigneeLegislations": project.other_assignee_legislations,
+        }
+
+        assert not contract.is_template
+        assert contract.checksum
+        contract.file.seek(0)
+        contract_content = extract_text(io.BytesIO(contract.file.read()))
+        expected_contract_values = [
+            odrl_content["issued"],
+            odrl_content["assigner"][0]["ex:companyName"],
+            odrl_content["assigner"][0]["ex:companyCode"],
+            odrl_content["assigner"][0]["ex:address"].split("\n")[0],
+            odrl_content["assigner"][0]["ex:email"],
+            odrl_content["assigner"][0]["ex:phone"],
+            odrl_content["assigner"][0]["ex:representative"],
+            odrl_content["assigner"][0]["ex:personalCode"],
+            odrl_content["assignee"][0]["ex:companyName"],
+            odrl_content["assignee"][0]["ex:companyCode"],
+            odrl_content["assignee"][0]["ex:address"].split("\n")[0],
+            odrl_content["assignee"][0]["ex:email"],
+            odrl_content["assignee"][0]["ex:phone"],
+            odrl_content["assignee"][0]["ex:representative"],
+            odrl_content["assignee"][0]["ex:personalCode"],
+            odrl_content["permission"][0]["target"]["ex:name"],
+            *odrl_content["permission"][0]["target"].get("ex:scopes", []),
+            odrl_content["ex:paymentTerms"],
+            odrl_content["ex:otherAssignerLegislations"],
+            odrl_content["ex:otherAssigneeLegislations"],
+        ]
+        # Ensure all required values from odrl were transferred to the contract.
+        for index, value in enumerate(expected_contract_values):
+            if value := str(value).strip():
+                assert value in contract_content, f"Expected '{value}' (index={index}) not found in PDF."
+
+        assert template_copy.is_template
+        assert template_copy.file.path != template.file.path
+        assert template_copy.file.read() == template.file.read()
+        assert template_copy.checksum
+
+    def test_unauthorized_not_representative(self, app, dataset: Dataset):
+        """Assigner without representative rights cannot form agreement."""
+        template = SmartContractTemplate.objects.create(
+            file=ContentFile(
+                open(settings.BASE_DIR / "tests/smart_contracts/files/contract_template.md").read(),
+                name="contract_template.md",
+            )
+        )
+
+        assignee_organization, assigner_organization = OrganizationFactory.create_batch(2)
+        dataset.organization = assignee_organization
+        dataset.save()
+
+        assigner_user = UserFactory(
+            organization=assigner_organization,
+            is_viisp_login=True,
+            viisp_company_code=assigner_organization.company_code,
+        )
+        app.set_user(assigner_user)
+
+        # No signing rights
+        RepresentativeFactory(user=assigner_user, content_object=assigner_organization, can_make_agreements=False)
+
+        assignee_user = UserFactory(
+            organization=assignee_organization,
+            is_viisp_login=True,
+            viisp_company_code=assignee_organization.company_code,
+        )
+
+        assignee_contact = ContactFactory(
+            organization=assignee_organization,
+            object_id=assignee_user.pk,
+            content_type=ContentType.objects.get_for_model(User),
+            email=assignee_user.email,
+            phone=assignee_user.phone,
+        )
+        assigner_contact = ContactFactory(
+            organization=assigner_organization,
+            object_id=assigner_user.pk,
+            content_type=ContentType.objects.get_for_model(User),
+            email=assigner_user.email,
+            phone=assigner_user.phone,
+        )
+
+        project = ProjectFactory(
+            organization=assignee_organization,
+            datasets=[dataset],
+            other_assignee_legislations="Test",
+        )
+
+        agreement = AgreementFactory(
+            template=template,
+            project=project,
+            assignee=assignee_organization,
+            assignee_representative=assignee_contact,
+            assigner=assigner_organization,
+            assigner_representative=assigner_contact,
+            other_assigner_legislations="Legislation D; Legislation E; Legislation F.",
+            payment_terms="Payment term A; Payment term B.",
+            created_by=assigner_user,
+            status=AgreementStatuses.APPROVED,
+        )
+
+        response = app.post(
+            reverse("organization-agreement-form", args=[assigner_organization.pk, agreement.pk]),
+            {},
+            expect_errors=True,
+        )
+
+        assert response.status_code == 403
+        agreement.refresh_from_db()
+        assert agreement.status == AgreementStatuses.APPROVED
+        assert not agreement.files.exists()
+
+    def test_unauthorized_not_viisp_authorized(self, app, dataset: Dataset):
+        """Assigner not VIISP-authorized cannot form an agreement."""
+        template = SmartContractTemplate.objects.create(
+            file=ContentFile(
+                open(settings.BASE_DIR / "tests/smart_contracts/files/contract_template.md").read(),
+                name="contract_template.md",
+            )
+        )
+
+        assignee_organization, assigner_organization = OrganizationFactory.create_batch(2)
+        dataset.organization = assignee_organization
+        dataset.save()
+
+        assigner_user = UserFactory(
+            organization=assigner_organization,
+            is_viisp_login=False,
+            viisp_company_code="invalid",
+        )
+        app.set_user(assigner_user)
+
+        # Has signing rights but invalid Viisp
+        RepresentativeFactory(user=assigner_user, content_object=assigner_organization, can_make_agreements=True)
+
+        assignee_user = UserFactory(
+            organization=assignee_organization,
+            is_viisp_login=True,
+            viisp_company_code=assignee_organization.company_code,
+        )
+
+        assignee_contact = ContactFactory(
+            organization=assignee_organization,
+            object_id=assignee_user.pk,
+            content_type=ContentType.objects.get_for_model(User),
+            email=assignee_user.email,
+            phone=assignee_user.phone,
+        )
+        assigner_contact = ContactFactory(
+            organization=assigner_organization,
+            object_id=assigner_user.pk,
+            content_type=ContentType.objects.get_for_model(User),
+            email=assigner_user.email,
+            phone=assigner_user.phone,
+        )
+
+        project = ProjectFactory(
+            organization=assignee_organization,
+            datasets=[dataset],
+            other_assignee_legislations="Test",
+        )
+
+        agreement = AgreementFactory(
+            template=template,
+            project=project,
+            assignee=assignee_organization,
+            assignee_representative=assignee_contact,
+            assigner=assigner_organization,
+            assigner_representative=assigner_contact,
+            other_assigner_legislations="Legislation D; Legislation E; Legislation F.",
+            payment_terms="Payment term A; Payment term B.",
+            created_by=assigner_user,
+            status=AgreementStatuses.APPROVED,
+        )
+
+        response = app.post(
+            reverse("organization-agreement-form", args=[assigner_organization.pk, agreement.pk]),
+            {},
+            expect_errors=True,
+        )
+
+        assert response.status_code == 403
+        agreement.refresh_from_db()
+        assert agreement.status == AgreementStatuses.APPROVED
+        assert not agreement.files.exists()
+
+    @pytest.mark.parametrize("initial_status", [
+        AgreementStatuses.CREATED,
+        AgreementStatuses.SUBMITTED,
+        AgreementStatuses.FORMED,
+        AgreementStatuses.INITIATED,
+        AgreementStatuses.SIGNED,
+        AgreementStatuses.ACTIVE,
+        AgreementStatuses.TERMINATED,
+    ])
+    def test_incorrect_agreement_status(self, initial_status, app, dataset: Dataset):
+        """Cannot form an agreement if status is not APPROVED."""
+        template = SmartContractTemplate.objects.create(
+            file=ContentFile(
+                open(settings.BASE_DIR / "tests/smart_contracts/files/contract_template.md").read(),
+                name="contract_template.md",
+            )
+        )
+
+        assignee_organization, assigner_organization = OrganizationFactory.create_batch(2)
+        dataset.organization = assignee_organization
+        dataset.save()
+
+        assigner_user = UserFactory(
+            organization=assigner_organization,
+            is_viisp_login=True,
+            viisp_company_code=assigner_organization.company_code,
+        )
+        app.set_user(assigner_user)
+
+        RepresentativeFactory(user=assigner_user, content_object=assigner_organization, can_make_agreements=True)
+
+        assignee_user = UserFactory(
+            organization=assignee_organization,
+            is_viisp_login=True,
+            viisp_company_code=assignee_organization.company_code,
+        )
+
+        assignee_contact = ContactFactory(
+            organization=assignee_organization,
+            object_id=assignee_user.pk,
+            content_type=ContentType.objects.get_for_model(User),
+            email=assignee_user.email,
+            phone=assignee_user.phone,
+        )
+
+        project = ProjectFactory(
+            organization=assignee_organization,
+            datasets=[dataset],
+            other_assignee_legislations="Test",
+        )
+
+        agreement = AgreementFactory(
+            template=template,
+            project=project,
+            assignee=assignee_organization,
+            assignee_representative=assignee_contact,
+            assigner=assigner_organization,
+            assigner_representative=assignee_contact,
+            other_assigner_legislations="Legislation D; Legislation E; Legislation F.",
+            payment_terms="Payment term A; Payment term B.",
+            created_by=assigner_user,
+            status=initial_status,
+        )
+
+        response = app.post(
+            reverse("organization-agreement-form", args=[assigner_organization.pk, agreement.pk]),
+            {},
+            expect_errors=True,
+        )
+
+        assert response.status_code == 302
+        agreement.refresh_from_db()
+        assert agreement.status == initial_status
+        assert not agreement.files.exists()
+
+
+class TestOrganizationBasedAgreementNegotiateSign:
+    def test_success(self, app: DjangoTestApp, agreement_pdf: Path, agreement_two_signers: str, odrl_json: Path):
+        # Arrange
+        template = SmartContractTemplate.objects.create(
+            file=ContentFile("### Template content", name="contract_template.md")
+        )
+
+        assigner_organization, assignee_organization = OrganizationFactory.create_batch(2)
+        assigner_user = UserFactory(
+            organization=assigner_organization,
+            is_viisp_login=True,
+            viisp_company_code=assigner_organization.company_code,
+        )
+        assignee_user = UserFactory(
+            organization=assignee_organization,
+            is_viisp_login=True,
+            viisp_company_code=assignee_organization.company_code,
+        )
+
+        RepresentativeFactory(user=assigner_user, content_object=assigner_organization, can_make_agreements=True)
+        assigner_contact = ContactFactory(
+            organization=assigner_organization,
+            object_id=assigner_user.pk,
+            content_type=ContentType.objects.get_for_model(User),
+            email=assigner_user.email,
+            phone=assigner_user.email,
+        )
+        ContactFactory(
+            organization=assignee_organization,
+            object_id=assignee_user.pk,
+            content_type=ContentType.objects.get_for_model(User),
+            email=assignee_user.email,
+            phone=assignee_user.email,
+        )
+
+        project = ProjectFactory(organization=assignee_organization)
+        agreement = AgreementFactory(
+            template=template,
+            project=project,
+            assignee=assignee_organization,
+            assigner=assigner_organization,
+            assigner_representative=assigner_contact,
+            status=AgreementStatuses.INITIATED,
+            created_by=assignee_user,
+        )
+
+        AgreementJSONFileFactory(agreement=agreement, json_path=odrl_json)
+        AgreementPDFFileFactory(agreement=agreement, pdf_path=agreement_pdf)
+        app.set_user(assigner_user)
+
+        # Act
+        response = app.post(
+            reverse("organization-agreement-sign", args=[assigner_organization.pk, agreement.pk]),
+            upload_files=[("file", "agreement.adoc", agreement_two_signers.read_bytes(), "text/plain")]
+        )
+
+        # Assert
+        assert response.status_code == 302
+        agreement.refresh_from_db()
+        assert agreement.status == AgreementStatuses.SIGNED
+        assert agreement.is_agent_sync_enabled
+
+    @pytest.mark.parametrize("initial_status", [
+        AgreementStatuses.CREATED,
+        AgreementStatuses.SUBMITTED,
+        AgreementStatuses.APPROVED,
+        AgreementStatuses.SIGNED,
+        AgreementStatuses.ACTIVE,
+        AgreementStatuses.TERMINATED,
+    ])
+    def test_incorrect_status(
+            self, initial_status, app: DjangoTestApp, agreement_pdf: Path, agreement_two_signers: str, odrl_json: Path
+    ):
+        # Arrange
+        template = SmartContractTemplate.objects.create(
+            file=ContentFile("### Template content", name="contract_template.md")
+        )
+
+        assigner_organization, assignee_organization = OrganizationFactory.create_batch(2)
+        assigner_user = UserFactory(organization=assigner_organization, is_viisp_login=True,
+                                    viisp_company_code=assigner_organization.company_code)
+        assignee_user = UserFactory(organization=assignee_organization, is_viisp_login=True,
+                                    viisp_company_code=assignee_organization.company_code)
+
+        RepresentativeFactory(user=assigner_user, content_object=assigner_organization, can_make_agreements=True)
+        assigner_contact = ContactFactory(
+            organization=assigner_organization,
+            object_id=assigner_user.pk,
+            content_type=ContentType.objects.get_for_model(User),
+            email=assigner_user.email,
+            phone=assigner_user.email,
+        )
+        ContactFactory(
+            organization=assignee_organization,
+            object_id=assignee_user.pk,
+            content_type=ContentType.objects.get_for_model(User),
+            email=assignee_user.email,
+            phone=assignee_user.email,
+        )
+
+        project = ProjectFactory(organization=assignee_organization)
+        agreement = AgreementFactory(
+            template=template,
+            project=project,
+            assignee=assignee_organization,
+            assigner=assigner_organization,
+            assigner_representative=assigner_contact,
+            status=initial_status,
+            created_by=assignee_user,
+        )
+
+        AgreementJSONFileFactory(agreement=agreement, json_path=odrl_json)
+        AgreementPDFFileFactory(agreement=agreement, pdf_path=agreement_pdf)
+        app.set_user(assigner_user)
+
+        # Act
+        response = app.post(
+            reverse("organization-agreement-sign", args=[assigner_organization.pk, agreement.pk]),
+            upload_files=[("file", "agreement.adoc", agreement_two_signers.read_bytes(), "text/plain")],
+            expect_errors=True
+        )
+
+        # Assert
+        assert response.status_code == 200
+        assert "form" in response.context
+        assert "Pasirašyti galima tik sutartis su būsenomis" in str(response.context["form"].errors.get("file", ""))
+        agreement.refresh_from_db()
+        assert agreement.status == initial_status
+
+    def test_pdf_file_missing(self, app: DjangoTestApp, agreement_two_signers: str):
+        # Arrange
+        template = SmartContractTemplate.objects.create(
+            file=ContentFile("### Template content", name="contract_template.md")
+        )
+
+        assigner_organization, assignee_organization = OrganizationFactory.create_batch(2)
+        assigner_user = UserFactory(
+            organization=assigner_organization,
+            viisp_company_code=assigner_organization.company_code,
+            is_viisp_login=True,
+        )
+        assignee_user = UserFactory(organization=assignee_organization)
+
+        RepresentativeFactory(user=assigner_user, content_object=assigner_organization, can_make_agreements=True)
+        assigner_contact = ContactFactory(
+            organization=assigner_organization,
+            object_id=assigner_user.pk,
+            content_type=ContentType.objects.get_for_model(User),
+        )
+
+        project = ProjectFactory(organization=assignee_organization)
+        agreement = AgreementFactory(
+            template=template,
+            project=project,
+            assignee=assignee_organization,
+            assigner=assigner_organization,
+            assigner_representative=assigner_contact,
+            status=AgreementStatuses.INITIATED,
+            created_by=assignee_user,
+        )
+
+        app.set_user(assigner_user)
+
+        # Act
+        response = app.post(
+            reverse("organization-agreement-sign", args=[assigner_organization.pk, agreement.pk]),
+            upload_files=[("file", "agreement.adoc", agreement_two_signers.read_bytes(), "text/plain")],
+        )
+
+        # Assert
+        assert response.status_code == 302
+        # Expect an error message about missing PDF
+        agreement.refresh_from_db()
+        assert agreement.status == AgreementStatuses.INITIATED
+
+    def test_multiple_pdf_files(self, app: DjangoTestApp, agreement_pdf: Path, agreement_two_signers: str):
+        # Arrange
+        template = SmartContractTemplate.objects.create(
+            file=ContentFile("### Template content", name="contract_template.md")
+        )
+
+        assigner_organization, assignee_organization = OrganizationFactory.create_batch(2)
+        assigner_user = UserFactory(
+            organization=assigner_organization,
+            viisp_company_code=assigner_organization.company_code,
+            is_viisp_login=True,
+        )
+        assignee_user = UserFactory(organization=assignee_organization)
+
+        RepresentativeFactory(user=assigner_user, content_object=assigner_organization, can_make_agreements=True)
+        assigner_contact = ContactFactory(
+            organization=assigner_organization,
+            object_id=assigner_user.pk,
+            content_type=ContentType.objects.get_for_model(User),
+        )
+
+        project = ProjectFactory(organization=assignee_organization)
+        agreement = AgreementFactory(
+            template=template,
+            project=project,
+            assignee=assignee_organization,
+            assigner=assigner_organization,
+            assigner_representative=assigner_contact,
+            status=AgreementStatuses.INITIATED,
+            created_by=assignee_user,
+        )
+
+        # Two PDFs
+        AgreementPDFFileFactory(agreement=agreement, pdf_path=agreement_pdf)
+        AgreementPDFFileFactory(agreement=agreement, pdf_path=agreement_pdf)
+        app.set_user(assigner_user)
+
+        # Act
+        response = app.post(
+            reverse("organization-agreement-sign", args=[assigner_organization.pk, agreement.pk]),
+            upload_files=[("file", "agreement.adoc", agreement_two_signers.read_bytes(), "text/plain")]
+        )
+
+        # Assert
+        assert response.status_code == 302
+        agreement.refresh_from_db()
+        assert agreement.status == AgreementStatuses.INITIATED
+
+    def test_wrong_signer(self, app: DjangoTestApp, agreement_pdf: Path, agreement_two_signers: str, odrl_json: Path):
+        # Arrange
+        template = SmartContractTemplate.objects.create(
+            file=ContentFile("### Template content", name="contract_template.md")
+        )
+
+        assigner_organization, assignee_organization = OrganizationFactory.create_batch(2)
+        wrong_user = UserFactory(organization=assignee_organization)  # Not assigner
+        assignee_user = UserFactory(organization=assignee_organization)
+
+        RepresentativeFactory(user=wrong_user, content_object=assigner_organization, can_make_agreements=True)
+        assigner_contact = ContactFactory(
+            organization=assigner_organization,
+            object_id=wrong_user.pk,
+            content_type=ContentType.objects.get_for_model(User),
+        )
+
+        project = ProjectFactory(organization=assignee_organization)
+        agreement = AgreementFactory(
+            template=template,
+            project=project,
+            assignee=assignee_organization,
+            assigner=assigner_organization,
+            assigner_representative=assigner_contact,
+            status=AgreementStatuses.INITIATED,
+            created_by=assignee_user,
+        )
+
+        AgreementJSONFileFactory(agreement=agreement, json_path=odrl_json)
+        AgreementPDFFileFactory(agreement=agreement, pdf_path=agreement_pdf)
+        app.set_user(wrong_user)
+
+        # Act
+        response = app.post(
+            reverse("organization-agreement-sign", args=[assigner_organization.pk, agreement.pk]),
+            upload_files=[("file", "agreement.adoc", agreement_two_signers.read_bytes(), "text/plain")],
+            expect_errors=True,
+        )
+
+        # Assert
+        assert response.status_code == 403
+        agreement.refresh_from_db()
+        # Status should not change because the wrong user tried to sign
+        assert agreement.status == AgreementStatuses.INITIATED

--- a/tests/smart_contracts/test_views.py
+++ b/tests/smart_contracts/test_views.py
@@ -32,7 +32,7 @@ pytestmark = pytest.mark.django_db
 test_contracts_dir = Path(__file__).parent / "files" / "test_contracts"
 
 
-class TestProjectAgreementListView:
+class TestProjectBasedAgreementListView:
     def test_cannot_list_for_personal_project(self, app: DjangoTestApp) -> None:
         user = UserFactory()
         project = ProjectFactory(user=user)
@@ -95,7 +95,7 @@ class TestProjectAgreementListView:
         assert response.context["agreements"].count() == 1
 
 
-class TestProjectAgreementDetailView:
+class TestProjectBasedAgreementDetailView:
     def test_cannot_show_details_without_permission(
         self, app: DjangoTestApp, organization: Organization
     ) -> None:

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -2883,6 +2883,12 @@ msgstr "Add contact"
 msgid "Kontaktų redagavimas"
 msgstr "Contact editing"
 
+msgid "Organizacijos sutartys"
+msgstr "Organization agreements"
+
+msgid "Sutartis"
+msgstr "Agreement"
+
 msgid "Organizacijos redagavimas"
 msgstr "Edit organization"
 
@@ -3806,6 +3812,9 @@ msgstr "The attached file is not a ZIP archive."
 msgid "Įkelti pasirašytą dokumentą (Gavėjo)"
 msgstr "Upload document signed by data receiver"
 
+msgid "Veiksmas įvykdytas sėkmingai."
+msgstr "Action was executed successfully"
+
 msgid ""
 "Veiksmas gali būti atliekamas tik sutarčiai esant būsenoje "
 "{expected_status}.Dabartinė būsena: {current_status}."
@@ -3827,8 +3836,8 @@ msgstr "The proposal has been successfully submitted to the data provider."
 msgid "Pasiūlymas sėkmingai patvirtintas."
 msgstr "Proposal was successfully confirmed."
 
-msgid "Sutarties dokumentas sukurtas"
-msgstr "Agreement document is created"
+msgid "Sutarties dokumentas sukurtas sėkmingai."
+msgstr "Agreement document created successfully"
 
 msgid "Įkelti pasirašytą sutartį"
 msgstr "Upload signed document"
@@ -3868,9 +3877,6 @@ msgstr "Legal basis for data provision (obligation)"
 
 msgid "Mokėjimo sąlygos"
 msgstr "Payment terms"
-
-msgid "Sutartis"
-msgstr "Agreement"
 
 #, python-brace-format
 msgid "Sutartis: {organization}"

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -2768,6 +2768,21 @@ msgstr "Use case"
 msgid "Paskutinės sinchronizacijos data"
 msgstr "Date of last synchronization"
 
+msgid "Laukiama gavėjo veiksmų"
+msgstr "Awaiting for the recipient's actions"
+
+msgid "Peržiūrėti pateiktą pasiūlymą"
+msgstr "Review proposal"
+
+msgid "Formuoti sutartį"
+msgstr "Form agreement"
+
+msgid "Laukiama kol gavėjas įkels pasirašytą dokumentą"
+msgstr "Awaiting for signed document upload by data recipient (assignee)"
+
+msgid "Įkelti pasirašytą dokumentą (Teikėjo)"
+msgstr "Upload document signed by data receiver"
+
 msgid "Informacija duomenų teikėjo registravimui"
 msgstr "Data provider information for registration"
 
@@ -3778,9 +3793,6 @@ msgstr "Submit proposal"
 msgid "Patvirtinti pasiūlymą"
 msgstr "Confirm proposal"
 
-msgid "Formuoti sutartį"
-msgstr "Form agreement"
-
 msgid "Dokumentas turi būti adoc formato."
 msgstr "The document must be in adoc format."
 
@@ -3794,8 +3806,41 @@ msgstr "The attached file is not a ZIP archive."
 msgid "Įkelti pasirašytą dokumentą (Gavėjo)"
 msgstr "Upload document signed by data receiver"
 
-msgid "Įkelti pasirašytą dokumentą (Teikėjo)"
-msgstr "Upload document signed by data receiver"
+msgid ""
+"Veiksmas gali būti atliekamas tik sutarčiai esant būsenoje "
+"{expected_status}.Dabartinė būsena: {current_status}."
+msgstr ""
+"The action can only be executed when the agreement has the status "
+"{expected_status}. Current status: {current_status}"
+
+msgid "PDF failas sutarčiai nėra sukurtas."
+msgstr "PDF file for the agreement is not created."
+
+msgid "Rasti keli PDF failai. Susisiekite su administratoriumi."
+msgstr ""
+"Multiple PDF files were found related to the agreement. Please contact the "
+"administrator."
+
+msgid "Pasiūlymas sėkmingai pateiktas duomenų teikėjui."
+msgstr "The proposal has been successfully submitted to the data provider."
+
+msgid "Pasiūlymas sėkmingai patvirtintas."
+msgstr "Proposal was successfully confirmed."
+
+msgid "Sutarties dokumentas sukurtas"
+msgstr "Agreement document is created"
+
+msgid "Įkelti pasirašytą sutartį"
+msgstr "Upload signed document"
+
+msgid "Sutarties dokumentas įkeltas sėkmingai."
+msgstr "Agreement document uploaded successfully"
+
+msgid "Šią sutartį šiuo metu turi pasirašyti duomenų gavėjo atstovas."
+msgstr "Agreement document needs to be signed by data recipient first."
+
+msgid "Šią sutartį šiuo metu turi pasirašyti duomenų teikėjo atstovas."
+msgstr "Agreement document needs to be signed by data provider."
 
 msgid "Failas turi būti Markdown formato (.md)."
 msgstr "File must be in Markdown format (.md)."
@@ -3926,47 +3971,11 @@ msgstr "Invalid ADOC file: {error}"
 msgid "Generuoti sutartis"
 msgstr "Generate agreements"
 
-msgid "Grįžti į sutartis"
-msgstr "Go back to agreements"
-
-msgid "Laukiama gavėjo veiksmų"
-msgstr "Awaiting for the recipient's actions"
-
-msgid "Peržiūrėti pateiktą pasiūlymą"
-msgstr "Review proposal"
-
 msgid "Laukiama teikėjo patvirtinimo"
 msgstr "Waiting for confirmation from the provider"
 
-msgid "Laukiama kol gavėjas įkels pasirašytą dokumentą"
-msgstr "Awaiting for signed document upload by data recipient (assignee)"
-
 msgid "Laukiama kol teikėjas įkels pasirašytą dokumentą"
 msgstr "Awaiting for signed document upload by data provider (assigner)"
-
-msgid "Sutarties identifikatorius"
-msgstr "Agreement id"
-
-msgid "Nėra sutarčių dokumentų."
-msgstr "No agreement documents."
-
-msgid "Sutarties derinimo informacija"
-msgstr "Agreement negotation information"
-
-msgid "Nėra susietų duomenų išteklių."
-msgstr "No related datasets found."
-
-msgid "Duomenų gavimo tikslas"
-msgstr "Purpose of data acquisition"
-
-msgid "Nėra pasirinktas duomenų gavėjo atstovas."
-msgstr "Data receiver representative is not selected."
-
-msgid "Nėra pasirinktas duomenų teikėjo atstovas."
-msgstr "Data provider representative is not selected."
-
-msgid "Šablono failas nepridėtas."
-msgstr "Template file is not added."
 
 msgid ""
 "Panaudojimo atvejis registruotas fizinio asmens vardu negali turėti sutarčių."
@@ -3984,44 +3993,6 @@ msgstr "Agreements generated successfully"
 
 msgid "Sutarčių generavime kilo klaidų"
 msgstr "Errors occurred while generating agreements"
-
-#, python-brace-format
-msgid ""
-"Veiksmas gali būti atliekamas tik sutarčiai esant būsenoje "
-"{expected_status}.Dabartinė būsena: {current_status}."
-msgstr ""
-"The action can only be executed when the agreement has the status "
-"{expected_status}. Current status: {current_status}"
-
-msgid "Pasiūlymas sėkmingai pateiktas duomenų teikėjui."
-msgstr "The proposal has been successfully submitted to the data provider."
-
-msgid "Pasiūlymas sėkmingai patvirtintas."
-msgstr "Proposal was successfully confirmed."
-
-msgid "Sutarties dokumentas sukurtas"
-msgstr "Agreement document is created"
-
-msgid "PDF failas sutarčiai nėra sukurtas."
-msgstr "PDF file for the agreement is not created."
-
-msgid ""
-"Rasti keli PDF failai susieti su sutartimi. Susisiekite su administratoriumi."
-msgstr ""
-"Multiple PDF files were found related to the agreement. Please contact the "
-"administrator."
-
-msgid "Įkelti pasirašytą sutartį"
-msgstr "Upload signed document"
-
-msgid "Šią sutartį šiuo metu turi pasirašyti duomenų gavėjo atstovas"
-msgstr "Agreement document needs to be signed by data recipient first."
-
-msgid "Sutarties dokumentas įkeltas sėkmingai"
-msgstr "Agreement document uploaded successfully"
-
-msgid "Šią sutartį šiuo metu turi pasirašyti duomenų teikėjo atstovas."
-msgstr "Agreement document needs to be signed by data provider."
 
 msgid "Rodoma tituliniame puslapyje"
 msgstr "Shown in home page"
@@ -5146,8 +5117,35 @@ msgstr "Register request to open data"
 msgid "Statistika"
 msgstr "Statistics"
 
+msgid "Grįžti į sutartis"
+msgstr "Go back to agreements"
+
+msgid "Sutarties identifikatorius"
+msgstr "Agreement id"
+
+msgid "Nėra sutarčių dokumentų."
+msgstr "No agreement documents."
+
 msgid "Nėra sutarčių."
 msgstr "No agreements."
+
+msgid "Sutarties derinimo informacija"
+msgstr "Agreement negotation information"
+
+msgid "Nėra susietų duomenų išteklių."
+msgstr "No related datasets found."
+
+msgid "Duomenų gavimo tikslas"
+msgstr "Purpose of data acquisition"
+
+msgid "Nėra pasirinktas duomenų gavėjo atstovas."
+msgstr "Data receiver representative is not selected."
+
+msgid "Nėra pasirinktas duomenų teikėjo atstovas."
+msgstr "Data provider representative is not selected."
+
+msgid "Šablono failas nepridėtas."
+msgstr "Template file is not added."
 
 msgid "Pradinis"
 msgstr "First"

--- a/vitrina/orgs/templates/vitrina/orgs/organization_agreements.html
+++ b/vitrina/orgs/templates/vitrina/orgs/organization_agreements.html
@@ -32,7 +32,17 @@
             {{ agreement.get_status_display }}
             <span class="icon info-icon has-tooltip-multiline is-middle"
                   data-tooltip="{{ agreement_status_descriptions|get_item:agreement.status }}">
-                <i class="fas fa-info-circle"></i>
+                <i class="fas fa-info-circle
+                    {% if agreement.status in 'SUBMITTED,APPROVED,INITIATED' %}
+                        has-text-warning
+                    {% elif agreement.status in 'ACTIVE,SIGNED' %}
+                        has-text-success
+                    {% elif agreement.status in 'CREATED,FORMED' %}
+                        has-text-danger
+                    {% elif agreement.status == 'TERMINATED' %}
+                        has-text-black
+                    {% endif %}
+                "></i>
             </span>
         </td>
 

--- a/vitrina/orgs/templates/vitrina/orgs/organization_agreements.html
+++ b/vitrina/orgs/templates/vitrina/orgs/organization_agreements.html
@@ -37,9 +37,7 @@
                         has-text-warning
                     {% elif agreement.status in 'ACTIVE,SIGNED' %}
                         has-text-success
-                    {% elif agreement.status in 'CREATED,FORMED' %}
-                        has-text-danger
-                    {% elif agreement.status == 'TERMINATED' %}
+                    {% else %}
                         has-text-black
                     {% endif %}
                 "></i>

--- a/vitrina/orgs/templates/vitrina/orgs/organization_agreements_detail.html
+++ b/vitrina/orgs/templates/vitrina/orgs/organization_agreements_detail.html
@@ -17,23 +17,23 @@
             </button>
         {% elif agreement.status == "SUBMITTED" %}
             {% if can_approve_agreements %}
-{#                <a href="{% url "organization-agreement-approve" project.pk agreement.pk %}" class="button is-primary m-t-xs m-b-lg">#}
+                <a href="{% url "organization-agreement-approve" organization.pk agreement.pk %}" class="button is-primary m-t-xs m-b-lg">
                     {% translate "Peržiūrėti pateiktą pasiūlymą" %}
-{#                </a>#}
+                </a>
             {% endif %}
         {% elif can_form_agreements and agreement.status == "APPROVED" %}
-{#            <a href="{% url "organization-agreement-form" project.pk agreement.pk %}" class="button is-primary m-t-xs m-b-lg">#}
+            <a href="{% url "organization-agreement-form" organization.pk agreement.pk %}" class="button is-primary m-t-xs m-b-lg">
                 {% translate "Formuoti sutartį" %}
-{#            </a>#}
+            </a>
         {% elif agreement.status == "FORMED" %}
             <button class="button is-primary m-t-xs m-b-lg" disabled>
                 {% translate "Laukiama kol gavėjas įkels pasirašytą dokumentą" %}
             </button>
         {% elif agreement.status == "INITIATED" %}
             {% if can_sign_agreements %}
-{#                <a href="{% url "organization-agreement-sign" project.pk agreement.pk %}" class="button is-primary m-t-xs m-b-lg">#}
+                <a href="{% url "organization-agreement-sign" organization.pk agreement.pk %}" class="button is-primary m-t-xs m-b-lg">
                     {% translate "Įkelti pasirašytą dokumentą (Teikėjo)" %}
-{#                </a>#}
+                </a>
             {% endif %}
         {% endif %}
     </div>

--- a/vitrina/orgs/templates/vitrina/orgs/organization_agreements_detail.html
+++ b/vitrina/orgs/templates/vitrina/orgs/organization_agreements_detail.html
@@ -15,12 +15,10 @@
             <button class="button is-primary m-t-xs m-b-lg" disabled>
                 {% translate "Laukiama gavėjo veiksmų" %}
             </button>
-        {% elif agreement.status == "SUBMITTED" %}
-            {% if can_approve_agreements %}
-                <a href="{% url "organization-agreement-approve" organization.pk agreement.pk %}" class="button is-primary m-t-xs m-b-lg">
-                    {% translate "Peržiūrėti pateiktą pasiūlymą" %}
-                </a>
-            {% endif %}
+        {% elif agreement.status == "SUBMITTED" and can_approve_agreements %}
+            <a href="{% url "organization-agreement-approve" organization.pk agreement.pk %}" class="button is-primary m-t-xs m-b-lg">
+                {% translate "Peržiūrėti pateiktą pasiūlymą" %}
+            </a>
         {% elif can_form_agreements and agreement.status == "APPROVED" %}
             <a href="{% url "organization-agreement-form" organization.pk agreement.pk %}" class="button is-primary m-t-xs m-b-lg">
                 {% translate "Formuoti sutartį" %}
@@ -29,12 +27,10 @@
             <button class="button is-primary m-t-xs m-b-lg" disabled>
                 {% translate "Laukiama kol gavėjas įkels pasirašytą dokumentą" %}
             </button>
-        {% elif agreement.status == "INITIATED" %}
-            {% if can_sign_agreements %}
-                <a href="{% url "organization-agreement-sign" organization.pk agreement.pk %}" class="button is-primary m-t-xs m-b-lg">
-                    {% translate "Įkelti pasirašytą dokumentą (Teikėjo)" %}
-                </a>
-            {% endif %}
+        {% elif agreement.status == "INITIATED" and can_sign_agreements %}
+            <a href="{% url "organization-agreement-sign" organization.pk agreement.pk %}" class="button is-primary m-t-xs m-b-lg">
+                {% translate "Įkelti pasirašytą dokumentą (Teikėjo)" %}
+            </a>
         {% endif %}
     </div>
 {% endblock %}

--- a/vitrina/orgs/templates/vitrina/orgs/organization_based_agreement_negotiate.html
+++ b/vitrina/orgs/templates/vitrina/orgs/organization_based_agreement_negotiate.html
@@ -1,4 +1,4 @@
 {% extends "vitrina/agreements/base_agreement_negotiate.html" %}
 {% block tabs %}
-    {% include "vitrina/projects/tabs.html" %}
+    {% include "vitrina/orgs/tabs.html" %}
 {% endblock %}

--- a/vitrina/orgs/urls.py
+++ b/vitrina/orgs/urls.py
@@ -29,8 +29,8 @@ from vitrina.orgs.views import (
     ContactDeleteView,
     create_remote_organization,
     check_organization,
-    OrganizationAgreementListView,
-    OrganizationAgreementDetailView,
+    OrganizationBasedAgreementListView,
+    OrganizationBasedAgreementDetailView,
     OrganizationBasedAgreementApproveView,
     OrganizationBasedAgreementFormView,
     OrganizationBasedAgreementSignView,
@@ -141,12 +141,12 @@ urlpatterns = [
     ),
     path(
         "orgs/<int:pk>/agreements/",
-        OrganizationAgreementListView.as_view(),
+        OrganizationBasedAgreementListView.as_view(),
         name="organization-agreement-list",
     ),
     path(
         "orgs/<int:pk>/agreements/<uuid:agreement_id>/",
-        OrganizationAgreementDetailView.as_view(),
+        OrganizationBasedAgreementDetailView.as_view(),
         name="organization-agreement-detail",
     ),
     path(

--- a/vitrina/orgs/urls.py
+++ b/vitrina/orgs/urls.py
@@ -31,6 +31,9 @@ from vitrina.orgs.views import (
     check_organization,
     OrganizationAgreementListView,
     OrganizationAgreementDetailView,
+    OrganizationBasedAgreementApproveView,
+    OrganizationBasedAgreementFormView,
+    OrganizationBasedAgreementSignView,
 )
 from vitrina.orgs.views import (
     OrganizationDetailView,
@@ -147,9 +150,19 @@ urlpatterns = [
         name="organization-agreement-detail",
     ),
     path(
-        "orgs/<int:pk>/agreements/<uuid:agreement_id>/",
-        OrganizationAgreementDetailView.as_view(),
-        name="organization-agreements-detail",
+        "orgs/<int:pk>/agreements/<uuid:agreement_id>/approve",
+        OrganizationBasedAgreementApproveView.as_view(),
+        name="organization-agreement-approve",
+    ),
+    path(
+        "orgs/<int:pk>/agreements/<uuid:agreement_id>/form",
+        OrganizationBasedAgreementFormView.as_view(),
+        name="organization-agreement-form",
+    ),
+    path(
+        "orgs/<int:pk>/agreements/<uuid:agreement_id>/sign",
+        OrganizationBasedAgreementSignView.as_view(),
+        name="organization-agreement-sign",
     ),
     path(
         "register/<token>/",

--- a/vitrina/orgs/views.py
+++ b/vitrina/orgs/views.py
@@ -850,15 +850,15 @@ class OrganizationBasedAgreementNegotiateMixin(OrganizationBaseViewMixin, Agreem
 
 
 class OrganizationBasedAgreementApproveView(AgreementApproveMixin, OrganizationBasedAgreementNegotiateMixin):
-    pass
+    """Organization-based agreement form view responsible for moving the agreement to status `APPROVED`"""
 
 
 class OrganizationBasedAgreementFormView(AgreementFormMixin, OrganizationBasedAgreementNegotiateMixin):
-    pass
+    """Organization-based agreement form view responsible for moving the agreement to status `FORMED`"""
 
 
 class OrganizationBasedAgreementSignView(AgreementSignMixin, OrganizationBasedAgreementNegotiateMixin):
-    pass
+    """Organization-based agreement form view responsible for moving the agreement to status `SIGNED`"""
 
 
 class OrganizationUpdateView(LoginRequiredMixin, PermissionRequiredMixin, RevisionMixin, UpdateView):

--- a/vitrina/orgs/views.py
+++ b/vitrina/orgs/views.py
@@ -729,7 +729,7 @@ class OrganizationProjectsView(
         return context_data
 
 
-class OrganizationAgreementListView(OrganizationBaseViewMixin, BaseAgreementListView):
+class OrganizationBasedAgreementListView(OrganizationBaseViewMixin, BaseAgreementListView):
     template_name = "vitrina/orgs/organization_agreements.html"
     parent_type = "organization"
 
@@ -773,7 +773,7 @@ class OrganizationAgreementListView(OrganizationBaseViewMixin, BaseAgreementList
         return context
 
 
-class OrganizationAgreementDetailView(OrganizationBaseViewMixin, BaseAgreementDetailView):
+class OrganizationBasedAgreementDetailView(OrganizationBaseViewMixin, BaseAgreementDetailView):
     template_name = "vitrina/orgs/organization_agreements_detail.html"
     parent_type = "organization"
 
@@ -803,8 +803,8 @@ class OrganizationAgreementDetailView(OrganizationBaseViewMixin, BaseAgreementDe
                     reverse("home"): _("Pradžia"),
                     reverse("organization-list"): _("Organizacijos"),
                     reverse("organization-detail", args=[self.organization.pk]): self.organization.title,
-                    reverse("organization-agreement-list", args=[self.organization.pk]): "Sutartys",
-                    None: _("Sutartys"),
+                    reverse("organization-agreement-list", args=[self.organization.pk]): _("Organizacijos sutartys"),
+                    None: _("Sutartis"),
                 },
             }
         )
@@ -813,6 +813,8 @@ class OrganizationAgreementDetailView(OrganizationBaseViewMixin, BaseAgreementDe
 
 
 class OrganizationBasedAgreementNegotiateMixin(OrganizationBaseViewMixin, AgreementNegotiateMixin):
+    """Mixin class used for organization-based agreement status-change views"""
+
     template_name = "vitrina/orgs/organization_based_agreement_negotiate.html"
 
     def get_agreement_queryset(self) -> QuerySet:

--- a/vitrina/orgs/views.py
+++ b/vitrina/orgs/views.py
@@ -14,7 +14,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMix
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.handlers.wsgi import WSGIRequest
-from django.db.models import Q, Count, QuerySet
+from django.db.models import Q, Count, QuerySet, Case, When, IntegerField
 from django.forms import BaseForm
 from django.http import HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
@@ -38,6 +38,13 @@ from reversion.models import Version
 
 from vitrina.classifiers.models import AreaOfManagement
 from vitrina.orgs.permissions import can_view_organization_agreements, can_view_organization_agreement
+from vitrina.smart_contracts import AgreementStatuses
+from vitrina.smart_contracts.mixins import (
+    AgreementNegotiateMixin,
+    AgreementApproveMixin,
+    AgreementSignMixin,
+    AgreementFormMixin,
+)
 from vitrina.smart_contracts.models import Agreement
 from vitrina.smart_contracts.permissions import (
     can_approve_agreements,
@@ -735,7 +742,25 @@ class OrganizationAgreementListView(OrganizationBaseViewMixin, BaseAgreementList
         return can_view_organization_agreements(self.request.user, self.organization)
 
     def get_queryset(self) -> QuerySet:
-        return get_agreements(self.request.user).filter(assigner=self.organization)
+        return (
+            get_agreements(self.request.user)
+            .filter(assigner=self.organization)
+            .annotate(
+                priority=Case(
+                    When(status=AgreementStatuses.ACTIVE, then=0),
+                    When(status=AgreementStatuses.SIGNED, then=1),
+                    When(status=AgreementStatuses.SUBMITTED, then=2),
+                    When(status=AgreementStatuses.APPROVED, then=3),
+                    When(status=AgreementStatuses.INITIATED, then=4),
+                    When(status=AgreementStatuses.CREATED, then=5),
+                    When(status=AgreementStatuses.FORMED, then=6),
+                    When(status=AgreementStatuses.TERMINATED, then=7),
+                    default=8,
+                    output_field=IntegerField(),
+                )
+            )
+            .order_by("priority", "created_at")
+        )
 
     def get_context_data(self, **kwargs: Any) -> dict:
         context = super().get_context_data(**kwargs)
@@ -756,11 +781,8 @@ class OrganizationAgreementDetailView(OrganizationBaseViewMixin, BaseAgreementDe
         super().setup(request, *args, **kwargs)
         self.parent: Organization = self.organization
 
-        self.agreement = get_object_or_404(
-            Agreement.objects.all().select_related("assigner").prefetch_related("scopes"),
-            assigner=self.organization,
-            pk=self.kwargs["agreement_id"],
-        )
+    def get_agreement_queryset(self) -> QuerySet:
+        return Agreement.objects.filter(assigner=self.organization)
 
     def has_permission(self) -> bool:
         return can_view_organization_agreement(self.request.user, self.agreement)
@@ -788,6 +810,55 @@ class OrganizationAgreementDetailView(OrganizationBaseViewMixin, BaseAgreementDe
         )
 
         return context
+
+
+class OrganizationBasedAgreementNegotiateMixin(OrganizationBaseViewMixin, AgreementNegotiateMixin):
+    template_name = "vitrina/orgs/organization_based_agreement_negotiate.html"
+
+    def get_agreement_queryset(self) -> QuerySet:
+        return Agreement.objects.filter(assigner=self.organization)
+
+    def get_success_url(self) -> str:
+        return reverse("organization-agreement-detail", args=[self.organization.pk, self.agreement.pk])
+
+    def get_context_data(self, **kwargs: Any) -> dict:
+        context = super().get_context_data(**kwargs)
+        context.update(
+            {
+                "current_title": self.title,
+                "parent_links": self.get_parent_links(self.title),
+                "agreement": self.agreement,
+                "project": self.agreement.project,
+                "datasets": self.agreement.project.datasets.filter(organization=self.agreement.assigner).all(),
+            }
+        )
+
+        return context
+
+    def get_parent_links(self, current_action_name: str) -> dict[str | None, str]:
+        organization_pk = self.organization.pk
+        return {
+            reverse("home"): _("Pradžia"),
+            reverse("organization-list"): _("Panaudojimo atvejai"),
+            reverse("organization-detail", args=[organization_pk]): self.organization,
+            reverse("organization-agreement-list", args=[organization_pk]): _("Sutartys"),
+            reverse(
+                "organization-agreement-detail", args=[organization_pk, self.agreement.pk]
+            ): self.agreement.detail_page_title,
+            None: current_action_name,
+        }
+
+
+class OrganizationBasedAgreementApproveView(AgreementApproveMixin, OrganizationBasedAgreementNegotiateMixin):
+    pass
+
+
+class OrganizationBasedAgreementFormView(AgreementFormMixin, OrganizationBasedAgreementNegotiateMixin):
+    pass
+
+
+class OrganizationBasedAgreementSignView(AgreementSignMixin, OrganizationBasedAgreementNegotiateMixin):
+    pass
 
 
 class OrganizationUpdateView(LoginRequiredMixin, PermissionRequiredMixin, RevisionMixin, UpdateView):

--- a/vitrina/orgs/views.py
+++ b/vitrina/orgs/views.py
@@ -747,11 +747,11 @@ class OrganizationBasedAgreementListView(OrganizationBaseViewMixin, BaseAgreemen
             .filter(assigner=self.organization)
             .annotate(
                 priority=Case(
-                    When(status=AgreementStatuses.ACTIVE, then=0),
-                    When(status=AgreementStatuses.SIGNED, then=1),
-                    When(status=AgreementStatuses.SUBMITTED, then=2),
-                    When(status=AgreementStatuses.APPROVED, then=3),
-                    When(status=AgreementStatuses.INITIATED, then=4),
+                    When(status=AgreementStatuses.SUBMITTED, then=0),
+                    When(status=AgreementStatuses.APPROVED, then=1),
+                    When(status=AgreementStatuses.INITIATED, then=2),
+                    When(status=AgreementStatuses.ACTIVE, then=3),
+                    When(status=AgreementStatuses.SIGNED, then=4),
                     When(status=AgreementStatuses.CREATED, then=5),
                     When(status=AgreementStatuses.FORMED, then=6),
                     When(status=AgreementStatuses.TERMINATED, then=7),

--- a/vitrina/smart_contracts/mixins.py
+++ b/vitrina/smart_contracts/mixins.py
@@ -86,6 +86,8 @@ class AgreementNegotiateMixin(BaseAgreementMixin, LoginRequiredMixin, FormView):
 
 
 class AgreementActionMixin:
+    """Mixin with common logic for all agreement status change views."""
+
     def dispatch(self, request: WSGIRequest, *args: Any, **kwargs: Any) -> HttpResponse:
         if not self.has_permission():
             return self.handle_no_permission()
@@ -123,6 +125,8 @@ class AgreementActionMixin:
 
 
 class AgreementUploadSignedFileMixin(AgreementActionMixin):
+    """Mixin holding the common logic for Initiate/Sign status change for agreements."""
+
     expected_status: AgreementStatuses | None = None
     next_status: AgreementStatuses | None = None
     signer_role_check: Callable[[User, Agreement], bool] | None = None
@@ -271,6 +275,8 @@ class AgreementSignMixin(AgreementUploadSignedFileMixin):
 
 
 class ProjectBasedAgreementNegotiateMixin(BaseProjectMixin, AgreementNegotiateMixin):
+    """Mixin class used for project-based agreement status-change views"""
+
     template_name = "smart_contracts/agreement_negotiate.html"
 
     detail_url_name = "project-detail"

--- a/vitrina/smart_contracts/mixins.py
+++ b/vitrina/smart_contracts/mixins.py
@@ -2,11 +2,11 @@ import os
 from typing import Any, Callable
 
 from django.contrib import messages
-from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.files.base import ContentFile
 from django.core.handlers.wsgi import WSGIRequest
 from django.db import transaction
-from django.db.models import Prefetch
+from django.db.models import Prefetch, QuerySet
 from django.forms.models import ModelForm
 from django.http import HttpResponseRedirect
 from django.http.response import HttpResponse
@@ -29,6 +29,13 @@ from vitrina.smart_contracts.models import (
     Agreement,
     AgreementFile,
 )
+from vitrina.smart_contracts.permissions import (
+    can_submit_agreements,
+    can_approve_agreements,
+    can_form_agreements,
+    can_initiate_agreements,
+    can_sign_agreements,
+)
 from vitrina.users.models import User
 from vitrina.projects.views import ProjectViewBaseMixin
 
@@ -50,16 +57,18 @@ class BaseProjectMixin(ProjectViewBaseMixin):
 
 
 class BaseAgreementMixin:
+    def get_agreement_queryset(self) -> QuerySet:
+        return Agreement.objects.all()
+
     def setup(self, request: WSGIRequest, *args: Any, **kwargs: Any) -> None:
         super().setup(request, *args, **kwargs)
         self.agreement = get_object_or_404(
-            Agreement.objects.all().select_related("assigner").prefetch_related("scopes"),
-            project=self.project,
+            self.get_agreement_queryset().select_related("assigner").prefetch_related("scopes"),
             pk=self.kwargs["agreement_id"],
         )
 
 
-class AgreementNegotiateMixin(BaseAgreementMixin, LoginRequiredMixin, PermissionRequiredMixin, FormView):
+class AgreementNegotiateMixin(BaseAgreementMixin, LoginRequiredMixin, FormView):
     template_name = None
     form_class = None
     title = ""
@@ -70,7 +79,36 @@ class AgreementNegotiateMixin(BaseAgreementMixin, LoginRequiredMixin, Permission
     def has_permission(self) -> None:
         raise NotImplementedError
 
-    def validate_status(self, expected_status: str) -> bool:
+    def get_form_kwargs(self) -> dict:
+        kwargs = super().get_form_kwargs()
+        kwargs["agreement"] = self.agreement
+        return kwargs
+
+
+class AgreementActionMixin:
+    def dispatch(self, request: WSGIRequest, *args: Any, **kwargs: Any) -> HttpResponse:
+        if not self.has_permission():
+            return self.handle_no_permission()
+        return super().dispatch(request, *args, **kwargs)
+
+    @transaction.atomic
+    def form_valid(self, form: ModelForm) -> HttpResponse:
+        if self.expected_status and not self.validate_status(self.expected_status):
+            return HttpResponseRedirect(self.get_success_url())
+
+        self.perform_action(form)
+        if self.next_status:
+            self.agreement.status = self.next_status
+        self.agreement.save()
+
+        messages.success(self.request, self.success_message or _("Veiksmas įvykdytas sėkmingai."))
+        return HttpResponseRedirect(self.get_success_url())
+
+    def perform_action(self, form: ModelForm) -> None:
+        """Override in child classes for extra per-action logic."""
+        return None
+
+    def validate_status(self, expected_status: AgreementStatuses) -> bool:
         if self.agreement.status != expected_status:
             error_message = _(
                 "Veiksmas gali būti atliekamas tik sutarčiai esant būsenoje {expected_status}."
@@ -84,11 +122,12 @@ class AgreementNegotiateMixin(BaseAgreementMixin, LoginRequiredMixin, Permission
         return True
 
 
-class AgreementUploadSignedFileMixin:
+class AgreementUploadSignedFileMixin(AgreementActionMixin):
     expected_status: AgreementStatuses | None = None
     next_status: AgreementStatuses | None = None
-    signer_check: Callable[[User, Agreement], bool] | None = None
+    signer_role_check: Callable[[User, Agreement], bool] | None = None
     success_message: str | None = None
+    signer_error_message: str | None = None
 
     def get_form_kwargs(self) -> dict:
         kwargs = super().get_form_kwargs()
@@ -103,8 +142,15 @@ class AgreementUploadSignedFileMixin:
         if not self.has_permission():
             return self.handle_no_permission()
 
-        if error := self._validate_pdf_state():
-            messages.error(request, error)
+        count = AgreementFile.objects.filter(
+            agreement=self.agreement,
+            file__iendswith=AgreementFile.AllowedFileTypes.PDF,
+        ).count()
+        if count == 0:
+            messages.error(request, _("PDF failas sutarčiai nėra sukurtas."))
+            return HttpResponseRedirect(self.get_success_url())
+        elif count > 1:
+            messages.error(request, _("Rasti keli PDF failai. Susisiekite su administratoriumi."))
             return HttpResponseRedirect(self.get_success_url())
 
         has_expected_status = self.agreement.status == self.expected_status
@@ -115,99 +161,65 @@ class AgreementUploadSignedFileMixin:
 
         return super().dispatch(request, *args, **kwargs)
 
-    def _validate_pdf_state(self) -> str | None:
-        count = AgreementFile.objects.filter(
-            agreement=self.agreement,
-            file__iendswith=AgreementFile.AllowedFileTypes.PDF,
-        ).count()
-
-        if count == 0:
-            return _("PDF failas sutarčiai nėra sukurtas.")
-        elif count > 1:
-            return _("Rasti keli PDF failai. Susisiekite su administratoriumi.")
-        return None
-
-    @transaction.atomic
-    def form_valid(self, form: ModelForm) -> HttpResponseRedirect:
-        if not self.validate_status(self.expected_status):
-            return HttpResponseRedirect(self.get_success_url())
-
-        self._execute_action(form)
-
-        return HttpResponseRedirect(self.get_success_url())
-
-    def _execute_action(self, form: ModelForm) -> None:
+    def perform_action(self, form: ModelForm) -> None:
         uploaded_file = form.cleaned_data["file"]
-
-        self.agreement.status = self.next_status
-        self.agreement.save()
-
         AgreementFile.objects.create(
             agreement=self.agreement,
             file_name=uploaded_file.name,
             file=uploaded_file,
         )
 
-        messages.success(self.request, self.success_message)
 
-
-class AgreementSubmitMixin:
+class AgreementSubmitMixin(AgreementActionMixin):
     form_class = AgreementSubmitForm
     title = _("Pateikti pasiūlymą")
+
     expected_status = AgreementStatuses.CREATED
+    next_status = AgreementStatuses.SUBMITTED
 
-    def _execute_action(self, form: ModelForm) -> HttpResponse:
-        if not self.validate_status(self.expected_status):
-            return HttpResponseRedirect(self.get_success_url())
+    success_message = _("Pasiūlymas sėkmingai pateiktas duomenų teikėjui.")
 
-        self.agreement.status = AgreementStatuses.SUBMITTED
+    def has_permission(self) -> bool:
+        return can_submit_agreements(self.request.user, self.agreement)
+
+    def perform_action(self, form: ModelForm) -> None:
         self.agreement.assignee_representative = form.cleaned_data["assignee_representative"]
-        self.agreement.save()
-
-        messages.success(self.request, _("Pasiūlymas sėkmingai pateiktas duomenų teikėjui."))
-        return HttpResponseRedirect(self.get_success_url())
-
-    def form_valid(self, form: ModelForm) -> HttpResponse:
-        return self._execute_action(form)
 
 
-class AgreementApproveMixin:
+class AgreementApproveMixin(AgreementActionMixin):
     form_class = AgreementApproveForm
     title = _("Patvirtinti pasiūlymą")
+
     expected_status = AgreementStatuses.SUBMITTED
+    next_status = AgreementStatuses.APPROVED
 
-    def _execute_action(self, form: ModelForm) -> HttpResponse:
-        if not self.validate_status(self.expected_status):
-            return HttpResponseRedirect(self.get_success_url())
+    success_message = _("Pasiūlymas sėkmingai patvirtintas.")
 
-        self.agreement.status = AgreementStatuses.APPROVED
+    def has_permission(self) -> bool:
+        return can_approve_agreements(self.request.user, self.agreement)
+
+    def perform_action(self, form: ModelForm) -> None:
         self.agreement.template = form.cleaned_data["template"]
         self.agreement.assigner_representative = form.cleaned_data["assigner_representative"]
         self.agreement.other_assigner_legislations = form.cleaned_data["other_assigner_legislations"]
-        self.agreement.save()
-
-        messages.success(self.request, _("Pasiūlymas sėkmingai patvirtintas."))
-        return HttpResponseRedirect(self.get_success_url())
-
-    def form_valid(self, form: ModelForm) -> HttpResponse:
-        return self._execute_action(form)
 
 
-class AgreementFormMixin:
+class AgreementFormMixin(AgreementActionMixin):
     form_class = AgreementFormForm
     title = _("Formuoti sutartį")
+
     expected_status = AgreementStatuses.APPROVED
+    next_status = AgreementStatuses.FORMED
 
-    def _execute_action(self, form: ModelForm) -> HttpResponse:
-        if not self.validate_status(AgreementStatuses.APPROVED):
-            return HttpResponseRedirect(self.get_success_url())
+    success_message = _("Sutarties dokumentas sukurtas sėkmingai.")
 
+    def has_permission(self) -> bool:
+        return can_form_agreements(self.request.user, self.agreement)
+
+    def perform_action(self, form: ModelForm) -> None:
         template = self.agreement.template
-
-        self.agreement.status = AgreementStatuses.FORMED
-        self.agreement.save()
-
         self.agreement.generate_contract_pdf_file(template=template)
+
         file_name, extension = os.path.splitext(os.path.basename(template.file.name))
         copy_file_name = f"{file_name}_copy{extension}"
         with template.file.open() as file:
@@ -216,12 +228,6 @@ class AgreementFormMixin:
                 is_template=True,
                 file_name=copy_file_name,
             )
-
-        messages.success(self.request, _("Sutarties dokumentas sukurtas"))
-        return HttpResponseRedirect(self.get_success_url())
-
-    def form_valid(self, form: ModelForm) -> HttpResponse:
-        return self._execute_action(form)
 
 
 class AgreementInitiateMixin(AgreementUploadSignedFileMixin):
@@ -234,7 +240,11 @@ class AgreementInitiateMixin(AgreementUploadSignedFileMixin):
     success_message = _("Sutarties dokumentas įkeltas sėkmingai.")
     signer_error_message = _("Šią sutartį šiuo metu turi pasirašyti duomenų gavėjo atstovas.")
 
-    def signer_role_check(self, user: User, agreement: Agreement) -> bool:
+    def has_permission(self) -> bool:
+        return can_initiate_agreements(self.request.user, self.agreement)
+
+    @staticmethod
+    def signer_role_check(user: User, agreement: Agreement) -> bool:
         return user.viisp_organization == agreement.assignee
 
 
@@ -248,14 +258,16 @@ class AgreementSignMixin(AgreementUploadSignedFileMixin):
     success_message = _("Sutarties dokumentas įkeltas sėkmingai.")
     signer_error_message = _("Šią sutartį šiuo metu turi pasirašyti duomenų teikėjo atstovas.")
 
-    def signer_role_check(self, user: User, agreement: Agreement) -> bool:
+    def has_permission(self) -> bool:
+        return can_sign_agreements(self.request.user, self.agreement)
+
+    @staticmethod
+    def signer_role_check(user: User, agreement: Agreement) -> bool:
         return user.viisp_organization == agreement.assigner
 
-    def _execute_action(self, form: ModelForm) -> None:
-        super()._execute_action(form)
-
+    def perform_action(self, form: ModelForm) -> None:
+        super().perform_action(form)
         self.agreement.is_agent_sync_enabled = True
-        self.agreement.save()
 
 
 class ProjectBasedAgreementNegotiateMixin(BaseProjectMixin, AgreementNegotiateMixin):
@@ -264,41 +276,33 @@ class ProjectBasedAgreementNegotiateMixin(BaseProjectMixin, AgreementNegotiateMi
     detail_url_name = "project-detail"
     history_url_name = "project-history"
 
-    def setup(self, request: WSGIRequest, *args: Any, **kwargs: Any) -> None:
-        self.object = self.get_project(kwargs["pk"])
-        return super().setup(request, *args, **kwargs)
-
-    def get_form_kwargs(self) -> dict:
-        kwargs = super().get_form_kwargs()
-        kwargs["agreement"] = self.agreement
-        return kwargs
+    def get_agreement_queryset(self) -> QuerySet:
+        return Agreement.objects.filter(project=self.project)
 
     def get_success_url(self) -> str:
-        return reverse("project-agreement-detail", args=[self.object.pk, self.agreement.pk])
+        return reverse("project-agreement-detail", args=[self.project.pk, self.agreement.pk])
 
     def get_context_data(self, **kwargs: Any) -> dict:
         context = super().get_context_data(**kwargs)
-
         context.update(
             {
                 "current_title": self.title,
                 "parent_links": self.get_parent_links(self.title),
                 "agreement": self.agreement,
-                "project": self.agreement.project,
-                "datasets": self.object.datasets.filter(organization=self.agreement.assigner).all(),
+                "project": self.project,
+                "datasets": self.project.datasets.all(),
             }
         )
 
         return context
 
     def get_parent_links(self, current_action_name: str) -> dict[str | None, str]:
+        project_pk = self.project.pk
         return {
             reverse("home"): _("Pradžia"),
             reverse("project-list"): _("Panaudojimo atvejai"),
-            reverse("project-detail", args=[self.project.pk]): self.project,
-            reverse("project-agreement-list", args=[self.object.pk]): _("Sutartys"),
-            reverse(
-                "project-agreement-detail", args=[self.object.pk, self.agreement.pk]
-            ): self.agreement.detail_page_title,
+            reverse("project-detail", args=[project_pk]): self.project,
+            reverse("project-agreement-list", args=[project_pk]): _("Sutartys"),
+            reverse("project-agreement-detail", args=[project_pk, self.agreement.pk]): self.agreement.detail_page_title,
             None: current_action_name,
         }

--- a/vitrina/smart_contracts/urls.py
+++ b/vitrina/smart_contracts/urls.py
@@ -2,8 +2,8 @@ from django.urls import path
 
 from vitrina.smart_contracts.views import (
     AgreementCreateView,
-    ProjectAgreementListView,
-    ProjectAgreementDetailView,
+    ProjectBasedAgreementListView,
+    ProjectBasedAgreementDetailView,
     ProjectBasedAgreementSubmitView,
     ProjectBasedAgreementApproveView,
     ProjectBasedAgreementFormView,
@@ -19,12 +19,12 @@ urlpatterns = [
     ),
     path(
         "projects/<int:pk>/agreement/",
-        ProjectAgreementListView.as_view(),
+        ProjectBasedAgreementListView.as_view(),
         name="project-agreement-list",
     ),
     path(
         "projects/<int:pk>/agreement/<uuid:agreement_id>/",
-        ProjectAgreementDetailView.as_view(),
+        ProjectBasedAgreementDetailView.as_view(),
         name="project-agreement-detail",
     ),
     path(

--- a/vitrina/smart_contracts/views.py
+++ b/vitrina/smart_contracts/views.py
@@ -7,7 +7,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.handlers.wsgi import WSGIRequest
 from django.core.paginator import Paginator
 from django.db import transaction
-from django.db.models import Q
+from django.db.models import Q, QuerySet
 from django.forms import modelformset_factory, BaseFormSet
 from django.http import HttpResponseRedirect
 from django.http.response import HttpResponseBase, HttpResponse
@@ -75,7 +75,7 @@ class BaseAgreementListView(LoginRequiredMixin, PermissionRequiredMixin, Templat
 
         context.update(
             {
-                "agreements": agreements,
+                "agreements": page.object_list,
                 "agreement_status_descriptions": AGREEMENT_STATUS_DESCRIPTIONS,
                 "page_obj": page,
                 "paginator": paginator,
@@ -88,7 +88,7 @@ class BaseAgreementListView(LoginRequiredMixin, PermissionRequiredMixin, Templat
         return context
 
 
-class BaseAgreementDetailView(LoginRequiredMixin, PermissionRequiredMixin, TemplateView):
+class BaseAgreementDetailView(BaseAgreementMixin, LoginRequiredMixin, PermissionRequiredMixin, TemplateView):
     template_name = None
     parent: object = None
     parent_type: str = None
@@ -150,13 +150,16 @@ class ProjectAgreementListView(BaseProjectMixin, BaseAgreementListView):
         return context
 
 
-class ProjectAgreementDetailView(BaseProjectMixin, BaseAgreementMixin, BaseAgreementDetailView):
+class ProjectAgreementDetailView(BaseProjectMixin, BaseAgreementDetailView):
     template_name = "smart_contracts/agreement_detail.html"
     parent_type = "project"
 
     def setup(self, request: WSGIRequest, *args: Any, **kwargs: Any) -> None:
         super().setup(request, *args, **kwargs)
         self.parent: Project = self.get_project(kwargs["pk"])
+
+    def get_agreement_queryset(self) -> QuerySet:
+        return Agreement.objects.filter(project=self.project)
 
     def has_permission(self) -> bool:
         return can_view_agreement(self.request.user, self.agreement)
@@ -314,25 +317,20 @@ class AgreementCreateView(
 
 
 class ProjectBasedAgreementSubmitView(AgreementSubmitMixin, ProjectBasedAgreementNegotiateMixin):
-    def has_permission(self) -> bool:
-        return can_submit_agreements(self.request.user, self.agreement)
+    pass
 
 
 class ProjectBasedAgreementApproveView(AgreementApproveMixin, ProjectBasedAgreementNegotiateMixin):
-    def has_permission(self) -> bool:
-        return can_approve_agreements(self.request.user, self.agreement)
+    pass
 
 
 class ProjectBasedAgreementFormView(AgreementFormMixin, ProjectBasedAgreementNegotiateMixin):
-    def has_permission(self) -> bool:
-        return can_form_agreements(self.request.user, self.agreement)
+    pass
 
 
 class ProjectBasedAgreementInitiateView(AgreementInitiateMixin, ProjectBasedAgreementNegotiateMixin):
-    def has_permission(self) -> bool:
-        return can_initiate_agreements(self.request.user, self.agreement)
+    pass
 
 
 class ProjectBasedAgreementSignView(AgreementSignMixin, ProjectBasedAgreementNegotiateMixin):
-    def has_permission(self) -> bool:
-        return can_sign_agreements(self.request.user, self.agreement)
+    pass

--- a/vitrina/smart_contracts/views.py
+++ b/vitrina/smart_contracts/views.py
@@ -317,20 +317,20 @@ class AgreementCreateView(
 
 
 class ProjectBasedAgreementSubmitView(AgreementSubmitMixin, ProjectBasedAgreementNegotiateMixin):
-    pass
+    """Project-based agreement form view responsible for moving the agreement to status `SUBMITTED`"""
 
 
 class ProjectBasedAgreementApproveView(AgreementApproveMixin, ProjectBasedAgreementNegotiateMixin):
-    pass
+    """Project-based agreement form view responsible for moving the agreement to status `APPROVED`"""
 
 
 class ProjectBasedAgreementFormView(AgreementFormMixin, ProjectBasedAgreementNegotiateMixin):
-    pass
+    """Project-based agreement form view responsible for moving the agreement to status `FORMED`"""
 
 
 class ProjectBasedAgreementInitiateView(AgreementInitiateMixin, ProjectBasedAgreementNegotiateMixin):
-    pass
+    """Project-based agreement form view responsible for moving the agreement to status `INITIATED`"""
 
 
 class ProjectBasedAgreementSignView(AgreementSignMixin, ProjectBasedAgreementNegotiateMixin):
-    pass
+    """Project-based agreement form view responsible for moving the agreement to status `SIGNED`"""

--- a/vitrina/smart_contracts/views.py
+++ b/vitrina/smart_contracts/views.py
@@ -117,7 +117,7 @@ class BaseAgreementDetailView(BaseAgreementMixin, LoginRequiredMixin, Permission
         return context
 
 
-class ProjectAgreementListView(BaseProjectMixin, BaseAgreementListView):
+class ProjectBasedAgreementListView(BaseProjectMixin, BaseAgreementListView):
     template_name = "smart_contracts/agreement_list.html"
     parent_type = "project"
 
@@ -150,7 +150,7 @@ class ProjectAgreementListView(BaseProjectMixin, BaseAgreementListView):
         return context
 
 
-class ProjectAgreementDetailView(BaseProjectMixin, BaseAgreementDetailView):
+class ProjectBasedAgreementDetailView(BaseProjectMixin, BaseAgreementDetailView):
     template_name = "smart_contracts/agreement_detail.html"
     parent_type = "project"
 

--- a/vitrina/templates/vitrina/agreements/base_agreement_negotiate.html
+++ b/vitrina/templates/vitrina/agreements/base_agreement_negotiate.html
@@ -1,0 +1,123 @@
+{% extends "base_form.html" %}
+{% load i18n %}
+{% load markdown_tags %}
+
+{% block content %}
+    {% block tabs %}{% endblock %}
+
+    <div class="columns is-centered">
+        <div class="column is-half has-background-white-ter p-4">
+
+            <h3 class="title is-3 has-text-weight-semibold mb-5">
+                {% trans "Sutarties derinimo informacija" %}
+            </h3>
+
+            <h3 class="title is-5 has-text-weight-semibold mb-3">
+                {% trans "Duomenų ištekliai" %}:
+            </h3>
+            <div class="ml-5 mb-4">
+                {% if datasets %}
+                    <ul>
+                        {% for dataset in datasets %}
+                            <li class="mb-2">
+                                <a href="{% url 'dataset-detail' dataset.pk %}" target="_blank"
+                                   class="has-text-link is-inline-flex is-align-items-center">
+                                    <span>{{ dataset.title }}</span>
+                                    <span class="icon is-small ml-1 is-inline-flex is-align-items-center">
+                                        <i class="fas fa-external-link-alt"></i>
+                                    </span>
+                                </a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% else %}
+                    <p class="has-text-grey">
+                        {% trans "Nėra susietų duomenų išteklių." %}
+                    </p>
+                {% endif %}
+            </div>
+
+            <h3 class="title is-5 has-text-weight-semibold mb-3">
+                {% trans "Duomenų gavimo tikslas" %}:
+            </h3>
+            <div class="content ml-5 mb-4">
+                {% block description %}
+                    {{ project.description|markdown|safe }}
+                {% endblock %}
+            </div>
+
+            <h3 class="title is-5 has-text-weight-semibold mb-3">
+                {% trans "Duomenų gavimo teisinis pagrindas" %}:
+            </h3>
+            <div class="content ml-5 mb-4">
+                {% block other_legislation %}
+                    {{ project.other_assignee_legislations|markdown|safe }}
+                {% endblock %}
+            </div>
+
+            {% if agreement.status in "SUBMITTED APPROVED FORMED INITIATED" %}
+                <h3 class="title is-5 has-text-weight-semibold mb-3">
+                    {% trans "Duomenų gavėjo atstovas" %}:
+                </h3>
+                <div class="ml-5 mb-4">
+                    {% block agreement.assignee_representative %}
+                        {% if agreement.assignee_representative %}
+                            <ul>
+                                <li class="mb-2">{{ agreement.assignee_representative }}</li>
+                            </ul>
+                        {% else %}
+                            <p class="has-text-grey">
+                                {% trans "Nėra pasirinktas duomenų gavėjo atstovas." %}
+                            </p>
+                        {% endif %}
+                    {% endblock %}
+                </div>
+
+                {% if agreement.status in "APPROVED FORMED INITIATED" %}
+                    <h3 class="title is-5 has-text-weight-semibold mb-3">
+                        {% trans "Duomenų teikėjo atstovas" %}:
+                    </h3>
+                    <div class="ml-5 mb-4">
+                        {% block agreement.assigner_representative %}
+                            {% if agreement.assigner_representative %}
+                                <ul><li class="mb-2">{{ agreement.assigner_representative }}</li></ul>
+                            {% else %}
+                                <p class="has-text-grey">
+                                    {% trans "Nėra pasirinktas duomenų teikėjo atstovas." %}
+                                </p>
+                            {% endif %}
+                        {% endblock %}
+                    </div>
+
+                    <h3 class="title is-5 has-text-weight-semibold mb-3">
+                        {% trans "Duomenų teikimo teisinis pagrindas (prievolė)" %}:
+                    </h3>
+                    <div class="content ml-5 mb-4">
+                        {% block agreement.other_assigner_legislations %}
+                            {{ agreement.other_assigner_legislations|markdown|safe }}
+                        {% endblock %}
+                    </div>
+
+                    <h3 class="title is-5 has-text-weight-semibold mb-3">
+                        {% trans "Sutarties šablonas" %}:
+                    </h3>
+                    <div class="ml-5 mb-4">
+                        {% if agreement.template and agreement.template.file %}
+                            <ul>
+                                <li class="mb-2">
+                                    <a href="{{ agreement.template.file.url }}" target="_blank" class="has-text-link">
+                                        {{ agreement.template.file.name }}
+                                    </a>
+                                </li>
+                            </ul>
+                        {% else %}
+                            <p class="has-text-grey">{% trans "Šablono failas nepridėtas." %}</p>
+                        {% endif %}
+                    </div>
+                {% endif %}
+            {% endif %}
+        </div>
+    </div>
+
+    {{ block.super }}
+{% endblock %}


### PR DESCRIPTION
- Introduce the different actions that can be performed by assigner (Approve, Form, Sign) on company page.
- Extended views & templates, re-used code.
- Order agreements by:
    1) Actions are finished
    2) Action is needed
    3) Action is needed but from the other side of the contract (Assignee)
- has_permission works for both Organization & Project based views, so re-use that as well;