### PR TITLE
Fix celery on test env

### DIFF
--- a/docker-compose.template.yml
+++ b/docker-compose.template.yml
@@ -69,6 +69,9 @@ services:
       - katalogas
 
   katalogas-${BRANCH}-celery:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
     image: katalogas-${BRANCH}:latest
     command: celery -A vitrina worker -l info
     environment:
@@ -84,14 +87,14 @@ services:
       - SPINTA_SERVER_URL=https://test.data.gov.lt
       - SPINTA_SERVER_NAME='Test Data Gov'
       - USE_OTP_VALIDATION=False
-    volumes:
-      - .:/app
     depends_on:
       - katalogas-${BRANCH}-redis
       - katalogas-${BRANCH}-database
     restart: always
     networks:
-      - katalogas
+      katalogas:
+        aliases:
+          - katalogas-${BRANCH}
 
 volumes:
   ${BRANCH}-postgres:

--- a/vitrina/__init__.py
+++ b/vitrina/__init__.py
@@ -1,0 +1,3 @@
+from .celery import app as celery_app
+
+__all__ = ("celery_app",)

--- a/vitrina/structure/admin.py
+++ b/vitrina/structure/admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from django.forms import ModelForm
 from django.http import HttpRequest
+from django.db import transaction
 
 from vitrina.structure.models import Prefix, ManifestValidationEntry
 from vitrina.structure.tasks import validate_manifest_task
@@ -16,7 +17,7 @@ class ManifestValidationEntryAdmin(admin.ModelAdmin):
 
     def save_model(self, request: HttpRequest, obj: ManifestValidationEntry, form: ModelForm, change: bool) -> None:
         super().save_model(request, obj, form, change)
-        validate_manifest_task.delay(obj.uuid)
+        transaction.on_commit(lambda: validate_manifest_task.delay(obj.uuid))
 
 
 admin.site.register(Prefix, PrefixAdmin)


### PR DESCRIPTION
Fixes issue where Django used default Celery broker settings and tried to connect to the wrong broker.
Also updated docker settings, because apparently Celery was failing to run before.
Also added a fix to create task only after changes are commited to database, to avoid error, where Celery tries to execute task before Manifest actually exists.