### PR TITLE
Fix file download URL

### DIFF
--- a/vitrina/templates/vitrina/agreements/base_agreement_detail.html
+++ b/vitrina/templates/vitrina/agreements/base_agreement_detail.html
@@ -131,7 +131,7 @@
                 {% for file in agreement_files %}
                     <tr>
                         <td>{{ file.created_at|date:"Y-m-d H:i" }}</td>
-                        <td><a href="{% url "agreement-file-download" project.pk agreement.pk file.pk %}" target="_blank">{{ file.file_name }}</a></td>
+                        <td><a href="{% url "agreement-file-download" agreement.pk file.pk %}" target="_blank">{{ file.file_name }}</a></td>
                     </tr>
                 {% endfor %}
             </tbody>


### PR DESCRIPTION
**Summary:**
Fix agreement file download URL. Currently breaks contract detail page, if any file is uploaded