### PR TITLE
2070 usecase related actions history

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,12 @@ v 1.12 (unreleased)
 
 Improvements
 
+https://github.com/atviriduomenys/katalogas/issues/2070
+
+- Update `HistoryView` to list history rows per `Revision`
+- Display list of modified related objects next to each history row.
+- Add `Agreement`, `AgreementFile`, `UseCaseClient` and `UseCaseClientScope` model changes to be included in `Project` history tab.
+
 - https://github.com/atviriduomenys/katalogas/issues/2155
 
 Corrected some texts

--- a/tests/datasets/test_views.py
+++ b/tests/datasets/test_views.py
@@ -3078,7 +3078,8 @@ def test_dataset_history_view_with_permission(app: DjangoTestApp):
     assert resp.context["detail_url_name"] == "dataset-detail"
     assert resp.context["history_url_name"] == "dataset-history"
     assert len(resp.context["history"]) == 1
-    assert resp.context["history"][0]["action"] == revision_comment.to_json()
+    history_action = resp.context["history"][0]["action"]
+    assert history_action["comment"] == f"{revision_comment.action}({revision_comment.kwargs})"
     assert resp.context["history"][0]["user"] == user
 
 

--- a/tests/projects/test_views.py
+++ b/tests/projects/test_views.py
@@ -279,7 +279,8 @@ def test_project_history_view_with_permission(app: DjangoTestApp):
     assert resp.context['detail_url_name'] == 'project-detail'
     assert resp.context['history_url_name'] == 'project-history'
     assert len(resp.context['history']) == 1
-    assert resp.context['history'][0]['action'] == revision_comment.to_json()
+    history_action = resp.context['history'][0]['action']
+    assert history_action["comment"] == f"{revision_comment.action}({revision_comment.kwargs})"
     assert resp.context['history'][0]['user'] == user
 
 
@@ -685,7 +686,7 @@ def test_client_scope_toggle(app: DjangoTestApp, oauth_settings):
         url = reverse(
             "project-clients-scopes-detail-toggle", args=[project.pk, client.pk, scope.pk]
         )
-        resp = app.get(url)
+        resp = app.post(url)
 
         assert resp.status_code == 302
 

--- a/tests/projects/test_views.py
+++ b/tests/projects/test_views.py
@@ -4,6 +4,7 @@ from urllib.parse import parse_qs
 
 import pytest
 import requests_mock
+import reversion
 from PIL import Image
 from django.urls import reverse, resolve
 from django_webtest import DjangoTestApp
@@ -12,10 +13,10 @@ from webtest import Upload
 
 from vitrina.datasets.factories import DatasetFactory
 from vitrina.comments.models import Comment
-from vitrina.projects.factories import ProjectFactory, UseCaseClientFactory
+from vitrina.projects.factories import ProjectFactory, UseCaseClientFactory, UseCaseClientScopeFactory
 from vitrina.projects.models import Project, UseCaseClient, UseCaseClientScope
 from vitrina.smart_contracts import AgreementStatuses
-from vitrina.smart_contracts.factories import AgreementFactory
+from vitrina.smart_contracts.factories import AgreementFactory, AgreementPDFFileFactory
 from vitrina.smart_contracts.models import AgreementScope
 from vitrina.users.factories import UserFactory
 from filer.models.imagemodels import Image as FilerImage
@@ -275,13 +276,34 @@ def test_project_history_view_with_permission(app: DjangoTestApp):
     form['title'] = "Updated title"
     form['description'] = "Updated description"
     resp = form.submit().follow()
+    with reversion.create_revision():
+        agreement_file = AgreementPDFFileFactory(agreement__project=project)
+        scope = UseCaseClientScopeFactory(use_case_client__use_case=project)
+    
+    action_objects = [
+        (str(agreement_file.agreement), None),
+        (str(agreement_file), None),
+        (str(scope.use_case_client), None),
+        (str(scope), None)
+    ]
+
     resp = resp.click(linkid="history-tab")
+    project.refresh_from_db()
     assert resp.context['detail_url_name'] == 'project-detail'
     assert resp.context['history_url_name'] == 'project-history'
-    assert len(resp.context['history']) == 1
-    history_action = resp.context['history'][0]['action']
-    assert history_action["comment"] == f"{revision_comment.action}({revision_comment.kwargs})"
-    assert resp.context['history'][0]['user'] == user
+    assert len(resp.context['history']) == 2
+
+    entry1 = resp.context['history'][0]
+    assert entry1["action"]["comment"] == ""
+    assert len(entry1["action"]["objects"]) == 4
+    assert set(entry1["action"]["objects"]) == set(action_objects)
+    assert entry1['user'] is None
+
+    entry2 = resp.context['history'][1]
+    assert entry2["action"]["comment"] == f"{revision_comment.action}({revision_comment.kwargs})"
+    assert len(entry2["action"]["objects"]) == 1
+    assert entry2["action"]["objects"][0] == (str(project), project.get_absolute_url())
+    assert entry2['user'] == user
 
 
 def test_request_comment_with_status(app: DjangoTestApp):

