### PR TITLE
[1630]: do not export soap params

### DIFF
--- a/tests/structure/test_services.py
+++ b/tests/structure/test_services.py
@@ -1674,6 +1674,45 @@ def test_structure_export__prefixes(app: DjangoTestApp):
 
 
 @pytest.mark.django_db
+def test_structure_export__soap_parameters(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+    manifest = (
+        'id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n'
+        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
+        '2,,get_data,,,,soap,,http://www.example.com,,,,,,,,,,\n'
+        '3,,,,,,param,action_type,input/ActionType,input(),,,,,,,,,\n'
+        '4,,,,Model,,,,,,,,,,open,,,,\n'
+        '5,,,,,test_property,,,,,,,,,,,,,\n'
+    )
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(
+            file=FileField(filename='file.csv', data=manifest)
+        ),
+        dataset=DatasetFactory(
+            title="Title",
+            description="Description"
+        )
+    )
+
+    structure.dataset.current_structure = structure
+    structure.dataset.save()
+    create_structure_objects(structure)
+
+    assert DatasetDistribution.objects.first()
+    
+    resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk]))
+    assert resp.text == (
+        'id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n'
+        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n'
+        '2,,get_data,,,,soap,,http://www.example.com,,,,,,,,,,,get_data,\r\n'
+        '4,,,,Model,,,,,,,,,,develop,,open,,,,\r\n'
+        '5,,,,,test_property,,,,,,,,,develop,,,,,,\r\n'
+        ',,,,,,,,,,,,,,,,,,,,\r\n'
+    )
+
+
+@pytest.mark.django_db
 def test_structure_export__models_and_props(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)

--- a/vitrina/structure/services.py
+++ b/vitrina/structure/services.py
@@ -1051,7 +1051,6 @@ def _has_soap_params_as_dataset_params(dataset: Dataset) -> bool:
         return False
 
     distributions = dataset.datasetdistribution_set.prefetch_related("metadata").all()
-
     if not distributions.exists():
         return False
 

--- a/vitrina/structure/services.py
+++ b/vitrina/structure/services.py
@@ -1036,8 +1036,42 @@ def _dataset_to_tabular(dataset: Dataset, separator: bool = False):
         )
     yield from _prefixes_to_tabular(dataset, separator=separator)
     yield from _enums_to_tabular(dataset, separator=separator)
-    yield from _params_to_tabular(dataset, separator=separator)
+    if not _has_soap_params_as_dataset_params(dataset):
+        yield from _params_to_tabular(dataset, separator=separator)
     yield from _models_to_tabular(dataset, separator=separator)
+
+
+def _has_soap_params_as_dataset_params(dataset: Dataset) -> bool:
+    """
+    Check if a dataset has SOAP parameters defined at the dataset level rather than at the distribution level.
+    """
+    ct = ContentType.objects.get_for_model(dataset)
+    params = Param.objects.filter(content_type=ct, object_id=dataset.pk)
+    if not params.exists():
+        return False
+
+    distributions = dataset.datasetdistribution_set.prefetch_related("metadata").all()
+
+    if not distributions.exists():
+        return False
+
+    soap_distribution_ids = [
+        distribution.pk
+        for distribution in distributions
+        if distribution.metadata.exists() and distribution.metadata.first().type == "soap"
+    ]
+
+    if not soap_distribution_ids:
+        return False
+
+    content_type = ContentType.objects.get_for_model(DatasetDistribution)
+    distributions_with_params = set(
+        Param.objects.filter(content_type=content_type, object_id__in=soap_distribution_ids).values_list(
+            "object_id", flat=True
+        )
+    )
+
+    return True if not distributions_with_params else False
 
 
 def _enums_to_tabular(obj: models.Model, separator: bool = False):
@@ -1071,7 +1105,7 @@ def _enums_to_tabular(obj: models.Model, separator: bool = False):
         yield to_row(DATASET, {})
 
 
-def _params_to_tabular(obj: models.Model, separator: bool = False):
+def _params_to_tabular(obj: models.Model | Dataset, separator: bool = False):
     ct = ContentType.objects.get_for_model(obj)
     params = Param.objects.filter(content_type=ct, object_id=obj.pk)
 


### PR DESCRIPTION
Related to: https://github.com/atviriduomenys/spinta/issues/1630
Related DSA: https://github.com/atviriduomenys/demo-saltiniai/blob/main/manifest/datasets/gov/vssa/demo/wsdl/wsdl_rctest.csv

This is workaround to solve SOAP params import problem. 

Currently, we import resource params as dataset params. When we export such DSA, it breaks spinta `load`  with `KeyError` because spinta does not understand such params as dataset params.
 
Correct solution would be:
1. Fix structure import: save resource params as distribution params.
2. Do db data migration and find dataset params -> resource params.

Migration part is problematic. It would be hard to find correct distribution params should be set to.
Changes in this PR skips dataset params to be exported if dataset has any SOAP distribution and params are not set for any of these distributions. 

