### PR TITLE
[1906]: Export DSA for specific version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changes
 v 1.14.0 (unreleased)
 ==================
 
+Improvements:
+
+https://github.com/atviriduomenys/katalogas/issues/1906
+
+- Export Dataset structure for a specific version.
 
 v 1.13.0 (2026-01-26)
 ==================

--- a/tests/datasets/test_views.py
+++ b/tests/datasets/test_views.py
@@ -3494,6 +3494,24 @@ def test_dataset_structure_import_standardized(app: DjangoTestApp):
     assert structure.file.original_filename == "file.csv"
 
 
+def test_dataset_structure_import_with_version(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    dataset = DatasetFactory()
+    version = VersionFactory(dataset=dataset, status=VersionStatus.DRAFT)
+
+    app.set_user(user)
+    resp = app.get(reverse("dataset-structure-import", args=[dataset.pk, version.pk]))
+    form = resp.forms["dataset-structure-form"]
+    form["file"] = Upload("file.csv", MANIFEST.encode())
+    form.submit()
+
+    dataset.refresh_from_db()
+    structure = DatasetStructure.objects.get(dataset=dataset)
+    assert dataset.current_structure == structure
+    assert File.objects.count() == 1
+    assert structure.file.original_filename == "file.csv"
+
+
 def test_dataset_assign_new_category_without_permission(app: DjangoTestApp):
     user = UserFactory()
     app.set_user(user)

--- a/tests/structure/test_services.py
+++ b/tests/structure/test_services.py
@@ -12,6 +12,7 @@ from vitrina.datasets.factories import DatasetStructureFactory, DatasetFactory
 from vitrina.datasets.models import Dataset
 from vitrina.resources.factories import DatasetDistributionFactory, FileFormat
 from vitrina.resources.models import DatasetDistribution
+from vitrina.structure import VersionStatus
 from vitrina.structure.factories import VersionFactory
 from vitrina.structure.models import (
     Metadata,
@@ -1493,6 +1494,39 @@ def test_uri_prefix(app: DjangoTestApp):
             type=Comment.STRUCTURE_ERROR,
         ).values_list("body", flat=True)
     ) == ['Prefiksas "spinta" duomenų ištekliuje neegzistuoja.']
+
+
+@pytest.mark.django_db
+def test_structure_export__dataset_name(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+    manifest = (
+        'id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n'
+        '1,,,,,,prefix,spinta,,,,,,,,https://github.com/atviriduomenys/spinta/issues/,,,\n'
+        '2,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
+        '3,,,,,,prefix,dcat,,,,,,,,http://www.w3.org/ns/dcat#,,,\n'
+        '4,,,,,,,dct,,,,,,,,http://purl.org/dc/terms/,,,'
+    )
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(
+            file=FileField(filename='file.csv', data=manifest)
+        ),
+        dataset=DatasetFactory(
+            title="Title",
+            description="Description"
+        )
+    )
+    structure.dataset.current_structure = structure
+    structure.dataset.save()
+    version = VersionFactory(dataset=structure.dataset, major=3, status=VersionStatus.PRE_RELEASE)
+    create_structure_objects(structure, version)
+    resp = app.get(
+        reverse(
+            "dataset-structure-export",
+            args=[structure.dataset.pk, version.pk]
+        )
+    )
+    assert "datasets/gov/ivpk/adp/3" in resp.text
 
 
 @pytest.mark.django_db

--- a/tests/structure/test_services.py
+++ b/tests/structure/test_services.py
@@ -15,9 +15,18 @@ from vitrina.resources.factories import DatasetDistributionFactory, FileFormat
 from vitrina.resources.models import DatasetDistribution
 from vitrina.structure import VersionStatus
 from vitrina.structure.factories import VersionFactory
-from vitrina.structure.models import (Base, Enum, EnumItem, Metadata, Model,
-                                      Param, ParamItem, Prefix, Property,
-                                      PropertyList)
+from vitrina.structure.models import (
+    Base,
+    Enum,
+    EnumItem,
+    Metadata,
+    Model,
+    Param,
+    ParamItem,
+    Prefix,
+    Property,
+    PropertyList,
+)
 from vitrina.structure.services import create_structure_objects
 from vitrina.users.factories import UserFactory
 
@@ -1492,31 +1501,21 @@ def test_structure_export__dataset_name(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n'
-        '1,,,,,,prefix,spinta,,,,,,,,https://github.com/atviriduomenys/spinta/issues/,,,\n'
-        '2,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        '3,,,,,,prefix,dcat,,,,,,,,http://www.w3.org/ns/dcat#,,,\n'
-        '4,,,,,,,dct,,,,,,,,http://purl.org/dc/terms/,,,'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n"
+        "1,,,,,,prefix,spinta,,,,,,,,https://github.com/atviriduomenys/spinta/issues/,,,\n"
+        "2,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        "3,,,,,,prefix,dcat,,,,,,,,http://www.w3.org/ns/dcat#,,,\n"
+        "4,,,,,,,dct,,,,,,,,http://purl.org/dc/terms/,,,"
     )
     structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        ),
-        dataset=DatasetFactory(
-            title="Title",
-            description="Description"
-        )
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=DatasetFactory(title="Title", description="Description"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = VersionFactory(dataset=structure.dataset, major=3, status=VersionStatus.PRE_RELEASE)
     create_structure_objects(structure, version)
-    resp = app.get(
-        reverse(
-            "dataset-structure-export",
-            args=[structure.dataset.pk, version.pk]
-        )
-    )
+    resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk, version.pk]))
     assert "datasets/gov/ivpk/adp/3" in resp.text
 
 
@@ -1543,20 +1542,10 @@ def test_structure_export__prefixes(app: DjangoTestApp, use_version):
     if use_version:
         metadata_version = VersionFactory(dataset=structure.dataset)
         create_structure_objects(structure, metadata_version)
-        resp = app.get(
-            reverse(
-                "dataset-structure-export",
-                args=[structure.dataset.pk, metadata_version.pk]
-            )
-        )
+        resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk, metadata_version.pk]))
     else:
         create_structure_objects(structure)
-        resp = app.get(
-            reverse(
-                "dataset-structure-export-no-version",
-                args=[structure.dataset.pk]
-            )
-        )
+        resp = app.get(reverse("dataset-structure-export-no-version", args=[structure.dataset.pk]))
 
     assert resp.text == (
         "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
@@ -1616,27 +1605,21 @@ def test_structure_export__multiple_versions(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
 
-    dataset = DatasetFactory(
-        title="Multi-Version Dataset",
-        description="Dataset with multiple versions"
-    )
+    dataset = DatasetFactory(title="Multi-Version Dataset", description="Dataset with multiple versions")
 
     # Version 1: one model, one property, one prefix, one enum, and one param
     version1 = VersionFactory(dataset=dataset, version=1)
     manifest_v1 = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n'
-        '1,datasets/gov/test/multi,,,,,,,,,,,,,,,,Multi-Version Dataset,Multi-Version Dataset description\n'
-        '2,,,,,,prefix,dct,,,,,,,,http://purl.org/dc/terms/,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n"
+        "1,datasets/gov/test/multi,,,,,,,,,,,,,,,,Multi-Version Dataset,Multi-Version Dataset description\n"
+        "2,,,,,,prefix,dct,,,,,,,,http://purl.org/dc/terms/,,,\n"
         '3,,,,,,enum,Status,,"ACTIVE",,,,,,,,,\n'
         '4,,,,,,param,Filter,,"all",,,,,,,,,\n'
-        '5,,,,Person,,,id,,,,,,,,,,,Person Model,\n'
-        '6,,,,,id,integer,,,,,5,,,open,dct:identifier,,Person ID,'
+        "5,,,,Person,,,id,,,,,,,,,,,Person Model,\n"
+        "6,,,,,id,integer,,,,,5,,,open,dct:identifier,,Person ID,"
     )
     structure_v1 = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='v1.csv', data=manifest_v1)
-        ),
-        dataset=dataset
+        file=FilerFileFactory(file=FileField(filename="v1.csv", data=manifest_v1)), dataset=dataset
     )
     dataset.current_structure = structure_v1
     dataset.save()
@@ -1645,25 +1628,22 @@ def test_structure_export__multiple_versions(app: DjangoTestApp):
     # Version 2: Add another prefix, enum item, param item, property to Person, and add City model
     version2 = VersionFactory(dataset=dataset, version=2)
     manifest_v2 = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n'
-        '1,datasets/gov/test/multi,,,,,,,,,,,,,,,,Multi-Version Dataset,Multi-Version Dataset description\n'
-        '2,,,,,,prefix,dct,,,,,,,,http://purl.org/dc/terms/,,,\n'
-        '3,,,,,,prefix,dcat,,,,,,,,http://www.w3.org/ns/dcat#,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n"
+        "1,datasets/gov/test/multi,,,,,,,,,,,,,,,,Multi-Version Dataset,Multi-Version Dataset description\n"
+        "2,,,,,,prefix,dct,,,,,,,,http://purl.org/dc/terms/,,,\n"
+        "3,,,,,,prefix,dcat,,,,,,,,http://www.w3.org/ns/dcat#,,,\n"
         '4,,,,,,enum,Status,,"ACTIVE",,,,,,,,,\n'
         '5,,,,,,,,,"INACTIVE",,,,,,,,,\n'
         '6,,,,,,param,Filter,,"all",,,,,,,,,\n'
         '7,,,,,,,,,"recent",,,,,,,,,\n'
-        '8,,,,Person,,,id,,,,,,,,,,,Person Model,\n'
-        '9,,,,,id,integer,,,,,5,,,open,dct:identifier,,Person ID,\n'
-        '10,,,,,name,string,,,,,2,,,open,dct:title,,Person Name,\n'
-        '11,,,,City,,,id,,,,,,,,,,,City Model,\n'
-        '12,,,,,id,integer,,,,,5,,,open,dct:identifier,,City ID,'
+        "8,,,,Person,,,id,,,,,,,,,,,Person Model,\n"
+        "9,,,,,id,integer,,,,,5,,,open,dct:identifier,,Person ID,\n"
+        "10,,,,,name,string,,,,,2,,,open,dct:title,,Person Name,\n"
+        "11,,,,City,,,id,,,,,,,,,,,City Model,\n"
+        "12,,,,,id,integer,,,,,5,,,open,dct:identifier,,City ID,"
     )
     structure_v2 = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='v2.csv', data=manifest_v2)
-        ),
-        dataset=dataset
+        file=FilerFileFactory(file=FileField(filename="v2.csv", data=manifest_v2)), dataset=dataset
     )
     dataset.current_structure = structure_v2
     dataset.save()
@@ -1672,31 +1652,28 @@ def test_structure_export__multiple_versions(app: DjangoTestApp):
     # Version 3: Add another prefix, enum, param, property to City, and add Country model
     version3 = VersionFactory(dataset=dataset, version=3)
     manifest_v3 = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n'
-        '1,datasets/gov/test/multi,,,,,,,,,,,,,,,,Multi-Version Dataset,Multi-Version Dataset description\n'
-        '2,,,,,,prefix,dct,,,,,,,,http://purl.org/dc/terms/,,,\n'
-        '3,,,,,,prefix,dcat,,,,,,,,http://www.w3.org/ns/dcat#,,,\n'
-        '4,,,,,,prefix,foaf,,,,,,,,http://xmlns.com/foaf/0.1/,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n"
+        "1,datasets/gov/test/multi,,,,,,,,,,,,,,,,Multi-Version Dataset,Multi-Version Dataset description\n"
+        "2,,,,,,prefix,dct,,,,,,,,http://purl.org/dc/terms/,,,\n"
+        "3,,,,,,prefix,dcat,,,,,,,,http://www.w3.org/ns/dcat#,,,\n"
+        "4,,,,,,prefix,foaf,,,,,,,,http://xmlns.com/foaf/0.1/,,,\n"
         '5,,,,,,enum,Status,,"ACTIVE",,,,,,,,,\n'
         '6,,,,,,,,,"INACTIVE",,,,,,,,,\n'
         '7,,,,,,enum,Priority,,"HIGH",,,,,,,,,\n'
         '8,,,,,,param,Filter,,"all",,,,,,,,,\n'
         '9,,,,,,,,,"recent",,,,,,,,,\n'
         '10,,,,,,param,Sort,,"name",,,,,,,,,\n'
-        '11,,,,Person,,,id,,,,,,,,,,,Person Model,\n'
-        '12,,,,,id,integer,,,,,5,,,open,dct:identifier,,Person ID,\n'
-        '13,,,,,name,string,,,,,2,,,open,dct:title,,Person Name,\n'
-        '14,,,,City,,,id,,,,,,,,,,,City Model,\n'
-        '15,,,,,id,integer,,,,,5,,,open,dct:identifier,,City ID,\n'
-        '16,,,,,name,string,,,,,2,,,open,dct:title,,City Name,\n'
-        '17,,,,Country,,,id,,,,,,,,,,,Country Model,\n'
-        '18,,,,,id,integer,,,,,5,,,open,dct:identifier,,Country ID,'
+        "11,,,,Person,,,id,,,,,,,,,,,Person Model,\n"
+        "12,,,,,id,integer,,,,,5,,,open,dct:identifier,,Person ID,\n"
+        "13,,,,,name,string,,,,,2,,,open,dct:title,,Person Name,\n"
+        "14,,,,City,,,id,,,,,,,,,,,City Model,\n"
+        "15,,,,,id,integer,,,,,5,,,open,dct:identifier,,City ID,\n"
+        "16,,,,,name,string,,,,,2,,,open,dct:title,,City Name,\n"
+        "17,,,,Country,,,id,,,,,,,,,,,Country Model,\n"
+        "18,,,,,id,integer,,,,,5,,,open,dct:identifier,,Country ID,"
     )
     structure_v3 = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='v3.csv', data=manifest_v3)
-        ),
-        dataset=dataset
+        file=FilerFileFactory(file=FileField(filename="v3.csv", data=manifest_v3)), dataset=dataset
     )
     dataset.current_structure = structure_v3
     dataset.save()