--- a/tests/requests/test_views.py
+++ b/tests/requests/test_views.py
@@ -142,7 +142,8 @@ def test_request_history_view_with_permission(app: DjangoTestApp):
     assert resp.context['detail_url_name'] == 'request-detail'
     assert resp.context['history_url_name'] == 'request-history'
     assert len(resp.context['history']) == 1
-    assert resp.context['history'][0]['action'] == revision_comment.to_json()
+    history_action = resp.context['history'][0]['action']
+    assert history_action["comment"] == f"{revision_comment.action}({revision_comment.kwargs})"
     assert resp.context['history'][0]['user'] == user
 
 

--- a/tests/test_reversion_utils.py
+++ b/tests/test_reversion_utils.py
@@ -2,14 +2,13 @@ import reversion
 from reversion.models import Version
 from vitrina.smart_contracts.factories import AgreementPDFFileFactory
 from vitrina.smart_contracts.models import Agreement, AgreementFile
-from vitrina.reversion_utils import get_version_ids
+from vitrina.reversion_utils import get_version_ids, ChildVersionModel
 
 
 
 def test_get_version_ids():
     with reversion.create_revision():
         agreement_file = AgreementPDFFileFactory()
-
  
     agreement_file_version_ids = Version.objects.get_for_object(agreement_file).values_list("id", flat=True)
     agreement_version_ids = Version.objects.get_for_object(agreement_file.agreement).values_list("id", flat=True)
@@ -18,10 +17,10 @@ def test_get_version_ids():
     version_ids =  list(agreement_file_version_ids) + list(agreement_version_ids) + list(project_version_ids)
 
     agreement_children = [
-        {"model": AgreementFile, "relation": AgreementFile.agreement},
+        ChildVersionModel(model=AgreementFile, relation=AgreementFile.agreement),
     ]
     project_children = [
-        {"model": Agreement, "relation": Agreement.project, "children": agreement_children}
+        ChildVersionModel(model=Agreement, relation=Agreement.project, children=agreement_children)
     ]
 
     assert len(version_ids) == 3

--- a/tests/test_reversion_utils.py
+++ b/tests/test_reversion_utils.py
@@ -1,0 +1,28 @@
+import reversion
+from reversion.models import Version
+from vitrina.smart_contracts.factories import AgreementPDFFileFactory
+from vitrina.smart_contracts.models import Agreement, AgreementFile
+from vitrina.reversion_utils import get_version_ids
+
+
+
+def test_get_version_ids():
+    with reversion.create_revision():
+        agreement_file = AgreementPDFFileFactory()
+
+ 
+    agreement_file_version_ids = Version.objects.get_for_object(agreement_file).values_list("id", flat=True)
+    agreement_version_ids = Version.objects.get_for_object(agreement_file.agreement).values_list("id", flat=True)
+    project_version_ids = Version.objects.get_for_object(agreement_file.agreement.project).values_list("id", flat=True)
+
+    version_ids =  list(agreement_file_version_ids) + list(agreement_version_ids) + list(project_version_ids)
+
+    agreement_children = [
+        {"model": AgreementFile, "relation": AgreementFile.agreement},
+    ]
+    project_children = [
+        {"model": Agreement, "relation": Agreement.project, "children": agreement_children}
+    ]
+
+    assert len(version_ids) == 3
+    assert set(version_ids) == get_version_ids(agreement_file.agreement.project, project_children)

--- a/tests/test_reversion_utils.py
+++ b/tests/test_reversion_utils.py
@@ -2,7 +2,7 @@ import reversion
 from reversion.models import Version
 from vitrina.smart_contracts.factories import AgreementPDFFileFactory
 from vitrina.smart_contracts.models import Agreement, AgreementFile
-from vitrina.reversion_utils import get_version_ids, ChildVersionModel
+from vitrina.reversion_utils import get_version_ids, VersionRelationSpec
 
 
 
