### PR TITLE
[1647] Implement `is_enabled` flag check permission

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,10 @@ Refactored representative role model to split coordinator and manager roles into
 - Ensured backward compatibility by updating all role checks and queryset filters referencing legacy roles
 - Added logic to not let OPEN_DATA_COORDINATORS add/update/delete RESOURCE_MANAGERS and RESOURCE_COORDINATORS
 
+https://github.com/atviriduomenys/spinta/issues/1647
+
+- Adding an API permission to check if Agent is enabled (in Catalog) before performing any requests coming from the Agent (spinta/other(custom) implementations).
+
 v 1.11.3 (2026-01-05)
 ==================
 

--- a/tests/uapi/agreements/test_views.py
+++ b/tests/uapi/agreements/test_views.py
@@ -75,6 +75,31 @@ def test_sync_done_update_404_when_agreement_sync_disabled(
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
+def test_sync_agent_is_disabled(
+    app: DjangoTestApp,
+    organization: Organization,
+    project: Project,
+    valid_token_disabled_agent: str,
+):
+    agreement = AgreementFactory(
+        project=project,
+        assigner=organization,
+        assignee=organization,
+        is_agent_sync_enabled=True,
+    )
+
+    response = app.put(
+        reverse("uapi-agent-sync-done", kwargs={"agreement_id": agreement.pk}),
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token_disabled_agent}"},
+        expect_errors=True,
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.json == {
+        "detail": "The agent is disabled. Enable the agent in the Data catalog to access this API."
+    }
+
+
 def test_sync_done_updates_last_sync_date_and_status_to_active(
     app: DjangoTestApp,
     organization: Organization,

--- a/tests/uapi/conftest.py
+++ b/tests/uapi/conftest.py
@@ -34,11 +34,12 @@ def _generate_test_token(
     jwk: RSAKey,
     scopes: Iterable[str] = ("datasets:write",),
     organization: Organization = None,
-    expires_in: int = 900
+    expires_in: int = 900,
+    agent_is_enabled: bool = True,
 ):
     oauth_client_id = None
     if organization:
-        agent = AgentFactory(organization=organization, oauth_client_id=str(uuid.uuid4()))
+        agent = AgentFactory(organization=organization, oauth_client_id=str(uuid.uuid4()), is_enabled=agent_is_enabled)
         oauth_client_id =agent.oauth_client_id
     now = datetime.utcnow()
     claims = {
@@ -87,6 +88,19 @@ def valid_token(
     organization: Organization,
 ) -> str:
     return _generate_test_token(test_jwk, organization=organization, scopes=OAUTH_AGENT_DEFAULT_SCOPES)
+
+
+@pytest.fixture()
+def valid_token_disabled_agent(
+    test_jwk: RSAKey,
+    organization: Organization,
+) -> str:
+    return _generate_test_token(
+        test_jwk,
+        organization=organization,
+        scopes=OAUTH_AGENT_DEFAULT_SCOPES,
+        agent_is_enabled=False,
+    )
 
 
 @pytest.fixture

--- a/tests/uapi/dataset/test_views.py
+++ b/tests/uapi/dataset/test_views.py
@@ -11,7 +11,6 @@ from django_webtest import DjangoTestApp
 from factory.django import FileField
 from rest_framework import status
 from rest_framework.exceptions import ErrorDetail
-from reversion.models import Version
 
 from tests.conftest import _normalize_csv
 from tests.uapi.conftest import _generate_test_token, _build_reverse_uapi_url
@@ -236,6 +235,39 @@ def test_create_specific_scope(
         "service": False,
         "series": False,
         "subclass": DCATResourceSubclass.DATASET,
+    }
+
+
+def test_create_agent_is_disabled(
+    app: DjangoTestApp,
+    organization: Organization,
+    url_dataset: str,
+    domain: str,
+    valid_token_disabled_agent: str,
+):
+    dataset_parent = DatasetFactory()
+    data = {
+        "name": "/datasets/gov/vssa/isris/dcat/uapi/Model",
+        "title": "DataSet 1",
+        "description": "DataSet 1 description",
+        "service": True,
+        "subclass": DCATResourceSubclass.SERVICE,
+        "parent_id": dataset_parent.pk,
+    }
+    response = app.post(
+        url_dataset,
+        data,
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token_disabled_agent}"},
+        expect_errors=True,
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.json == {
+        "code": "Forbidden",
+        "type": "system",
+        "template": "Access is forbidden.",
+        "message": "The agent is disabled. Enable the agent in the Data catalog to access this API.",
+        "additionalProperties": None,
     }
 
 
@@ -470,6 +502,29 @@ def test_list_specific_scope(
                 "subclass": DCATResourceSubclass.DATASET,
             }
         ]
+    }
+
+
+def test_list_agent_is_disabled(
+    app: DjangoTestApp,
+    organization: Organization,
+    url_dataset: str,
+    domain: str,
+    valid_token_disabled_agent: str,
+):
+    response = app.get(
+        url_dataset,
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token_disabled_agent}"},
+        expect_errors=True,
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.json == {
+        "code": "Forbidden",
+        "type": "system",
+        "template": "Access is forbidden.",
+        "message": "The agent is disabled. Enable the agent in the Data catalog to access this API.",
+        "additionalProperties": None,
     }
 
 
@@ -792,6 +847,33 @@ def test_action_upload_dataset_structure_specific_scope(
     assert file.label == f"dataset_{dataset.id}_structure.csv"
 
 
+def test_action_upload_agent_is_disabled(
+    app: DjangoTestApp,
+    organization: Organization,
+    dataset: Dataset,
+    dsa: str,
+    url_dataset_structure: str,
+    test_jwk: RSAKey,
+    valid_token_disabled_agent: str,
+):
+    response = app.post(
+        url_dataset_structure,
+        dsa,
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token_disabled_agent}"},
+        content_type="text/csv",
+        expect_errors=True,
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.json == {
+        "code": "Forbidden",
+        "type": "system",
+        "template": "Access is forbidden.",
+        "message": "The agent is disabled. Enable the agent in the Data catalog to access this API.",
+        "additionalProperties": None,
+    }
+
+
 @pytest.mark.parametrize("invalid_scopes", [["invalid_scope"], [], [""]])
 def test_action_upload_dataset_structure_token_does_not_have_necessary_scopes(
     invalid_scopes: Iterable[str],
@@ -1021,7 +1103,43 @@ def test_action_get_dataset_structure_no_dataset(
         "message": "No Dataset matches the given query.",
         "additionalProperties": None,
     }
-def test_action_cant_get_dataset_invalid_token(
+
+
+def test_action_get_agent_is_disabled(
+    app: DjangoTestApp,
+    organization: Organization,
+    dataset: Dataset,
+    dsa: str,
+    url_dataset_structure: str,
+    valid_token_disabled_agent: str,
+):
+    structure = DatasetStructureFactory(
+        dataset=dataset,
+        file=FilerFileFactory(
+            file=FileField(filename=f"dataset_{dataset.id}_structure.csv", data=dsa)
+        )
+    )
+    dataset.current_structure = structure
+    dataset.save()
+    create_structure_objects(structure)
+
+    response = app.get(
+        url_dataset_structure,
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token_disabled_agent}"},
+        expect_errors=True,
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.json == {
+        "code": "Forbidden",
+        "type": "system",
+        "template": "Access is forbidden.",
+        "message": "The agent is disabled. Enable the agent in the Data catalog to access this API.",
+        "additionalProperties": None,
+    }
+
+
+def test_action_get_invalid_token(
     app: DjangoTestApp,
     organization: Organization,
     url_dataset_structure: str,
@@ -1104,6 +1222,32 @@ def test_action_update_dataset_structure_specific_scope(
     )
 
     assert response.status_code == status.HTTP_501_NOT_IMPLEMENTED
+
+
+def test_action_update_agent_is_disabled(
+    app: DjangoTestApp,
+    organization: Organization,
+    dataset: Dataset,
+    dsa: str,
+    url_dataset_structure: str,
+    valid_token_disabled_agent: str,
+):
+    response = app.put(
+        url_dataset_structure,
+        dsa,
+        content_type="text/csv",
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token_disabled_agent}"},
+        expect_errors=True,
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.json == {
+        "code": "Forbidden",
+        "type": "system",
+        "template": "Access is forbidden.",
+        "message": "The agent is disabled. Enable the agent in the Data catalog to access this API.",
+        "additionalProperties": None,
+    }
 
 
 @pytest.mark.parametrize("invalid_scopes", [["invalid_scope"], [], [""]])

--- a/tests/uapi/distribution/test_views.py
+++ b/tests/uapi/distribution/test_views.py
@@ -131,6 +131,38 @@ def test_create_specific_scope(
     }
 
 
+def test_create_agent_is_disabled(
+    app: DjangoTestApp,
+    organization: Organization,
+    dataset: Dataset,
+    url_distribution: str,
+    domain: str,
+    valid_token_disabled_agent: str,
+):
+    file_content = b"Sample CSV content"
+    data = {
+        "dataset": str(dataset.id),
+        "title": "Title",
+    }
+
+    response = app.post(
+        url_distribution,
+        data,
+        upload_files=[("file", "test.csv", file_content)],
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token_disabled_agent}"},
+        expect_errors=True,
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.json == {
+        "code": "Forbidden",
+        "type": "system",
+        "template": "Access is forbidden.",
+        "message": "The agent is disabled. Enable the agent in the Data catalog to access this API.",
+        "additionalProperties": None,
+    }
+
+
 @pytest.mark.parametrize("invalid_scopes", [["invalid_scope"], [], [""]])
 def test_create_token_does_not_have_necessary_scopes(
     invalid_scopes: Iterable[str],
@@ -256,7 +288,6 @@ def test_create_unexpected_exception_raised(
     }
 
 
-
 def test_list(
     app: DjangoTestApp,
     organization: Organization,
@@ -339,6 +370,30 @@ def test_list_specific_scope(
                 "upload_to_storage": distribution.upload_to_storage,
             }
         ]
+    }
+
+
+def test_list_agent_is_disabled(
+    app: DjangoTestApp,
+    organization: Organization,
+    dataset: Dataset,
+    url_distribution: str,
+    domain: str,
+    valid_token_disabled_agent: str,
+):
+    response = app.get(
+        url_distribution,
+        extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token_disabled_agent}"},
+        expect_errors=True,
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.json == {
+        "code": "Forbidden",
+        "type": "system",
+        "template": "Access is forbidden.",
+        "message": "The agent is disabled. Enable the agent in the Data catalog to access this API.",
+        "additionalProperties": None,
     }
 
 

--- a/vitrina/uapi/permissions.py
+++ b/vitrina/uapi/permissions.py
@@ -1,0 +1,19 @@
+from django.views import View
+from rest_framework.permissions import BasePermission
+from rest_framework.request import Request
+
+from vitrina.api.oauth import OAuthClientAuthenticator
+from vitrina.uapi.models import Agent
+
+
+class IsAgentEnabled(BasePermission):
+    message = "The agent is disabled. Enable the agent in the Data catalog to access this API."
+
+    def has_permission(self, request: Request, view: View) -> bool:
+        if not (oauth_client_id := OAuthClientAuthenticator.resolve_client_id_from_token(request.auth)):
+            return False
+
+        if Agent.objects.filter(oauth_client_id=oauth_client_id, is_enabled=True).exists():
+            return True
+
+        return False

--- a/vitrina/uapi/views/mixins.py
+++ b/vitrina/uapi/views/mixins.py
@@ -1,0 +1,21 @@
+from vitrina.api.oauth import (
+    OAuth2Authentication,
+    IsOAuthTokenValid,
+    OAuthTokenHasScopes,
+    OAuthTokenHasValidOrganizationClaim,
+)
+from vitrina.uapi.permissions import IsAgentEnabled
+
+
+class AgentAuthViewSetMixin:
+    authentication_classes = [OAuth2Authentication]
+    permission_classes = [
+        IsOAuthTokenValid,
+        OAuthTokenHasScopes,
+        OAuthTokenHasValidOrganizationClaim,
+        IsAgentEnabled,
+    ]
+
+    # Mapping of DRF action names to the required OAuth scopes.
+    # ! Must be defined in subclasses.
+    required_scopes: dict[str, list[str]] = {}

--- a/vitrina/uapi/views/views.py
+++ b/vitrina/uapi/views/views.py
@@ -16,12 +16,6 @@ from rest_framework.serializers import Serializer
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
-from vitrina.api.oauth import (
-    OAuth2Authentication,
-    IsOAuthTokenValid,
-    OAuthTokenHasScopes,
-    OAuthTokenHasValidOrganizationClaim,
-)
 from vitrina.api.serializers import PostDatasetDistributionSerializer
 from vitrina.datasets.models import Dataset, DatasetStructure, DCATResourceSubclass
 from vitrina.exceptions import UAPIException
@@ -40,15 +34,10 @@ from vitrina.uapi.serializers.serializers import (
 )
 from vitrina.uapi.utils.utils import extract_type_from_url
 from vitrina.uapi.utils.views import UAPIExceptionHandlerMixin
+from vitrina.uapi.views.mixins import AgentAuthViewSetMixin
 
 
-class DatasetViewSet(UAPIExceptionHandlerMixin, viewsets.ModelViewSet):
-    authentication_classes = [OAuth2Authentication]
-    permission_classes = [
-        IsOAuthTokenValid,
-        OAuthTokenHasScopes,
-        OAuthTokenHasValidOrganizationClaim,
-    ]
+class DatasetViewSet(UAPIExceptionHandlerMixin, AgentAuthViewSetMixin, viewsets.ModelViewSet):
     required_scopes = {
         "create": ["uapi:/datasets/gov/vssa/dcat/Dataset/:create"],
         "list": ["uapi:/datasets/gov/vssa/dcat/Dataset/:getall"],
@@ -247,13 +236,7 @@ class DatasetViewSet(UAPIExceptionHandlerMixin, viewsets.ModelViewSet):
         return Response(status=status.HTTP_501_NOT_IMPLEMENTED)
 
 
-class DistributionViewSet(UAPIExceptionHandlerMixin, viewsets.ModelViewSet):
-    authentication_classes = [OAuth2Authentication]
-    permission_classes = [
-        IsOAuthTokenValid,
-        OAuthTokenHasScopes,
-        OAuthTokenHasValidOrganizationClaim,
-    ]
+class DistributionViewSet(UAPIExceptionHandlerMixin, AgentAuthViewSetMixin, viewsets.ModelViewSet):
     required_scopes = {
         "create": ["uapi:/datasets/gov/vssa/dcat/Distribution/:create"],
         "list": ["uapi:/datasets/gov/vssa/dcat/Distribution/:getall"],
@@ -337,13 +320,7 @@ class DistributionViewSet(UAPIExceptionHandlerMixin, viewsets.ModelViewSet):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 
-class AgentSyncDoneViewSet(viewsets.ModelViewSet):
-    authentication_classes = [OAuth2Authentication]
-    permission_classes = [
-        IsOAuthTokenValid,
-        OAuthTokenHasScopes,
-        OAuthTokenHasValidOrganizationClaim,
-    ]
+class AgentSyncDoneViewSet(AgentAuthViewSetMixin, viewsets.ModelViewSet):
     required_scopes = {"update": ["uapi:/datasets/gov/vssa/dcat/Agreement/:patch"]}
 
     lookup_url_kwarg = "agreement_id"
@@ -363,7 +340,7 @@ class AgentSyncDoneViewSet(viewsets.ModelViewSet):
 
         # Agent Sync changes are determined by time between Agreement.updated_at
         # and Agreement.last_sync_date. This endpoint should not update
-        # Agreement.updated_at in case changes were made since start of sync that
+        # Agreement.updated_at in case changes were made since the start of sync that
         # haven't been synced.
         agreement.save(update_fields=["last_sync_date", "status"])
 


### PR DESCRIPTION
`Agent` object in the **Catalog** has a flag `is_enabled`, adding a permission that checks it when calls via API are being made. If the Agent is disabled, we should deny any calls to the appropriate API endpoints.