@@ -1704,99 +1681,77 @@ def test_structure_export__multiple_versions(app: DjangoTestApp):
 
     version_expectations = {
         version1: {
-            'present': {
-                'models': ['Person'],
-                'properties': ['Person ID'],
-                'prefixes': ['dct'],
-                'enums': ['Status'],
-                'enum_values': ['ACTIVE'],
-                'params': ['Filter'],
-                'param_values': ['all'],
+            "present": {
+                "models": ["Person"],
+                "properties": ["Person ID"],
+                "prefixes": ["dct"],
+                "enums": ["Status"],
+                "enum_values": ["ACTIVE"],
+                "params": ["Filter"],
+                "param_values": ["all"],
             },
-            'absent': {
-                'models': ['City', 'Country'],
-                'properties': [
-                    'Person Name', 'City ID', 'City Name', 'Country ID'
-                ],
-                'prefixes': ['dcat', 'foaf'],
-                'enums': ['Priority'],
-                'enum_values': ['INACTIVE', 'HIGH'],
-                'params': ['Sort'],
-                'param_values': ['recent'],
+            "absent": {
+                "models": ["City", "Country"],
+                "properties": ["Person Name", "City ID", "City Name", "Country ID"],
+                "prefixes": ["dcat", "foaf"],
+                "enums": ["Priority"],
+                "enum_values": ["INACTIVE", "HIGH"],
+                "params": ["Sort"],
+                "param_values": ["recent"],
             },
         },
         version2: {
-            'present': {
-                'models': ['Person', 'City'],
-                'properties': ['Person ID', 'Person Name', 'City ID'],
-                'prefixes': ['dct', 'dcat'],
-                'enums': ['Status'],
-                'enum_values': ['ACTIVE', 'INACTIVE'],
-                'params': ['Filter'],
-                'param_values': ['all', 'recent'],
+            "present": {
+                "models": ["Person", "City"],
+                "properties": ["Person ID", "Person Name", "City ID"],
+                "prefixes": ["dct", "dcat"],
+                "enums": ["Status"],
+                "enum_values": ["ACTIVE", "INACTIVE"],
+                "params": ["Filter"],
+                "param_values": ["all", "recent"],
             },
-            'absent': {
-                'models': ['Country'],
-                'properties': ['City Name', 'Country ID'],
-                'prefixes': ['foaf'],
-                'enums': ['Priority'],
-                'enum_values': ['HIGH'],
-                'params': ['Sort'],
+            "absent": {
+                "models": ["Country"],
+                "properties": ["City Name", "Country ID"],
+                "prefixes": ["foaf"],
+                "enums": ["Priority"],
+                "enum_values": ["HIGH"],
+                "params": ["Sort"],
             },
         },
         version3: {
-            'present': {
-                'models': ['Person', 'City', 'Country'],
-                'properties': [
-                    'Person ID', 'Person Name', 'City ID',
-                    'City Name', 'Country ID'
-                ],
-                'prefixes': ['dct', 'dcat', 'foaf'],
-                'enums': ['Status', 'Priority'],
-                'enum_values': ['ACTIVE', 'INACTIVE', 'HIGH'],
-                'params': ['Filter', 'Sort'],
-                'param_values': ['all', 'recent'],
+            "present": {
+                "models": ["Person", "City", "Country"],
+                "properties": ["Person ID", "Person Name", "City ID", "City Name", "Country ID"],
+                "prefixes": ["dct", "dcat", "foaf"],
+                "enums": ["Status", "Priority"],
+                "enum_values": ["ACTIVE", "INACTIVE", "HIGH"],
+                "params": ["Filter", "Sort"],
+                "param_values": ["all", "recent"],
             },
-            'absent': {},
+            "absent": {},
         },
     }
 
     exports = {}
     for version, expectations in version_expectations.items():
-        resp = app.get(
-            reverse(
-                "dataset-structure-export",
-                args=[dataset.pk, version.pk]
-            )
-        )
+        resp = app.get(reverse("dataset-structure-export", args=[dataset.pk, version.pk]))
         exports[version] = resp.text
         text = resp.text
 
-        for category, items in expectations['present'].items():
+        for category, items in expectations["present"].items():
             for item in items:
-                msg = (
-                    f"Version {version.version}: "
-                    f"Expected '{item}' in {category} but not found"
-                )
+                msg = f"Version {version.version}: Expected '{item}' in {category} but not found"
                 assert item in text, msg
 
-        for category, items in expectations['absent'].items():
+        for category, items in expectations["absent"].items():
             for item in items:
-                msg = (
-                    f"Version {version.version}: "
-                    f"Unexpected '{item}' found in {category}"
-                )
+                msg = f"Version {version.version}: Unexpected '{item}' found in {category}"
                 assert item not in text, msg
 
-    assert exports[version1] != exports[version2], (
-        "Version 1 and Version 2 exports should be different"
-    )
-    assert exports[version2] != exports[version3], (
-        "Version 2 and Version 3 exports should be different"
-    )
-    assert exports[version1] != exports[version3], (
-        "Version 1 and Version 3 exports should be different"
-    )
+    assert exports[version1] != exports[version2], "Version 1 and Version 2 exports should be different"
+    assert exports[version2] != exports[version3], "Version 2 and Version 3 exports should be different"
+    assert exports[version1] != exports[version3], "Version 1 and Version 3 exports should be different"
 
 
 @pytest.mark.django_db
@@ -1825,37 +1780,27 @@ def test_structure_export__models_and_props(app: DjangoTestApp, use_version):
     structure.dataset.save()
 
     expected_output = (
-        'id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n'
-        '2,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
-        '3,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n'
-        '4,,,,Licence,,,id,,,page(id),,,,develop,,,,,Licence,\r\n'
-        '5,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n'
-        '6,,,,,title,string,,,,,,,2,develop,,open,dct:title,,,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
-        '7,,,,Catalog,,,id,,,,,,,develop,,,,,Catalog,\r\n'
-        '8,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
+        "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n"
+        "2,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
+        "3,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n"
+        "4,,,,Licence,,,id,,,page(id),,,,develop,,,,,Licence,\r\n"
+        "5,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
+        "6,,,,,title,string,,,,,,,2,develop,,open,dct:title,,,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
+        "7,,,,Catalog,,,id,,,,,,,develop,,,,,Catalog,\r\n"
+        "8,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
     )
 
     if use_version:
         metadata_version = VersionFactory(dataset=structure.dataset)
         create_structure_objects(structure, metadata_version)
-        resp = app.get(
-            reverse(
-                "dataset-structure-export",
-                args=[structure.dataset.pk, metadata_version.pk]
-            )
-        )
+        resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk, metadata_version.pk]))
     else:
         create_structure_objects(structure)
-        resp = app.get(
-            reverse(
-                "dataset-structure-export-no-version",
-                args=[structure.dataset.pk]
-            )
-        )
+        resp = app.get(reverse("dataset-structure-export-no-version", args=[structure.dataset.pk]))
 
     assert resp.text == expected_output
 
@@ -1886,37 +1831,27 @@ def test_structure_export__base_model(app: DjangoTestApp, use_version):
     structure.dataset.save()
 
     expected_output = (
-        'id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n'
-        '2,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
-        '3,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n'
-        '4,,,,Base,,,,,,,,,,develop,,,,,,\r\n'
-        '5,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
-        '6,,,Base,,,,,,,,,,,,,,,,,\r\n'
-        '7,,,,Catalog,,,,,,,,,,develop,,,,,,\r\n'
-        '8,,,,,title,string,,,,,,,2,develop,,open,dct:title,,,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
+        "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n"
+        "2,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
+        "3,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n"
+        "4,,,,Base,,,,,,,,,,develop,,,,,,\r\n"
+        "5,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
+        "6,,,Base,,,,,,,,,,,,,,,,,\r\n"
+        "7,,,,Catalog,,,,,,,,,,develop,,,,,,\r\n"
+        "8,,,,,title,string,,,,,,,2,develop,,open,dct:title,,,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
     )
 
     if use_version:
         metadata_version = VersionFactory(dataset=structure.dataset)
         create_structure_objects(structure, metadata_version)
-        resp = app.get(
-            reverse(
-                "dataset-structure-export",
-                args=[structure.dataset.pk, metadata_version.pk]
-            )
-        )
+        resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk, metadata_version.pk]))
     else:
         create_structure_objects(structure)
-        resp = app.get(
-            reverse(
-                "dataset-structure-export-no-version",
-                args=[structure.dataset.pk]
-            )
-        )
+        resp = app.get(reverse("dataset-structure-export-no-version", args=[structure.dataset.pk]))
 
     assert resp.text == expected_output
 
@@ -1947,38 +1882,28 @@ def test_structure_export__property_ref(app: DjangoTestApp, use_version):
     structure.dataset.save()
 
     expected_output = (
-        'id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n'
-        '2,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
-        '3,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n'
-        '4,,,,Country,,,,,,,,,,develop,,,,,,\r\n'
-        '5,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n'
-        '6,,,,,title,string,,,,,,,5,develop,,open,dct:title,,,\r\n'
-        '7,,,,,continent,ref,Continent[id],,,,,,5,develop,,open,dct:continent,,,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
-        '8,,,,Continent,,,,,,,,,,develop,,,,,,\r\n'
-        '9,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
+        "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n"
+        "2,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
+        "3,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n"
+        "4,,,,Country,,,,,,,,,,develop,,,,,,\r\n"
+        "5,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
+        "6,,,,,title,string,,,,,,,5,develop,,open,dct:title,,,\r\n"
+        "7,,,,,continent,ref,Continent[id],,,,,,5,develop,,open,dct:continent,,,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
+        "8,,,,Continent,,,,,,,,,,develop,,,,,,\r\n"
+        "9,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
     )
 
     if use_version:
         metadata_version = VersionFactory(dataset=structure.dataset)
         create_structure_objects(structure, metadata_version)
-        resp = app.get(
-            reverse(
-                "dataset-structure-export",
-                args=[structure.dataset.pk, metadata_version.pk]
-            )
-        )
+        resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk, metadata_version.pk]))
     else:
         create_structure_objects(structure)
-        resp = app.get(
-            reverse(
-                "dataset-structure-export-no-version",
-                args=[structure.dataset.pk]
-            )
-        )
+        resp = app.get(reverse("dataset-structure-export-no-version", args=[structure.dataset.pk]))
 
     assert resp.text == expected_output
 
@@ -2007,11 +1932,11 @@ def test_structure_export__model_ref(app: DjangoTestApp, use_version):
     structure.dataset.save()
 
     expected_output = (
-        'id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n'
-        '2,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
-        '3,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n'
+        "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n"
+        "2,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
+        "3,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n"
         '4,,,,Country,,,"id, title",,,,,,,develop,,,,,,\r\n'
         "5,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
         "6,,,,,title,string,,,,,,,5,develop,,open,dct:title,,,\r\n"
@@ -2022,20 +1947,10 @@ def test_structure_export__model_ref(app: DjangoTestApp, use_version):
     if use_version:
         metadata_version = VersionFactory(dataset=structure.dataset)
         create_structure_objects(structure, metadata_version)
-        resp = app.get(
-            reverse(
-                "dataset-structure-export",
-                args=[structure.dataset.pk, metadata_version.pk]
-            )
-        )
+        resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk, metadata_version.pk]))
     else:
         create_structure_objects(structure)
-        resp = app.get(
-            reverse(
-                "dataset-structure-export-no-version",
-                args=[structure.dataset.pk]
-            )
-        )
+        resp = app.get(reverse("dataset-structure-export-no-version", args=[structure.dataset.pk]))
 
     assert resp.text == expected_output
 
@@ -2105,43 +2020,34 @@ def test_structure_export__enums(app: DjangoTestApp, use_version):
     structure.dataset.save()
 
     expected_output = (
-        'id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n'
-        '2,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
-        '3,,,,,,enum,Size,,,SMALL,,,,develop,,,,,,\r\n'
-        '4,,,,,,,,,,MEDIUM,,,,develop,,,,,,\r\n'
-        '5,,,,,,,,,,BIG,,,,develop,,,,,,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
-        '6,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n'
-        '7,,,,City,,,,,,,,,,develop,,,,,,\r\n'
-        '8,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n'
-        '9,,,,,size,Size,,,,,,,5,develop,,open,dct:size,,,\r\n'
-        '10,,,,,type,string,,,,,,,5,develop,,open,dct:type,,,\r\n'
-        '11,,,,,,enum,Type,,,CREATED,,,,develop,,,,,,\r\n'
-        '12,,,,,,,,,,MODIFIED,,,,develop,,,,,,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
+        "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n"
+        "2,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
+        "3,,,,,,enum,Size,,,SMALL,,,,develop,,,,,,\r\n"
+        "4,,,,,,,,,,MEDIUM,,,,develop,,,,,,\r\n"
+        "5,,,,,,,,,,BIG,,,,develop,,,,,,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
+        "6,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n"
+        "7,,,,City,,,,,,,,,,develop,,,,,,\r\n"
+        "8,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
+        "9,,,,,size,Size,,,,,,,5,develop,,open,dct:size,,,\r\n"
+        "10,,,,,type,string,,,,,,,5,develop,,open,dct:type,,,\r\n"
+        "11,,,,,,enum,Type,,,CREATED,,,,develop,,,,,,\r\n"
+        "12,,,,,,,,,,MODIFIED,,,,develop,,,,,,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
     )
 
     if use_version:
         metadata_version = VersionFactory(dataset=structure.dataset)
         create_structure_objects(structure, metadata_version)
-        resp = app.get(
-            reverse(
-                "dataset-structure-export",
-                args=[structure.dataset.pk, metadata_version.pk]
-            )
-        )
+        resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk, metadata_version.pk]))
     else:
         create_structure_objects(structure)
-        resp = app.get(
-            reverse(
-                "dataset-structure-export-no-version",
-                args=[structure.dataset.pk]
-            )
-        )
+        resp = app.get(reverse("dataset-structure-export-no-version", args=[structure.dataset.pk]))
 
     assert resp.text == expected_output
+
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("use_version", [False, True])
@@ -2170,42 +2076,33 @@ def test_structure_export__params(app: DjangoTestApp, use_version):
     structure.dataset.save()
 
     expected_output = (
-        'id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n'
-        '2,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
-        '3,,,,,,param,country,,,lt,,,,develop,,,,,,\r\n'
-        '4,,,,,,,,,,lv,,,,develop,,,,,,\r\n'
-        '5,,,,,,,,,,ee,,,,develop,,,,,,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
-        '6,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n'
-        '7,,,,City,,,,,,,,,,develop,,,,,,\r\n'
-        '8,,,,,,param,type,,,created,,,,develop,,,,,,\r\n'
-        '9,,,,,,,,,,modified,,,,develop,,,,,,\r\n'
-        '10,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n'
-        '11,,,,,type,string,,,,,,,5,develop,,open,dct:type,,,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
+        "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n"
+        "2,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
+        "3,,,,,,param,country,,,lt,,,,develop,,,,,,\r\n"
+        "4,,,,,,,,,,lv,,,,develop,,,,,,\r\n"
+        "5,,,,,,,,,,ee,,,,develop,,,,,,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
+        "6,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n"
+        "7,,,,City,,,,,,,,,,develop,,,,,,\r\n"
+        "8,,,,,,param,type,,,created,,,,develop,,,,,,\r\n"
+        "9,,,,,,,,,,modified,,,,develop,,,,,,\r\n"
+        "10,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
+        "11,,,,,type,string,,,,,,,5,develop,,open,dct:type,,,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
     )
 
     if use_version:
         metadata_version = VersionFactory(dataset=structure.dataset)
         create_structure_objects(structure, metadata_version)
-        resp = app.get(
-            reverse(
-                "dataset-structure-export",
-                args=[structure.dataset.pk, metadata_version.pk]
-            )
-        )
+        resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk, metadata_version.pk]))
     else:
         create_structure_objects(structure)
-        resp = app.get(
-            reverse(
-                "dataset-structure-export-no-version",
-                args=[structure.dataset.pk]
-            )
-        )
+        resp = app.get(reverse("dataset-structure-export-no-version", args=[structure.dataset.pk]))
 
     assert resp.text == expected_output
+
 
 @pytest.mark.django_db
 def test_import_structure_with_wrong_datasets_name(app: DjangoTestApp):

--- a/tests/structure/test_services.py
+++ b/tests/structure/test_services.py
@@ -1515,7 +1515,7 @@ def test_structure_export__prefixes(app: DjangoTestApp):
     structure.dataset.save()
 
     create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