@@ -17,10 +17,10 @@ def test_get_version_ids():
     version_ids =  list(agreement_file_version_ids) + list(agreement_version_ids) + list(project_version_ids)
 
     agreement_children = [
-        ChildVersionModel(model=AgreementFile, relation=AgreementFile.agreement),
+        VersionRelationSpec(target_model=AgreementFile, parent_fk=AgreementFile.agreement),
     ]
     project_children = [
-        ChildVersionModel(model=Agreement, relation=Agreement.project, children=agreement_children)
+        VersionRelationSpec(target_model=Agreement, parent_fk=Agreement.project, nested=agreement_children)
     ]
 
     assert len(version_ids) == 3

--- a/vitrina/projects/factories.py
+++ b/vitrina/projects/factories.py
@@ -5,7 +5,7 @@ from factory.django import DjangoModelFactory
 
 from vitrina.cms.factories import FilerImageFactory
 from vitrina.datasets.models import Dataset
-from vitrina.projects.models import Project, UseCaseClient
+from vitrina.projects.models import Project, UseCaseClient, UseCaseClientScope
 
 
 class ProjectFactory(DjangoModelFactory):
@@ -35,3 +35,14 @@ class UseCaseClientFactory(DjangoModelFactory):
     use_case = factory.SubFactory(ProjectFactory)
     name = factory.Faker("catch_phrase")
     client_id = factory.Faker("uuid4")
+
+
+class UseCaseClientScopeFactory(DjangoModelFactory):
+    class Meta:
+        model = UseCaseClientScope
+
+    resource = factory.Faker("uri")
+    action = "getall"
+    scope = factory.Faker("uri")
+    use_case_client = factory.SubFactory(UseCaseClientFactory)
+    is_active = True

--- a/vitrina/projects/models.py
+++ b/vitrina/projects/models.py
@@ -140,3 +140,6 @@ class UseCaseClientScope(UUIDBaseModel):
     class Meta:
         verbose_name = _("Kliento leidimas")
         verbose_name_plural = _("Kliento leidimai")
+
+    def __str__(self):
+        return self.scope

--- a/vitrina/projects/templates/vitrina/projects/client_detail.html
+++ b/vitrina/projects/templates/vitrina/projects/client_detail.html
@@ -66,14 +66,18 @@
                     <tr>
                         <th scope="row">{{ scope.scope }}</th>
                         <td style="width:10%">
-                            <a href="{% url 'project-clients-scopes-detail-toggle' project.pk client.uuid scope.uuid %}"
-                                 class="button is-warning is-small">
-                                {% if scope.is_active %}
-                                    {% translate "Išjungti" %}
-                                {% else %}
-                                    {% translate "Įjungti" %}
-                                {% endif %}
-                            </a>
+                            <form method="post"
+                                action="{% url 'project-clients-scopes-detail-toggle' project.pk client.uuid scope.uuid %}"
+                                style="display:inline;">
+                                {% csrf_token %}
+                                <button type="submit" class="button is-warning is-small">
+                                    {% if scope.is_active %}
+                                        {% translate "Išjungti" %}
+                                    {% else %}
+                                        {% translate "Įjungti" %}
+                                    {% endif %}
+                                </button>
+                            </form>
                         </td>
                     </tr>
                 {% endfor %}

--- a/vitrina/projects/views.py
+++ b/vitrina/projects/views.py
@@ -51,7 +51,7 @@ from vitrina.projects.services import (
     can_manage_datasets,
 )
 from vitrina.smart_contracts.permissions import can_view_agreements
-from vitrina.reversion_utils import get_version_ids, ChildVersionModel
+from vitrina.reversion_utils import get_version_ids, VersionRelationSpec
 
 
 logger = logging.getLogger()
@@ -258,13 +258,15 @@ class ProjectHistoryView(ProjectViewBaseMixin, HistoryView):
 
     def get_history_objects(self):
         agreement_children = [
-            ChildVersionModel(model=AgreementFile, relation=AgreementFile.agreement),
-            ChildVersionModel(model=AgreementScope, relation=AgreementScope.agreement),
+            VersionRelationSpec(target_model=AgreementFile, parent_fk=AgreementFile.agreement),
+            VersionRelationSpec(target_model=AgreementScope, parent_fk=AgreementScope.agreement),
         ]
-        client_children = [ChildVersionModel(model=UseCaseClientScope, relation=UseCaseClientScope.use_case_client)]
+        client_children = [
+            VersionRelationSpec(target_model=UseCaseClientScope, parent_fk=UseCaseClientScope.use_case_client)
+        ]
         project_children = [
-            ChildVersionModel(model=Agreement, relation=Agreement.project, children=agreement_children),
-            ChildVersionModel(model=UseCaseClient, relation=UseCaseClient.use_case, children=client_children),
+            VersionRelationSpec(target_model=Agreement, parent_fk=Agreement.project, nested=agreement_children),
+            VersionRelationSpec(target_model=UseCaseClient, parent_fk=UseCaseClient.use_case, nested=client_children),
         ]
         history_objects_ids = get_version_ids(self.project, project_children)
         return Version.objects.filter(id__in=history_objects_ids)

