### PR TITLE
Make `LOGGING` configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,7 @@ SPINTA_SERVER_URL=https://127.0.0.1:8000
 SPINTA_SERVER_NAME=127.0.0.1:8000
 SPINTA_PATH=spinta-env/data
 USE_OTP_VALIDATION=True
+DJANGO_LOGGING={"version": 1, "disable_existing_loggers": false, "handlers": {"console": {"level": "DEBUG", "class": "logging.StreamHandler"}}, "root": {"handlers": ["console"], "level": "WARNING"}}
 
 RECAPTCHA_SILENCE_KEY_ERROR=True
 RECAPTCHA_PUBLIC_KEY="6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,9 @@ Refactored representative role model to split coordinator and manager roles into
 - Ensured backward compatibility by updating all role checks and queryset filters referencing legacy roles
 - Added logic to not let OPEN_DATA_COORDINATORS add/update/delete RESOURCE_MANAGERS and RESOURCE_COORDINATORS
 
+<No ticket>
+- Make django `LOGGING` configurable from `.env`.
+
 v 1.11.3 (2026-01-05)
 ==================
 

--- a/vitrina/settings.py
+++ b/vitrina/settings.py
@@ -455,20 +455,24 @@ ACCOUNT_UNIQUE_EMAIL = True
 ACCOUNT_EMAIL_VERIFICATION = "mandatory"
 ACCOUNT_SIGNUP_REDIRECT_URL = "password-set"
 
-LOGGING = {
-    "version": 1,
-    "disable_existing_loggers": False,
-    "handlers": {
-        "console": {
-            "level": "INFO",
-            "class": "logging.StreamHandler",
+LOGGING = env.json(
+    "DJANGO_LOGGING",
+    default={
+        "version": 1,
+        "disable_existing_loggers": False,
+        "handlers": {
+            "console": {
+                "level": "INFO",
+                "class": "logging.StreamHandler",
+            },
+        },
+        "root": {
+            "handlers": ["console"],
+            "level": "WARNING",
         },
     },
-    "root": {
-        "handlers": ["console"],
-        "level": "WARNING",
-    },
-}
+)
+
 CORS_ALLOWED_ORIGINS = ["https://test.epaslaugos.lt"]
 ACCOUNT_AUTHENTICATED_LOGIN_REDIRECT = False
 


### PR DESCRIPTION
If we had this before the issue with server space filling up from logs would've been a 1 minute fix:

```
DJANGO_LOGGING='{"version": 1, "disable_existing_loggers": false, "handlers": {"console": {"level": "INFO", "class": "logging.StreamHandler"}}, "loggers": {"elasticsearch": {"level": "WARNING", "handlers": ["console"], "propagate": false}, "spinta": {"level": "WARNING", "handlers": ["console"], "propagate": false}}, "root": {"handlers": ["console"], "level": "WARNING"}}'
```