-    resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk]))
+    resp = app.get(reverse("dataset-structure-export-no-version", args=[structure.dataset.pk]))
     assert resp.text == (
         "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
         "1,,,,,,prefix,spinta,,,,,,,,,,https://github.com/atviriduomenys/spinta/issues/,,,\r\n"
@@ -1593,7 +1593,7 @@ def test_structure_export__models_and_props(app: DjangoTestApp):
     structure.dataset.save()
     create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
 
-    resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk]))
+    resp = app.get(reverse("dataset-structure-export-no-version", args=[structure.dataset.pk]))
     assert resp.text == (
         "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
         "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n"
@@ -1635,7 +1635,7 @@ def test_structure_export__base_model(app: DjangoTestApp):
     structure.dataset.save()
     create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
 
-    resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk]))
+    resp = app.get(reverse("dataset-structure-export-no-version", args=[structure.dataset.pk]))
     assert resp.text == (
         "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
         "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n"
@@ -1677,7 +1677,7 @@ def test_structure_export__property_ref(app: DjangoTestApp):
     structure.dataset.save()
     create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
 
-    resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk]))
+    resp = app.get(reverse("dataset-structure-export-no-version", args=[structure.dataset.pk]))
     assert resp.text == (
         "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
         "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n"
@@ -1718,7 +1718,7 @@ def test_structure_export__model_ref(app: DjangoTestApp):
     structure.dataset.save()
     create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
 
-    resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk]))
+    resp = app.get(reverse("dataset-structure-export-no-version", args=[structure.dataset.pk]))
     assert resp.text == (
         "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
         "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n"
@@ -1755,7 +1755,7 @@ def test_structure_export__comments(app: DjangoTestApp):
     structure.dataset.save()
     create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
 
-    resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk]))
+    resp = app.get(reverse("dataset-structure-export-no-version", args=[structure.dataset.pk]))
     assert resp.text == (
         "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
         "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n"
@@ -1797,7 +1797,7 @@ def test_structure_export__enums(app: DjangoTestApp):
     structure.dataset.save()
     create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
 
-    resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk]))
+    resp = app.get(reverse("dataset-structure-export-no-version", args=[structure.dataset.pk]))
     assert resp.text == (
         "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
         "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n"
@@ -1844,7 +1844,7 @@ def test_structure_export__params(app: DjangoTestApp):
     structure.dataset.save()
     create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
 
-    resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk]))
+    resp = app.get(reverse("dataset-structure-export-no-version", args=[structure.dataset.pk]))
     assert resp.text == (
         "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
         "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n"
@@ -2021,7 +2021,7 @@ def test_structure_export_after_changing_model_name(app: DjangoTestApp):
     assert model.ref_model_properties.count() == 1
     assert model.ref_model_properties.first().metadata.first().ref == "test_dataset/Salis"
 
-    resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk]))
+    resp = app.get(reverse("dataset-structure-export-no-version", args=[structure.dataset.pk]))
     assert resp.text == (
         "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
         "1,test_dataset,,,,,,,,,,,,,,,,,,Title,Description\r\n"
@@ -2068,7 +2068,7 @@ def test_structure_export_after_changing_dataset_title_and_description(app: Djan
     assert structure.dataset.metadata.first().title == "Edited title"
     assert structure.dataset.metadata.first().description == "Edited description"
 
-    resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk]))
+    resp = app.get(reverse("dataset-structure-export-no-version", args=[structure.dataset.pk]))
     assert resp.text == (
         "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
         f"1,{structure.dataset.organization.name + 'edited_dataset'},,,,,,,,,,,,,,,,,,Edited title,Edited description\r\n"
@@ -2187,7 +2187,7 @@ def test_structure_export__visibility_row(app: DjangoTestApp):
     structure.dataset.save()
     create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
 
-    resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk]))
+    resp = app.get(reverse("dataset-structure-export-no-version", args=[structure.dataset.pk]))
     assert resp.text == (
         "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
         "1,example,,,,,,,,,,,,,,,,,,Pavadinimas,Aprašymas\r\n"
@@ -2224,7 +2224,7 @@ def test_structure_export__eli_row(app: DjangoTestApp):
     structure.dataset.save()
     create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
 
-    resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk]))
+    resp = app.get(reverse("dataset-structure-export-no-version", args=[structure.dataset.pk]))
     assert resp.text == (
         "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
         "1,example,,,,,,,,,,,,,,,,,,Pavadinimas,Aprašymas\r\n"
@@ -2261,7 +2261,7 @@ def test_structure_export__status_row(app: DjangoTestApp, setup_default_status_d
     structure.dataset.save()
     create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
 
-    resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk]))
+    resp = app.get(reverse("dataset-structure-export-no-version", args=[structure.dataset.pk]))
     assert resp.text == (
         "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
         "1,example,,,,,,,,,,,,,,,,,,Pavadinimas,Aprašymas\r\n"

--- a/tests/structure/test_services.py
+++ b/tests/structure/test_services.py
@@ -8,27 +8,18 @@ from vitrina.classifiers.models import Status
 from vitrina.cms.factories import FilerFileFactory
 from vitrina.comments.factories import CommentFactory
 from vitrina.comments.models import Comment
-from vitrina.datasets.factories import DatasetStructureFactory, DatasetFactory
+from vitrina.datasets.factories import DatasetFactory, DatasetStructureFactory
 from vitrina.datasets.models import Dataset
+from vitrina.orgs.factories import ViispRepresentativeFactory
 from vitrina.resources.factories import DatasetDistributionFactory, FileFormat
 from vitrina.resources.models import DatasetDistribution
 from vitrina.structure import VersionStatus
 from vitrina.structure.factories import VersionFactory
-from vitrina.structure.models import (
-    Metadata,
-    Prefix,
-    Model,
-    Property,
-    PropertyList,
-    Enum,
-    Param,
-    EnumItem,
-    ParamItem,
-    Base,
-)
+from vitrina.structure.models import (Base, Enum, EnumItem, Metadata, Model,
+                                      Param, ParamItem, Prefix, Property,
+                                      PropertyList)
 from vitrina.structure.services import create_structure_objects
 from vitrina.users.factories import UserFactory
-from vitrina.orgs.factories import ViispRepresentativeFactory
 
 
 @pytest.fixture
@@ -1601,9 +1592,10 @@ def test_structure_export__with_resource_params(app: DjangoTestApp):
     structure.dataset.current_structure = structure
     structure.dataset.save()
 
-    create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
+    version = structure.dataset.metadata.first().metadata_version
+    create_structure_objects(structure, version)
 
-    resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk]))
+    resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk, version.pk]))
     assert resp.text == (
         "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
         "1,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n"
@@ -1826,7 +1818,7 @@ def test_structure_export__models_and_props(app: DjangoTestApp, use_version):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description"),
+        dataset=DatasetFactory(title="Title", description="Description", metadata=False),
     )
 
     structure.dataset.current_structure = structure
@@ -1887,7 +1879,7 @@ def test_structure_export__base_model(app: DjangoTestApp, use_version):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description"),
+        dataset=DatasetFactory(title="Title", description="Description", metadata=False),
     )
 
     structure.dataset.current_structure = structure
@@ -1948,7 +1940,7 @@ def test_structure_export__property_ref(app: DjangoTestApp, use_version):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description"),
+        dataset=DatasetFactory(title="Title", description="Description", metadata=False),
     )
 
     structure.dataset.current_structure = structure