--- a/vitrina/projects/views.py
+++ b/vitrina/projects/views.py
@@ -51,7 +51,7 @@ from vitrina.projects.services import (
     can_manage_datasets,
 )
 from vitrina.smart_contracts.permissions import can_view_agreements
-from vitrina.reversion_utils import get_version_ids
+from vitrina.reversion_utils import get_version_ids, ChildVersionModel
 
 
 logger = logging.getLogger()
@@ -258,13 +258,13 @@ class ProjectHistoryView(ProjectViewBaseMixin, HistoryView):
 
     def get_history_objects(self):
         agreement_children = [
-            {"model": AgreementFile, "relation": AgreementFile.agreement},
-            {"model": AgreementScope, "relation": AgreementScope.agreement},
+            ChildVersionModel(model=AgreementFile, relation=AgreementFile.agreement),
+            ChildVersionModel(model=AgreementScope, relation=AgreementScope.agreement),
         ]
-        client_children = [{"model": UseCaseClientScope, "relation": UseCaseClientScope.use_case_client}]
+        client_children = [ChildVersionModel(model=UseCaseClientScope, relation=UseCaseClientScope.use_case_client)]
         project_children = [
-            {"model": Agreement, "relation": Agreement.project, "children": agreement_children},
-            {"model": UseCaseClient, "relation": UseCaseClient.use_case, "children": client_children},
+            ChildVersionModel(model=Agreement, relation=Agreement.project, children=agreement_children),
+            ChildVersionModel(model=UseCaseClient, relation=UseCaseClient.use_case, children=client_children),
         ]
         history_objects_ids = get_version_ids(self.project, project_children)
         return Version.objects.filter(id__in=history_objects_ids)

--- a/vitrina/projects/views.py
+++ b/vitrina/projects/views.py
@@ -834,11 +834,11 @@ class ClientScopeToggleView(PermissionRequiredMixin, View):
         return can_manage_clients(self.request.user, self.project)
 
     @transaction.atomic
-    def get(self, request, **kwargs) -> HttpResponse:
+    def post(self, request, **kwargs) -> HttpResponse:
         self.scope.is_active = not self.scope.is_active  # Toggle to the opposite status
-        self.scope.save(update_fields=["is_active", "updated_at"])
         OAuthClientManagement.update_oauth_client(
             client_id=self.client.client_id,
             new_scopes=list(self.client.scopes.filter(is_active=True).values_list("scope", flat=True)),
         )
+        self.scope.save(update_fields=["is_active", "updated_at"])
         return redirect(reverse("project-clients-detail", args=[self.project.pk, self.client.uuid]))

--- a/vitrina/projects/views.py
+++ b/vitrina/projects/views.py
@@ -21,6 +21,7 @@ from django.utils.translation import gettext_lazy as _
 from django.urls import reverse
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.mixins import PermissionRequiredMixin
+from reversion.models import Version
 
 import requests
 
@@ -35,7 +36,7 @@ from vitrina.projects.forms import ProjectForm, ClientCreateForm, ClientScopeCre
 from vitrina.projects.models import Project, UseCaseClient, UseCaseClientScope
 from vitrina.settings import SPINTA_SERVER_URL
 from vitrina.smart_contracts import AgreementStatuses
-from vitrina.smart_contracts.models import AgreementScope
+from vitrina.smart_contracts.models import AgreementScope, Agreement, AgreementFile
 from vitrina.structure.models import Metadata, Property
 from vitrina.tasks.models import Task
 from vitrina.views import HistoryView
@@ -50,6 +51,7 @@ from vitrina.projects.services import (
     can_manage_datasets,
 )
 from vitrina.smart_contracts.permissions import can_view_agreements
+from vitrina.reversion_utils import get_version_ids
 
 
 logger = logging.getLogger()
@@ -253,6 +255,19 @@ class ProjectHistoryView(ProjectViewBaseMixin, HistoryView):
         context["can_view_agreements"] = can_view_agreements(self.request.user, self.object)
         context["parent_links"].update({None: _("Istorija")})
         return context
