### PR TITLE
[1647] Adjust sync done view set

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,7 @@ Refactored representative role model to split coordinator and manager roles into
 https://github.com/atviriduomenys/spinta/issues/1647
 
 - Adding an API permission to check if Agent is enabled (in Catalog) before performing any requests coming from the Agent (spinta/other(custom) implementations).
+- Adjusting Sync-done API endpoint to return errors in UDTS format.
 
 v 1.11.3 (2026-01-05)
 ==================

--- a/tests/uapi/agreements/test_views.py
+++ b/tests/uapi/agreements/test_views.py
@@ -31,6 +31,13 @@ def test_sync_done_update_404_when_agreement_does_not_exist(
     )
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json == {
+        "code": "not_found",
+        "type": "NotFound",
+        "template": "The requested resource was not found.",
+        "message": "No Agreement matches the given query.",
+        "additionalProperties": None,
+    }
 
 
 def test_sync_done_update_404_when_different_organization_in_token(
@@ -51,6 +58,13 @@ def test_sync_done_update_404_when_different_organization_in_token(
     )
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json == {
+        "code": "not_found",
+        "type": "NotFound",
+        "template": "The requested resource was not found.",
+        "message": "No Agreement matches the given query.",
+        "additionalProperties": None,
+    }
 
 
 def test_sync_done_update_404_when_agreement_sync_disabled(
@@ -73,6 +87,13 @@ def test_sync_done_update_404_when_agreement_sync_disabled(
     )
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json == {
+        "code": "not_found",
+        "type": "NotFound",
+        "template": "The requested resource was not found.",
+        "message": "No Agreement matches the given query.",
+        "additionalProperties": None,
+    }
 
 
 def test_sync_agent_is_disabled(
@@ -96,7 +117,11 @@ def test_sync_agent_is_disabled(
 
     assert response.status_code == status.HTTP_403_FORBIDDEN
     assert response.json == {
-        "detail": "The agent is disabled. Enable the agent in the Data catalog to access this API."
+        "code": "Forbidden",
+        "type": "system",
+        "template": "Access is forbidden.",
+        "message": "The agent is disabled. Enable the agent in the Data catalog to access this API.",
+        "additionalProperties": None,
     }
 
 

--- a/tests/uapi/conftest.py
+++ b/tests/uapi/conftest.py
@@ -40,7 +40,7 @@ def _generate_test_token(
     oauth_client_id = None
     if organization:
         agent = AgentFactory(organization=organization, oauth_client_id=str(uuid.uuid4()), is_enabled=agent_is_enabled)
-        oauth_client_id =agent.oauth_client_id
+        oauth_client_id = agent.oauth_client_id
     now = datetime.utcnow()
     claims = {
         "iss": "test-issuer",

--- a/vitrina/uapi/views/views.py
+++ b/vitrina/uapi/views/views.py
@@ -320,7 +320,7 @@ class DistributionViewSet(UAPIExceptionHandlerMixin, AgentAuthViewSetMixin, view
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 
-class AgentSyncDoneViewSet(AgentAuthViewSetMixin, viewsets.ModelViewSet):
+class AgentSyncDoneViewSet(UAPIExceptionHandlerMixin, AgentAuthViewSetMixin, viewsets.ModelViewSet):
     required_scopes = {"update": ["uapi:/datasets/gov/vssa/dcat/Agreement/:patch"]}
 
     lookup_url_kwarg = "agreement_id"


### PR DESCRIPTION
`AgentSyncDoneViewSet` was not inheriting `UAPIExceptionHandlerMixin`, since it is mandatory for UAPI endpoints to follow the UAPI best practices, adding it, adjusting the tests appropriately.

Reference to UAPI example:
- https://ivpk.github.io/uapi/#tag/objects