@@ -2008,12 +2000,11 @@ def test_structure_export__model_ref(app: DjangoTestApp, use_version):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description"),
+        dataset=DatasetFactory(title="Title", description="Description", metadata=False),
     )
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
 
     expected_output = (
         'id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n'
@@ -2065,11 +2056,11 @@ def test_structure_export__comments(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description"),
+        dataset=DatasetFactory(title="Title", description="Description", metadata=False),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
+    create_structure_objects(structure)
 
     resp = app.get(reverse("dataset-structure-export-no-version", args=[structure.dataset.pk]))
     assert resp.text == (
@@ -2108,7 +2099,7 @@ def test_structure_export__enums(app: DjangoTestApp, use_version):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description"),
+        dataset=DatasetFactory(title="Title", description="Description", metadata=False),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -2173,7 +2164,7 @@ def test_structure_export__params(app: DjangoTestApp, use_version):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description"),
+        dataset=DatasetFactory(title="Title", description="Description", metadata=False),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -2348,12 +2339,12 @@ def test_structure_export_after_changing_model_name(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description"),
+        dataset=DatasetFactory(title="Title", description="Description", metadata=False),
     )
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    version = create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
+    version = create_structure_objects(structure)
 
     model = Model.objects.get(dataset=structure.dataset, metadata__name="test_dataset/Model")
     form = app.get(reverse("model-update", args=[structure.dataset.pk, version.pk, model.name])).forms["model-form"]
@@ -2439,12 +2430,12 @@ def test_structure_export_after_changing_distribution_title_and_description(app:
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Dataset", description="Dataset description"),
+        dataset=DatasetFactory(title="Dataset", description="Dataset description", metadata=False),
     )
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
+    version = create_structure_objects(structure)
     dist_format = FileFormat()
 
     distribution = DatasetDistribution.objects.first()
@@ -2462,7 +2453,7 @@ def test_structure_export_after_changing_distribution_title_and_description(app:
     assert distribution.metadata.first().title == "Edited title"
     assert distribution.metadata.first().description == "Edited description"
 
-    resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk]))
+    resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk, version.pk]))
     assert resp.text == (
         "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
         "1,test_dataset,,,,,,,,,,,,,,,,,,Dataset,Dataset description\r\n"
@@ -2484,12 +2475,12 @@ def test_structure_export_after_changing_distribution_level(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Dataset", description="Dataset description"),
+        dataset=DatasetFactory(title="Dataset", description="Dataset description", metadata=False),
     )
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
+    version = create_structure_objects(structure)
     dist_format = FileFormat()
 
     distribution = DatasetDistribution.objects.first()
@@ -2505,7 +2496,7 @@ def test_structure_export_after_changing_distribution_level(app: DjangoTestApp):
     assert distribution.metadata.count() == 1
     assert distribution.metadata.first().level_given == 2
 
-    resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk]))
+    resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk, version.pk]))
     assert resp.text == (
         "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
         "1,test_dataset,,,,,,,,,,,,,,,,,,Dataset,Dataset description\r\n"

--- a/tests/structure/test_services.py
+++ b/tests/structure/test_services.py
@@ -1496,7 +1496,8 @@ def test_uri_prefix(app: DjangoTestApp):
 
 
 @pytest.mark.django_db
-def test_structure_export__prefixes(app: DjangoTestApp):
+@pytest.mark.parametrize("use_version", [False, True])
+def test_structure_export__prefixes(app: DjangoTestApp, use_version):
     user = UserFactory(is_staff=True)
     app.set_user(user)
     manifest = (
@@ -1514,8 +1515,24 @@ def test_structure_export__prefixes(app: DjangoTestApp):
     structure.dataset.current_structure = structure
     structure.dataset.save()
 
-    create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
-    resp = app.get(reverse("dataset-structure-export-no-version", args=[structure.dataset.pk]))
+    if use_version:
+        metadata_version = VersionFactory(dataset=structure.dataset)
+        create_structure_objects(structure, metadata_version)
+        resp = app.get(
+            reverse(
+                "dataset-structure-export",
+                args=[structure.dataset.pk, metadata_version.pk]
+            )
+        )
+    else:
+        create_structure_objects(structure)
+        resp = app.get(
+            reverse(
+                "dataset-structure-export-no-version",
+                args=[structure.dataset.pk]
+            )
+        )
+
     assert resp.text == (
         "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
         "1,,,,,,prefix,spinta,,,,,,,,,,https://github.com/atviriduomenys/spinta/issues/,,,\r\n"
@@ -1569,7 +1586,196 @@ def test_structure_export__with_resource_params(app: DjangoTestApp):
 
 
 @pytest.mark.django_db
-def test_structure_export__models_and_props(app: DjangoTestApp):
+def test_structure_export__multiple_versions(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+
+    dataset = DatasetFactory(
+        title="Multi-Version Dataset",
+        description="Dataset with multiple versions"
+    )
+
+    # Version 1: one model, one property, one prefix, one enum, and one param
+    version1 = VersionFactory(dataset=dataset, version=1)
+    manifest_v1 = (
+        'id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n'
+        '1,datasets/gov/test/multi,,,,,,,,,,,,,,,,Multi-Version Dataset,Multi-Version Dataset description\n'
+        '2,,,,,,prefix,dct,,,,,,,,http://purl.org/dc/terms/,,,\n'
+        '3,,,,,,enum,Status,,"ACTIVE",,,,,,,,,\n'
+        '4,,,,,,param,Filter,,"all",,,,,,,,,\n'
+        '5,,,,Person,,,id,,,,,,,,,,,Person Model,\n'
+        '6,,,,,id,integer,,,,,5,,,open,dct:identifier,,Person ID,'
+    )
+    structure_v1 = DatasetStructureFactory(
+        file=FilerFileFactory(
+            file=FileField(filename='v1.csv', data=manifest_v1)
+        ),
+        dataset=dataset
+    )
+    dataset.current_structure = structure_v1
+    dataset.save()
+    create_structure_objects(structure_v1, version1)
+
+    # Version 2: Add another prefix, enum item, param item, property to Person, and add City model
+    version2 = VersionFactory(dataset=dataset, version=2)
+    manifest_v2 = (
+        'id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n'
+        '1,datasets/gov/test/multi,,,,,,,,,,,,,,,,Multi-Version Dataset,Multi-Version Dataset description\n'
+        '2,,,,,,prefix,dct,,,,,,,,http://purl.org/dc/terms/,,,\n'
+        '3,,,,,,prefix,dcat,,,,,,,,http://www.w3.org/ns/dcat#,,,\n'
+        '4,,,,,,enum,Status,,"ACTIVE",,,,,,,,,\n'
+        '5,,,,,,,,,"INACTIVE",,,,,,,,,\n'
+        '6,,,,,,param,Filter,,"all",,,,,,,,,\n'
+        '7,,,,,,,,,"recent",,,,,,,,,\n'
+        '8,,,,Person,,,id,,,,,,,,,,,Person Model,\n'
+        '9,,,,,id,integer,,,,,5,,,open,dct:identifier,,Person ID,\n'
+        '10,,,,,name,string,,,,,2,,,open,dct:title,,Person Name,\n'
+        '11,,,,City,,,id,,,,,,,,,,,City Model,\n'
+        '12,,,,,id,integer,,,,,5,,,open,dct:identifier,,City ID,'
+    )
+    structure_v2 = DatasetStructureFactory(
+        file=FilerFileFactory(
+            file=FileField(filename='v2.csv', data=manifest_v2)
+        ),
+        dataset=dataset
+    )
+    dataset.current_structure = structure_v2
+    dataset.save()
+    create_structure_objects(structure_v2, version2)
+
+    # Version 3: Add another prefix, enum, param, property to City, and add Country model
+    version3 = VersionFactory(dataset=dataset, version=3)
+    manifest_v3 = (
+        'id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n'
+        '1,datasets/gov/test/multi,,,,,,,,,,,,,,,,Multi-Version Dataset,Multi-Version Dataset description\n'
+        '2,,,,,,prefix,dct,,,,,,,,http://purl.org/dc/terms/,,,\n'
+        '3,,,,,,prefix,dcat,,,,,,,,http://www.w3.org/ns/dcat#,,,\n'
+        '4,,,,,,prefix,foaf,,,,,,,,http://xmlns.com/foaf/0.1/,,,\n'
+        '5,,,,,,enum,Status,,"ACTIVE",,,,,,,,,\n'
+        '6,,,,,,,,,"INACTIVE",,,,,,,,,\n'
+        '7,,,,,,enum,Priority,,"HIGH",,,,,,,,,\n'
+        '8,,,,,,param,Filter,,"all",,,,,,,,,\n'
+        '9,,,,,,,,,"recent",,,,,,,,,\n'
+        '10,,,,,,param,Sort,,"name",,,,,,,,,\n'
+        '11,,,,Person,,,id,,,,,,,,,,,Person Model,\n'
+        '12,,,,,id,integer,,,,,5,,,open,dct:identifier,,Person ID,\n'
+        '13,,,,,name,string,,,,,2,,,open,dct:title,,Person Name,\n'
+        '14,,,,City,,,id,,,,,,,,,,,City Model,\n'
+        '15,,,,,id,integer,,,,,5,,,open,dct:identifier,,City ID,\n'
+        '16,,,,,name,string,,,,,2,,,open,dct:title,,City Name,\n'
+        '17,,,,Country,,,id,,,,,,,,,,,Country Model,\n'
+        '18,,,,,id,integer,,,,,5,,,open,dct:identifier,,Country ID,'
+    )
+    structure_v3 = DatasetStructureFactory(
+        file=FilerFileFactory(
+            file=FileField(filename='v3.csv', data=manifest_v3)
+        ),
+        dataset=dataset
+    )
+    dataset.current_structure = structure_v3
+    dataset.save()
+    create_structure_objects(structure_v3, version3)
+
+    version_expectations = {
+        version1: {
+            'present': {
+                'models': ['Person'],
+                'properties': ['Person ID'],
+                'prefixes': ['dct'],
+                'enums': ['Status'],
+                'enum_values': ['ACTIVE'],
+                'params': ['Filter'],
+                'param_values': ['all'],
+            },
+            'absent': {
+                'models': ['City', 'Country'],
+                'properties': [
+                    'Person Name', 'City ID', 'City Name', 'Country ID'
+                ],
+                'prefixes': ['dcat', 'foaf'],
+                'enums': ['Priority'],
+                'enum_values': ['INACTIVE', 'HIGH'],
+                'params': ['Sort'],
+                'param_values': ['recent'],
+            },
+        },
+        version2: {
+            'present': {
+                'models': ['Person', 'City'],
+                'properties': ['Person ID', 'Person Name', 'City ID'],
+                'prefixes': ['dct', 'dcat'],
+                'enums': ['Status'],
+                'enum_values': ['ACTIVE', 'INACTIVE'],
+                'params': ['Filter'],
+                'param_values': ['all', 'recent'],
+            },
+            'absent': {
+                'models': ['Country'],
+                'properties': ['City Name', 'Country ID'],
+                'prefixes': ['foaf'],
+                'enums': ['Priority'],
+                'enum_values': ['HIGH'],
+                'params': ['Sort'],
+            },
+        },
+        version3: {
+            'present': {
+                'models': ['Person', 'City', 'Country'],
+                'properties': [
+                    'Person ID', 'Person Name', 'City ID',
+                    'City Name', 'Country ID'
+                ],
+                'prefixes': ['dct', 'dcat', 'foaf'],
+                'enums': ['Status', 'Priority'],
+                'enum_values': ['ACTIVE', 'INACTIVE', 'HIGH'],
+                'params': ['Filter', 'Sort'],
+                'param_values': ['all', 'recent'],
+            },
+            'absent': {},
+        },
+    }
+
+    exports = {}
+    for version, expectations in version_expectations.items():
+        resp = app.get(
+            reverse(
+                "dataset-structure-export",
+                args=[dataset.pk, version.pk]
+            )
+        )
+        exports[version] = resp.text
+        text = resp.text
+
+        for category, items in expectations['present'].items():
+            for item in items:
+                msg = (
+                    f"Version {version.version}: "
+                    f"Expected '{item}' in {category} but not found"
+                )
+                assert item in text, msg
+
+        for category, items in expectations['absent'].items():
+            for item in items:
+                msg = (
+                    f"Version {version.version}: "
+                    f"Unexpected '{item}' found in {category}"
+                )
+                assert item not in text, msg
+
+    assert exports[version1] != exports[version2], (
+        "Version 1 and Version 2 exports should be different"
+    )
+    assert exports[version2] != exports[version3], (
+        "Version 2 and Version 3 exports should be different"
+    )
+    assert exports[version1] != exports[version3], (
+        "Version 1 and Version 3 exports should be different"
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("use_version", [False, True])
+def test_structure_export__models_and_props(app: DjangoTestApp, use_version):
     user = UserFactory(is_staff=True)
     app.set_user(user)
     manifest = (
@@ -1591,27 +1797,46 @@ def test_structure_export__models_and_props(app: DjangoTestApp):
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
 
-    resp = app.get(reverse("dataset-structure-export-no-version", args=[structure.dataset.pk]))
-    assert resp.text == (
-        "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
-        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n"
-        "2,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n"
-        ",,,,,,,,,,,,,,,,,,,,\r\n"
-        "3,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n"
-        "4,,,,Licence,,,id,,,page(id),,,,develop,,,,,Licence,\r\n"
-        "5,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
-        "6,,,,,title,string,,,,,,,2,develop,,open,dct:title,,,\r\n"
-        ",,,,,,,,,,,,,,,,,,,,\r\n"
-        "7,,,,Catalog,,,id,,,,,,,develop,,,,,Catalog,\r\n"
-        "8,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
-        ",,,,,,,,,,,,,,,,,,,,\r\n"
+    expected_output = (
+        'id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n'
+        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n'
+        '2,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n'
+        ',,,,,,,,,,,,,,,,,,,,\r\n'
+        '3,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n'
+        '4,,,,Licence,,,id,,,page(id),,,,develop,,,,,Licence,\r\n'
+        '5,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n'
+        '6,,,,,title,string,,,,,,,2,develop,,open,dct:title,,,\r\n'
+        ',,,,,,,,,,,,,,,,,,,,\r\n'
+        '7,,,,Catalog,,,id,,,,,,,develop,,,,,Catalog,\r\n'
+        '8,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n'
+        ',,,,,,,,,,,,,,,,,,,,\r\n'
     )
+
+    if use_version:
+        metadata_version = VersionFactory(dataset=structure.dataset)
+        create_structure_objects(structure, metadata_version)
+        resp = app.get(
+            reverse(
+                "dataset-structure-export",
+                args=[structure.dataset.pk, metadata_version.pk]
+            )
+        )
+    else:
+        create_structure_objects(structure)
+        resp = app.get(
+            reverse(
+                "dataset-structure-export-no-version",
+                args=[structure.dataset.pk]
+            )
+        )
+
+    assert resp.text == expected_output
 
 
 @pytest.mark.django_db
-def test_structure_export__base_model(app: DjangoTestApp):
+@pytest.mark.parametrize("use_version", [False, True])
+def test_structure_export__base_model(app: DjangoTestApp, use_version):
     user = UserFactory(is_staff=True)
     app.set_user(user)
     manifest = (
@@ -1633,27 +1858,46 @@ def test_structure_export__base_model(app: DjangoTestApp):
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
 
-    resp = app.get(reverse("dataset-structure-export-no-version", args=[structure.dataset.pk]))
-    assert resp.text == (
-        "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
-        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n"
-        "2,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n"
-        ",,,,,,,,,,,,,,,,,,,,\r\n"
-        "3,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n"
-        "4,,,,Base,,,,,,,,,,develop,,,,,,\r\n"
-        "5,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
-        ",,,,,,,,,,,,,,,,,,,,\r\n"
-        "6,,,Base,,,,,,,,,,,,,,,,,\r\n"
-        "7,,,,Catalog,,,,,,,,,,develop,,,,,,\r\n"
-        "8,,,,,title,string,,,,,,,2,develop,,open,dct:title,,,\r\n"
-        ",,,,,,,,,,,,,,,,,,,,\r\n"
+    expected_output = (
+        'id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n'
+        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n'
+        '2,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n'
+        ',,,,,,,,,,,,,,,,,,,,\r\n'
+        '3,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n'
+        '4,,,,Base,,,,,,,,,,develop,,,,,,\r\n'
+        '5,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n'
+        ',,,,,,,,,,,,,,,,,,,,\r\n'
+        '6,,,Base,,,,,,,,,,,,,,,,,\r\n'
+        '7,,,,Catalog,,,,,,,,,,develop,,,,,,\r\n'
+        '8,,,,,title,string,,,,,,,2,develop,,open,dct:title,,,\r\n'
+        ',,,,,,,,,,,,,,,,,,,,\r\n'
     )
+
+    if use_version:
+        metadata_version = VersionFactory(dataset=structure.dataset)
+        create_structure_objects(structure, metadata_version)
+        resp = app.get(
+            reverse(
+                "dataset-structure-export",
+                args=[structure.dataset.pk, metadata_version.pk]
+            )
+        )
+    else:
+        create_structure_objects(structure)
+        resp = app.get(
+            reverse(
+                "dataset-structure-export-no-version",
+                args=[structure.dataset.pk]
+            )
+        )
+
+    assert resp.text == expected_output
 
 
 @pytest.mark.django_db
-def test_structure_export__property_ref(app: DjangoTestApp):
+@pytest.mark.parametrize("use_version", [False, True])
+def test_structure_export__property_ref(app: DjangoTestApp, use_version):
     user = UserFactory(is_staff=True)
     app.set_user(user)
     manifest = (
@@ -1675,28 +1919,47 @@ def test_structure_export__property_ref(app: DjangoTestApp):
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
 
-    resp = app.get(reverse("dataset-structure-export-no-version", args=[structure.dataset.pk]))
-    assert resp.text == (
-        "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
-        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n"
-        "2,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n"
-        ",,,,,,,,,,,,,,,,,,,,\r\n"
-        "3,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n"
-        "4,,,,Country,,,,,,,,,,develop,,,,,,\r\n"
-        "5,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
-        "6,,,,,title,string,,,,,,,5,develop,,open,dct:title,,,\r\n"
-        "7,,,,,continent,ref,Continent[id],,,,,,5,develop,,open,dct:continent,,,\r\n"
-        ",,,,,,,,,,,,,,,,,,,,\r\n"
-        "8,,,,Continent,,,,,,,,,,develop,,,,,,\r\n"
-        "9,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
-        ",,,,,,,,,,,,,,,,,,,,\r\n"
+    expected_output = (
+        'id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n'
+        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n'
+        '2,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n'
+        ',,,,,,,,,,,,,,,,,,,,\r\n'
+        '3,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n'
+        '4,,,,Country,,,,,,,,,,develop,,,,,,\r\n'
+        '5,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n'
+        '6,,,,,title,string,,,,,,,5,develop,,open,dct:title,,,\r\n'
+        '7,,,,,continent,ref,Continent[id],,,,,,5,develop,,open,dct:continent,,,\r\n'
+        ',,,,,,,,,,,,,,,,,,,,\r\n'
+        '8,,,,Continent,,,,,,,,,,develop,,,,,,\r\n'
+        '9,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n'
+        ',,,,,,,,,,,,,,,,,,,,\r\n'
     )
+
+    if use_version:
+        metadata_version = VersionFactory(dataset=structure.dataset)
+        create_structure_objects(structure, metadata_version)
+        resp = app.get(
+            reverse(
+                "dataset-structure-export",
+                args=[structure.dataset.pk, metadata_version.pk]
+            )
+        )
+    else:
+        create_structure_objects(structure)
+        resp = app.get(
+            reverse(
+                "dataset-structure-export-no-version",
+                args=[structure.dataset.pk]
+            )
+        )
+
+    assert resp.text == expected_output
 
 
 @pytest.mark.django_db
-def test_structure_export__model_ref(app: DjangoTestApp):
+@pytest.mark.parametrize("use_version", [False, True])
+def test_structure_export__model_ref(app: DjangoTestApp, use_version):
     user = UserFactory(is_staff=True)
     app.set_user(user)
     manifest = (
@@ -1718,19 +1981,38 @@ def test_structure_export__model_ref(app: DjangoTestApp):
     structure.dataset.save()
     create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
 
-    resp = app.get(reverse("dataset-structure-export-no-version", args=[structure.dataset.pk]))
-    assert resp.text == (
-        "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
-        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n"
-        "2,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n"
-        ",,,,,,,,,,,,,,,,,,,,\r\n"
-        "3,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n"
+    expected_output = (
+        'id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n'
+        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n'
+        '2,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n'
+        ',,,,,,,,,,,,,,,,,,,,\r\n'
+        '3,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n'
         '4,,,,Country,,,"id, title",,,,,,,develop,,,,,,\r\n'
         "5,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
         "6,,,,,title,string,,,,,,,5,develop,,open,dct:title,,,\r\n"
         "7,,,,,continent,ref,Continent,,,,,,5,develop,,open,dct:continent,,,\r\n"
         ",,,,,,,,,,,,,,,,,,,,\r\n"
     )
+
+    if use_version:
+        metadata_version = VersionFactory(dataset=structure.dataset)
+        create_structure_objects(structure, metadata_version)
+        resp = app.get(
+            reverse(
+                "dataset-structure-export",
+                args=[structure.dataset.pk, metadata_version.pk]
+            )
+        )
+    else:
+        create_structure_objects(structure)
+        resp = app.get(
+            reverse(
+                "dataset-structure-export-no-version",
+                args=[structure.dataset.pk]
+            )
+        )
+
+    assert resp.text == expected_output
 
 
 @pytest.mark.django_db
@@ -1771,7 +2053,8 @@ def test_structure_export__comments(app: DjangoTestApp):
 
 
 @pytest.mark.django_db
-def test_structure_export__enums(app: DjangoTestApp):
+@pytest.mark.parametrize("use_version", [False, True])
+def test_structure_export__enums(app: DjangoTestApp, use_version):
     user = UserFactory(is_staff=True)
     app.set_user(user)
     manifest = (
@@ -1795,31 +2078,49 @@ def test_structure_export__enums(app: DjangoTestApp):
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
 
-    resp = app.get(reverse("dataset-structure-export-no-version", args=[structure.dataset.pk]))
-    assert resp.text == (
-        "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
-        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n"
-        "2,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n"
-        ",,,,,,,,,,,,,,,,,,,,\r\n"
-        "3,,,,,,enum,Size,,,SMALL,,,,develop,,,,,,\r\n"
-        "4,,,,,,,,,,MEDIUM,,,,develop,,,,,,\r\n"
-        "5,,,,,,,,,,BIG,,,,develop,,,,,,\r\n"
-        ",,,,,,,,,,,,,,,,,,,,\r\n"
-        "6,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n"
-        "7,,,,City,,,,,,,,,,develop,,,,,,\r\n"
-        "8,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
-        "9,,,,,size,Size,,,,,,,5,develop,,open,dct:size,,,\r\n"
-        "10,,,,,type,string,,,,,,,5,develop,,open,dct:type,,,\r\n"
-        "11,,,,,,enum,Type,,,CREATED,,,,develop,,,,,,\r\n"
-        "12,,,,,,,,,,MODIFIED,,,,develop,,,,,,\r\n"
-        ",,,,,,,,,,,,,,,,,,,,\r\n"
+    expected_output = (
+        'id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n'
+        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n'
+        '2,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n'
+        ',,,,,,,,,,,,,,,,,,,,\r\n'
+        '3,,,,,,enum,Size,,,SMALL,,,,develop,,,,,,\r\n'
+        '4,,,,,,,,,,MEDIUM,,,,develop,,,,,,\r\n'
+        '5,,,,,,,,,,BIG,,,,develop,,,,,,\r\n'
+        ',,,,,,,,,,,,,,,,,,,,\r\n'
+        '6,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n'
+        '7,,,,City,,,,,,,,,,develop,,,,,,\r\n'
+        '8,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n'
+        '9,,,,,size,Size,,,,,,,5,develop,,open,dct:size,,,\r\n'
+        '10,,,,,type,string,,,,,,,5,develop,,open,dct:type,,,\r\n'
+        '11,,,,,,enum,Type,,,CREATED,,,,develop,,,,,,\r\n'
+        '12,,,,,,,,,,MODIFIED,,,,develop,,,,,,\r\n'
+        ',,,,,,,,,,,,,,,,,,,,\r\n'
     )
 
+    if use_version:
+        metadata_version = VersionFactory(dataset=structure.dataset)
+        create_structure_objects(structure, metadata_version)
+        resp = app.get(
+            reverse(
+                "dataset-structure-export",
+                args=[structure.dataset.pk, metadata_version.pk]
+            )
+        )
+    else:
+        create_structure_objects(structure)
+        resp = app.get(
+            reverse(
+                "dataset-structure-export-no-version",
+                args=[structure.dataset.pk]
+            )
+        )
+
+    assert resp.text == expected_output
 
 @pytest.mark.django_db
-def test_structure_export__params(app: DjangoTestApp):
+@pytest.mark.parametrize("use_version", [False, True])
+def test_structure_export__params(app: DjangoTestApp, use_version):
     user = UserFactory(is_staff=True)
     app.set_user(user)
     manifest = (
@@ -1842,27 +2143,44 @@ def test_structure_export__params(app: DjangoTestApp):
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
 
-    resp = app.get(reverse("dataset-structure-export-no-version", args=[structure.dataset.pk]))
-    assert resp.text == (
-        "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
-        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n"
-        "2,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n"
-        ",,,,,,,,,,,,,,,,,,,,\r\n"
-        "3,,,,,,param,country,,,lt,,,,develop,,,,,,\r\n"
-        "4,,,,,,,,,,lv,,,,develop,,,,,,\r\n"
-        "5,,,,,,,,,,ee,,,,develop,,,,,,\r\n"
-        ",,,,,,,,,,,,,,,,,,,,\r\n"
-        "6,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n"
-        "7,,,,City,,,,,,,,,,develop,,,,,,\r\n"
-        "8,,,,,,param,type,,,created,,,,develop,,,,,,\r\n"
-        "9,,,,,,,,,,modified,,,,develop,,,,,,\r\n"
-        "10,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
-        "11,,,,,type,string,,,,,,,5,develop,,open,dct:type,,,\r\n"
-        ",,,,,,,,,,,,,,,,,,,,\r\n"
+    expected_output = (
+        'id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n'
+        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n'
+        '2,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n'
+        ',,,,,,,,,,,,,,,,,,,,\r\n'
+        '3,,,,,,param,country,,,lt,,,,develop,,,,,,\r\n'
+        '4,,,,,,,,,,lv,,,,develop,,,,,,\r\n'
+        '5,,,,,,,,,,ee,,,,develop,,,,,,\r\n'
+        ',,,,,,,,,,,,,,,,,,,,\r\n'
+        '6,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n'
+        '7,,,,City,,,,,,,,,,develop,,,,,,\r\n'
+        '8,,,,,,param,type,,,created,,,,develop,,,,,,\r\n'
+        '9,,,,,,,,,,modified,,,,develop,,,,,,\r\n'
+        '10,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n'
+        '11,,,,,type,string,,,,,,,5,develop,,open,dct:type,,,\r\n'
+        ',,,,,,,,,,,,,,,,,,,,\r\n'
     )
 
+    if use_version:
+        metadata_version = VersionFactory(dataset=structure.dataset)
+        create_structure_objects(structure, metadata_version)
+        resp = app.get(
+            reverse(
+                "dataset-structure-export",
+                args=[structure.dataset.pk, metadata_version.pk]
+            )
+        )
+    else:
+        create_structure_objects(structure)
+        resp = app.get(
+            reverse(
+                "dataset-structure-export-no-version",
+                args=[structure.dataset.pk]
+            )
+        )
+
+    assert resp.text == expected_output
 
 @pytest.mark.django_db
 def test_import_structure_with_wrong_datasets_name(app: DjangoTestApp):

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -4331,7 +4331,7 @@ def test_manifest_export_openapi(app: DjangoTestApp):
     structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
+    version = create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
 
     ct = ContentType.objects.get_for_model(structure.dataset)
     representative = RepresentativeFactory(
@@ -4339,7 +4339,7 @@ def test_manifest_export_openapi(app: DjangoTestApp):
         object_id=structure.dataset.pk,
     )
     app.set_user(representative.user)
-    resp = app.get(reverse("dataset-structure-export-openapi", args=[structure.dataset.pk]))
+    resp = app.get(reverse("dataset-structure-export-openapi", args=[structure.dataset.pk, version.pk]))
 
     assert resp.status_code == 200
     assert resp.content_type == "application/json"

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -4400,7 +4400,7 @@ def test_manifest_export_openapi_soap_params(app: DjangoTestApp):
         object_id=structure.dataset.pk,
     )
     app.set_user(representative.user)
-    resp = app.get(reverse('dataset-structure-export-openapi', args=[structure.dataset.pk, version.pk]))
+    resp = app.get(reverse("dataset-structure-export-openapi", args=[structure.dataset.pk, version.pk]))
 
     assert resp.status_code == 200
     assert resp.content_type == "application/json"

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -4392,7 +4392,7 @@ def test_manifest_export_openapi_soap_params(app: DjangoTestApp):
     structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure)
+    version = create_structure_objects(structure)
 
     ct = ContentType.objects.get_for_model(structure.dataset)
     representative = RepresentativeFactory(
@@ -4400,7 +4400,7 @@ def test_manifest_export_openapi_soap_params(app: DjangoTestApp):
         object_id=structure.dataset.pk,
     )
     app.set_user(representative.user)
-    resp = app.get(reverse("dataset-structure-export-openapi", args=[structure.dataset.pk]))
+    resp = app.get(reverse('dataset-structure-export-openapi', args=[structure.dataset.pk, version.pk]))
 
     assert resp.status_code == 200
     assert resp.content_type == "application/json"

--- a/tests/uapi/conftest.py
+++ b/tests/uapi/conftest.py
@@ -115,11 +115,7 @@ def dataset(organization: Organization) -> Dataset:
         organization=organization,
         title="Title of the Dataset",
         description="Description of the Dataset.",
-<<<<<<< HEAD
-        metadata="test/dataset/TestModel",
-=======
         metadata="test/dataset"
->>>>>>> 8d4a8e55 ([1906]: fix failing uapi tests)
     )
     return dataset
 

--- a/tests/uapi/conftest.py
+++ b/tests/uapi/conftest.py
@@ -115,7 +115,11 @@ def dataset(organization: Organization) -> Dataset:
         organization=organization,
         title="Title of the Dataset",
         description="Description of the Dataset.",
+<<<<<<< HEAD
         metadata="test/dataset/TestModel",
+=======
+        metadata="test/dataset"
+>>>>>>> 8d4a8e55 ([1906]: fix failing uapi tests)
     )
     return dataset
 
@@ -182,7 +186,7 @@ def url_agent() -> str:
 @pytest.fixture
 def dsa() -> str:
     return """id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description
-,example70,,,,,,,,,,,,,,,,,
+,test/dataset,,,,,,,,,,,,,,,,,
 ,,users,,,,dask/json,,/path,,,,,,,,,,
 ,,,,,,,,,,,,,,,,,,
 ,,,,User,,,id,users,,,4,completed,package,open,,,Pavadinimas,

--- a/tests/uapi/conftest.py
+++ b/tests/uapi/conftest.py
@@ -115,7 +115,7 @@ def dataset(organization: Organization) -> Dataset:
         organization=organization,
         title="Title of the Dataset",
         description="Description of the Dataset.",
-        metadata="test/dataset"
+        metadata="test/dataset",
     )
     return dataset
 

--- a/tests/uapi/dataset/test_views.py
+++ b/tests/uapi/dataset/test_views.py
@@ -1068,7 +1068,7 @@ class TestActionGetDatasetStructure:
         expected_csv = f"""id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description
 {metadata_to_id_map["example70"]},example70,,,,,,,,,,,,,,,,,,Title of the Dataset,Description of the Dataset.
 {metadata_to_id_map["users"]},,users,,,,dask/json,,/path,,,,,,,,,,,users,
-{metadata_to_id_map["example70/User"]},,,,User,,,id,users,,,,,4,completed,package,open,,,Pavadinimas,
+{metadata_to_id_map["test/dataset/User"]},,,,User,,,id,users,,,,,4,completed,package,open,,,Pavadinimas,
 {metadata_to_id_map["id"]},,,,,id,integer,,id,,,,,,develop,,,,,,
 {metadata_to_id_map["full_name"]},,,,,full_name,string,,name,,,,,,develop,,,,,,
 {metadata_to_id_map["email_address"]},,,,,email_address,string,,email,,,,,,develop,,,,,,

--- a/tests/uapi/dataset/test_views.py
+++ b/tests/uapi/dataset/test_views.py
@@ -1054,7 +1054,7 @@ class TestActionGetDatasetStructure:
         )
         dataset.current_structure = structure
         dataset.save()
-        create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
+        version = create_structure_objects(structure)
 
         response = app.get(
             url_dataset_structure,
@@ -1064,9 +1064,9 @@ class TestActionGetDatasetStructure:
         assert response.status_code == status.HTTP_200_OK
         assert response.headers["Content-Type"] == "text/csv"
 
-        metadata_to_id_map = dict(Metadata.objects.all().values_list("name", "uuid"))
+        metadata_to_id_map = dict(Metadata.objects.filter(metadata_version=version).values_list("name", "uuid"))
         expected_csv = f"""id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description
-{metadata_to_id_map["example70"]},example70,,,,,,,,,,,,,,,,,,Title of the Dataset,Description of the Dataset.
+{metadata_to_id_map["test/dataset"]},test/dataset,,,,,,,,,,,,,,,,,,Title of the Dataset,Description of the Dataset.
 {metadata_to_id_map["users"]},,users,,,,dask/json,,/path,,,,,,,,,,,users,
 {metadata_to_id_map["test/dataset/User"]},,,,User,,,id,users,,,,,4,completed,package,open,,,Pavadinimas,
 {metadata_to_id_map["id"]},,,,,id,integer,,id,,,,,,develop,,,,,,

--- a/vitrina/datasets/factories.py
+++ b/vitrina/datasets/factories.py
@@ -130,6 +130,8 @@ class DatasetFactory(DjangoModelFactory):
     def metadata(self, create: bool, extracted: str, **kwargs) -> None:
         if not create:
             return
+        if extracted is False:
+            return
         name = extracted if extracted is not None else ((self.organization.name or "test/dataset/") + "abcd")
 
         MetadataFactory.create(

--- a/vitrina/structure/services.py
+++ b/vitrina/structure/services.py
@@ -1085,14 +1085,25 @@ def _dataset_to_tabular(dataset: Dataset, separator: bool = False, version: Vers
     yield from _prefixes_to_tabular(dataset, separator=separator, version=version)
     yield from _enums_to_tabular(dataset, separator=separator, version=version)
     yield from _params_to_tabular(dataset, separator=separator, version=version)
-    yield from _dataset_resources_to_tabular(dataset, separator=separator)
+    yield from _dataset_resources_to_tabular(dataset, separator=separator, version=version)
     yield from _models_to_tabular(dataset, separator=separator, version=version)
 
 
-def _dataset_resources_to_tabular(dataset: Dataset, separator: bool = False) -> Generator:
-    distributions = DatasetDistribution.objects.filter(dataset=dataset, model__isnull=True).order_by("metadata__order")
+def _dataset_resources_to_tabular(
+    dataset: Dataset, separator: bool = False, version: Version | None = None
+) -> Generator:
+    distribution_filter = {"dataset": dataset, "model__isnull": True}
+    metadata_queryset = Metadata.objects.all()
+    if version is not None:
+        distribution_filter["metadata_version"] = version
+        metadata_queryset = metadata_queryset.filter(metadata_version=version)
+    distributions = (
+        DatasetDistribution.objects.filter(**distribution_filter)
+        .prefetch_related(Prefetch("metadata", queryset=metadata_queryset.order_by("order")))
+        .order_by("metadata__order")
+    )
     for distribution in distributions:
-        yield from _resource_to_tabular(distribution)
+        yield from _resource_to_tabular(distribution, version=version)
 
 
 def _enums_to_tabular(obj: models.Model, separator: bool = False, version: Version | None = None) -> Generator:
@@ -1138,8 +1149,9 @@ def _enums_to_tabular(obj: models.Model, separator: bool = False, version: Versi
         yield to_row(DATASET, {})
 
 
-def _params_to_tabular(obj: models.Model | Dataset | DatasetDistribution,
-                       separator: bool = False, version: Version | None = None) -> Generator:
+def _params_to_tabular(
+    obj: models.Model | Dataset | DatasetDistribution, separator: bool = False, version: Version | None = None
+) -> Generator:
     ct = ContentType.objects.get_for_model(obj)
     param_filter = {"content_type": ct, "object_id": obj.pk}
     metadata_queryset = Metadata.objects.all()

--- a/vitrina/structure/services.py
+++ b/vitrina/structure/services.py
@@ -6,7 +6,7 @@ from json import JSONDecodeError
 from typing import Union, Tuple, List, Dict, Generator
 
 import requests
-from django.db.models import Q
+from django.db.models import Q, Prefetch
 from pyproj import Transformer
 
 import vitrina.datasets.structure as struct
@@ -986,9 +986,9 @@ class IterableFile:
         self.writes.append(data)
 
 
-def export_dataset_structure(dataset: Dataset) -> StringIO:
+def export_dataset_structure(dataset: Dataset, version: Version | None=None) -> StringIO:
     cols = DATASET
-    rows = datasets_to_tabular(dataset)
+    rows = datasets_to_tabular(dataset, version=version)
     rows = ({c: row[c] for c in cols} for row in rows)
     stream = IterableFile()
     writer = csv.DictWriter(stream, fieldnames=cols)
@@ -998,22 +998,22 @@ def export_dataset_structure(dataset: Dataset) -> StringIO:
         yield from stream
 
 
-def _export_dataset_structure_to_stringio(dataset: Dataset) -> StringIO:
+def _export_dataset_structure_to_stringio(dataset: Dataset, version: Version) -> StringIO:
     """Wrapper that converts the generator output to StringIO"""
 
     result = StringIO()
 
-    for chunk in export_dataset_structure(dataset):
+    for chunk in export_dataset_structure(dataset, version):
         result.write(chunk)
 
     result.seek(0)
     return result
 
 
-def datasets_to_tabular(dataset: Dataset):
+def datasets_to_tabular(dataset: Dataset, version: Version | None=None):
     if dataset.current_structure:
-        yield from _prefixes_to_tabular(dataset.current_structure, separator=True)
-    yield from _dataset_to_tabular(dataset, separator=True)
+        yield from _prefixes_to_tabular(dataset.current_structure, separator=True, version=version)
+    yield from _dataset_to_tabular(dataset, separator=True, version=version)
 
 
 def to_row(keys, values) -> Dict:
@@ -1024,9 +1024,19 @@ def _end_marker(name):
     yield to_row(DATASET, {name: "/"})
 
 
-def _prefixes_to_tabular(obj: models.Model, separator: bool = False):
+def _prefixes_to_tabular(obj: models.Model, separator: bool = False, version: Version | None=None):
     ct = ContentType.objects.get_for_model(obj)
-    prefixes = Prefix.objects.filter(content_type=ct, object_id=obj.pk).order_by("metadata__order")
+    prefix_filter = {"content_type": ct, "object_id": obj.pk}
+    if version is not None:
+        prefix_filter["metadata_version"] = version
+
+    metadata_queryset = Metadata.objects.all()
+    if version is not None:
+        metadata_queryset = metadata_queryset.filter(metadata_version=version)
+
+    prefixes = Prefix.objects.filter(**prefix_filter).prefetch_related(
+        Prefetch('metadata', queryset=metadata_queryset.order_by('order'))
+    ).order_by("metadata__order")
 
     first = True
     for prefix in prefixes:
@@ -1048,10 +1058,13 @@ def _prefixes_to_tabular(obj: models.Model, separator: bool = False):
         yield to_row(DATASET, {})
 
 
-def _dataset_to_tabular(dataset: Dataset, separator: bool = False):
+def _dataset_to_tabular(dataset: Dataset, separator: bool = False, version: Version | None=None):
     if lang := get_language():
         dataset.set_current_language(lang)
-    if meta := dataset.metadata.first():
+    meta_query = dataset.metadata.all()
+    if version is not None:
+        meta_query = meta_query.filter(metadata_version=version)
+    if meta := meta_query.first():
         yield to_row(
             DATASET,
             {
@@ -1063,11 +1076,11 @@ def _dataset_to_tabular(dataset: Dataset, separator: bool = False):
                 "description": dataset.description,
             },
         )
-    yield from _prefixes_to_tabular(dataset, separator=separator)
-    yield from _enums_to_tabular(dataset, separator=separator)
-    yield from _params_to_tabular(dataset, separator=separator)
+    yield from _prefixes_to_tabular(dataset, separator=separator, version=version)
+    yield from _enums_to_tabular(dataset, separator=separator, version=version)
+    yield from _params_to_tabular(dataset, separator=separator, version=version)
     yield from _dataset_resources_to_tabular(dataset, separator=separator)
-    yield from _models_to_tabular(dataset, separator=separator)
+    yield from _models_to_tabular(dataset, separator=separator, version=version)
 
 
 def _dataset_resources_to_tabular(dataset: Dataset, separator: bool = False) -> Generator:
@@ -1076,13 +1089,29 @@ def _dataset_resources_to_tabular(dataset: Dataset, separator: bool = False) -> 
         yield from _resource_to_tabular(distribution)
 
 
-def _enums_to_tabular(obj: models.Model, separator: bool = False):
+def _enums_to_tabular(obj: models.Model, separator: bool = False, version: Version | None=None):
     ct = ContentType.objects.get_for_model(obj)
-    enums = Enum.objects.filter(content_type=ct, object_id=obj.pk)
+    enum_filter = {"content_type": ct, "object_id": obj.pk}
+    if version is not None:
+        enum_filter["metadata_version"] = version
 
+    metadata_queryset = Metadata.objects.all()
+    if version is not None:
+        metadata_queryset = metadata_queryset.filter(metadata_version=version)
+
+    enumitem_filter = {}
+    if version is not None:
+        enumitem_filter["metadata_version"] = version
+    enumitem_queryset = EnumItem.objects.filter(**enumitem_filter).prefetch_related(
+        Prefetch('metadata', queryset=metadata_queryset.order_by('order'))
+    )
+    enums = Enum.objects.filter(**enum_filter).prefetch_related(
+        Prefetch('enumitem_set', queryset=enumitem_queryset)
+    )
     for enum in enums:
         first = True
-        for item in enum.enumitem_set.all().order_by("metadata__order"):
+        enumitems = list(enum.enumitem_set.all())
+        for item in enumitems:
             if meta := item.metadata.first():
                 yield to_row(
                     DATASET,
@@ -1107,13 +1136,31 @@ def _enums_to_tabular(obj: models.Model, separator: bool = False):
         yield to_row(DATASET, {})
 
 
-def _params_to_tabular(obj: models.Model | Dataset | DatasetDistribution, separator: bool = False):
+def _params_to_tabular(obj: models.Model | Dataset | DatasetDistribution, separator: bool = False, version: Version | None = None):
     ct = ContentType.objects.get_for_model(obj)
-    params = Param.objects.filter(content_type=ct, object_id=obj.pk)
+    param_filter = {"content_type": ct, "object_id": obj.pk}
+    if version is not None:
+        param_filter["metadata_version"] = version
+
+    metadata_queryset = Metadata.objects.all()
+    if version is not None:
+        metadata_queryset = metadata_queryset.filter(metadata_version=version)
+
+    paramitem_filter = {}
+    if version is not None:
+        paramitem_filter["metadata_version"] = version
+    paramitem_queryset = ParamItem.objects.filter(**paramitem_filter).prefetch_related(
+        Prefetch('metadata', queryset=metadata_queryset.order_by('order'))
+    )
+
+    params = Param.objects.filter(**param_filter).prefetch_related(
+        Prefetch('paramitem_set', queryset=paramitem_queryset)
+    )
 
     for param in params:
         first = True
-        for item in param.paramitem_set.all().order_by("metadata__order"):
+        paramitems = list(param.paramitem_set.all())
+        for item in paramitems:
             if meta := item.metadata.first():
                 yield to_row(
                     DATASET,
@@ -1138,27 +1185,68 @@ def _params_to_tabular(obj: models.Model | Dataset | DatasetDistribution, separa
         yield to_row(DATASET, {})
 
 
-def _models_to_tabular(dataset: Dataset, separator: bool = False):
-    dataset_models = Model.objects.filter(dataset=dataset).order_by("metadata__order")
+def _models_to_tabular(dataset: Dataset, separator: bool = False, version: Version | None = None):
+    model_filter = {"dataset": dataset}
+    if version is not None:
+        model_filter["metadata_version"] = version
+
+    metadata_queryset = Metadata.objects.all()
+    if version is not None:
+        metadata_queryset = metadata_queryset.filter(metadata_version=version)
+
+    property_metadata_queryset = Metadata.objects.all()
+    if version is not None:
+        property_metadata_queryset = property_metadata_queryset.filter(metadata_version=version)
+
+    distribution_metadata_queryset = Metadata.objects.all()
+    if version is not None:
+        distribution_metadata_queryset = distribution_metadata_queryset.filter(metadata_version=version)
+
+    base_metadata_queryset = Metadata.objects.all()
+    if version is not None:
+        base_metadata_queryset = base_metadata_queryset.filter(metadata_version=version)
+
+    property_list_filter = {}
+    if version is not None:
+        property_list_filter["metadata_version"] = version
+    property_list_queryset = PropertyList.objects.filter(**property_list_filter).select_related(
+        'property'
+    ).prefetch_related(
+        Prefetch('property__metadata', queryset=property_metadata_queryset)
+    )
+
+    dataset_models = Model.objects.filter(**model_filter).select_related(
+        'distribution', 'base'
+    ).prefetch_related(
+        Prefetch('metadata', queryset=metadata_queryset.order_by('order')),
+        Prefetch('property_list', queryset=property_list_queryset),
+        Prefetch('distribution__metadata', queryset=distribution_metadata_queryset),
+        Prefetch('base__metadata', queryset=base_metadata_queryset)
+    ).order_by("metadata__order")
 
     resource = None
     base = None
     for model in dataset_models:
         if model.distribution and not resource:
-            yield from _resource_to_tabular(model.distribution)
+            yield from _resource_to_tabular(model.distribution, version=version)
             resource = model.distribution
         elif not model.distribution and resource:
             yield from _end_marker("resource")
             resource = None
 
         if model.base and not base:
-            yield from _base_to_tabular(model.base)
+            yield from _base_to_tabular(model.base, version=version)
             base = model.base
         elif not model.base and base:
             yield from _end_marker("base")
             base = None
 
         if meta := model.metadata.first():
+            prop_names = []
+            for prop_list_item in model.property_list.all():
+                if prop_meta := prop_list_item.property.metadata.first():
+                    prop_names.append(prop_meta.name)
+
             yield to_row(
                 DATASET,
                 {
@@ -1175,30 +1263,71 @@ def _models_to_tabular(dataset: Dataset, separator: bool = False):
                     "count": meta.count,
                     "eli": meta.eli,
                     "prepare": meta.prepare,
-                    "ref": ", ".join([prop.property.name for prop in model.property_list.all()])
-                    if model.property_list.exists()
-                    else "",
+                    "ref": ", ".join(prop_names) if prop_names else "",
                 },
             )
 
             yield from _comments_to_tabular(model)
-            yield from _params_to_tabular(model)
-            yield from _properties_to_tabular(model)
+            yield from _params_to_tabular(model, version=version)
+            yield from _properties_to_tabular(model, version=version)
             if separator:
                 yield to_row(DATASET, {})
 
 
-def _resource_models_to_tabular(resource: DatasetDistribution, separator: bool = False):
-    resource_models = Model.objects.filter(distribution=resource, dataset=resource.dataset).order_by("metadata__order")
+def _resource_models_to_tabular(resource: DatasetDistribution, separator: bool = False, version: Version | None=None):
+    model_filter = {"distribution": resource, "dataset": resource.dataset}
+    if version is not None:
+        model_filter["metadata_version"] = version
+
+    metadata_queryset = Metadata.objects.all()
+    if version is not None:
+        metadata_queryset = metadata_queryset.filter(metadata_version=version)
+
+    property_metadata_queryset = Metadata.objects.all()
+    if version is not None:
+        property_metadata_queryset = property_metadata_queryset.filter(metadata_version=version)
+
+    distribution_metadata_queryset = Metadata.objects.all()
+    if version is not None:
+        distribution_metadata_queryset = distribution_metadata_queryset.filter(metadata_version=version)
+
+    base_metadata_queryset = Metadata.objects.all()
+    if version is not None:
+        base_metadata_queryset = base_metadata_queryset.filter(metadata_version=version)
+
+    property_list_filter = {}
+    if version is not None:
+        property_list_filter["metadata_version"] = version
+    property_list_queryset = PropertyList.objects.filter(**property_list_filter).select_related(
+        'property'
+    ).prefetch_related(
+        Prefetch('property__metadata', queryset=property_metadata_queryset)
+    )
+
+    resource_models = Model.objects.filter(**model_filter).select_related(
+        'base'
+    ).prefetch_related(
+        Prefetch('metadata', queryset=metadata_queryset.order_by('order')),
+        Prefetch('property_list', queryset=property_list_queryset),
+        Prefetch('distribution__metadata', queryset=distribution_metadata_queryset),
+        Prefetch('base__metadata', queryset=base_metadata_queryset)
+    ).order_by("metadata__order")
+
     base = None
     for model in resource_models:
         if model.base and not base:
-            yield from _base_to_tabular(model.base)
+            yield from _base_to_tabular(model.base, version=version)
             base = model.base
         elif not model.base and base:
             yield from _end_marker("base")
             base = None
+
         if meta := model.metadata.first():
+            prop_names = []
+            for prop_list_item in model.property_list.all():
+                if prop_meta := prop_list_item.property.metadata.first():
+                    prop_names.append(prop_meta.name)
+
             yield to_row(
                 DATASET,
                 {
@@ -1211,21 +1340,20 @@ def _resource_models_to_tabular(resource: DatasetDistribution, separator: bool =
                     "uri": meta.uri,
                     "source": meta.source,
                     "prepare": meta.prepare,
-                    "ref": ", ".join([prop.property.name for prop in model.property_list.all()])
-                    if model.property_list.exists()
-                    else "",
+                    "ref": ", ".join(prop_names) if prop_names else "",
                 },
             )
-            yield from _params_to_tabular(model)
-            yield from _properties_to_tabular(model)
+            yield from _params_to_tabular(model, version=version)
+            yield from _properties_to_tabular(model, version=version)
             if separator:
                 yield to_row(DATASET, {})
 
 
-def _resource_to_tabular(resource: DatasetDistribution):
+def _resource_to_tabular(resource: DatasetDistribution, version: Version | None=None):
     if lang := get_language():
         resource.set_current_language(lang)
-    if meta := resource.metadata.first():
+    meta = resource.metadata.first() if version is None else resource.metadata.filter(metadata_version=version).first()
+    if meta:
         yield to_row(
             DATASET,
             {
@@ -1247,12 +1375,14 @@ def _resource_to_tabular(resource: DatasetDistribution):
 
 def _comments_to_tabular(obj: models.Model):
     ct = ContentType.objects.get_for_model(obj)
-    comments = Comment.objects.filter(content_type=ct, object_id=obj.pk, type=Comment.STRUCTURE).order_by(
-        "metadata__order"
+    comments = Comment.objects.filter(
+        content_type=ct, object_id=obj.pk, type=Comment.STRUCTURE
+    ).prefetch_related(
+        Prefetch('metadata', queryset=Metadata.objects.all().order_by('order'))
     )
-
     first = True
-    for comment in comments:
+    comments_list = list(comments)
+    for comment in comments_list:
         if meta := comment.metadata.first():
             yield to_row(
                 DATASET,
@@ -1269,8 +1399,11 @@ def _comments_to_tabular(obj: models.Model):
             first = False
 
 
-def _base_to_tabular(base: Base):
-    if meta := base.metadata.first():
+def _base_to_tabular(base: Base, version: Version | None=None):
+    meta_query = base.metadata.all()
+    if version is not None:
+        meta_query = meta_query.filter(metadata_version=version)
+    if meta := meta_query.first():
         yield to_row(
             DATASET,
             {
@@ -1281,10 +1414,20 @@ def _base_to_tabular(base: Base):
         )
 
 
-def _properties_to_tabular(model: Model):
-    props = model.get_given_props()
+def _properties_to_tabular(model: Model, version: Version | None=None):
+    prop_filter = {"model": model, "given": True}
+    if version is not None:
+        prop_filter["metadata_version"] = version
 
-    for prop in props:
+    property_metadata_queryset = Metadata.objects.all()
+    if version is not None:
+        property_metadata_queryset = property_metadata_queryset.filter(metadata_version=version)
+
+    props = Property.objects.filter(**prop_filter).prefetch_related(
+        Prefetch('metadata', queryset=property_metadata_queryset.order_by('order'))
+    )
+    props_list = list(props)
+    for prop in props_list:
         if meta := prop.metadata.first():
             yield to_row(
                 DATASET,
@@ -1308,7 +1451,7 @@ def _properties_to_tabular(model: Model):
             )
 
             yield from _comments_to_tabular(prop)
-            yield from _enums_to_tabular(prop)
+            yield from _enums_to_tabular(prop, version=version)
 
 
 def _to_relative_model_name(name: str, dataset: Dataset) -> str:

--- a/vitrina/structure/services.py
+++ b/vitrina/structure/services.py
@@ -1272,7 +1272,9 @@ def _models_to_tabular(dataset: Dataset, separator: bool = False, version: Versi
                 yield to_row(DATASET, {})
 
 
-def _resource_models_to_tabular(resource: DatasetDistribution, separator: bool = False, version: Version | None = None) -> Generator:
+def _resource_models_to_tabular(
+    resource: DatasetDistribution, separator: bool = False, version: Version | None = None
+) -> Generator:
     model_filter = {"distribution": resource, "dataset": resource.dataset}
     model_metadata_filter = {}
     property_list_filter = {}

--- a/vitrina/structure/services.py
+++ b/vitrina/structure/services.py
@@ -1012,7 +1012,7 @@ def _export_dataset_structure_to_stringio(dataset: Dataset, version: Version) ->
     return result
 
 
-def datasets_to_tabular(dataset: Dataset, version: Version | None = None):
+def datasets_to_tabular(dataset: Dataset, version: Version | None = None) -> Generator:
     if dataset.current_structure:
         yield from _prefixes_to_tabular(dataset.current_structure, separator=True, version=version)
     yield from _dataset_to_tabular(dataset, separator=True, version=version)
@@ -1026,14 +1026,13 @@ def _end_marker(name):
     yield to_row(DATASET, {name: "/"})
 
 
-def _prefixes_to_tabular(obj: models.Model, separator: bool = False, version: Version | None = None):
+def _prefixes_to_tabular(obj: models.Model, separator: bool = False, version: Version | None = None) -> Generator:
     ct = ContentType.objects.get_for_model(obj)
     prefix_filter = {"content_type": ct, "object_id": obj.pk}
+    metadata_queryset = Metadata.objects.all()
+
     if version is not None:
         prefix_filter["metadata_version"] = version
-
-    metadata_queryset = Metadata.objects.all()
-    if version is not None:
         metadata_queryset = metadata_queryset.filter(metadata_version=version)
 
     prefixes = (
@@ -1062,7 +1061,7 @@ def _prefixes_to_tabular(obj: models.Model, separator: bool = False, version: Ve
         yield to_row(DATASET, {})
 
 
-def _dataset_to_tabular(dataset: Dataset, separator: bool = False, version: Version | None = None):
+def _dataset_to_tabular(dataset: Dataset, separator: bool = False, version: Version | None = None) -> Generator:
     if lang := get_language():
         dataset.set_current_language(lang)
     meta_query = dataset.metadata.all()
@@ -1096,27 +1095,25 @@ def _dataset_resources_to_tabular(dataset: Dataset, separator: bool = False) -> 
         yield from _resource_to_tabular(distribution)
 
 
-def _enums_to_tabular(obj: models.Model, separator: bool = False, version: Version | None = None):
+def _enums_to_tabular(obj: models.Model, separator: bool = False, version: Version | None = None) -> Generator:
     ct = ContentType.objects.get_for_model(obj)
     enum_filter = {"content_type": ct, "object_id": obj.pk}
+    metadata_queryset = Metadata.objects.all()
+    enum_item_filter = {}
+
     if version is not None:
         enum_filter["metadata_version"] = version
-
-    metadata_queryset = Metadata.objects.all()
-    if version is not None:
         metadata_queryset = metadata_queryset.filter(metadata_version=version)
+        enum_item_filter["metadata_version"] = version
 
-    enumitem_filter = {}
-    if version is not None:
-        enumitem_filter["metadata_version"] = version
-    enumitem_queryset = EnumItem.objects.filter(**enumitem_filter).prefetch_related(
+    enum_item_queryset = EnumItem.objects.filter(**enum_item_filter).prefetch_related(
         Prefetch("metadata", queryset=metadata_queryset.order_by("order"))
     )
-    enums = Enum.objects.filter(**enum_filter).prefetch_related(Prefetch("enumitem_set", queryset=enumitem_queryset))
+    enums = Enum.objects.filter(**enum_filter).prefetch_related(Prefetch("enumitem_set", queryset=enum_item_queryset))
     for enum in enums:
         first = True
-        enumitems = list(enum.enumitem_set.all())
-        for item in enumitems:
+        enum_items = list(enum.enumitem_set.all())
+        for item in enum_items:
             if meta := item.metadata.first():
                 yield to_row(
                     DATASET,
@@ -1141,31 +1138,30 @@ def _enums_to_tabular(obj: models.Model, separator: bool = False, version: Versi
         yield to_row(DATASET, {})
 
 
-def _params_to_tabular(obj: models.Model | Dataset | DatasetDistribution, separator: bool = False, version: Version | None = None):
+def _params_to_tabular(obj: models.Model | Dataset | DatasetDistribution,
+                       separator: bool = False, version: Version | None = None) -> Generator:
     ct = ContentType.objects.get_for_model(obj)
     param_filter = {"content_type": ct, "object_id": obj.pk}
+    metadata_queryset = Metadata.objects.all()
+    param_item_filter = {}
+
     if version is not None:
         param_filter["metadata_version"] = version
-
-    metadata_queryset = Metadata.objects.all()
-    if version is not None:
         metadata_queryset = metadata_queryset.filter(metadata_version=version)
+        param_item_filter["metadata_version"] = version
 
-    paramitem_filter = {}
-    if version is not None:
-        paramitem_filter["metadata_version"] = version
-    paramitem_queryset = ParamItem.objects.filter(**paramitem_filter).prefetch_related(
+    param_item_queryset = ParamItem.objects.filter(**param_item_filter).prefetch_related(
         Prefetch("metadata", queryset=metadata_queryset.order_by("order"))
     )
 
     params = Param.objects.filter(**param_filter).prefetch_related(
-        Prefetch("paramitem_set", queryset=paramitem_queryset)
+        Prefetch("paramitem_set", queryset=param_item_queryset)
     )
 
     for param in params:
         first = True
-        paramitems = list(param.paramitem_set.all())
-        for item in paramitems:
+        param_items = list(param.paramitem_set.all())
+        for item in param_items:
             if meta := item.metadata.first():
                 yield to_row(
                     DATASET,
@@ -1190,30 +1186,24 @@ def _params_to_tabular(obj: models.Model | Dataset | DatasetDistribution, separa
         yield to_row(DATASET, {})
 
 
-def _models_to_tabular(dataset: Dataset, separator: bool = False, version: Version | None = None):
+def _models_to_tabular(dataset: Dataset, separator: bool = False, version: Version | None = None) -> Generator:
     model_filter = {"dataset": dataset}
+    model_metadata_filter = {}
+    property_list_filter = {}
+    metadata_queryset = Metadata.objects.all()
+    property_metadata_queryset = Metadata.objects.all()
+    distribution_metadata_queryset = Metadata.objects.all()
+    base_metadata_queryset = Metadata.objects.all()
+
     if version is not None:
         model_filter["metadata_version"] = version
-
-    metadata_queryset = Metadata.objects.all()
-    if version is not None:
+        model_metadata_filter["metadata_version"] = version
+        property_list_filter["metadata_version"] = version
         metadata_queryset = metadata_queryset.filter(metadata_version=version)
-
-    property_metadata_queryset = Metadata.objects.all()
-    if version is not None:
         property_metadata_queryset = property_metadata_queryset.filter(metadata_version=version)
-
-    distribution_metadata_queryset = Metadata.objects.all()
-    if version is not None:
         distribution_metadata_queryset = distribution_metadata_queryset.filter(metadata_version=version)
-
-    base_metadata_queryset = Metadata.objects.all()
-    if version is not None:
         base_metadata_queryset = base_metadata_queryset.filter(metadata_version=version)
 
-    property_list_filter = {}
-    if version is not None:
-        property_list_filter["metadata_version"] = version
     property_list_queryset = (
         PropertyList.objects.filter(**property_list_filter)
         .select_related("property")
@@ -1250,10 +1240,10 @@ def _models_to_tabular(dataset: Dataset, separator: bool = False, version: Versi
             base = None
 
         if meta := model.metadata.first():
-            prop_names = []
+            prop_names = set()
             for prop_list_item in model.property_list.all():
                 if prop_meta := prop_list_item.property.metadata.first():
-                    prop_names.append(prop_meta.name)
+                    prop_names.add(prop_meta.name)
 
             yield to_row(
                 DATASET,
@@ -1271,7 +1261,7 @@ def _models_to_tabular(dataset: Dataset, separator: bool = False, version: Versi
                     "count": meta.count,
                     "eli": meta.eli,
                     "prepare": meta.prepare,
-                    "ref": ", ".join(prop_names) if prop_names else "",
+                    "ref": ", ".join(sorted(prop_names)) if prop_names else "",
                 },
             )
 
@@ -1282,30 +1272,24 @@ def _models_to_tabular(dataset: Dataset, separator: bool = False, version: Versi
                 yield to_row(DATASET, {})
 
 
-def _resource_models_to_tabular(resource: DatasetDistribution, separator: bool = False, version: Version | None = None):
+def _resource_models_to_tabular(resource: DatasetDistribution, separator: bool = False, version: Version | None = None) -> Generator:
     model_filter = {"distribution": resource, "dataset": resource.dataset}
+    model_metadata_filter = {}
+    property_list_filter = {}
+    metadata_queryset = Metadata.objects.all()
+    property_metadata_queryset = Metadata.objects.all()
+    distribution_metadata_queryset = Metadata.objects.all()
+    base_metadata_queryset = Metadata.objects.all()
+
     if version is not None:
         model_filter["metadata_version"] = version
-
-    metadata_queryset = Metadata.objects.all()
-    if version is not None:
+        model_metadata_filter["metadata_version"] = version
+        property_list_filter["metadata_version"] = version
         metadata_queryset = metadata_queryset.filter(metadata_version=version)
-
-    property_metadata_queryset = Metadata.objects.all()
-    if version is not None:
         property_metadata_queryset = property_metadata_queryset.filter(metadata_version=version)
-
-    distribution_metadata_queryset = Metadata.objects.all()
-    if version is not None:
         distribution_metadata_queryset = distribution_metadata_queryset.filter(metadata_version=version)
-
-    base_metadata_queryset = Metadata.objects.all()
-    if version is not None:
         base_metadata_queryset = base_metadata_queryset.filter(metadata_version=version)
 
-    property_list_filter = {}
-    if version is not None:
-        property_list_filter["metadata_version"] = version
     property_list_queryset = (
         PropertyList.objects.filter(**property_list_filter)
         .select_related("property")
@@ -1334,10 +1318,10 @@ def _resource_models_to_tabular(resource: DatasetDistribution, separator: bool =
             base = None
 
         if meta := model.metadata.first():
-            prop_names = []
+            prop_names = set()
             for prop_list_item in model.property_list.all():
                 if prop_meta := prop_list_item.property.metadata.first():
-                    prop_names.append(prop_meta.name)
+                    prop_names.add(prop_meta.name)
 
             yield to_row(
                 DATASET,
@@ -1351,7 +1335,7 @@ def _resource_models_to_tabular(resource: DatasetDistribution, separator: bool =
                     "uri": meta.uri,
                     "source": meta.source,
                     "prepare": meta.prepare,
-                    "ref": ", ".join(prop_names) if prop_names else "",
+                    "ref": ", ".join(sorted(prop_names)) if prop_names else "",
                 },
             )
             yield from _params_to_tabular(model, version=version)
@@ -1360,7 +1344,7 @@ def _resource_models_to_tabular(resource: DatasetDistribution, separator: bool =
                 yield to_row(DATASET, {})
 
 
-def _resource_to_tabular(resource: DatasetDistribution, version: Version | None = None):
+def _resource_to_tabular(resource: DatasetDistribution, version: Version | None = None) -> Generator:
     if lang := get_language():
         resource.set_current_language(lang)
     meta = resource.metadata.first() if version is None else resource.metadata.filter(metadata_version=version).first()
@@ -1384,7 +1368,7 @@ def _resource_to_tabular(resource: DatasetDistribution, version: Version | None 
     yield from _comments_to_tabular(resource)
 
 
-def _comments_to_tabular(obj: models.Model):
+def _comments_to_tabular(obj: models.Model) -> Generator:
     ct = ContentType.objects.get_for_model(obj)
     comments = Comment.objects.filter(content_type=ct, object_id=obj.pk, type=Comment.STRUCTURE).prefetch_related(
         Prefetch("metadata", queryset=Metadata.objects.all().order_by("order"))
@@ -1408,7 +1392,7 @@ def _comments_to_tabular(obj: models.Model):
             first = False
 
 
-def _base_to_tabular(base: Base, version: Version | None = None):
+def _base_to_tabular(base: Base, version: Version | None = None) -> Generator:
     meta_query = base.metadata.all()
     if version is not None:
         meta_query = meta_query.filter(metadata_version=version)
@@ -1423,13 +1407,12 @@ def _base_to_tabular(base: Base, version: Version | None = None):
         )
 
 
-def _properties_to_tabular(model: Model, version: Version | None = None):
+def _properties_to_tabular(model: Model, version: Version | None = None) -> Generator:
     prop_filter = {"model": model, "given": True}
+    property_metadata_queryset = Metadata.objects.all()
+
     if version is not None:
         prop_filter["metadata_version"] = version
-
-    property_metadata_queryset = Metadata.objects.all()
-    if version is not None:
         property_metadata_queryset = property_metadata_queryset.filter(metadata_version=version)
 
     props = Property.objects.filter(**prop_filter).prefetch_related(

--- a/vitrina/structure/services.py
+++ b/vitrina/structure/services.py
@@ -986,7 +986,7 @@ class IterableFile:
         self.writes.append(data)
 
 
-def export_dataset_structure(dataset: Dataset, version: Version | None=None) -> StringIO:
+def export_dataset_structure(dataset: Dataset, version: Version | None = None) -> StringIO:
     if not version:
         version = dataset.latest_version()
     cols = DATASET
@@ -1012,7 +1012,7 @@ def _export_dataset_structure_to_stringio(dataset: Dataset, version: Version) ->
     return result
 
 
-def datasets_to_tabular(dataset: Dataset, version: Version | None=None):
+def datasets_to_tabular(dataset: Dataset, version: Version | None = None):
     if dataset.current_structure:
         yield from _prefixes_to_tabular(dataset.current_structure, separator=True, version=version)
     yield from _dataset_to_tabular(dataset, separator=True, version=version)
@@ -1026,7 +1026,7 @@ def _end_marker(name):
     yield to_row(DATASET, {name: "/"})
 
 
-def _prefixes_to_tabular(obj: models.Model, separator: bool = False, version: Version | None=None):
+def _prefixes_to_tabular(obj: models.Model, separator: bool = False, version: Version | None = None):
     ct = ContentType.objects.get_for_model(obj)
     prefix_filter = {"content_type": ct, "object_id": obj.pk}
     if version is not None:
@@ -1036,9 +1036,11 @@ def _prefixes_to_tabular(obj: models.Model, separator: bool = False, version: Ve
     if version is not None:
         metadata_queryset = metadata_queryset.filter(metadata_version=version)
 
-    prefixes = Prefix.objects.filter(**prefix_filter).prefetch_related(
-        Prefetch('metadata', queryset=metadata_queryset.order_by('order'))
-    ).order_by("metadata__order")
+    prefixes = (
+        Prefix.objects.filter(**prefix_filter)
+        .prefetch_related(Prefetch("metadata", queryset=metadata_queryset.order_by("order")))
+        .order_by("metadata__order")
+    )
 
     first = True
     for prefix in prefixes:
@@ -1060,7 +1062,7 @@ def _prefixes_to_tabular(obj: models.Model, separator: bool = False, version: Ve
         yield to_row(DATASET, {})
 
 
-def _dataset_to_tabular(dataset: Dataset, separator: bool = False, version: Version | None=None):
+def _dataset_to_tabular(dataset: Dataset, separator: bool = False, version: Version | None = None):
     if lang := get_language():
         dataset.set_current_language(lang)
     meta_query = dataset.metadata.all()
@@ -1094,7 +1096,7 @@ def _dataset_resources_to_tabular(dataset: Dataset, separator: bool = False) -> 
         yield from _resource_to_tabular(distribution)
 
 
-def _enums_to_tabular(obj: models.Model, separator: bool = False, version: Version | None=None):
+def _enums_to_tabular(obj: models.Model, separator: bool = False, version: Version | None = None):
     ct = ContentType.objects.get_for_model(obj)
     enum_filter = {"content_type": ct, "object_id": obj.pk}
     if version is not None:
@@ -1108,11 +1110,9 @@ def _enums_to_tabular(obj: models.Model, separator: bool = False, version: Versi
     if version is not None:
         enumitem_filter["metadata_version"] = version
     enumitem_queryset = EnumItem.objects.filter(**enumitem_filter).prefetch_related(
-        Prefetch('metadata', queryset=metadata_queryset.order_by('order'))
+        Prefetch("metadata", queryset=metadata_queryset.order_by("order"))
     )
-    enums = Enum.objects.filter(**enum_filter).prefetch_related(
-        Prefetch('enumitem_set', queryset=enumitem_queryset)
-    )
+    enums = Enum.objects.filter(**enum_filter).prefetch_related(Prefetch("enumitem_set", queryset=enumitem_queryset))
     for enum in enums:
         first = True
         enumitems = list(enum.enumitem_set.all())
@@ -1155,11 +1155,11 @@ def _params_to_tabular(obj: models.Model | Dataset | DatasetDistribution, separa
     if version is not None:
         paramitem_filter["metadata_version"] = version
     paramitem_queryset = ParamItem.objects.filter(**paramitem_filter).prefetch_related(
-        Prefetch('metadata', queryset=metadata_queryset.order_by('order'))
+        Prefetch("metadata", queryset=metadata_queryset.order_by("order"))
     )
 
     params = Param.objects.filter(**param_filter).prefetch_related(
-        Prefetch('paramitem_set', queryset=paramitem_queryset)
+        Prefetch("paramitem_set", queryset=paramitem_queryset)
     )
 
     for param in params:
@@ -1214,20 +1214,23 @@ def _models_to_tabular(dataset: Dataset, separator: bool = False, version: Versi
     property_list_filter = {}
     if version is not None:
         property_list_filter["metadata_version"] = version
-    property_list_queryset = PropertyList.objects.filter(**property_list_filter).select_related(
-        'property'
-    ).prefetch_related(
-        Prefetch('property__metadata', queryset=property_metadata_queryset)
+    property_list_queryset = (
+        PropertyList.objects.filter(**property_list_filter)
+        .select_related("property")
+        .prefetch_related(Prefetch("property__metadata", queryset=property_metadata_queryset))
     )
 
-    dataset_models = Model.objects.filter(**model_filter).select_related(
-        'distribution', 'base'
-    ).prefetch_related(
-        Prefetch('metadata', queryset=metadata_queryset.order_by('order')),
-        Prefetch('property_list', queryset=property_list_queryset),
-        Prefetch('distribution__metadata', queryset=distribution_metadata_queryset),
-        Prefetch('base__metadata', queryset=base_metadata_queryset)
-    ).order_by("metadata__order")
+    dataset_models = (
+        Model.objects.filter(**model_filter)
+        .select_related("distribution", "base")
+        .prefetch_related(
+            Prefetch("metadata", queryset=metadata_queryset.order_by("order")),
+            Prefetch("property_list", queryset=property_list_queryset),
+            Prefetch("distribution__metadata", queryset=distribution_metadata_queryset),
+            Prefetch("base__metadata", queryset=base_metadata_queryset),
+        )
+        .order_by("metadata__order")
+    )
 
     resource = None
     base = None
@@ -1279,7 +1282,7 @@ def _models_to_tabular(dataset: Dataset, separator: bool = False, version: Versi
                 yield to_row(DATASET, {})
 
 
-def _resource_models_to_tabular(resource: DatasetDistribution, separator: bool = False, version: Version | None=None):
+def _resource_models_to_tabular(resource: DatasetDistribution, separator: bool = False, version: Version | None = None):
     model_filter = {"distribution": resource, "dataset": resource.dataset}
     if version is not None:
         model_filter["metadata_version"] = version
@@ -1303,20 +1306,23 @@ def _resource_models_to_tabular(resource: DatasetDistribution, separator: bool =
     property_list_filter = {}
     if version is not None:
         property_list_filter["metadata_version"] = version
-    property_list_queryset = PropertyList.objects.filter(**property_list_filter).select_related(
-        'property'
-    ).prefetch_related(
-        Prefetch('property__metadata', queryset=property_metadata_queryset)
+    property_list_queryset = (
+        PropertyList.objects.filter(**property_list_filter)
+        .select_related("property")
+        .prefetch_related(Prefetch("property__metadata", queryset=property_metadata_queryset))
     )
 
-    resource_models = Model.objects.filter(**model_filter).select_related(
-        'base'
-    ).prefetch_related(
-        Prefetch('metadata', queryset=metadata_queryset.order_by('order')),
-        Prefetch('property_list', queryset=property_list_queryset),
-        Prefetch('distribution__metadata', queryset=distribution_metadata_queryset),
-        Prefetch('base__metadata', queryset=base_metadata_queryset)
-    ).order_by("metadata__order")
+    resource_models = (
+        Model.objects.filter(**model_filter)
+        .select_related("base")
+        .prefetch_related(
+            Prefetch("metadata", queryset=metadata_queryset.order_by("order")),
+            Prefetch("property_list", queryset=property_list_queryset),
+            Prefetch("distribution__metadata", queryset=distribution_metadata_queryset),
+            Prefetch("base__metadata", queryset=base_metadata_queryset),
+        )
+        .order_by("metadata__order")
+    )
 
     base = None
     for model in resource_models:
@@ -1354,7 +1360,7 @@ def _resource_models_to_tabular(resource: DatasetDistribution, separator: bool =
                 yield to_row(DATASET, {})
 
 
-def _resource_to_tabular(resource: DatasetDistribution, version: Version | None=None):
+def _resource_to_tabular(resource: DatasetDistribution, version: Version | None = None):
     if lang := get_language():
         resource.set_current_language(lang)
     meta = resource.metadata.first() if version is None else resource.metadata.filter(metadata_version=version).first()
@@ -1380,10 +1386,8 @@ def _resource_to_tabular(resource: DatasetDistribution, version: Version | None=
 
 def _comments_to_tabular(obj: models.Model):
     ct = ContentType.objects.get_for_model(obj)
-    comments = Comment.objects.filter(
-        content_type=ct, object_id=obj.pk, type=Comment.STRUCTURE
-    ).prefetch_related(
-        Prefetch('metadata', queryset=Metadata.objects.all().order_by('order'))
+    comments = Comment.objects.filter(content_type=ct, object_id=obj.pk, type=Comment.STRUCTURE).prefetch_related(
+        Prefetch("metadata", queryset=Metadata.objects.all().order_by("order"))
     )
     first = True
     comments_list = list(comments)
@@ -1404,7 +1408,7 @@ def _comments_to_tabular(obj: models.Model):
             first = False
 
 
-def _base_to_tabular(base: Base, version: Version | None=None):
+def _base_to_tabular(base: Base, version: Version | None = None):
     meta_query = base.metadata.all()
     if version is not None:
         meta_query = meta_query.filter(metadata_version=version)
@@ -1419,7 +1423,7 @@ def _base_to_tabular(base: Base, version: Version | None=None):
         )
 
 
-def _properties_to_tabular(model: Model, version: Version | None=None):
+def _properties_to_tabular(model: Model, version: Version | None = None):
     prop_filter = {"model": model, "given": True}
     if version is not None:
         prop_filter["metadata_version"] = version
@@ -1429,7 +1433,7 @@ def _properties_to_tabular(model: Model, version: Version | None=None):
         property_metadata_queryset = property_metadata_queryset.filter(metadata_version=version)
 
     props = Property.objects.filter(**prop_filter).prefetch_related(
-        Prefetch('metadata', queryset=property_metadata_queryset.order_by('order'))
+        Prefetch("metadata", queryset=property_metadata_queryset.order_by("order"))
     )
     props_list = list(props)
     for prop in props_list:

--- a/vitrina/structure/services.py
+++ b/vitrina/structure/services.py
@@ -987,6 +987,8 @@ class IterableFile:
 
 
 def export_dataset_structure(dataset: Dataset, version: Version | None=None) -> StringIO:
+    if not version:
+        version = dataset.latest_version()
     cols = DATASET
     rows = datasets_to_tabular(dataset, version=version)
     rows = ({c: row[c] for c in cols} for row in rows)

--- a/vitrina/structure/services.py
+++ b/vitrina/structure/services.py
@@ -1067,11 +1067,14 @@ def _dataset_to_tabular(dataset: Dataset, separator: bool = False, version: Vers
     if version is not None:
         meta_query = meta_query.filter(metadata_version=version)
     if meta := meta_query.first():
+        dataset_name = meta.name
+        if version is not None and version.status != VersionStatus.DRAFT and version.major is not None:
+            dataset_name = f"{meta.name}/{version.major}"
         yield to_row(
             DATASET,
             {
                 "id": meta.uuid,
-                "dataset": meta.name,
+                "dataset": dataset_name,
                 "level": meta.level_given,
                 "access": _get_access(meta.access),
                 "title": dataset.title,

--- a/vitrina/structure/templates/vitrina/structure/dataset_structure.html
+++ b/vitrina/structure/templates/vitrina/structure/dataset_structure.html
@@ -33,11 +33,11 @@
 
         {% if can_manage_structure %}
             {% if version_id %}
-                {% url 'dataset-structure-export' view.kwargs.pk version_id as export_url %}
-                {% url 'dataset-structure-export-openapi' view.kwargs.pk version_id as export_openapi_url %}
+                {% url "dataset-structure-export" view.kwargs.pk version_id as export_url %}
+                {% url "dataset-structure-export-openapi" view.kwargs.pk version_id as export_openapi_url %}
             {% else %}
-                {% url 'dataset-structure-export-no-version' view.kwargs.pk as export_url %}
-                {% url 'dataset-structure-export-openapi-no-version' view.kwargs.pk as export_openapi_url %}
+                {% url "dataset-structure-export-no-version" view.kwargs.pk as export_url %}
+                {% url "dataset-structure-export-openapi-no-version" view.kwargs.pk as export_openapi_url %}
             {% endif %}
             <a class="button is-primary mb-5 ml-2" href="{{export_url}}">
                 {% translate "Eksportuoti" %}

--- a/vitrina/structure/templates/vitrina/structure/dataset_structure.html
+++ b/vitrina/structure/templates/vitrina/structure/dataset_structure.html
@@ -32,11 +32,18 @@
         {% endif %}
 
         {% if can_manage_structure %}
-            <a class="button is-primary mb-5 ml-2" href="{% url 'dataset-structure-export' view.kwargs.pk %}">
+            {% if version_id %}
+                {% url 'dataset-structure-export' view.kwargs.pk version_id as export_url %}
+                {% url 'dataset-structure-export-openapi' view.kwargs.pk version_id as export_openapi_url %}
+            {% else %}
+                {% url 'dataset-structure-export-no-version' view.kwargs.pk as export_url %}
+                {% url 'dataset-structure-export-openapi-no-version' view.kwargs.pk as export_openapi_url %}
+            {% endif %}
+            <a class="button is-primary mb-5 ml-2" href="{{export_url}}">
                 {% translate "Eksportuoti" %}
             </a>
             {% if request.user.is_superuser %}
-                <a class="button is-primary mb-5 ml-2" href="{% url 'dataset-structure-export-openapi' view.kwargs.pk %}">
+                <a class="button is-primary mb-5 ml-2" href="{{ export_openapi_url }}">
                     {% translate "Eksportuoti OpenAPI" %}
                 </a>
             {% endif %}

--- a/vitrina/structure/urls.py
+++ b/vitrina/structure/urls.py
@@ -194,12 +194,22 @@ urlpatterns = [
     path(
         "datasets/<int:pk>/structure/export/",
         DatasetStructureExportView.as_view(),
+        name="dataset-structure-export-no-version",
+    ),
+    path(
+        "datasets/<int:pk>/versions/<int:version_id>/structure/export/",
+        DatasetStructureExportView.as_view(),
         name="dataset-structure-export",
+    ),
+    path(
+        "datasets/<int:pk>/versions/<int:version_id>/structure/export/openapi/",
+        DatasetStructureExportOpenAPIView.as_view(),
+        name="dataset-structure-export-openapi",
     ),
     path(
         "datasets/<int:pk>/structure/export/openapi/",
         DatasetStructureExportOpenAPIView.as_view(),
-        name="dataset-structure-export-openapi",
+        name="dataset-structure-export-openapi-no-version",
     ),
     path(
         "datasets/<int:pk>/versions/<int:version_id>/<str:model>/<str:prop>/enum/add/",

--- a/vitrina/structure/views.py
+++ b/vitrina/structure/views.py
@@ -1767,9 +1767,9 @@ class DatasetStructureExportView(DatasetStructureMixin, PermissionRequiredMixin,
     def get(self, request, *args, **kwargs):
         version = self.metadata_version or self.dataset.latest_version()
         stream = export_dataset_structure(self.dataset, version=version)
-        
+
         filename = (
-            "dsa_manifest_draft.csv" 
+            "dsa_manifest_draft.csv"
             if version.status == VersionStatus.DRAFT
             else f"dsa_manifest_{version.external_version}.csv"
             if version

--- a/vitrina/structure/views.py
+++ b/vitrina/structure/views.py
@@ -1767,9 +1767,17 @@ class DatasetStructureExportView(DatasetStructureMixin, PermissionRequiredMixin,
     def get(self, request, *args, **kwargs):
         version = self.metadata_version or self.dataset.latest_version()
         stream = export_dataset_structure(self.dataset, version=version)
+        
+        filename = (
+            "dsa_manifest_draft.csv" 
+            if version.status == VersionStatus.DRAFT
+            else f"dsa_manifest_{version.external_version}.csv"
+            if version
+            else "dsa_manifest.csv"
+        )
 
         response = StreamingHttpResponse(stream, content_type="text/csv")
-        response["Content-Disposition"] = "attachment; filename=manifest.csv"
+        response["Content-Disposition"] = f"attachment; filename={filename}"
         return response
 
 

--- a/vitrina/structure/views.py
+++ b/vitrina/structure/views.py
@@ -281,6 +281,7 @@ class DatasetStructureView(
         context["can_manage_structure"] = self.can_manage_structure
         context["models"] = self.models
         context["version"] = dataset.dataset_version.filter(deployed__isnull=False).order_by("-deployed").first()
+        context["version_id"] = self.metadata_version.pk if self.metadata_version else None
         return context
 
     def get_structure_url(self):
@@ -1759,29 +1760,26 @@ class ChangesApiView(ApiView):
         return crumbs
 
 
-class DatasetStructureExportView(PermissionRequiredMixin, View):
+class DatasetStructureExportView(DatasetStructureMixin, PermissionRequiredMixin, View):
     def has_permission(self):
-        dataset = get_object_or_404(Dataset, pk=self.kwargs.get("pk"))
-        return has_perm(self.request.user, Action.STRUCTURE, Dataset, dataset)
+        return has_perm(self.request.user, Action.STRUCTURE, Dataset, self.dataset)
 
     def get(self, request, *args, **kwargs):
-        dataset = get_object_or_404(Dataset, pk=kwargs.get("pk"))
-        stream = export_dataset_structure(dataset)
+        version = self.metadata_version or self.dataset.latest_version()
+        stream = export_dataset_structure(self.dataset, version=version)
 
         response = StreamingHttpResponse(stream, content_type="text/csv")
         response["Content-Disposition"] = "attachment; filename=manifest.csv"
         return response
 
 
-class DatasetStructureExportOpenAPIView(PermissionRequiredMixin, View):
+class DatasetStructureExportOpenAPIView(DatasetStructureMixin, PermissionRequiredMixin, View):
     def has_permission(self):
-        dataset = get_object_or_404(Dataset, pk=self.kwargs.get("pk"))
-        return has_perm(self.request.user, Action.STRUCTURE, Dataset, dataset)
+        return has_perm(self.request.user, Action.STRUCTURE, Dataset, self.dataset)
 
     def get(self, request, *args, **kwargs):
-        dataset = get_object_or_404(Dataset, pk=kwargs.get("pk"))
-
-        manifest_stream = _export_dataset_structure_to_stringio(dataset)
+        version = self.metadata_version or self.dataset.latest_version()
+        manifest_stream = _export_dataset_structure_to_stringio(self.dataset, version=version)
         manifest_path = ManifestPath(file=manifest_stream)
         openapi_spec = create_openapi_manifest(manifest_path)
 

--- a/vitrina/uapi/urls.py
+++ b/vitrina/uapi/urls.py
@@ -65,7 +65,7 @@ urlpatterns = [
                 "put": "update_dataset_structure",
             }
         ),
-        name="uapi-dataset-structure",
+        name="uapi-dataset-structure-no-version",
     ),
     path(
         f"{STATIC_UAPI_BASE_PATH}Distribution/",

--- a/vitrina/uapi/urls.py
+++ b/vitrina/uapi/urls.py
@@ -65,7 +65,7 @@ urlpatterns = [
                 "put": "update_dataset_structure",
             }
         ),
-        name="uapi-dataset-structure-no-version",
+        name="uapi-dataset-structure",
     ),
     path(
         f"{STATIC_UAPI_BASE_PATH}Distribution/",


### PR DESCRIPTION
Implements: - https://github.com/atviriduomenys/katalogas/issues/1906

User picks a version in dataset structure version picker and button "Eksportuoti" and "Eksportuoti OpenAPI" gets url with version preset.
If version is not provided - structure for latest version is exported.
Add version number after dataset name as in https://ivpk.github.io/uapi/#section/Concepts/Version is defined.
Fix N+1 query problem by prefetching related objects.

Structure with dependencies and adjustments for OpenAPI will be implemented with later PRs