+
+    def get_history_objects(self):
+        agreement_children = [
+            {"model": AgreementFile, "relation": AgreementFile.agreement},
+            {"model": AgreementScope, "relation": AgreementScope.agreement},
+        ]
+        client_children = [{"model": UseCaseClientScope, "relation": UseCaseClientScope.use_case_client}]
+        project_children = [
+            {"model": Agreement, "relation": Agreement.project, "children": agreement_children},
+            {"model": UseCaseClient, "relation": UseCaseClient.use_case, "children": client_children},
+        ]
+        history_objects_ids = get_version_ids(self.project, project_children)
+        return Version.objects.filter(id__in=history_objects_ids)
 
 
 class ProjectDatasetsView(ProjectViewBaseMixin, PermissionRequiredMixin, ListView):

--- a/vitrina/reversion_utils.py
+++ b/vitrina/reversion_utils.py
@@ -1,0 +1,75 @@
+import json
+from typing import Any
+from uuid import UUID
+from django.db import models
+from reversion.models import Version
+from django.db.models import Q
+
+
+def extract_fields_from_version_serialized_data(serialized_data: str) -> dict[str, Any]:
+    payload = json.loads(serialized_data)
+    return payload[0].get("fields", {})
+
+
+def get_child_version_ids(parent_id: int | str | UUID, children: list[dict[str, Any]]) -> set[int]:
+    matching_versions: set[int] = set()
+    for child in children:
+        child_model: type[models.Model] = child["model"]
+        relation_field: str = child["relation"].field.name
+        grand_children = child.get("children")
+
+        candidate_versions = Version.objects.get_for_model(child_model).filter(
+            Q(serialized_data__contains=f'"{relation_field}": {parent_id}')
+            | Q(serialized_data__contains=f'"{relation_field}": "{parent_id}"')
+        )
+
+        for version in candidate_versions.iterator():
+            fields = extract_fields_from_version_serialized_data(version.serialized_data)
+            if str(fields.get(relation_field)) == str(parent_id):
+                matching_versions.add(version.id)
+                if grand_children:
+                    matching_versions.update(get_child_version_ids(version.object_id, grand_children))
+    return matching_versions
+
+
+def get_version_ids(instance: models.Model, children: list[dict[str, Any]] | None = None) -> set[int]:
+    """
+    Collect django-reversion Version IDs for an instance and optionally its related (child) objects.
+
+    This function is safe even if the underlying Django model instances were deleted,
+    because it never loads the objects from the database—only Version rows.
+
+    Args:
+        instance:
+            Model instance that Versions IDs are needed.
+        children:
+            Optional traversal specification for related models.
+
+            Structure:
+                children = [
+                    {
+                        "model": <Django model class>,
+                        "relation": <relation on the child model pointing to the parent>,
+                        "children": [<same structure for grand-children>],  # optional
+                    },
+                    ...
+                ]
+
+            Notes:
+                - "relation" must be a Django relation (e.g. ForeignKey descriptor),
+                and `relation.field.name` is used to read the FK value from
+                reversion's serialized_data.
+                - Nested "children" allows recursive traversal to any depth.
+
+    Returns:
+        A set of Version ids matching the parent and related objects.
+    """
+
+    matching_versions: set[int] = set()
+
+    matching_versions.update(Version.objects.get_for_object(instance).values_list("id", flat=True))
+
+    if children:
+        matching_versions.update(get_child_version_ids(instance.pk, children))
+
+    return matching_versions

--- a/vitrina/reversion_utils.py
+++ b/vitrina/reversion_utils.py
@@ -8,10 +8,10 @@ from django.db.models import Q
 
 
 @dataclass
-class ChildVersionModel:
-    model: type[models.Model]
-    relation: models.ForeignKey
-    children: list["ChildVersionModel"] | None = None
+class VersionRelationSpec:
+    target_model: type[models.Model]
+    parent_fk: models.ForeignKey
+    nested: list["VersionRelationSpec"] | None = None
 
 
 def extract_fields_from_version_serialized_data(serialized_data: str) -> dict[str, Any]:
@@ -19,12 +19,12 @@ def extract_fields_from_version_serialized_data(serialized_data: str) -> dict[st
     return payload[0].get("fields", {})
 
 
-def get_child_version_ids(parent_id: int | str | UUID, children: list[ChildVersionModel]) -> set[int]:
+def get_child_version_ids(parent_id: int | str | UUID, children: list[VersionRelationSpec]) -> set[int]:
     matching_versions: set[int] = set()
     for child in children:
-        child_model: type[models.Model] = child.model
-        relation_field: str = child.relation.field.name
-        grand_children = child.children
+        child_model: type[models.Model] = child.target_model
+        relation_field: str = child.parent_fk.field.name
+        grand_children = child.nested
 
         candidate_versions = Version.objects.get_for_model(child_model).filter(
             Q(serialized_data__contains=f'"{relation_field}": {parent_id}')
@@ -40,7 +40,7 @@ def get_child_version_ids(parent_id: int | str | UUID, children: list[ChildVersi
     return matching_versions
 
 
-def get_version_ids(instance: models.Model, children: list[ChildVersionModel] | None = None) -> set[int]:
+def get_version_ids(instance: models.Model, children: list[VersionRelationSpec] | None = None) -> set[int]:
     """
     Collect django-reversion Version IDs for an instance and optionally its related (child) objects.
 

--- a/vitrina/reversion_utils.py
+++ b/vitrina/reversion_utils.py
@@ -1,9 +1,17 @@
 import json
 from typing import Any
 from uuid import UUID
+from dataclasses import dataclass
 from django.db import models
 from reversion.models import Version
 from django.db.models import Q
+
+
+@dataclass
+class ChildVersionModel:
+    model: type[models.Model]
+    relation: models.ForeignKey
+    children: list["ChildVersionModel"] | None = None
 
 
 def extract_fields_from_version_serialized_data(serialized_data: str) -> dict[str, Any]:
@@ -11,12 +19,12 @@ def extract_fields_from_version_serialized_data(serialized_data: str) -> dict[st
     return payload[0].get("fields", {})
 
 
-def get_child_version_ids(parent_id: int | str | UUID, children: list[dict[str, Any]]) -> set[int]:
+def get_child_version_ids(parent_id: int | str | UUID, children: list[ChildVersionModel]) -> set[int]:
     matching_versions: set[int] = set()
     for child in children:
-        child_model: type[models.Model] = child["model"]
-        relation_field: str = child["relation"].field.name
-        grand_children = child.get("children")
+        child_model: type[models.Model] = child.model
+        relation_field: str = child.relation.field.name
+        grand_children = child.children
 
         candidate_versions = Version.objects.get_for_model(child_model).filter(
             Q(serialized_data__contains=f'"{relation_field}": {parent_id}')
@@ -32,7 +40,7 @@ def get_child_version_ids(parent_id: int | str | UUID, children: list[dict[str, 
     return matching_versions
 
 
-def get_version_ids(instance: models.Model, children: list[dict[str, Any]] | None = None) -> set[int]:
+def get_version_ids(instance: models.Model, children: list[ChildVersionModel] | None = None) -> set[int]:
     """
     Collect django-reversion Version IDs for an instance and optionally its related (child) objects.
 
@@ -44,17 +52,6 @@ def get_version_ids(instance: models.Model, children: list[dict[str, Any]] | Non
             Model instance that Versions IDs are needed.
         children:
             Optional traversal specification for related models.
-
-            Structure:
-                children = [
-                    {
-                        "model": <Django model class>,
-                        "relation": <relation on the child model pointing to the parent>,
-                        "children": [<same structure for grand-children>],  # optional
-                    },
-                    ...
-                ]
-
             Notes:
                 - "relation" must be a Django relation (e.g. ForeignKey descriptor),
                 and `relation.field.name` is used to read the FK value from

--- a/vitrina/smart_contracts/models.py
+++ b/vitrina/smart_contracts/models.py
@@ -265,6 +265,9 @@ class AgreementScope(UUIDBaseModel):
         verbose_name = _("Sutarties leidimas")
         verbose_name_plural = _("Sutarties leidimai")
 
+    def __str__(self):
+        return self.scope
+
 
 class AgreementFile(UUIDBaseModel):
     class AllowedFileTypes(models.TextChoices):

--- a/vitrina/templates/history.html
+++ b/vitrina/templates/history.html
@@ -41,6 +41,7 @@
                     {% endfor %}
                     </tbody>
                 </table>
+                {% include "vitrina/common/pagination.html" %}
             {% endif %}
         </div>
     </div>

--- a/vitrina/templates/history.html
+++ b/vitrina/templates/history.html
@@ -21,7 +21,22 @@
                         <tr>
                             <td>{{ h.date|date:"SHORT_DATETIME_FORMAT" }}</td>
                             <td>{{ h.user|default_if_none:"-" }}</td>
-                            <td>{{ h.action|default_if_none:"-" }}</td>
+                            <td>
+                                {{ h.action.comment|default_if_none:"-" }}
+                                <div class="content">
+                                    <ul>
+                                        {% for repr, url in h.action.objects %}
+                                            <li>
+                                                {% if url %}
+                                                    <a href="{{url}}">{{ repr }}</a>
+                                                {% else %}
+                                                    {{ repr }}
+                                                {% endif %}
+                                            </li>
+                                        {% endfor %}
+                                    </ul>
+                                </div>
+                            </td>
                         </tr>
                     {% endfor %}
                     </tbody>

--- a/vitrina/templates/history.html
+++ b/vitrina/templates/history.html
@@ -17,15 +17,15 @@
                         <th>{% translate "Naudotojas" %}</th>
                         <th>{% translate "Veiksmas" %}</th>
                     </tr>
-                    {% for h in history %}
+                    {% for history_row in history %}
                         <tr>
-                            <td>{{ h.date|date:"SHORT_DATETIME_FORMAT" }}</td>
-                            <td>{{ h.user|default_if_none:"-" }}</td>
+                            <td>{{ history_row.date|date:"SHORT_DATETIME_FORMAT" }}</td>
+                            <td>{{ history_row.user|default_if_none:"-" }}</td>
                             <td>
-                                {{ h.action.comment|default_if_none:"-" }}
+                                {{ history_row.action.comment|default_if_none:"-" }}
                                 <div class="content">
                                     <ul>
-                                        {% for repr, url in h.action.objects %}
+                                        {% for repr, url in history_row.action.objects %}
                                             <li>
                                                 {% if url %}
                                                     <a href="{{url}}">{{ repr }}</a>

--- a/vitrina/views.py
+++ b/vitrina/views.py
@@ -3,6 +3,7 @@ from importlib.metadata import version, PackageNotFoundError
 import json
 
 from django.core.exceptions import ImproperlyConfigured
+from django.core.paginator import Paginator
 from django.db.models import Model, QuerySet, Prefetch
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.forms import BaseFormSet
@@ -107,6 +108,7 @@ class HistoryView(PermissionRequiredMixin, TemplateView):
     detail_url_name = None
     history_url_name = None
     tabs_template_name: str
+    paginate_by = 20
 
     object: Model
 
@@ -120,6 +122,9 @@ class HistoryView(PermissionRequiredMixin, TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        paginator = Paginator(self.get_revisions(), self.paginate_by)
+        page_obj = paginator.get_page(self.request.GET.get("page"))
+
         context.update(
             {
                 "detail_url_name": self.get_detail_url_name(),
@@ -127,22 +132,23 @@ class HistoryView(PermissionRequiredMixin, TemplateView):
                 "detail_url": self.get_detail_url(),
                 "child_resources_url": self.get_child_resources_url(),
                 "history_url": self.get_history_url(),
-                "history": self.get_history_list(),
+                "history": self.get_history_list(page_obj.object_list),
                 "can_manage_history": has_perm(
                     self.request.user,
                     Action.HISTORY_VIEW,
                     self.get_history_object(),
                 ),
                 "tabs_template_name": self.tabs_template_name,
+                "page_obj": page_obj,
             }
         )
 
         return context
 
-    def get_history_list(self) -> list[dict[str, Any]]:
+    def get_history_list(self, revisions: QuerySet[Revision]) -> list[dict[str, Any]]:
         history = []
 
-        for revision in self.get_revisions():
+        for revision in revisions:
             entry = {
                 "date": revision.date_created,
                 "user": revision.user,

--- a/vitrina/views.py
+++ b/vitrina/views.py
@@ -1,8 +1,9 @@
 from typing import Type, Any
 from importlib.metadata import version, PackageNotFoundError
+import json
 
 from django.core.exceptions import ImproperlyConfigured
-from django.db.models import Model
+from django.db.models import Model, QuerySet, Prefetch
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.forms import BaseFormSet
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect, JsonResponse
@@ -13,7 +14,7 @@ from django.db.models import Count
 from django.views.generic.base import TemplateResponseMixin, ContextMixin
 from django.views.generic.edit import ProcessFormView
 
-from reversion.models import Version
+from reversion.models import Version, Revision
 
 from vitrina.classifiers.models import Category
 from vitrina.datasets.models import Dataset
@@ -23,6 +24,7 @@ from vitrina.statistics.models import StatRoute
 from vitrina.users.models import User
 from vitrina.orgs.services import has_perm, Action
 from vitrina.projects.models import Project
+from vitrina.utils import RevisionComment
 
 
 def home(request):
@@ -125,21 +127,7 @@ class HistoryView(PermissionRequiredMixin, TemplateView):
                 "detail_url": self.get_detail_url(),
                 "child_resources_url": self.get_child_resources_url(),
                 "history_url": self.get_history_url(),
-                "history": [
-                    {
-                        "date": version.revision.date_created,
-                        "user": version.revision.user,
-                        "action": self.model.HISTORY_MESSAGES.get(
-                            version.revision.comment,
-                        )
-                        if (
-                            hasattr(self.model, "HISTORY_MESSAGES")
-                            and self.model.HISTORY_MESSAGES.get(version.revision.comment)
-                        )
-                        else version.revision.comment,
-                    }
-                    for version in self.get_history_objects()
-                ],
+                "history": self.get_history_list(),
                 "can_manage_history": has_perm(
                     self.request.user,
                     Action.HISTORY_VIEW,
@@ -148,15 +136,60 @@ class HistoryView(PermissionRequiredMixin, TemplateView):
                 "tabs_template_name": self.tabs_template_name,
             }
         )
-        context["history"] = self._deduplicate_and_sort_history(context["history"])
 
         return context
 
-    def _deduplicate_and_sort_history(self, history: list[dict]) -> list[dict]:
-        unique_entries = {tuple(entry.items()) for entry in history}
-        unique_history = [dict(entry) for entry in unique_entries]
+    def get_history_list(self) -> list[dict[str, Any]]:
+        history = []
 
-        return sorted(unique_history, key=lambda x: x["date"], reverse=True)
+        for revision in self.get_revisions():
+            entry = {
+                "date": revision.date_created,
+                "user": revision.user,
+                "action": {
+                    "comment": self.prep_comment_for_display(revision.comment),
+                    "objects": self.prep_versions_for_display(revision.version_set.all()),
+                },
+            }
+            history.append(entry)
+        return history
+
+    def prep_versions_for_display(self, versions: QuerySet[Version]) -> list[tuple[str, str | None]]:
+        objects = []
+        for version_obj in versions:
+            model = version_obj.content_type.model_class()
+            try:
+                object = model.objects.get(pk=version_obj.object_id)
+            except model.DoesNotExist:
+                object = None
+
+            url = None
+
+            if object and hasattr(object, "get_absolute_url"):
+                url = object.get_absolute_url()
+
+            objects.append((version_obj.object_repr, url))
+        return objects
+
+    def prep_comment_for_display(self, comment: str) -> str:
+        try:
+            revision_comment = RevisionComment.from_json(comment)
+            return f"{revision_comment.action}({revision_comment.kwargs})"
+        except (json.JSONDecodeError, ValueError, TypeError):
+            return (
+                self.model.HISTORY_MESSAGES.get(comment)
+                if (hasattr(self.model, "HISTORY_MESSAGES") and self.model.HISTORY_MESSAGES.get(comment))
+                else comment
+            )
+
+    def get_revisions(self) -> QuerySet[Revision]:
+        versions = self.get_history_objects()
+        return (
+            Revision.objects.filter(version__in=self.get_history_objects())
+            .distinct()
+            .order_by("-date_created")
+            .prefetch_related(Prefetch("version_set", queryset=versions))
+        )
 
     def get_detail_url_name(self):
         return self.detail_url_name
@@ -184,8 +217,8 @@ class HistoryView(PermissionRequiredMixin, TemplateView):
     def get_detail_object(self):
         return self.object
 
-    def get_history_objects(self):
-        return Version.objects.get_for_object(self.get_history_object()).order_by("-revision__date_created")
+    def get_history_objects(self) -> QuerySet[Version]:
+        return Version.objects.get_for_object(self.get_history_object())
 
 
 class HistoryMixin:

--- a/vitrina/views.py
+++ b/vitrina/views.py
@@ -163,15 +163,9 @@ class HistoryView(PermissionRequiredMixin, TemplateView):
     def prep_versions_for_display(self, versions: QuerySet[Version]) -> list[tuple[str, str | None]]:
         objects = []
         for version_obj in versions:
-            model = version_obj.content_type.model_class()
-            try:
-                object = model.objects.get(pk=version_obj.object_id)
-            except model.DoesNotExist:
-                object = None
-
             url = None
 
-            if object and hasattr(object, "get_absolute_url"):
+            if (object := version_obj.object) and hasattr(object, "get_absolute_url"):
                 url = object.get_absolute_url()
 
             objects.append((version_obj.object_repr, url))


### PR DESCRIPTION
- Updates history display logic from "per Version" to "per Revision".
- Updates history action message to display view name + kwargs used when request was made, if comment can be deserialized to `RevisionComment`. Falls back to old logic (raw output) if it cant.
- Lists all Version objects for single entry (Revision) filtered by parent model, instead of showing all Versions that belong to Revision. This is done by looping through every Version object and checking if it is related to main (parent) object at  time when Version was created. This way allows to find Versions that belong to instances that are now deleted or moved to different parent.
- Updates Project history to include changes made to following models:
  - Project
  - Agreement
  - AgreementFile
  - UseCaseClient
  - UseCaseClientScope
