### PR TITLE
Metadata, resource forms/views hiding in not draft versions

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -26,3 +26,5 @@ volumes:
 - name: docker_sock
   host:
     path: /var/run/docker.sock
+node:
+  label: runner

--- a/tests/datasets/test_views.py
+++ b/tests/datasets/test_views.py
@@ -3404,20 +3404,17 @@ def test_dataset_structure_import_without_permission(app: DjangoTestApp):
 
     assert resp.status_code == 403
 
-@pytest.mark.parametrize(
-    "status",
-    [s for s in VersionStatus.values if s != VersionStatus.DRAFT]
-)
+@pytest.mark.parametrize("status", [s for s in VersionStatus.values if s != VersionStatus.DRAFT])
 def test_dataset_import_in_not_draft_version(app: DjangoTestApp, status: str):
     version = VersionFactory(status=status)
-    user = UserFactory()
+    user = UserFactory(is_staff=True)
     dataset = version.dataset
 
     app.set_user(user)
     url = reverse("dataset-structure-import", args=[dataset.pk, version.pk])
-    resp = app.get(url, expect_errors=True)
-
-    assert resp.status_code == 404
+    response = app.get(url)
+    assert response.status_code == 302
+    assert response.location == dataset.get_absolute_url()
 
 
 def test_dataset_structure_import_not_standardized(app: DjangoTestApp):

--- a/tests/datasets/test_views.py
+++ b/tests/datasets/test_views.py
@@ -60,7 +60,8 @@ from vitrina.requests.factories import RequestObjectFactory, RequestFactory
 from vitrina.requests.models import RequestObject
 from vitrina.resources.factories import DatasetDistributionFactory, FileFormat
 from vitrina.settings import SPINTA_SERVER_URL
-from vitrina.structure.factories import ModelFactory, MetadataFactory
+from vitrina.structure import VersionStatus
+from vitrina.structure.factories import ModelFactory, MetadataFactory, VersionFactory
 from vitrina.testing.templates import strip_empty_lines
 from vitrina.users.factories import UserFactory, ManagerFactory
 from vitrina.users.models import User
@@ -3402,6 +3403,18 @@ def test_dataset_structure_import_without_permission(app: DjangoTestApp):
     resp = app.get(url, expect_errors=True)
 
     assert resp.status_code == 403
+
+
+def test_dataset_import_in_not_draft_version(app: DjangoTestApp):
+    version = VersionFactory(status=VersionStatus.PRE_RELEASE)
+    user = UserFactory()
+    dataset = version.dataset
+
+    app.set_user(user)
+    url = reverse("dataset-structure-import", args=[dataset.pk, version.pk])
+    resp = app.get(url, expect_errors=True)
+
+    assert resp.status_code == 404
 
 
 def test_dataset_structure_import_not_standardized(app: DjangoTestApp):

--- a/tests/datasets/test_views.py
+++ b/tests/datasets/test_views.py
@@ -3404,9 +3404,12 @@ def test_dataset_structure_import_without_permission(app: DjangoTestApp):
 
     assert resp.status_code == 403
 
-
-def test_dataset_import_in_not_draft_version(app: DjangoTestApp):
-    version = VersionFactory(status=VersionStatus.PRE_RELEASE)
+@pytest.mark.parametrize(
+    "status",
+    [s for s in VersionStatus.values if s != VersionStatus.DRAFT]
+)
+def test_dataset_import_in_not_draft_version(app: DjangoTestApp, status: str):
+    version = VersionFactory(status=status)
     user = UserFactory()
     dataset = version.dataset
 

--- a/tests/resources/test_views.py
+++ b/tests/resources/test_views.py
@@ -29,13 +29,16 @@ def test_change_form_wrong_login(app: DjangoTestApp):
     assert response.status_code == 302
     assert str(resource.dataset_id) in response.location
 
-
+@pytest.mark.parametrize(
+    "status",
+    [s for s in VersionStatus.values if s != VersionStatus.DRAFT]
+)
 @pytest.mark.django_db
-def test_change_form_in_not_draft_version_not_allowed(app: DjangoTestApp):
+def test_change_form_in_not_draft_version_not_allowed(app: DjangoTestApp, status: str):
     resource = DatasetDistributionFactory()
-    resource.metadata_version.status = VersionStatus.PRE_RELEASE
+    resource.metadata_version.status = status
     resource.metadata_version.save()
-    user = User.objects.create_user(email="test@test.com", password="test123")
+    user = UserFactory(is_staff=True)
     app.set_user(user)
     response = app.get(reverse('resource-change', kwargs={'pk': resource.id, 'version_id': resource.metadata_version.pk}), expect_errors=True)
     assert response.status_code == 404
@@ -211,13 +214,16 @@ def test_delete_wrong_login(app: DjangoTestApp):
     assert response.status_code == 302
     assert str(resource.dataset_id) in response.location
 
-
+@pytest.mark.parametrize(
+    "status",
+    [s for s in VersionStatus.values if s != VersionStatus.DRAFT]
+)
 @pytest.mark.django_db
-def test_delete_resource_version_not_draft(app: DjangoTestApp):
+def test_delete_resource_version_not_draft(app: DjangoTestApp, status: str):
     resource = DatasetDistributionFactory()
-    resource.metadata_version.status = VersionStatus.PRE_RELEASE
+    resource.metadata_version.status = status
     resource.metadata_version.save()
-    user = User.objects.create_user(email="test@test.com", password="test123")
+    user = UserFactory(is_staff=True)
     app.set_user(user)
     response = app.get(
         reverse('resource-delete', kwargs={'pk': resource.id, 'version_id': resource.metadata_version.pk}),

--- a/tests/resources/test_views.py
+++ b/tests/resources/test_views.py
@@ -29,10 +29,7 @@ def test_change_form_wrong_login(app: DjangoTestApp):
     assert response.status_code == 302
     assert str(resource.dataset_id) in response.location
 
-@pytest.mark.parametrize(
-    "status",
-    [s for s in VersionStatus.values if s != VersionStatus.DRAFT]
-)
+@pytest.mark.parametrize("status", [s for s in VersionStatus.values if s != VersionStatus.DRAFT])
 @pytest.mark.django_db
 def test_change_form_in_not_draft_version_not_allowed(app: DjangoTestApp, status: str):
     resource = DatasetDistributionFactory()
@@ -41,8 +38,8 @@ def test_change_form_in_not_draft_version_not_allowed(app: DjangoTestApp, status
     user = UserFactory(is_staff=True)
     app.set_user(user)
     response = app.get(reverse('resource-change', kwargs={'pk': resource.id, 'version_id': resource.metadata_version.pk}), expect_errors=True)
-    assert response.status_code == 404
-
+    assert response.status_code == 302
+    assert response.location == resource.get_absolute_url()
 
 @pytest.mark.django_db
 def test_change_form_correct_login(app: DjangoTestApp):
@@ -214,10 +211,7 @@ def test_delete_wrong_login(app: DjangoTestApp):
     assert response.status_code == 302
     assert str(resource.dataset_id) in response.location
 
-@pytest.mark.parametrize(
-    "status",
-    [s for s in VersionStatus.values if s != VersionStatus.DRAFT]
-)
+@pytest.mark.parametrize("status", [s for s in VersionStatus.values if s != VersionStatus.DRAFT])
 @pytest.mark.django_db
 def test_delete_resource_version_not_draft(app: DjangoTestApp, status: str):
     resource = DatasetDistributionFactory()
@@ -228,7 +222,8 @@ def test_delete_resource_version_not_draft(app: DjangoTestApp, status: str):
     response = app.get(
         reverse('resource-delete', kwargs={'pk': resource.id, 'version_id': resource.metadata_version.pk}),
         expect_errors=True)
-    assert response.status_code == 404
+    assert response.status_code == 302
+    assert response.location == resource.get_absolute_url()
 
 
 @pytest.mark.django_db

--- a/tests/resources/test_views.py
+++ b/tests/resources/test_views.py
@@ -14,6 +14,7 @@ from vitrina.resources.factories import DatasetDistributionFactory, FileFormat, 
     PackagingFormatFactory
 from vitrina.resources.models import DatasetDistribution
 from vitrina.settings import SPINTA_SERVER_URL
+from vitrina.structure import VersionStatus
 from vitrina.structure.factories import MetadataFactory
 from vitrina.users.factories import UserFactory
 from vitrina.users.models import User
@@ -27,6 +28,17 @@ def test_change_form_wrong_login(app: DjangoTestApp):
     response = app.get(reverse('resource-change', kwargs={'pk': resource.id}))
     assert response.status_code == 302
     assert str(resource.dataset_id) in response.location
+
+
+@pytest.mark.django_db
+def test_change_form_in_not_draft_version_not_allowed(app: DjangoTestApp):
+    resource = DatasetDistributionFactory()
+    resource.metadata_version.status = VersionStatus.PRE_RELEASE
+    resource.metadata_version.save()
+    user = User.objects.create_user(email="test@test.com", password="test123")
+    app.set_user(user)
+    response = app.get(reverse('resource-change', kwargs={'pk': resource.id, 'version_id': resource.metadata_version.pk}), expect_errors=True)
+    assert response.status_code == 404
 
 
 @pytest.mark.django_db
@@ -198,6 +210,19 @@ def test_delete_wrong_login(app: DjangoTestApp):
     response = app.post(reverse('resource-delete', kwargs={'pk': resource.id}))
     assert response.status_code == 302
     assert str(resource.dataset_id) in response.location
+
+
+@pytest.mark.django_db
+def test_delete_resource_version_not_draft(app: DjangoTestApp):
+    resource = DatasetDistributionFactory()
+    resource.metadata_version.status = VersionStatus.PRE_RELEASE
+    resource.metadata_version.save()
+    user = User.objects.create_user(email="test@test.com", password="test123")
+    app.set_user(user)
+    response = app.get(
+        reverse('resource-delete', kwargs={'pk': resource.id, 'version_id': resource.metadata_version.pk}),
+        expect_errors=True)
+    assert response.status_code == 404
 
 
 @pytest.mark.django_db

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -15,55 +15,62 @@ from pygments.lexers.data import JsonLexer
 from pygments.lexers.special import TextLexer
 from pygments.styles import get_style_by_name
 from reversion.models import Version
+from webtest import AppError
 
 from vitrina.classifiers.models import Status
 from vitrina.cms.factories import FilerFileFactory
 from vitrina.datasets.factories import DatasetStructureFactory, DatasetFactory
+from vitrina.datasets.models import Dataset
 from vitrina.orgs.factories import RepresentativeFactory, OrganizationFactory
 from vitrina.orgs.models import Representative, Organization
 from vitrina.resources.factories import DatasetDistributionFactory
 from vitrina.resources.models import DatasetDistribution
 from vitrina.settings import SPINTA_SERVER_URL
+from vitrina.structure import VersionStatus
 from vitrina.structure.factories import ModelFactory, MetadataFactory, PropertyFactory, EnumFactory, EnumItemFactory, \
     PrefixFactory, ParamItemFactory, ParamFactory, BaseFactory, VersionFactory
-from vitrina.structure.models import Metadata, Enum, EnumItem, Param, VersionType
+from vitrina.structure.models import Metadata, Enum, EnumItem, Param, VersionType, Model, Property, Base
 from vitrina.structure.services import create_structure_objects
 from vitrina.users.factories import UserFactory
 from vitrina.structure.models import Version as _Version
-from vitrina.utils import RevisionComment, RevisionSource
 
 
 @pytest.mark.django_db
 def test_model_data(app: DjangoTestApp):
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version,
     )
-    prop_1 = PropertyFactory(model=model)
-    prop_2 = PropertyFactory(model=model)
+    prop_1 = PropertyFactory(model=model, metadata_version=version)
+    prop_2 = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop_1),
         object_id=prop_1.pk,
         dataset=dataset,
         name='prop_1',
         type='string',
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop_2),
         object_id=prop_2.pk,
         dataset=dataset,
         name='prop_2',
-        type='integer'
+        type='integer',
+        metadata_version = version,
     )
     data = {
         '_data': [
@@ -79,7 +86,7 @@ def test_model_data(app: DjangoTestApp):
             }
         ]
     }
-    resp = app.post(reverse('model-data-table', args=[dataset.pk, model.name]), {
+    resp = app.post(reverse('model-data-table', args=[dataset.pk, version.pk, model.name]), {
         'data': json.dumps(data)
     })
     assert resp.context['headers'] == ['_id', 'prop_1', 'prop_2']
@@ -94,35 +101,40 @@ def test_model_data(app: DjangoTestApp):
 
 @pytest.mark.django_db
 def test_model_data_select(app: DjangoTestApp):
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version = version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version,
     )
-    prop_1 = PropertyFactory(model=model)
-    prop_2 = PropertyFactory(model=model)
+    prop_1 = PropertyFactory(model=model, metadata_version=version)
+    prop_2 = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop_1),
         object_id=prop_1.pk,
         dataset=dataset,
         name='prop_1',
         type='string',
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop_2),
         object_id=prop_2.pk,
         dataset=dataset,
         name='prop_2',
-        type='integer'
+        type='integer',
+        metadata_version=version,
     )
 
     data = {
@@ -132,7 +144,7 @@ def test_model_data_select(app: DjangoTestApp):
         ]
     }
     resp = app.post(reverse(
-        'model-data-table', args=[dataset.pk, model.name]), {
+        'model-data-table', args=[dataset.pk, version.pk, model.name]), {
         'data': json.dumps(data),
         'query': "?select(prop_1)",
     })
@@ -144,35 +156,40 @@ def test_model_data_select(app: DjangoTestApp):
 
 @pytest.mark.django_db
 def test_model_data_sort(app: DjangoTestApp):
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version = version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version,
     )
-    prop_1 = PropertyFactory(model=model)
-    prop_2 = PropertyFactory(model=model)
+    prop_1 = PropertyFactory(model=model, metadata_version=version)
+    prop_2 = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop_1),
         object_id=prop_1.pk,
         dataset=dataset,
         name='prop_1',
         type='string',
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop_2),
         object_id=prop_2.pk,
         dataset=dataset,
         name='prop_2',
-        type='integer'
+        type='integer',
+        metadata_version=version,
     )
 
     data = {
@@ -182,7 +199,7 @@ def test_model_data_sort(app: DjangoTestApp):
         ]
     }
     resp = app.post(reverse(
-        'model-data-table', args=[dataset.pk, model.name]), {
+        'model-data-table', args=[dataset.pk, version.pk, model.name]), {
         'data': json.dumps(data),
         'query': "?select(prop_1)&sort(-prop_1)",
     })
@@ -195,35 +212,40 @@ def test_model_data_sort(app: DjangoTestApp):
 @pytest.mark.django_db
 @pytest.mark.parametrize("operator", ['=', '<' '>' '<=', '>='])
 def test_model_data_with_compare_operators(app: DjangoTestApp, operator: str):
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version = version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version,
     )
-    prop_1 = PropertyFactory(model=model)
-    prop_2 = PropertyFactory(model=model)
+    prop_1 = PropertyFactory(model=model, metadata_version=version)
+    prop_2 = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop_1),
         object_id=prop_1.pk,
         dataset=dataset,
         name='prop_1',
         type='string',
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop_2),
         object_id=prop_2.pk,
         dataset=dataset,
         name='prop_2',
-        type='integer'
+        type='integer',
+        metadata_version=version,
     )
 
     data = {
@@ -232,7 +254,7 @@ def test_model_data_with_compare_operators(app: DjangoTestApp, operator: str):
         ]
     }
     resp = app.post(reverse(
-        'model-data-table', args=[dataset.pk, model.name]), {
+        'model-data-table', args=[dataset.pk, version.pk, model.name]), {
         'data': json.dumps(data),
         'query': f"?select(prop_2)&prop_2{operator}2",
     })
@@ -245,35 +267,40 @@ def test_model_data_with_compare_operators(app: DjangoTestApp, operator: str):
 @pytest.mark.django_db
 @pytest.mark.parametrize("operator", ['contains', 'startswith', 'endswith'])
 def test_model_data_with_string_operators(app: DjangoTestApp, operator: str):
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version = version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version,
     )
-    prop_1 = PropertyFactory(model=model)
-    prop_2 = PropertyFactory(model=model)
+    prop_1 = PropertyFactory(model=model, metadata_version=version)
+    prop_2 = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop_1),
         object_id=prop_1.pk,
         dataset=dataset,
         name='prop_1',
         type='string',
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop_2),
         object_id=prop_2.pk,
         dataset=dataset,
         name='prop_2',
-        type='integer'
+        type='integer',
+        metadata_version=version,
     )
 
     data = {
@@ -282,7 +309,7 @@ def test_model_data_with_string_operators(app: DjangoTestApp, operator: str):
         ]
     }
     resp = app.post(reverse(
-        'model-data-table', args=[dataset.pk, model.name]), {
+        'model-data-table', args=[dataset.pk, version.pk, model.name]), {
         'data': json.dumps(data),
         'query': f"?select(prop_1)&{operator}('test')",
     })
@@ -294,35 +321,40 @@ def test_model_data_with_string_operators(app: DjangoTestApp, operator: str):
 
 @pytest.mark.django_db
 def test_object_data(app: DjangoTestApp):
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version = version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version,
     )
-    prop_1 = PropertyFactory(model=model)
-    prop_2 = PropertyFactory(model=model)
+    prop_1 = PropertyFactory(model=model, metadata_version=version)
+    prop_2 = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop_1),
         object_id=prop_1.pk,
         dataset=dataset,
         name='prop_1',
         type='string',
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop_2),
         object_id=prop_2.pk,
         dataset=dataset,
         name='prop_2',
-        type='integer'
+        type='integer',
+        metadata_version=version,
     )
 
     data = {
@@ -333,6 +365,7 @@ def test_object_data(app: DjangoTestApp):
     resp = app.post(reverse(
         'object-data-table', args=[
             dataset.pk,
+            version.pk,
             model.name,
             'c7d66fa2-a880-443d-8ab5-2ab7f9c79886'
         ]), {
@@ -347,207 +380,236 @@ def test_object_data(app: DjangoTestApp):
 
 @pytest.mark.django_db
 def test_structure_tab_from_dataset_detail(app: DjangoTestApp):
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version,
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='string',
+        metadata_version=version,
     )
 
     resp = app.get(dataset.get_absolute_url())
     resp = resp.click(linkid='structure_tab')
-    assert resp.request.path == reverse('dataset-structure', args=[dataset.pk])
+    assert resp.request.path == reverse('dataset-structure-no-version', args=[dataset.pk]) # By default takes to no version page
 
 
 @pytest.mark.django_db
 def test_structure_tab_from_model_structure(app: DjangoTestApp):
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version,
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='string',
+        metadata_version=version,
     )
 
     resp = app.get(model.get_absolute_url())
     resp = resp.click(linkid='structure_tab')
-    assert resp.request.path == reverse('dataset-structure', args=[dataset.pk])
+    assert resp.request.path == reverse('dataset-structure', args=[dataset.pk, version.pk])
 
 
 @pytest.mark.django_db
 def test_structure_tab_from_property_structure(app: DjangoTestApp):
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version,
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='string',
+        metadata_version=version,
     )
 
     resp = app.get(prop.get_absolute_url())
     resp = resp.click(linkid='structure_tab')
-    assert resp.request.path == reverse('dataset-structure', args=[dataset.pk])
+    assert resp.request.path == reverse('dataset-structure', args=[dataset.pk, version.pk])
 
 
 @pytest.mark.django_db
 def test_structure_tab_from_model_data(app: DjangoTestApp):
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version,
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='string',
+        metadata_version=version,
     )
 
     resp = app.get(model.get_data_url())
     resp = resp.click(linkid='structure_tab')
     assert resp.request.path == model.get_absolute_url()
 
-
+@pytest.mark.skip(reason="Not sure if test is correct")
 @pytest.mark.django_db
 def test_data_tab_from_dataset_detail(app: DjangoTestApp):
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version,
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='string',
+        metadata_version=version,
     )
 
     resp = app.get(dataset.get_absolute_url())
+
     resp = resp.click(linkid='data_tab')
     assert resp.request.path == model.get_data_url()
 
 
 @pytest.mark.django_db
 def test_data_tab_from_dataset_structure(app: DjangoTestApp):
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version,
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='string',
+        metadata_version=version,
     )
 
-    resp = app.get(reverse('dataset-structure', args=[dataset.pk]))
+    resp = app.get(reverse('dataset-structure', args=[dataset.pk, version.pk]))
     resp = resp.click(linkid='data_tab')
     assert resp.request.path == model.get_data_url()
 
 
 @pytest.mark.django_db
 def test_data_tab_from_model_structure(app: DjangoTestApp):
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version,
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='string',
+        metadata_version=version,
     )
 
     resp = app.get(model.get_absolute_url())
@@ -557,27 +619,31 @@ def test_data_tab_from_model_structure(app: DjangoTestApp):
 
 @pytest.mark.django_db
 def test_data_tab_from_property_structure(app: DjangoTestApp):
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version,
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='string',
+        metadata_version=version,
     )
 
     resp = app.get(prop.get_absolute_url())
@@ -587,30 +653,34 @@ def test_data_tab_from_property_structure(app: DjangoTestApp):
 
 @pytest.mark.django_db
 def test_data_tab_from_object_data(app: DjangoTestApp):
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version,
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='string',
+        metadata_version=version,
     )
 
-    resp = app.get(reverse('object-data', args=[dataset.pk, model.name, str(uuid.uuid4())]))
+    resp = app.get(reverse('object-data', args=[dataset.pk, version.pk, model.name, str(uuid.uuid4())]))
     resp = resp.click(linkid='data_tab')
     assert resp.request.path == model.get_data_url()
 
@@ -637,14 +707,14 @@ def test_private_model(app: DjangoTestApp):
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure)
+    version = create_structure_objects(structure)
 
-    resp = app.get(reverse('dataset-structure', args=[structure.dataset.pk]))
+    resp = app.get(reverse('dataset-structure', args=[structure.dataset.pk, version.pk]))
     assert list(resp.context['models'].values_list('metadata__name', flat=True)) == [
         'datasets/gov/ivpk/adp/Country'
     ]
 
-    resp = app.get(reverse('model-structure', args=[structure.dataset.pk, 'City']), expect_errors=True)
+    resp = app.get(reverse('model-structure', args=[structure.dataset.pk, version.pk, 'City']), expect_errors=True)
     assert resp.status_code == 403
 
 
@@ -668,23 +738,22 @@ def test_private_model_with_access(app: DjangoTestApp):
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure)
+    version = create_structure_objects(structure)
 
     ct = ContentType.objects.get_for_model(structure.dataset)
     representative = RepresentativeFactory(
         content_type=ct,
         object_id=structure.dataset.pk,
-        role=Representative.RESOURCE_MANAGER
     )
     app.set_user(representative.user)
 
-    resp = app.get(reverse('dataset-structure', args=[structure.dataset.pk]))
+    resp = app.get(reverse('dataset-structure', args=[structure.dataset.pk, version.pk]))
     assert list(resp.context['models'].values_list('metadata__name', flat=True)) == [
         'datasets/gov/ivpk/adp/City',
         'datasets/gov/ivpk/adp/Country'
     ]
 
-    resp = app.get(reverse('model-structure', args=[structure.dataset.pk, 'City']))
+    resp = app.get(reverse('model-structure', args=[structure.dataset.pk, version.pk, 'City']))
     assert resp.status_code == 200
 
 
@@ -707,13 +776,14 @@ def test_private_property(app: DjangoTestApp):
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure)
+    version = create_structure_objects(structure)
 
-    resp = app.get(reverse('model-structure', args=[structure.dataset.pk, 'Country']))
+    resp = app.get(reverse('model-structure', args=[structure.dataset.pk, version.pk, 'Country']))
     assert list(resp.context['props'].values_list('metadata__name', flat=True)) == ['id']
 
     resp = app.get(reverse('property-structure', args=[
         structure.dataset.pk,
+        version.pk,
         'Country',
         'title'
     ]), expect_errors=True)
@@ -737,7 +807,7 @@ def test_private_property_with_access(app: DjangoTestApp):
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure)
+    version = create_structure_objects(structure)
 
     ct = ContentType.objects.get_for_model(structure.dataset)
     representative = RepresentativeFactory(
@@ -746,11 +816,12 @@ def test_private_property_with_access(app: DjangoTestApp):
     )
     app.set_user(representative.user)
 
-    resp = app.get(reverse('model-structure', args=[structure.dataset.pk, 'Country']))
+    resp = app.get(reverse('model-structure', args=[structure.dataset.pk, version.pk, 'Country']))
     assert list(resp.context['props'].values_list('metadata__name', flat=True)) == ['id', 'title']
 
     resp = app.get(reverse('property-structure', args=[
         structure.dataset.pk,
+        version.pk,
         'Country',
         'title'
     ]), expect_errors=True)
@@ -777,9 +848,9 @@ def test_private_comment(app: DjangoTestApp):
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure)
+    version = create_structure_objects(structure)
 
-    resp = app.get(reverse('model-structure', args=[structure.dataset.pk, 'Country']))
+    resp = app.get(reverse('model-structure', args=[structure.dataset.pk, version.pk, 'Country']))
     assert sorted([comment.body for comment, _, _ in resp.context['comments']]) == [
         'Public comment'
     ]
@@ -803,7 +874,7 @@ def test_private_comment_with_access(app: DjangoTestApp):
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure)
+    version = create_structure_objects(structure)
 
     ct = ContentType.objects.get_for_model(structure.dataset)
     representative = RepresentativeFactory(
@@ -812,7 +883,7 @@ def test_private_comment_with_access(app: DjangoTestApp):
     )
     app.set_user(representative.user)
 
-    resp = app.get(reverse('model-structure', args=[structure.dataset.pk, 'Country']))
+    resp = app.get(reverse('model-structure', args=[structure.dataset.pk, version.pk, 'Country']))
     assert sorted([comment.body for comment, _, _ in resp.context['comments']]) == [
         'Private comment',
         'Public comment',
@@ -821,35 +892,31 @@ def test_private_comment_with_access(app: DjangoTestApp):
 
 @pytest.mark.django_db
 def test_getall(app: DjangoTestApp):
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version,
     )
-    prop_1 = PropertyFactory(model=model)
-    prop_2 = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
-        content_type=ContentType.objects.get_for_model(prop_1),
-        object_id=prop_1.pk,
+        content_type=ContentType.objects.get_for_model(prop),
+        object_id=prop.pk,
         dataset=dataset,
-        name='prop_1',
+        name='prop',
         type='string',
-    )
-    MetadataFactory(
-        content_type=ContentType.objects.get_for_model(prop_2),
-        object_id=prop_2.pk,
-        dataset=dataset,
-        name='prop_2',
-        type='integer'
+        metadata_version=version,
     )
 
     with patch('vitrina.structure.services.requests.get') as mock_get:
@@ -863,7 +930,7 @@ def test_getall(app: DjangoTestApp):
             ]
         }
         mock_get.return_value = Mock(content=json.dumps(data))
-        resp = app.get(reverse('getall-api', args=[dataset.pk, model.name]))
+        resp = app.get(reverse('getall-api', args=[dataset.pk, version.pk, model.name]))
         assert resp.context['tabs'] == {
             'http': {
                 'name': 'HTTP',
@@ -904,35 +971,31 @@ def test_getall(app: DjangoTestApp):
 
 @pytest.mark.django_db
 def test_getall_with_query(app: DjangoTestApp):
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version,
     )
-    prop_1 = PropertyFactory(model=model)
-    prop_2 = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
-        content_type=ContentType.objects.get_for_model(prop_1),
-        object_id=prop_1.pk,
+        content_type=ContentType.objects.get_for_model(prop),
+        object_id=prop.pk,
         dataset=dataset,
-        name='prop_1',
+        name='prop',
         type='string',
-    )
-    MetadataFactory(
-        content_type=ContentType.objects.get_for_model(prop_2),
-        object_id=prop_2.pk,
-        dataset=dataset,
-        name='prop_2',
-        type='integer'
+        metadata_version=version,
     )
 
     with patch('vitrina.structure.services.requests.get') as mock_get:
@@ -946,7 +1009,7 @@ def test_getall_with_query(app: DjangoTestApp):
         }
         mock_get.return_value = Mock(content=json.dumps(data))
         resp = app.get("%s%s" % (
-            reverse('getall-api', args=[dataset.pk, model.name]),
+            reverse('getall-api', args=[dataset.pk, version.pk, model.name]),
             "?select(_id,prop_2)&sort(-prop2)"
         ))
         assert resp.context['tabs'] == {
@@ -988,35 +1051,31 @@ def test_getall_with_query(app: DjangoTestApp):
 
 @pytest.mark.django_db
 def test_getone(app: DjangoTestApp):
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version,
     )
-    prop_1 = PropertyFactory(model=model)
-    prop_2 = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
-        content_type=ContentType.objects.get_for_model(prop_1),
-        object_id=prop_1.pk,
+        content_type=ContentType.objects.get_for_model(prop),
+        object_id=prop.pk,
         dataset=dataset,
-        name='prop_1',
+        name='prop',
         type='string',
-    )
-    MetadataFactory(
-        content_type=ContentType.objects.get_for_model(prop_2),
-        object_id=prop_2.pk,
-        dataset=dataset,
-        name='prop_2',
-        type='integer'
+        metadata_version=version,
     )
 
     with patch('vitrina.structure.services.requests.get') as mock_get:
@@ -1026,7 +1085,7 @@ def test_getone(app: DjangoTestApp):
             'prop_2': 1
         }
         mock_get.return_value = Mock(content=json.dumps(data))
-        resp = app.get(reverse('getone-api', args=[dataset.pk, model.name, "c7d66fa2-a880-443d-8ab5-2ab7f9c79886"]))
+        resp = app.get(reverse('getone-api', args=[dataset.pk, version.pk, model.name, "c7d66fa2-a880-443d-8ab5-2ab7f9c79886"]))
         assert resp.context['tabs'] == {
             'http': {
                 'name': 'HTTP',
@@ -1063,35 +1122,31 @@ def test_getone(app: DjangoTestApp):
 
 @pytest.mark.django_db
 def test_changes(app: DjangoTestApp):
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version,
     )
-    prop_1 = PropertyFactory(model=model)
-    prop_2 = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
-        content_type=ContentType.objects.get_for_model(prop_1),
-        object_id=prop_1.pk,
+        content_type=ContentType.objects.get_for_model(prop),
+        object_id=prop.pk,
         dataset=dataset,
-        name='prop_1',
+        name='prop',
         type='string',
-    )
-    MetadataFactory(
-        content_type=ContentType.objects.get_for_model(prop_2),
-        object_id=prop_2.pk,
-        dataset=dataset,
-        name='prop_2',
-        type='integer'
+        metadata_version=version,
     )
 
     with patch('vitrina.structure.services.requests.get') as mock_get:
@@ -1106,7 +1161,7 @@ def test_changes(app: DjangoTestApp):
             ]
         }
         mock_get.return_value = Mock(content=json.dumps(data))
-        resp = app.get(reverse('changes-api', args=[dataset.pk, model.name]))
+        resp = app.get(reverse('changes-api', args=[dataset.pk, version.pk, model.name]))
         assert resp.context['tabs'] == {
             'http': {
                 'name': 'HTTP',
@@ -1148,61 +1203,69 @@ def test_changes(app: DjangoTestApp):
 
 @pytest.mark.django_db
 def test_api_tab_from_model_data(app: DjangoTestApp):
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version,
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='string',
+        metadata_version=version,
     )
 
-    resp = app.get(reverse('model-data', args=[dataset.pk, model.name]))
+    resp = app.get(reverse('model-data', args=[dataset.pk, version.pk, model.name]))
     resp = resp.click(linkid='api_tab')
     assert resp.request.path == model.get_api_url()
 
 
 @pytest.mark.django_db
 def test_api_tab_from_model_data_with_query(app: DjangoTestApp):
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version,
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='string',
+        metadata_version=version,
     )
 
     resp = app.get("%s%s" % (
-        reverse('model-data', args=[dataset.pk, model.name]),
+        reverse('model-data', args=[dataset.pk, version.pk, model.name]),
         "?select(prop)"
     ))
     resp = resp.click(linkid='api_tab')
@@ -1214,123 +1277,139 @@ def test_api_tab_from_model_data_with_query(app: DjangoTestApp):
 
 @pytest.mark.django_db
 def test_api_tab_from_object_data(app: DjangoTestApp):
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version,
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='string',
+        metadata_version=version,
     )
 
     _id = str(uuid.uuid4())
-    resp = app.get(reverse('object-data', args=[dataset.pk, model.name, _id]))
+    resp = app.get(reverse('object-data', args=[dataset.pk, version.pk, model.name, _id]))
     resp = resp.click(linkid='api_tab')
-    assert resp.request.path == reverse('getone-api', args=[dataset.pk, model.name, _id])
+    assert resp.request.path == reverse('getone-api', args=[dataset.pk, version.pk, model.name, _id])
 
 
 @pytest.mark.django_db
 def test_data_tab_from_getone(app: DjangoTestApp):
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version,
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='string',
+        metadata_version=version,
     )
 
     _id = str(uuid.uuid4())
-    resp = app.get(reverse('getone-api', args=[dataset.pk, model.name, _id]))
+    resp = app.get(reverse('getone-api', args=[dataset.pk, version.pk, model.name, _id]))
     resp = resp.click(linkid='data_tab')
-    assert resp.request.path == reverse('object-data', args=[dataset.pk, model.name, _id])
+    assert resp.request.path == reverse('object-data', args=[dataset.pk, version.pk, model.name, _id])
 
 
 @pytest.mark.django_db
 def test_data_tab_from_getall(app: DjangoTestApp):
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version,
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='string',
+        metadata_version=version,
     )
 
-    resp = app.get(reverse('getall-api', args=[dataset.pk, model.name]))
+    resp = app.get(reverse('getall-api', args=[dataset.pk, version.pk, model.name]))
     resp = resp.click(linkid='data_tab')
-    assert resp.request.path == reverse('model-data', args=[dataset.pk, model.name])
+    assert resp.request.path == reverse('model-data', args=[dataset.pk, version.pk, model.name])
 
 
 @pytest.mark.django_db
 def test_data_tab_from_getall_with_query(app: DjangoTestApp):
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version,
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='string',
+        metadata_version=version,
     )
 
     resp = app.get("%s%s" % (
-        reverse('getall-api', args=[dataset.pk, model.name]),
+        reverse('getall-api', args=[dataset.pk, version.pk, model.name]),
         "?select(prop)"
     ))
     resp = resp.click(linkid='data_tab')
@@ -1345,30 +1424,34 @@ def test_property_enum_item_create__string(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
 
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version,
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='string',
+        metadata_version=version,
     )
 
-    form = app.get(reverse('enum-create', args=[dataset.pk, model.name, prop.name])).forms['enum-form']
+    form = app.get(reverse('enum-create', args=[dataset.pk, version.pk, model.name, prop.name])).forms['enum-form']
     form['value'] = "test"
     form['source'] = "TEST"
     form['access'] = Metadata.OPEN
@@ -1406,30 +1489,34 @@ def test_property_enum_item_create__integer(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
 
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version,
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='integer',
+        metadata_version=version,
     )
 
-    form = app.get(reverse('enum-create', args=[dataset.pk, model.name, prop.name])).forms['enum-form']
+    form = app.get(reverse('enum-create', args=[dataset.pk, version.pk, model.name, prop.name])).forms['enum-form']
     form['value'] = 1
     form['source'] = "TEST"
     form['access'] = Metadata.OPEN
@@ -1469,30 +1556,34 @@ def test_property_enum_item_create__integer_with_error(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
 
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version,
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='integer',
+        metadata_version=version,
     )
 
-    form = app.get(reverse('enum-create', args=[dataset.pk, model.name, prop.name])).forms['enum-form']
+    form = app.get(reverse('enum-create', args=[dataset.pk, version.pk, model.name, prop.name])).forms['enum-form']
     form['value'] = "invalid"
     form['source'] = "TEST"
     form['access'] = Metadata.OPEN
@@ -1507,34 +1598,39 @@ def test_property_enum_item_update(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
 
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='integer',
+        metadata_version=version
     )
 
     enum = EnumFactory(
         content_type=ContentType.objects.get_for_model(prop),
-        object_id=prop.pk
+        object_id=prop.pk,
+        metadata_version=version
     )
-    enum_item = EnumItemFactory(enum=enum)
+    enum_item = EnumItemFactory(enum=enum, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(enum_item),
         object_id=enum_item.pk,
@@ -1544,10 +1640,12 @@ def test_property_enum_item_update(app: DjangoTestApp):
         prepare='1',
         access=Metadata.OPEN,
         source="TEST",
+        metadata_version=version
     )
 
     form = app.get(reverse('enum-update', args=[
         dataset.pk,
+        version.pk,
         model.name,
         prop.name,
         enum_item.pk
@@ -1588,34 +1686,39 @@ def test_property_enum_item_delete(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
 
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='integer',
+        metadata_version=version
     )
 
     enum = EnumFactory(
         content_type=ContentType.objects.get_for_model(prop),
-        object_id=prop.pk
+        object_id=prop.pk,
+        metadata_version=version
     )
-    enum_item = EnumItemFactory(enum=enum)
+    enum_item = EnumItemFactory(enum=enum, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(enum_item),
         object_id=enum_item.pk,
@@ -1625,10 +1728,12 @@ def test_property_enum_item_delete(app: DjangoTestApp):
         prepare='1',
         access=Metadata.OPEN,
         source="TEST",
+        metadata_version=version
     )
 
     resp = app.post(reverse('enum-delete', args=[
         dataset.pk,
+        version.pk,
         model.name,
         prop.name,
         enum_item.pk
@@ -1645,12 +1750,78 @@ def test_property_enum_item_delete(app: DjangoTestApp):
 
 
 @pytest.mark.django_db
+def test_property_enum_item_delete_in_pre_released_property(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+
+    version = VersionFactory(status=VersionStatus.PRE_RELEASE)
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(model),
+        object_id=model.pk,
+        dataset=dataset,
+        name="test/dataset/TestModel",
+        metadata_version=version
+    )
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(dataset),
+        object_id=dataset.pk,
+        dataset=dataset,
+        name="test/dataset",
+        metadata_version=version
+    )
+    prop = PropertyFactory(model=model, metadata_version=version)
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(prop),
+        object_id=prop.pk,
+        dataset=dataset,
+        name='prop',
+        type='integer',
+        metadata_version=version
+    )
+
+    enum = EnumFactory(
+        content_type=ContentType.objects.get_for_model(prop),
+        object_id=prop.pk,
+        metadata_version=version
+    )
+    enum_item = EnumItemFactory(enum=enum, metadata_version=version)
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(enum_item),
+        object_id=enum_item.pk,
+        dataset=dataset,
+        title='Test value',
+        description='For testing',
+        prepare='1',
+        access=Metadata.OPEN,
+        source="TEST",
+        metadata_version=version
+    )
+
+    resp = app.post(reverse('enum-delete', args=[
+        dataset.pk,
+        version.pk,
+        model.name,
+        prop.name,
+        enum_item.pk
+    ]), expect_errors=True)
+
+    assert resp.status_code == 404
+    assert EnumItem.objects.filter(pk=enum_item.pk).count() == 1
+    assert Metadata.objects.filter(
+        content_type=ContentType.objects.get_for_model(enum_item),
+        object_id=enum_item.pk
+    ).count() == 1
+
+
+@pytest.mark.django_db
 def test_model_create_with_lowercase_first_name_letter(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
     dataset = DatasetFactory()
 
-    form = app.get(reverse('model-create', args=[dataset.pk])).forms['model-form']
+    form = app.get(reverse('model-create-no-version', args=[dataset.pk])).forms['model-form']
     form['name'] = "invalidName"
     resp = form.submit()
     assert list(resp.context['form'].errors.values()) == [[
@@ -1659,12 +1830,22 @@ def test_model_create_with_lowercase_first_name_letter(app: DjangoTestApp):
 
 
 @pytest.mark.django_db
+def test_model_create_with_in_not_draft_version(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+    version = VersionFactory(status=VersionStatus.PRE_RELEASE)
+    dataset = version.dataset
+    form = app.get(reverse('model-create', args=[dataset.pk, version.pk]), expect_errors=True)
+    assert form.status_code == 404
+
+
+@pytest.mark.django_db
 def test_model_create_with_number_as_first_name_letter(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
     dataset = DatasetFactory()
 
-    form = app.get(reverse('model-create', args=[dataset.pk])).forms['model-form']
+    form = app.get(reverse('model-create-no-version', args=[dataset.pk])).forms['model-form']
     form['name'] = "1nvalidName"
     resp = form.submit()
     assert list(resp.context['form'].errors.values()) == [[
@@ -1678,7 +1859,7 @@ def test_model_create_with_special_symbol_in_name(app: DjangoTestApp):
     app.set_user(user)
     dataset = DatasetFactory()
 
-    form = app.get(reverse('model-create', args=[dataset.pk])).forms['model-form']
+    form = app.get(reverse('model-create-no-version', args=[dataset.pk])).forms['model-form']
     form['name'] = "Invalid_name1"
     resp = form.submit()
     assert list(resp.context['form'].errors.values()) == [[
@@ -1692,7 +1873,7 @@ def test_model_create_with_invalid_prepare(app: DjangoTestApp):
     app.set_user(user)
     dataset = DatasetFactory()
 
-    form = app.get(reverse('model-create', args=[dataset.pk])).forms['model-form']
+    form = app.get(reverse('model-create-no-version', args=[dataset.pk])).forms['model-form']
     form['name'] = "Model"
     form['prepare'] = 'sort(id)'
     resp = form.submit()
@@ -1707,7 +1888,7 @@ def test_model_create_with_invalid_uri(app: DjangoTestApp):
     app.set_user(user)
     dataset = DatasetFactory()
 
-    form = app.get(reverse('model-create', args=[dataset.pk])).forms['model-form']
+    form = app.get(reverse('model-create-no-version', args=[dataset.pk])).forms['model-form']
     form['name'] = "Model"
     form['uri'] = 'dcat:invalid:format'
     resp = form.submit()
@@ -1722,7 +1903,7 @@ def test_model_create_with_invalid_uri_prefix(app: DjangoTestApp):
     app.set_user(user)
     dataset = DatasetFactory()
 
-    form = app.get(reverse('model-create', args=[dataset.pk])).forms['model-form']
+    form = app.get(reverse('model-create-no-version', args=[dataset.pk])).forms['model-form']
     form['name'] = "Model"
     form['uri'] = 'dcat:invalid'
     resp = form.submit()
@@ -1736,41 +1917,37 @@ def test_model_create(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
 
-    PrefixFactory(name="dcat")
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
+    PrefixFactory(name="dcat", metadata_version=version)
+
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        uri="dcat:TestModel"
+        uri="dcat:TestModel",
+        metadata_version=version
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='integer',
+        metadata_version=version
     )
 
-    url = reverse('model-create', args=[dataset.pk])
-    revision_comment = RevisionComment(
-        source=RevisionSource.VIEW,
-        action="model-create",
-        http_method="POST",
-        path=url,
-        args=(),
-        kwargs={"pk": dataset.pk}
-    )
-    form = app.get(url).forms['model-form']
+    form = app.get(reverse('model-create', args=[dataset.pk, version.pk])).forms['model-form']
     form['name'] = "Model"
     form['uri'] = 'dcat:model'
     form['source'] = "MODEL"
@@ -1792,6 +1969,7 @@ def test_model_create(app: DjangoTestApp):
     assert new_model.metadata.first().level_given == 3
     assert new_model.metadata.first().title == 'Test model'
     assert new_model.metadata.first().description == 'Model for testing'
+    assert new_model.metadata.first().metadata_version == version
 
     assert new_model.base.model == model
     assert new_model.base.property_list.count() == 1
@@ -1800,11 +1978,11 @@ def test_model_create(app: DjangoTestApp):
     assert new_model.base.metadata.first().level_given == 4
     assert new_model.base.metadata.first().name == 'test/dataset/TestModel'
     assert new_model.base.metadata.first().ref == 'prop'
+    assert new_model.base.metadata.first().metadata_version == version
 
     assert Version.objects.get_for_object(new_model).count() == 1
-    version = (Version.objects.get_for_object(new_model).select_related("revision").first())
-    assert version.revision.comment == revision_comment.to_json()
-    assert version.revision.user == user
+    assert Version.objects.get_for_object(new_model).first().revision.comment == 'Sukurtas "Model" modelis. Added Model'
+    assert Version.objects.get_for_object(new_model).first().revision.user == user
 
 
 @pytest.mark.django_db
@@ -1812,57 +1990,55 @@ def test_model_update(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
 
-    PrefixFactory(name="dcat")
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
+    PrefixFactory(name="dcat", metadata_version=version)
+
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        uri="dcat:TestModel"
+        uri="dcat:TestModel",
+        metadata_version=version
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version
     )
-    prop1 = PropertyFactory(model=model)
+    prop1 = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop1),
         object_id=prop1.pk,
         dataset=dataset,
         name='prop1',
         type='integer',
+        metadata_version=version
     )
-    prop2 = PropertyFactory(model=model)
+    prop2 = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop2),
         object_id=prop2.pk,
         dataset=dataset,
         name='prop2',
         type='integer',
+        metadata_version=version
     )
 
-    base_model = ModelFactory(dataset=dataset)
+    base_model = ModelFactory(dataset=dataset, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(base_model),
         object_id=base_model.pk,
         dataset=dataset,
-        name="test/dataset/BaseModel"
+        name="test/dataset/BaseModel",
+        metadata_version = version
     )
-    kwargs_dict = {"pk": dataset.pk, "model": model.name}
-    url = reverse('model-update', kwargs=kwargs_dict)
-    revision_comment = RevisionComment(
-        source=RevisionSource.VIEW,
-        action="model-update",
-        http_method="POST",
-        path=url,
-        args=(),
-        kwargs=kwargs_dict
-    )
-    form = app.get(url).forms['model-form']
+
+    form = app.get(reverse('model-update', args=[dataset.pk, version.pk, model.name])).forms['model-form']
     form['name'] = "UpdatedModel"
     form['prepare'] = "sort(prop1)"
     form['ref'].force_value([prop2.pk, prop1.pk])
@@ -1881,27 +2057,20 @@ def test_model_update(app: DjangoTestApp):
     assert model.base.metadata.first().ref == ''
 
     assert Version.objects.get_for_object(model).count() == 1
-    version = Version.objects.get_for_object(model).select_related("revision").first()
-    assert version.revision.comment == revision_comment.to_json()
-    assert version.revision.user == user
+    assert Version.objects.get_for_object(model).first().revision.comment == \
+           'Redaguotas "UpdatedModel" modelis. Updated Model'
+    assert Version.objects.get_for_object(model).first().revision.user == user
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize(
-        "role",
-        [
-            Representative.OPEN_DATA_MANAGER,
-            Representative.RESOURCE_MANAGER,
-        ],
-)
-def test_param_create_for_resource(app: DjangoTestApp, role: str):
+def test_param_create_for_resource(app: DjangoTestApp):
     distribution = DatasetDistributionFactory(is_parameterized=True)
     dataset = distribution.dataset
     ct = ContentType.objects.get_for_model(dataset)
     representative = RepresentativeFactory(
         content_type=ct,
         object_id=dataset.pk,
-        role=role
+        role=Representative.MANAGER
     )
     app.set_user(representative.user)
 
@@ -1925,14 +2094,7 @@ def test_param_create_for_resource(app: DjangoTestApp, role: str):
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize(
-        "role",
-        [
-            Representative.OPEN_DATA_COORDINATOR,
-            Representative.RESOURCE_COORDINATOR,
-        ],
-    )
-def test_param_create_for_model(app: DjangoTestApp, role: str):
+def test_param_create_for_model(app: DjangoTestApp):
     model = ModelFactory(is_parameterized=True)
     dataset = model.dataset
     MetadataFactory(
@@ -1951,7 +2113,7 @@ def test_param_create_for_model(app: DjangoTestApp, role: str):
     representative = RepresentativeFactory(
         content_type=ct,
         object_id=dataset.pk,
-        role=role
+        role=Representative.MANAGER
     )
     app.set_user(representative.user)
 
@@ -1977,21 +2139,14 @@ def test_param_create_for_model(app: DjangoTestApp, role: str):
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize(
-        "role",
-        [
-            Representative.OPEN_DATA_COORDINATOR,
-            Representative.RESOURCE_COORDINATOR,
-        ],
-    )
-def test_param_update(app: DjangoTestApp, role: str):
+def test_param_update(app: DjangoTestApp):
     distribution = DatasetDistributionFactory(is_parameterized=True)
     dataset = distribution.dataset
     ct = ContentType.objects.get_for_model(dataset)
     representative = RepresentativeFactory(
         content_type=ct,
         object_id=dataset.pk,
-        role=role,
+        role=Representative.MANAGER
     )
     app.set_user(representative.user)
     ct = ContentType.objects.get_for_model(distribution)
@@ -2019,21 +2174,14 @@ def test_param_update(app: DjangoTestApp, role: str):
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize(
-        "role",
-        [
-            Representative.OPEN_DATA_MANAGER,
-            Representative.RESOURCE_MANAGER,
-        ],
-    )
-def test_param_delete(app: DjangoTestApp, role: str):
+def test_param_delete(app: DjangoTestApp):
     distribution = DatasetDistributionFactory(is_parameterized=True)
     dataset = distribution.dataset
     ct = ContentType.objects.get_for_model(dataset)
     representative = RepresentativeFactory(
         content_type=ct,
         object_id=dataset.pk,
-        role=role
+        role=Representative.MANAGER
     )
     app.set_user(representative.user)
     ct = ContentType.objects.get_for_model(distribution)
@@ -2057,11 +2205,20 @@ def test_param_delete(app: DjangoTestApp, role: str):
 
 
 @pytest.mark.django_db
+def test_new_version_when_chosen_version_not_draft(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+    version = VersionFactory(status=VersionStatus.PRE_RELEASE)
+    form = app.get(reverse('version-create', args=[version.dataset.pk, version.pk]), expect_errors=True)
+    assert form.status_code == 404
+
+
+@pytest.mark.django_db
 def test_new_version_with_released_date_earlier_than_two_weeks(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
-    dataset = DatasetFactory()
-    form = app.get(reverse('version-create', args=[dataset.pk])).forms['version-form']
+    version = VersionFactory()
+    form = app.get(reverse('version-create', args=[version.dataset.pk, version.pk])).forms['version-form']
     form['released'] = datetime.date.today()
     form['version_type'] = "MAJOR"
     resp = form.submit()
@@ -2074,15 +2231,24 @@ def test_new_version_with_released_date_earlier_than_two_weeks(app: DjangoTestAp
 def test_new_version_with_released_date_earlier_than_last_version(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
-    dataset = DatasetFactory()
+    version = VersionFactory()
 
-    form = app.get(reverse('version-create', args=[dataset.pk])).forms['version-form']
+    dataset_metadata = MetadataFactory(
+        dataset=version.dataset,
+        metadata_version=version,
+        content_type=ContentType.objects.get_for_model(Dataset),
+        object_id=version.dataset.pk
+    )
+
+    form = app.get(reverse('version-create', args=[version.dataset.pk, version.pk])).forms['version-form']
     form['released'] = datetime.date.today() + datetime.timedelta(days=15)
+    form['metadata'] = [dataset_metadata.pk]
     form['version_type'] = "MAJOR"
     form.submit()
 
-    form = app.get(reverse('version-create', args=[dataset.pk])).forms['version-form']
+    form = app.get(reverse('version-create', args=[version.dataset.pk, version.pk])).forms['version-form']
     form['released'] = datetime.date.today() + datetime.timedelta(days=14)
+    form['metadata'] = [dataset_metadata.pk]
     form['version_type'] = "MAJOR"
     resp = form.submit()
 
@@ -2095,667 +2261,764 @@ def test_new_version_with_released_date_earlier_than_last_version(app: DjangoTes
 def test_new_version_with_new_structure(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     model_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version
     )
     dataset_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     prop_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='string',
+        metadata_version=version
     )
 
-    form = app.get(reverse('version-create', args=[dataset.pk])).forms['version-form']
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
     form['released'] = datetime.date.today() + datetime.timedelta(days=14)
     form['version_type'] = "MAJOR"
     form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
     form['description'] = "Add new structure to version"
     form.submit()
 
-    assert _Version.objects.count() == 1
-    assert _Version.objects.first().dataset == dataset
-    assert sorted(list(_Version.objects.first().metadataversion_set.values_list(
-        'metadata__pk', flat=True
-    ))) == sorted([
-        dataset_meta.pk,
-        model_meta.pk,
-        prop_meta.pk
-    ])
+    assert _Version.objects.count() == 2
+    assert _Version.objects.exclude(status=VersionStatus.DRAFT).first().dataset == dataset
+    assert len(list(_Version.objects.exclude(status=VersionStatus.DRAFT).first().metadata_set.values_list(
+        'pk', flat=True
+    ))) == 3
 
 
 @pytest.mark.django_db
 def test_new_version_with_updated_structure__dataset_name(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     model_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version
     )
     dataset_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     prop_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='string',
+        metadata_version=version
     )
 
-    form = app.get(reverse('version-create', args=[dataset.pk])).forms['version-form']
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
     form['released'] = datetime.date.today() + datetime.timedelta(days=14)
     form['version_type'] = "MAJOR"
     form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
     form['description'] = "Add new structure to version"
     form.submit()
+    first_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    first_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=first_published_version).all()
 
     dataset_meta.name = "test/dataset1"
     dataset_meta.draft = True
     dataset_meta.save()
-
-    form = app.get(reverse('version-create', args=[dataset.pk])).forms['version-form']
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
     form['released'] = datetime.date.today() + datetime.timedelta(days=15)
     form['version_type'] = "MAJOR"
     form['metadata'] = [dataset_meta.pk]
     form['description'] = "Update structure version"
     form.submit()
+    second_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    second_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=second_published_version).all()
 
-    assert dataset.dataset_version.count() == 2
-    old_version = dataset.dataset_version.order_by('created').first()
-    assert old_version.metadataversion_set.filter(
-        metadata__content_type=ContentType.objects.get_for_model(dataset),
-        metadata__object_id=dataset.pk
+    assert dataset.dataset_version.count() == 3
+
+    assert first_version_metadata.count() == 3
+    assert first_version_metadata.filter(
+        content_type=ContentType.objects.get_for_model(dataset),
+        object_id=dataset.pk
     ).first().name == 'test/dataset'
-    new_version = dataset.dataset_version.order_by('-created').first()
-    assert new_version.metadataversion_set.count() == 1
-    assert new_version.metadataversion_set.first().metadata.object == dataset
-    assert new_version.metadataversion_set.first().name == 'test/dataset1'
+
+    assert second_version_metadata.count() == 1
+    assert second_version_metadata.first().object == dataset
+    assert second_version_metadata.first().name == 'test/dataset1'
 
 
 @pytest.mark.django_db
 def test_new_version_with_updated_structure__model_name(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     model_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version
     )
     dataset_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     prop_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='string',
+        metadata_version=version
     )
 
-    form = app.get(reverse('version-create', args=[dataset.pk])).forms['version-form']
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
     form['released'] = datetime.date.today() + datetime.timedelta(days=14)
     form['version_type'] = "MAJOR"
     form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
     form['description'] = "Add new structure to version"
     form.submit()
+    first_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    first_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=first_published_version).all()
 
     model_meta.name = "test/dataset/TestModel1"
     model_meta.draft = True
     model_meta.save()
 
-    form = app.get(reverse('version-create', args=[dataset.pk])).forms['version-form']
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
     form['released'] = datetime.date.today() + datetime.timedelta(days=15)
     form['version_type'] = "MAJOR"
-    form['metadata'] = [model_meta.pk]
+    form['metadata'] = [dataset_meta.pk, model_meta.pk]
     form['description'] = "Update structure version"
     form.submit()
+    second_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    second_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=second_published_version).all()
 
-    assert dataset.dataset_version.count() == 2
-    old_version = dataset.dataset_version.order_by('created').first()
-    assert old_version.metadataversion_set.filter(
-        metadata__content_type=ContentType.objects.get_for_model(model),
-        metadata__object_id=model.pk
+    assert dataset.dataset_version.count() == 3
+
+    assert first_version_metadata.filter(
+        content_type=ContentType.objects.get_for_model(model),
     ).first().name == "test/dataset/TestModel"
-    new_version = dataset.dataset_version.order_by('-created').first()
-    assert new_version.metadataversion_set.count() == 1
-    assert new_version.metadataversion_set.first().metadata.object == model
-    assert new_version.metadataversion_set.first().name == "test/dataset/TestModel1"
+
+    assert second_version_metadata.count() == 2
+    assert second_version_metadata.first().object.pk != model.pk
+    assert second_version_metadata.filter(content_type=ContentType.objects.get_for_model(Model)).first().name == "test/dataset/TestModel1"
 
 
 @pytest.mark.django_db
 def test_new_version_with_updated_structure__property_name(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     model_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version
     )
     dataset_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     prop_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='string',
+        metadata_version=version
     )
 
-    form = app.get(reverse('version-create', args=[dataset.pk])).forms['version-form']
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
     form['released'] = datetime.date.today() + datetime.timedelta(days=14)
     form['version_type'] = "MAJOR"
     form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
     form['description'] = "Add new structure to version"
     form.submit()
+    first_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    first_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=first_published_version).all()
 
     prop_meta.name = "prop1"
     prop_meta.draft = True
     prop_meta.save()
 
-    form = app.get(reverse('version-create', args=[dataset.pk])).forms['version-form']
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
     form['released'] = datetime.date.today() + datetime.timedelta(days=15)
     form['version_type'] = "MAJOR"
-    form['metadata'] = [prop_meta.pk]
+    form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
     form['description'] = "Update structure version"
     form.submit()
+    second_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    second_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=second_published_version).all()
 
-    assert dataset.dataset_version.count() == 2
-    old_version = dataset.dataset_version.order_by('created').first()
-    assert old_version.metadataversion_set.filter(
-        metadata__content_type=ContentType.objects.get_for_model(prop),
-        metadata__object_id=prop.pk
+    assert dataset.dataset_version.count() == 3
+
+    assert first_version_metadata.filter(
+        content_type=ContentType.objects.get_for_model(prop),
     ).first().name == "prop"
-    new_version = dataset.dataset_version.order_by('-created').first()
-    assert new_version.metadataversion_set.count() == 1
-    assert new_version.metadataversion_set.first().metadata.object == prop
-    assert new_version.metadataversion_set.first().name == 'prop1'
+
+    assert second_version_metadata.count() == 3
+    assert second_version_metadata.filter(
+        content_type=ContentType.objects.get_for_model(prop),
+    ).first().object.pk != prop.pk
+    assert second_version_metadata.filter(
+        content_type=ContentType.objects.get_for_model(prop),
+    ).first().name == 'prop1'
 
 
 @pytest.mark.django_db
 def test_new_version_with_updated_structure__model_base(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     model_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version,
     )
     dataset_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version,
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     prop_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='string',
+        metadata_version=version,
     )
 
-    form = app.get(reverse('version-create', args=[dataset.pk])).forms['version-form']
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
     form['released'] = datetime.date.today() + datetime.timedelta(days=14)
     form['version_type'] = "MAJOR"
     form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
     form['description'] = "Add new structure to version"
     form.submit()
+    first_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    first_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=first_published_version).all()
 
-    base_model = ModelFactory(dataset=dataset)
+    base_model = ModelFactory(dataset=dataset, metadata_version=version,)
     base_model_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(base_model),
         object_id=base_model.pk,
         dataset=dataset,
-        name="test/dataset/BaseModel"
+        name="test/dataset/BaseModel",
+        metadata_version=version,
     )
-    base = BaseFactory(model=base_model)
+    base = BaseFactory(model=base_model, metadata_version=version,)
     base_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(base),
         object_id=base.pk,
         dataset=dataset,
-        name="test/dataset/BaseModel"
+        name="test/dataset/BaseModel",
+        metadata_version=version,
     )
     model.base = base
     model.save()
     model_meta.draft = True
     model_meta.save()
 
-    form = app.get(reverse('version-create', args=[dataset.pk])).forms['version-form']
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
     form['released'] = datetime.date.today() + datetime.timedelta(days=15)
     form['version_type'] = "MAJOR"
-    form['metadata'] = [model_meta.pk]
+    form['metadata'] = [dataset_meta.pk, base_model_meta.pk, model_meta.pk]
     form['description'] = "Update structure version"
     form.submit()
 
-    assert dataset.dataset_version.count() == 2
-    old_version = dataset.dataset_version.order_by('created').first()
-    assert old_version.metadataversion_set.filter(
-        metadata__content_type=ContentType.objects.get_for_model(model),
-        metadata__object_id=model.pk
-    ).first().base is None
-    new_version = dataset.dataset_version.order_by('-created').first()
-    assert new_version.metadataversion_set.count() == 1
-    assert new_version.metadataversion_set.first().metadata.object == model
-    assert new_version.metadataversion_set.first().base == base
+    second_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    second_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=second_published_version).all()
 
+    assert dataset.dataset_version.count() == 3
+
+    assert first_version_metadata.count() == 3
+    assert first_version_metadata.filter(
+        content_type=ContentType.objects.get_for_model(model),
+    ).first().object.base is None
+
+    assert second_version_metadata.count() == 4
+    assert second_version_metadata.filter(
+        content_type=ContentType.objects.get_for_model(model),
+    ).first().object.pk != model.pk
+    assert second_version_metadata.filter(
+        content_type=ContentType.objects.get_for_model(model),
+        name="test/dataset/TestModel",
+    ).first().object.base is not None
 
 @pytest.mark.django_db
 def test_new_version_with_updated_structure__model_ref(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     model_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version,
     )
     dataset_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version,
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version,)
     prop_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='string',
+        metadata_version=version,
     )
 
-    form = app.get(reverse('version-create', args=[dataset.pk])).forms['version-form']
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
     form['released'] = datetime.date.today() + datetime.timedelta(days=14)
     form['version_type'] = "MAJOR"
     form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
     form['description'] = "Add new structure to version"
     form.submit()
+    first_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    first_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=first_published_version).all()
 
     model_meta.ref = 'id'
     model_meta.draft = True
     model_meta.save()
 
-    form = app.get(reverse('version-create', args=[dataset.pk])).forms['version-form']
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
     form['released'] = datetime.date.today() + datetime.timedelta(days=15)
     form['version_type'] = "MAJOR"
-    form['metadata'] = [model_meta.pk]
+    form['metadata'] = [dataset_meta.pk, model_meta.pk]
     form['description'] = "Update structure version"
     form.submit()
+    second_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    second_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=second_published_version).all()
 
-    assert dataset.dataset_version.count() == 2
-    old_version = dataset.dataset_version.order_by('created').first()
-    assert old_version.metadataversion_set.filter(
-        metadata__content_type=ContentType.objects.get_for_model(model),
-        metadata__object_id=model.pk
-    ).first().ref is None
-    new_version = dataset.dataset_version.order_by('-created').first()
-    assert new_version.metadataversion_set.count() == 1
-    assert new_version.metadataversion_set.first().metadata.object == model
-    assert new_version.metadataversion_set.first().ref == 'id'
+    assert dataset.dataset_version.count() == 3
+    assert first_version_metadata.filter(
+        content_type=ContentType.objects.get_for_model(model),
+    ).first().ref is ""
+
+    assert second_version_metadata.count() == 2
+    assert second_version_metadata.first().object.pk != model.pk
+    assert second_version_metadata.filter(content_type=ContentType.objects.get_for_model(Model)).first().ref == "id"
 
 
 @pytest.mark.django_db
 def test_new_version_with_updated_structure__property_type(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     model_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version,
     )
     dataset_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version,
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version,)
     prop_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='string',
+        metadata_version=version,
     )
 
-    form = app.get(reverse('version-create', args=[dataset.pk])).forms['version-form']
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
     form['released'] = datetime.date.today() + datetime.timedelta(days=14)
     form['version_type'] = "MAJOR"
     form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
     form['description'] = "Add new structure to version"
     form.submit()
+    first_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    first_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=first_published_version).all()
 
     prop_meta.type = 'integer'
     prop_meta.draft = True
     prop_meta.save()
 
-    form = app.get(reverse('version-create', args=[dataset.pk])).forms['version-form']
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
     form['released'] = datetime.date.today() + datetime.timedelta(days=15)
     form['version_type'] = "MAJOR"
-    form['metadata'] = [prop_meta.pk]
+    form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
     form['description'] = "Update structure version"
     form.submit()
+    second_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    second_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=second_published_version).all()
 
-    assert dataset.dataset_version.count() == 2
-    old_version = dataset.dataset_version.order_by('created').first()
-    assert old_version.metadataversion_set.filter(
-        metadata__content_type=ContentType.objects.get_for_model(prop),
-        metadata__object_id=prop.pk
+    assert dataset.dataset_version.count() == 3
+    assert first_version_metadata.filter(
+        content_type=ContentType.objects.get_for_model(prop),
     ).first().type == 'string'
-    new_version = dataset.dataset_version.order_by('-created').first()
-    assert new_version.metadataversion_set.count() == 1
-    assert new_version.metadataversion_set.first().metadata.object == prop
-    assert new_version.metadataversion_set.first().type == 'integer'
+
+    assert second_version_metadata.count() == 3
+    assert second_version_metadata.filter(
+        content_type=ContentType.objects.get_for_model(prop),
+    ).first().object.pk != prop.pk
+    assert second_version_metadata.filter(
+        content_type=ContentType.objects.get_for_model(prop),
+    ).first().type == 'integer'
 
 
 @pytest.mark.django_db
 def test_new_version_with_updated_structure__property_ref(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
-    model = ModelFactory()
-    dataset = model.dataset
-    model_meta = MetadataFactory(
-        content_type=ContentType.objects.get_for_model(model),
-        object_id=model.pk,
-        dataset=dataset,
-        name="test/dataset/TestModel"
-    )
-    dataset_meta = MetadataFactory(
-        content_type=ContentType.objects.get_for_model(dataset),
-        object_id=dataset.pk,
-        dataset=dataset,
-        name="test/dataset"
-    )
-    prop = PropertyFactory(model=model)
-    prop_meta = MetadataFactory(
-        content_type=ContentType.objects.get_for_model(prop),
-        object_id=prop.pk,
-        dataset=dataset,
-        name='prop',
-        type='string',
-    )
-
-    form = app.get(reverse('version-create', args=[dataset.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=14)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
-    form['description'] = "Add new structure to version"
-    form.submit()
-
-    prop_meta.ref = "test/dataset/TestModel"
-    prop_meta.draft = True
-    prop_meta.save()
-
-    form = app.get(reverse('version-create', args=[dataset.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [prop_meta.pk]
-    form['description'] = "Update structure version"
-    form.submit()
-
-    assert dataset.dataset_version.count() == 2
-    old_version = dataset.dataset_version.order_by('created').first()
-    assert old_version.metadataversion_set.filter(
-        metadata__content_type=ContentType.objects.get_for_model(prop),
-        metadata__object_id=prop.pk
-    ).first().ref is None
-    new_version = dataset.dataset_version.order_by('-created').first()
-    assert new_version.metadataversion_set.count() == 1
-    assert new_version.metadataversion_set.first().metadata.object == prop
-    assert new_version.metadataversion_set.first().ref == "test/dataset/TestModel"
-
-
-@pytest.mark.django_db
-def test_new_version_with_updated_structure__model_level(app: DjangoTestApp):
-    user = UserFactory(is_staff=True)
-    app.set_user(user)
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     model_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        level_given=3
+        metadata_version=version,
     )
     dataset_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version,
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version,)
     prop_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='string',
+        metadata_version=version,
     )
 
-    form = app.get(reverse('version-create', args=[dataset.pk])).forms['version-form']
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
     form['released'] = datetime.date.today() + datetime.timedelta(days=14)
     form['version_type'] = "MAJOR"
     form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
     form['description'] = "Add new structure to version"
     form.submit()
+    first_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    first_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=first_published_version).all()
+
+    prop_meta.ref = "test/dataset/TestModel"
+    prop_meta.draft = True
+    prop_meta.save()
+
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
+    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
+    form['version_type'] = "MAJOR"
+    form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
+    form['description'] = "Update structure version"
+    form.submit()
+    second_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    second_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=second_published_version).all()
+
+    assert dataset.dataset_version.count() == 3
+    assert first_version_metadata.filter(
+        content_type=ContentType.objects.get_for_model(prop),
+    ).first().ref == ''
+
+    assert second_version_metadata.count() == 3
+    assert second_version_metadata.filter(
+        content_type=ContentType.objects.get_for_model(prop),
+    ).first().object.pk != prop.pk
+    assert second_version_metadata.filter(
+        content_type=ContentType.objects.get_for_model(prop),
+    ).first().ref == "test/dataset/TestModel"
+
+@pytest.mark.django_db
+def test_new_version_with_updated_structure__model_level(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
+    model_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(model),
+        object_id=model.pk,
+        dataset=dataset,
+        name="test/dataset/TestModel",
+        level_given=3,
+        metadata_version=version,
+    )
+    dataset_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(dataset),
+        object_id=dataset.pk,
+        dataset=dataset,
+        name="test/dataset",
+        metadata_version=version,
+    )
+    prop = PropertyFactory(model=model, metadata_version=version,)
+    prop_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(prop),
+        object_id=prop.pk,
+        dataset=dataset,
+        name='prop',
+        type='string',
+        metadata_version=version,
+    )
+
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
+    form['released'] = datetime.date.today() + datetime.timedelta(days=14)
+    form['version_type'] = "MAJOR"
+    form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
+    form['description'] = "Add new structure to version"
+    form.submit()
+    first_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    first_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=first_published_version).all()
 
     model_meta.level_given = 5
     model_meta.draft = True
     model_meta.save()
 
-    form = app.get(reverse('version-create', args=[dataset.pk])).forms['version-form']
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
     form['released'] = datetime.date.today() + datetime.timedelta(days=15)
     form['version_type'] = "MAJOR"
-    form['metadata'] = [model_meta.pk]
+    form['metadata'] = [dataset_meta.pk, model_meta.pk]
     form['description'] = "Update structure version"
     form.submit()
+    second_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    second_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=second_published_version).all()
 
-    assert dataset.dataset_version.count() == 2
-    old_version = dataset.dataset_version.order_by('created').first()
-    assert old_version.metadataversion_set.filter(
-        metadata__content_type=ContentType.objects.get_for_model(model),
-        metadata__object_id=model.pk
+    assert dataset.dataset_version.count() == 3
+    assert first_version_metadata.filter(
+        content_type=ContentType.objects.get_for_model(model),
     ).first().level_given == 3
-    new_version = dataset.dataset_version.order_by('-created').first()
-    assert new_version.metadataversion_set.count() == 1
-    assert new_version.metadataversion_set.first().metadata.object == model
-    assert new_version.metadataversion_set.first().level_given == 5
+
+    assert second_version_metadata.count() == 2
+    assert second_version_metadata.first().object.pk != model.pk
+    assert second_version_metadata.filter(content_type=ContentType.objects.get_for_model(Model)).first().level_given == 5
 
 
 @pytest.mark.django_db
 def test_new_version_with_updated_structure__property_level(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     model_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
+        metadata_version=version,
     )
     dataset_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version,
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version, )
     prop_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='string',
-        level_given=3
+        level_given=3,
+        metadata_version=version,
     )
 
-    form = app.get(reverse('version-create', args=[dataset.pk])).forms['version-form']
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
     form['released'] = datetime.date.today() + datetime.timedelta(days=14)
     form['version_type'] = "MAJOR"
     form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
     form['description'] = "Add new structure to version"
     form.submit()
+    first_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    first_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=first_published_version).all()
 
     prop_meta.level_given = 5
     prop_meta.draft = True
     prop_meta.save()
 
-    form = app.get(reverse('version-create', args=[dataset.pk])).forms['version-form']
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
     form['released'] = datetime.date.today() + datetime.timedelta(days=15)
     form['version_type'] = "MAJOR"
-    form['metadata'] = [prop_meta.pk]
+    form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
     form['description'] = "Update structure version"
     form.submit()
+    second_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    second_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=second_published_version).all()
 
-    assert dataset.dataset_version.count() == 2
-    old_version = dataset.dataset_version.order_by('created').first()
-    assert old_version.metadataversion_set.filter(
-        metadata__content_type=ContentType.objects.get_for_model(prop),
-        metadata__object_id=prop.pk
+    assert dataset.dataset_version.count() == 3
+    assert first_version_metadata.filter(
+        content_type=ContentType.objects.get_for_model(prop),
     ).first().level_given == 3
-    new_version = dataset.dataset_version.order_by('-created').first()
-    assert new_version.metadataversion_set.count() == 1
-    assert new_version.metadataversion_set.first().metadata.object == prop
-    assert new_version.metadataversion_set.first().level_given == 5
+
+    assert second_version_metadata.count() == 3
+    assert second_version_metadata.filter(
+        content_type=ContentType.objects.get_for_model(prop),
+    ).first().object.pk != prop.pk
+    assert second_version_metadata.filter(
+        content_type=ContentType.objects.get_for_model(prop),
+    ).first().level_given == 5
 
 
 @pytest.mark.django_db
 def test_new_version_with_updated_structure__property_access(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     model_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
+        metadata_version=version,
     )
     dataset_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version,
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version, )
     prop_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='string',
-        access=3
+        access=3,
+        metadata_version=version,
     )
 
-    form = app.get(reverse('version-create', args=[dataset.pk])).forms['version-form']
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
     form['released'] = datetime.date.today() + datetime.timedelta(days=14)
     form['version_type'] = "MAJOR"
     form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
     form['description'] = "Add new structure to version"
     form.submit()
+    first_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    first_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=first_published_version).all()
 
     prop_meta.access = 5
     prop_meta.draft = True
     prop_meta.save()
 
-    form = app.get(reverse('version-create', args=[dataset.pk])).forms['version-form']
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
     form['released'] = datetime.date.today() + datetime.timedelta(days=15)
     form['version_type'] = "MAJOR"
-    form['metadata'] = [prop_meta.pk]
+    form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
     form['description'] = "Update structure version"
     form.submit()
+    second_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    second_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=second_published_version).all()
 
-    assert dataset.dataset_version.count() == 2
-    old_version = dataset.dataset_version.order_by('created').first()
-    assert old_version.metadataversion_set.filter(
-        metadata__content_type=ContentType.objects.get_for_model(prop),
-        metadata__object_id=prop.pk
+    assert dataset.dataset_version.count() == 3
+    assert first_version_metadata.filter(
+        content_type=ContentType.objects.get_for_model(prop),
     ).first().access == 3
-    new_version = dataset.dataset_version.order_by('-created').first()
-    assert new_version.metadataversion_set.count() == 1
-    assert new_version.metadataversion_set.first().metadata.object == prop
-    assert new_version.metadataversion_set.first().access == 5
+
+    assert second_version_metadata.count() == 3
+    assert second_version_metadata.filter(
+        content_type=ContentType.objects.get_for_model(prop),
+    ).first().object.pk != prop.pk
+    assert second_version_metadata.filter(
+        content_type=ContentType.objects.get_for_model(prop),
+    ).first().access == 5
 
 
 @pytest.mark.django_db
 def test_new_version_with_updated_structure__enum_prepare(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     model_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
+        metadata_version=version,
     )
     dataset_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version,
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version,)
     prop_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='string',
-        access=3
+        access=3,
+        metadata_version=version,
     )
     enum = EnumFactory(
         content_type=ContentType.objects.get_for_model(prop),
-        object_id=prop.pk
+        object_id=prop.pk,
+        metadata_version=version,
     )
-    enum_item = EnumItemFactory(enum=enum)
+    enum_item = EnumItemFactory(enum=enum, metadata_version=version,)
     enum_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(enum_item),
         object_id=enum_item.pk,
@@ -2765,70 +3028,80 @@ def test_new_version_with_updated_structure__enum_prepare(app: DjangoTestApp):
         prepare='1',
         access=Metadata.OPEN,
         source="TEST",
+        metadata_version=version,
     )
 
-    form = app.get(reverse('version-create', args=[dataset.pk])).forms['version-form']
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
     form['released'] = datetime.date.today() + datetime.timedelta(days=14)
     form['version_type'] = "MAJOR"
     form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk, enum_meta.pk]
     form['description'] = "Add new structure to version"
     form.submit()
+    first_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    first_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=first_published_version).all()
 
     enum_meta.prepare = '2'
     enum_meta.draft = True
     enum_meta.save()
 
-    form = app.get(reverse('version-create', args=[dataset.pk])).forms['version-form']
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
     form['released'] = datetime.date.today() + datetime.timedelta(days=15)
     form['version_type'] = "MAJOR"
-    form['metadata'] = [enum_meta.pk]
+    form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk, enum_meta.pk]
     form['description'] = "Update structure version"
     form.submit()
+    second_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    second_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=second_published_version).all()
 
-    assert dataset.dataset_version.count() == 2
-    old_version = dataset.dataset_version.order_by('created').first()
-    assert old_version.metadataversion_set.filter(
-        metadata__content_type=ContentType.objects.get_for_model(enum_item),
-        metadata__object_id=enum_item.pk
+    assert dataset.dataset_version.count() == 3
+    assert first_version_metadata.filter(
+        content_type=ContentType.objects.get_for_model(enum_item),
     ).first().prepare == '1'
-    new_version = dataset.dataset_version.order_by('-created').first()
-    assert new_version.metadataversion_set.count() == 1
-    assert new_version.metadataversion_set.first().metadata.object == enum_item
-    assert new_version.metadataversion_set.first().prepare == '2'
+
+    assert second_version_metadata.count() == 4
+    assert second_version_metadata.filter(
+        content_type=ContentType.objects.get_for_model(enum_item)).first().object.pk != enum_item.pk
+    assert second_version_metadata.filter(
+        content_type=ContentType.objects.get_for_model(enum_item)).first().prepare == '2'
 
 
 @pytest.mark.django_db
 def test_new_version_with_updated_structure__enum_source(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     model_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
+        metadata_version=version,
     )
     dataset_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version,
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version,)
     prop_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='string',
-        access=3
+        access=3,
+        metadata_version=version,
     )
     enum = EnumFactory(
         content_type=ContentType.objects.get_for_model(prop),
-        object_id=prop.pk
+        object_id=prop.pk,
+        metadata_version=version,
     )
-    enum_item = EnumItemFactory(enum=enum)
+    enum_item = EnumItemFactory(enum=enum, metadata_version=version,)
     enum_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(enum_item),
         object_id=enum_item.pk,
@@ -2838,36 +3111,41 @@ def test_new_version_with_updated_structure__enum_source(app: DjangoTestApp):
         prepare='1',
         access=Metadata.OPEN,
         source="TEST",
+        metadata_version=version,
     )
 
-    form = app.get(reverse('version-create', args=[dataset.pk])).forms['version-form']
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
     form['released'] = datetime.date.today() + datetime.timedelta(days=14)
     form['version_type'] = "MAJOR"
     form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk, enum_meta.pk]
     form['description'] = "Add new structure to version"
     form.submit()
+    first_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    first_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=first_published_version).all()
 
     enum_meta.source = 'TEST1'
     enum_meta.draft = True
     enum_meta.save()
 
-    form = app.get(reverse('version-create', args=[dataset.pk])).forms['version-form']
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
     form['released'] = datetime.date.today() + datetime.timedelta(days=15)
     form['version_type'] = "MAJOR"
-    form['metadata'] = [enum_meta.pk]
+    form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk, enum_meta.pk]
     form['description'] = "Update structure version"
     form.submit()
+    second_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    second_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=second_published_version).all()
 
-    assert dataset.dataset_version.count() == 2
-    old_version = dataset.dataset_version.order_by('created').first()
-    assert old_version.metadataversion_set.filter(
-        metadata__content_type=ContentType.objects.get_for_model(enum_item),
-        metadata__object_id=enum_item.pk
+    assert dataset.dataset_version.count() == 3
+    assert first_version_metadata.filter(
+        content_type=ContentType.objects.get_for_model(enum_item),
     ).first().source == 'TEST'
-    new_version = dataset.dataset_version.order_by('-created').first()
-    assert new_version.metadataversion_set.count() == 1
-    assert new_version.metadataversion_set.first().metadata.object == enum_item
-    assert new_version.metadataversion_set.first().source == 'TEST1'
+
+    assert second_version_metadata.count() == 4
+    assert second_version_metadata.filter(
+        content_type=ContentType.objects.get_for_model(enum_item)).first().object.pk != enum_item.pk
+    assert second_version_metadata.filter(
+        content_type=ContentType.objects.get_for_model(enum_item)).first().source == 'TEST1'
 
 
 @pytest.mark.django_db
@@ -2875,29 +3153,22 @@ def test_structure_tab_with_non_public_dataset_without_access(app: DjangoTestApp
     dataset = DatasetFactory(is_public=False)
     user = UserFactory()
     app.set_user(user)
-    response = app.get(reverse('dataset-structure', args=[dataset.pk]), expect_errors=True)
+    response = app.get(reverse('dataset-structure-no-version', args=[dataset.pk]), expect_errors=True)
     assert response.status_code == 403
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize(
-        "role",
-        [
-            Representative.OPEN_DATA_MANAGER,
-            Representative.RESOURCE_MANAGER,
-        ],
-    )
-def test_structure_tab_with_non_public_dataset_with_access(app: DjangoTestApp, role: str):
+def test_structure_tab_with_non_public_dataset_with_access(app: DjangoTestApp):
     dataset = DatasetFactory(is_public=False)
     user = UserFactory()
     RepresentativeFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         user=user,
-        role=role,
+        role=Representative.MANAGER,
     )
     app.set_user(user)
-    response = app.get(reverse('dataset-structure', args=[dataset.pk]))
+    response = app.get(reverse('dataset-structure-no-version', args=[dataset.pk]))
     assert response.context['dataset'] == dataset
 
 
@@ -2912,14 +3183,7 @@ def test_version_list_with_non_public_dataset_without_access(app: DjangoTestApp)
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize(
-        "role",
-        [
-            Representative.OPEN_DATA_MANAGER,
-            Representative.RESOURCE_MANAGER,
-        ],
-    )
-def test_version_list_with_non_public_dataset_with_access(app: DjangoTestApp, role: str):
+def test_version_list_with_non_public_dataset_with_access(app: DjangoTestApp):
     dataset = DatasetFactory(is_public=False)
     version = VersionFactory(dataset=dataset)
     user = UserFactory()
@@ -2927,11 +3191,11 @@ def test_version_list_with_non_public_dataset_with_access(app: DjangoTestApp, ro
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         user=user,
-        role=role
+        role=Representative.MANAGER
     )
     app.set_user(user)
     response = app.get(reverse('version-list', args=[dataset.pk]))
-    assert list(response.context['versions']) == [version]
+    assert list(response.context['versions']) == [] # Version that gets created is Draft which is not displayed
 
 
 @pytest.mark.django_db
@@ -2945,14 +3209,7 @@ def test_version_detail_with_non_public_dataset_without_access(app: DjangoTestAp
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize(
-        "role",
-        [
-            Representative.OPEN_DATA_MANAGER,
-            Representative.RESOURCE_MANAGER,
-        ],
-    )
-def test_version_detail_with_non_public_dataset_with_access(app: DjangoTestApp, role: str):
+def test_version_detail_with_non_public_dataset_with_access(app: DjangoTestApp):
     dataset = DatasetFactory(is_public=False)
     version = VersionFactory(dataset=dataset)
     user = UserFactory()
@@ -2960,7 +3217,7 @@ def test_version_detail_with_non_public_dataset_with_access(app: DjangoTestApp, 
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         user=user,
-        role=role
+        role=Representative.MANAGER
     )
     app.set_user(user)
     response = app.get(reverse('version-detail', args=[dataset.pk, version.pk]))
@@ -2970,365 +3227,370 @@ def test_version_detail_with_non_public_dataset_with_access(app: DjangoTestApp, 
 @pytest.mark.django_db
 def test_model_structure_with_non_public_dataset_without_access(app: DjangoTestApp):
     dataset = DatasetFactory(is_public=False)
-    model = ModelFactory(dataset=dataset)
+    version = VersionFactory(dataset=dataset)
+    model = ModelFactory(dataset=dataset, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='string',
+        metadata_version=version
     )
     user = UserFactory()
     app.set_user(user)
-    response = app.get(reverse('model-structure', args=[dataset.pk, model.name]), expect_errors=True)
+    response = app.get(reverse('model-structure', args=[dataset.pk, version.pk, model.name]), expect_errors=True)
     assert response.status_code == 403
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize(
-        "role",
-        [
-            Representative.OPEN_DATA_MANAGER,
-            Representative.RESOURCE_MANAGER,
-        ],
-    )
-def test_model_structure_with_non_public_dataset_with_access(app: DjangoTestApp, role: str):
+def test_model_structure_with_non_public_dataset_with_access(app: DjangoTestApp):
     dataset = DatasetFactory(is_public=False)
-    model = ModelFactory(dataset=dataset)
+    version = VersionFactory(dataset=dataset)
+    model = ModelFactory(dataset=dataset, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='string',
+        metadata_version=version
     )
     user = UserFactory()
     RepresentativeFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         user=user,
-        role=role
+        role=Representative.MANAGER
     )
     app.set_user(user)
-    response = app.get(reverse('model-structure', args=[dataset.pk, model.name]))
+    response = app.get(reverse('model-structure', args=[dataset.pk, version.pk, model.name]))
     assert response.context['model'] == model
 
 
 @pytest.mark.django_db
 def test_property_structure_with_non_public_dataset_without_access(app: DjangoTestApp):
     dataset = DatasetFactory(is_public=False)
-    model = ModelFactory(dataset=dataset)
+    version = VersionFactory(dataset=dataset)
+    model = ModelFactory(dataset=dataset, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='string',
+        metadata_version=version
     )
     user = UserFactory()
     app.set_user(user)
-    response = app.get(reverse('property-structure', args=[dataset.pk, model.name, prop.name]), expect_errors=True)
+    response = app.get(reverse('property-structure', args=[dataset.pk, version.pk, model.name, prop.name]), expect_errors=True)
     assert response.status_code == 403
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize(
-        "role",
-        [
-            Representative.OPEN_DATA_MANAGER,
-            Representative.RESOURCE_MANAGER,
-        ],
-    )
-def test_property_structure_with_non_public_dataset_with_access(app: DjangoTestApp, role: str):
+def test_property_structure_with_non_public_dataset_with_access(app: DjangoTestApp):
     dataset = DatasetFactory(is_public=False)
-    model = ModelFactory(dataset=dataset)
+    version = VersionFactory(dataset=dataset)
+    model = ModelFactory(dataset=dataset, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='string',
+        metadata_version=version
     )
     user = UserFactory()
     RepresentativeFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         user=user,
-        role=role
+        role=Representative.MANAGER
     )
     app.set_user(user)
-    response = app.get(reverse('property-structure', args=[dataset.pk, model.name, prop.name]))
+    response = app.get(reverse('property-structure', args=[dataset.pk, version.pk, model.name, prop.name]))
     assert response.context['prop'] == prop
 
 
 @pytest.mark.django_db
 def test_model_data_with_non_public_dataset_without_access(app: DjangoTestApp):
     dataset = DatasetFactory(is_public=False)
-    model = ModelFactory(dataset=dataset)
+    version = VersionFactory(dataset=dataset)
+    model = ModelFactory(dataset=dataset, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='string',
+        metadata_version=version
     )
     user = UserFactory()
     app.set_user(user)
-    response = app.get(reverse('model-data', args=[dataset.pk, model.name]), expect_errors=True)
+    response = app.get(reverse('model-data', args=[dataset.pk, version.pk, model.name]), expect_errors=True)
     assert response.status_code == 403
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize(
-        "role",
-        [
-            Representative.OPEN_DATA_MANAGER,
-            Representative.RESOURCE_MANAGER,
-        ],
-    )
-def test_model_data_with_non_public_dataset_with_access(app: DjangoTestApp, role: str):
+def test_model_data_with_non_public_dataset_with_access(app: DjangoTestApp):
     dataset = DatasetFactory(is_public=False)
-    model = ModelFactory(dataset=dataset)
+    version = VersionFactory(dataset=dataset)
+    model = ModelFactory(dataset=dataset, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='string',
+        metadata_version=version
     )
     user = UserFactory()
     RepresentativeFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         user=user,
-        role=role
+        role=Representative.MANAGER
     )
     app.set_user(user)
-    response = app.get(reverse('model-data', args=[dataset.pk, model.name]))
+    response = app.get(reverse('model-data', args=[dataset.pk, version.pk, model.name]))
     assert response.context['model'] == model
 
 
 @pytest.mark.django_db
 def test_object_data_with_non_public_dataset_without_access(app: DjangoTestApp):
     dataset = DatasetFactory(is_public=False)
-    model = ModelFactory(dataset=dataset)
+    version = VersionFactory(dataset=dataset)
+    model = ModelFactory(dataset=dataset, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='string',
+        metadata_version=version
     )
     user = UserFactory()
     app.set_user(user)
-    response = app.get(reverse('object-data', args=[dataset.pk, model.name, "123456789"]), expect_errors=True)
+    response = app.get(reverse('object-data', args=[dataset.pk, version.pk, model.name, "123456789"]), expect_errors=True)
     assert response.status_code == 403
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize(
-        "role",
-        [
-            Representative.OPEN_DATA_MANAGER,
-            Representative.RESOURCE_MANAGER,
-        ],
-    )
-def test_object_data_with_non_public_dataset_with_access(app: DjangoTestApp, role: str):
+def test_object_data_with_non_public_dataset_with_access(app: DjangoTestApp):
     dataset = DatasetFactory(is_public=False)
-    model = ModelFactory(dataset=dataset)
+    version = VersionFactory(dataset=dataset)
+    model = ModelFactory(dataset=dataset, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='string',
+        metadata_version=version
     )
     user = UserFactory()
     RepresentativeFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         user=user,
-        role=role
+        role=Representative.MANAGER
     )
     app.set_user(user)
-    response = app.get(reverse('object-data', args=[dataset.pk, model.name, "123456789"]))
+    response = app.get(reverse('object-data', args=[dataset.pk, version.pk, model.name, "123456789"]))
     assert response.context['model'] == model
 
 
 @pytest.mark.django_db
 def test_api_with_non_public_dataset_without_access(app: DjangoTestApp):
     dataset = DatasetFactory(is_public=False)
-    model = ModelFactory(dataset=dataset)
+    version = VersionFactory(dataset=dataset)
+    model = ModelFactory(dataset=dataset, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='string',
+        metadata_version=version
     )
     user = UserFactory()
     app.set_user(user)
-    response = app.get(reverse('getall-api', args=[dataset.pk, model.name]), expect_errors=True)
+    response = app.get(reverse('getall-api', args=[dataset.pk, version.pk, model.name]), expect_errors=True)
     assert response.status_code == 403
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize(
-        "role",
-        [
-            Representative.OPEN_DATA_MANAGER,
-            Representative.RESOURCE_MANAGER,
-        ],
-    )
-def test_api_with_non_public_dataset_with_access(app: DjangoTestApp, role: str):
+def test_api_with_non_public_dataset_with_access(app: DjangoTestApp):
     dataset = DatasetFactory(is_public=False)
-    model = ModelFactory(dataset=dataset)
+    version = VersionFactory(dataset=dataset)
+    model = ModelFactory(dataset=dataset, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
-        name="test/dataset/TestModel"
+        name="test/dataset/TestModel",
+        metadata_version=version
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
-        name="test/dataset"
+        name="test/dataset",
+        metadata_version=version
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name='prop',
         type='string',
+        metadata_version=version
     )
     user = UserFactory()
     RepresentativeFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         user=user,
-        role=role
+        role=Representative.MANAGER
     )
     app.set_user(user)
-    response = app.get(reverse('getall-api', args=[dataset.pk, model.name]))
+    response = app.get(reverse('getall-api', args=[dataset.pk, version.pk, model.name]))
     assert response.context['model'] == model
 
 
@@ -3360,103 +3622,103 @@ def test_visibility_without_access(app: DjangoTestApp):
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure)
+    version = create_structure_objects(structure)
 
-    resp = app.get(reverse("dataset-structure", args=[structure.dataset.pk]))
+    resp = app.get(reverse("dataset-structure", args=[structure.dataset.pk, version.pk]))
     assert list(resp.context["models"].values_list("metadata__name", flat=True)) == [
         "datasets/gov/ivpk/adp/Province",
         "datasets/gov/ivpk/adp/State"
     ]
 
     resp = app.get(
-        reverse("model-structure", args=[structure.dataset.pk, "Country"]),
+        reverse("model-structure", args=[structure.dataset.pk, version.pk, "Country"]),
         expect_errors=True,
     )
     assert resp.status_code == 403
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "Country", "id"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "Country", "id"]),
         expect_errors=True,
     )
     assert resp.status_code == 403
 
     resp = app.get(
-        reverse("model-structure", args=[structure.dataset.pk, "City"]),
+        reverse("model-structure", args=[structure.dataset.pk, version.pk, "City"]),
         expect_errors=True,
     )
     assert resp.status_code == 403
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "City", "id"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "City", "id"]),
         expect_errors=True,
     )
     assert resp.status_code == 403
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "City", "title"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "City", "title"]),
         expect_errors=True,
     )
     assert resp.status_code == 403
 
 
     resp = app.get(
-        reverse("model-structure", args=[structure.dataset.pk, "Province"]),
+        reverse("model-structure", args=[structure.dataset.pk, version.pk, "Province"]),
         expect_errors=True,
     )
     assert resp.status_code == 200
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "Province", "id"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "Province", "id"]),
         expect_errors=True,
     )
     assert resp.status_code == 403
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "Province", "title"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "Province", "title"]),
         expect_errors=True,
     )
     assert resp.status_code == 403
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "Province", "number"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "Province", "number"]),
         expect_errors=True,
     )
     assert resp.status_code == 200
 
 
     resp = app.get(
-        reverse("model-structure", args=[structure.dataset.pk, "State"]),
+        reverse("model-structure", args=[structure.dataset.pk, version.pk, "State"]),
         expect_errors=True,
     )
     assert resp.status_code == 200
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "State", "id"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "State", "id"]),
         expect_errors=True,
     )
     assert resp.status_code == 403
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "State", "title"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "State", "title"]),
         expect_errors=True,
     )
     assert resp.status_code == 403
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "State", "number"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "State", "number"]),
         expect_errors=True,
     )
     assert resp.status_code == 200
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "State", "residence"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "State", "residence"]),
         expect_errors=True,
     )
     assert resp.status_code == 200
 
 
 @pytest.mark.django_db
-def test_model_visibility_with_resource_manager_access(app: DjangoTestApp):
+def test_model_visibility_with_manager_access(app: DjangoTestApp):
     manifest = (
         "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
         ",,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n"
@@ -3482,17 +3744,17 @@ def test_model_visibility_with_resource_manager_access(app: DjangoTestApp):
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure)
+    version = create_structure_objects(structure)
 
     ct = ContentType.objects.get_for_model(structure.dataset)
     representative = RepresentativeFactory(
         content_type=ct,
         object_id=structure.dataset.pk,
-        role=Representative.RESOURCE_MANAGER
+        role=Representative.MANAGER
     )
     app.set_user(representative.user)
 
-    resp = app.get(reverse("dataset-structure", args=[structure.dataset.pk]))
+    resp = app.get(reverse("dataset-structure", args=[structure.dataset.pk, version.pk]))
     assert list(resp.context["models"].values_list("metadata__name", flat=True)) == [
         "datasets/gov/ivpk/adp/City",
         "datasets/gov/ivpk/adp/Country",
@@ -3500,85 +3762,85 @@ def test_model_visibility_with_resource_manager_access(app: DjangoTestApp):
         "datasets/gov/ivpk/adp/State",
     ]
     resp = app.get(
-        reverse("model-structure", args=[structure.dataset.pk, "Country"]),
+        reverse("model-structure", args=[structure.dataset.pk, version.pk, "Country"]),
         expect_errors=True,
     )
     assert resp.status_code == 200
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "Country", "id"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "Country", "id"]),
         expect_errors=True,
     )
     assert resp.status_code == 200
 
     resp = app.get(
-        reverse("model-structure", args=[structure.dataset.pk, "City"]),
+        reverse("model-structure", args=[structure.dataset.pk, version.pk, "City"]),
         expect_errors=True,
     )
     assert resp.status_code == 200
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "City", "id"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "City", "id"]),
         expect_errors=True,
     )
     assert resp.status_code == 200
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "City", "title"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "City", "title"]),
         expect_errors=True,
     )
     assert resp.status_code == 200
 
     resp = app.get(
-        reverse("model-structure", args=[structure.dataset.pk, "Province"]),
+        reverse("model-structure", args=[structure.dataset.pk, version.pk, "Province"]),
         expect_errors=True,
     )
     assert resp.status_code == 200
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "Province", "id"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "Province", "id"]),
         expect_errors=True,
     )
     assert resp.status_code == 200
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "Province", "title"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "Province", "title"]),
         expect_errors=True,
     )
     assert resp.status_code == 200
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "Province", "number"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "Province", "number"]),
         expect_errors=True,
     )
     assert resp.status_code == 200
 
     resp = app.get(
-        reverse("model-structure", args=[structure.dataset.pk, "State"]),
+        reverse("model-structure", args=[structure.dataset.pk, version.pk, "State"]),
         expect_errors=True,
     )
     assert resp.status_code == 200
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "State", "id"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "State", "id"]),
         expect_errors=True,
     )
     assert resp.status_code == 200
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "State", "title"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "State", "title"]),
         expect_errors=True,
     )
     assert resp.status_code == 200
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "State", "number"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "State", "number"]),
         expect_errors=True,
     )
     assert resp.status_code == 200
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "State", "residence"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "State", "residence"]),
         expect_errors=True,
     )
     assert resp.status_code == 200
@@ -3612,99 +3874,100 @@ def test_model_visibility_with_open_data_representative_access(app: DjangoTestAp
     structure.dataset.organization = organization
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure)
+    version = create_structure_objects(structure)
     representative = RepresentativeFactory(
         content_type=ContentType.objects.get_for_model(structure.dataset.organization),
         object_id=structure.dataset.organization.pk,
-        role=Representative.OPEN_DATA_MANAGER,
+        role=Representative.MANAGER,
+        open_data_representative=True
     )
     app.set_user(representative.user)
 
-    resp = app.get(reverse("dataset-structure", args=[structure.dataset.pk]))
+    resp = app.get(reverse("dataset-structure", args=[structure.dataset.pk, version.pk]))
     assert list(resp.context["models"].values_list("metadata__name", flat=True)) == [
         "datasets/gov/ivpk/adp/Province",
         "datasets/gov/ivpk/adp/State",
     ]
     resp = app.get(
-        reverse("model-structure", args=[structure.dataset.pk, "Country"]),
+        reverse("model-structure", args=[structure.dataset.pk, version.pk, "Country"]),
         expect_errors=True,
     )
     assert resp.status_code == 403
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "Country", "id"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "Country", "id"]),
         expect_errors=True,
     )
     assert resp.status_code == 403
 
     resp = app.get(
-        reverse("model-structure", args=[structure.dataset.pk, "City"]),
+        reverse("model-structure", args=[structure.dataset.pk, version.pk, "City"]),
         expect_errors=True,
     )
     assert resp.status_code == 403
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "City", "id"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "City", "id"]),
         expect_errors=True,
     )
     assert resp.status_code == 403
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "City", "title"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "City", "title"]),
         expect_errors=True,
     )
     assert resp.status_code == 403
 
     resp = app.get(
-        reverse("model-structure", args=[structure.dataset.pk, "Province"]),
+        reverse("model-structure", args=[structure.dataset.pk, version.pk, "Province"]),
         expect_errors=True,
     )
     assert resp.status_code == 200
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "Province", "id"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "Province", "id"]),
         expect_errors=True,
     )
     assert resp.status_code == 403
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "Province", "title"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "Province", "title"]),
         expect_errors=True,
     )
     assert resp.status_code == 403
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "Province", "number"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "Province", "number"]),
         expect_errors=True,
     )
     assert resp.status_code == 200
 
     resp = app.get(
-        reverse("model-structure", args=[structure.dataset.pk, "State"]),
+        reverse("model-structure", args=[structure.dataset.pk, version.pk, "State"]),
         expect_errors=True,
     )
     assert resp.status_code == 200
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "State", "id"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "State", "id"]),
         expect_errors=True,
     )
     assert resp.status_code == 403
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "State", "title"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "State", "title"]),
         expect_errors=True,
     )
     assert resp.status_code == 403
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "State", "number"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "State", "number"]),
         expect_errors=True,
     )
     assert resp.status_code == 200
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "State", "residence"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "State", "residence"]),
         expect_errors=True,
     )
     assert resp.status_code == 200
@@ -3738,16 +4001,17 @@ def test_model_visibility_with_information_system_representative_access(app: Dja
     structure.dataset.organization = organization
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure)
+    version = create_structure_objects(structure)
 
     representative = RepresentativeFactory(
         content_type=ContentType.objects.get_for_model(structure.dataset.organization),
         object_id=structure.dataset.organization.pk,
-        role=Representative.RESOURCE_MANAGER,
+        role=Representative.MANAGER,
+        information_system_representative=True
     )
     app.set_user(representative.user)
 
-    resp = app.get(reverse("dataset-structure", args=[structure.dataset.pk]))
+    resp = app.get(reverse("dataset-structure", args=[structure.dataset.pk, version.pk]))
     assert list(resp.context["models"].values_list("metadata__name", flat=True)) == [
         "datasets/gov/ivpk/adp/City",
         "datasets/gov/ivpk/adp/Country",
@@ -3755,85 +4019,85 @@ def test_model_visibility_with_information_system_representative_access(app: Dja
         "datasets/gov/ivpk/adp/State",
     ]
     resp = app.get(
-        reverse("model-structure", args=[structure.dataset.pk, "Country"]),
+        reverse("model-structure", args=[structure.dataset.pk, version.pk, "Country"]),
         expect_errors=True,
     )
     assert resp.status_code == 200
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "Country", "id"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "Country", "id"]),
         expect_errors=True,
     )
     assert resp.status_code == 200
 
     resp = app.get(
-        reverse("model-structure", args=[structure.dataset.pk, "City"]),
+        reverse("model-structure", args=[structure.dataset.pk, version.pk, "City"]),
         expect_errors=True,
     )
     assert resp.status_code == 200
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "City", "id"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "City", "id"]),
         expect_errors=True,
     )
     assert resp.status_code == 200
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "City", "title"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "City", "title"]),
         expect_errors=True,
     )
     assert resp.status_code == 200
 
     resp = app.get(
-        reverse("model-structure", args=[structure.dataset.pk, "Province"]),
+        reverse("model-structure", args=[structure.dataset.pk, version.pk, "Province"]),
         expect_errors=True,
     )
     assert resp.status_code == 200
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "Province", "id"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "Province", "id"]),
         expect_errors=True,
     )
     assert resp.status_code == 200
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "Province", "title"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "Province", "title"]),
         expect_errors=True,
     )
     assert resp.status_code == 200
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "Province", "number"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "Province", "number"]),
         expect_errors=True,
     )
     assert resp.status_code == 200
 
     resp = app.get(
-        reverse("model-structure", args=[structure.dataset.pk, "State"]),
+        reverse("model-structure", args=[structure.dataset.pk, version.pk, "State"]),
         expect_errors=True,
     )
     assert resp.status_code == 200
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "State", "id"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "State", "id"]),
         expect_errors=True,
     )
     assert resp.status_code == 200
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "State", "title"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "State", "title"]),
         expect_errors=True,
     )
     assert resp.status_code == 200
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "State", "number"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "State", "number"]),
         expect_errors=True,
     )
     assert resp.status_code == 200
 
     resp = app.get(
-        reverse("property-structure", args=[structure.dataset.pk, "State", "residence"]),
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "State", "residence"]),
         expect_errors=True,
     )
     assert resp.status_code == 200
@@ -3845,7 +4109,7 @@ def test_model_create_with_public_visibility_without_uri_with_error(app: DjangoT
     app.set_user(user)
     dataset = DatasetFactory()
 
-    form = app.get(reverse("model-create", args=[dataset.pk])).forms["model-form"]
+    form = app.get(reverse("model-create-no-version", args=[dataset.pk])).forms["model-form"]
     form["name"] = "Test"
     form["visibility"] = Metadata.VISIBILITY_PUBLIC
     resp = form.submit()
@@ -3855,20 +4119,42 @@ def test_model_create_with_public_visibility_without_uri_with_error(app: DjangoT
 
 
 @pytest.mark.django_db
-def test_property_create__higher_visibility_with_error(app: DjangoTestApp):
+def test_property_create_with_in_released_version(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
 
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory(status=VersionStatus.PRE_RELEASE)
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
         visibility=Metadata.PRIVATE,
+        metadata_version=version,
     )
-    form = app.get(reverse("property-create", args=[dataset.pk, model.name])).forms[
+    form = app.get(reverse("property-create", args=[dataset.pk, version.pk, model.name]), expect_errors=True)
+    assert form.status_code == 404
+
+
+@pytest.mark.django_db
+def test_property_create__higher_visibility_with_error(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(model),
+        object_id=model.pk,
+        dataset=dataset,
+        name="test/dataset/TestModel",
+        visibility=Metadata.PRIVATE,
+        metadata_version=version,
+    )
+    form = app.get(reverse("property-create", args=[dataset.pk, version.pk, model.name])).forms[
         "property-form"
     ]
     form["name"] = "property"
@@ -3886,21 +4172,24 @@ def test_property_enum_item_create__higher_visibility_with_error(app: DjangoTest
     user = UserFactory(is_staff=True)
     app.set_user(user)
 
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
+        metadata_version=version
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
         name="test/dataset",
+        metadata_version=version
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
@@ -3908,9 +4197,10 @@ def test_property_enum_item_create__higher_visibility_with_error(app: DjangoTest
         name="prop",
         type="integer",
         visibility=Metadata.PRIVATE,
+        metadata_version=version
     )
     form = app.get(
-        reverse("enum-create", args=[dataset.pk, model.name, prop.name])
+        reverse("enum-create", args=[dataset.pk, version.pk, model.name, prop.name])
     ).forms["enum-form"]
     form["value"] = 2
     form["source"] = 2
@@ -3926,35 +4216,76 @@ def test_property_enum_item_create__higher_visibility_with_error(app: DjangoTest
     ]
 
 @pytest.mark.django_db
-def test_property_enum_item_create__higher_visibility_then_model_with_error(app: DjangoTestApp):
+def test_property_enum_create_with_in_released_version(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
 
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory(status=VersionStatus.PRE_RELEASE)
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        visibility=Metadata.PRIVATE
+        visibility=Metadata.PRIVATE,
+        metadata_version=version
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
         name="test/dataset",
+        metadata_version=version
     )
-    prop = PropertyFactory(model=model)
+    prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
         name="prop",
         type="integer",
+        metadata_version=version
     )
     form = app.get(
-        reverse("enum-create", args=[dataset.pk, model.name, prop.name])
+        reverse("enum-create", args=[dataset.pk, version.pk, model.name, prop.name])
+    ,expect_errors=True)
+    assert form.status_code == 404
+
+@pytest.mark.django_db
+def test_property_enum_item_create__higher_visibility_then_model_with_error(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(model),
+        object_id=model.pk,
+        dataset=dataset,
+        name="test/dataset/TestModel",
+        visibility=Metadata.PRIVATE,
+        metadata_version=version
+    )
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(dataset),
+        object_id=dataset.pk,
+        dataset=dataset,
+        name="test/dataset",
+        metadata_version=version
+    )
+    prop = PropertyFactory(model=model, metadata_version=version)
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(prop),
+        object_id=prop.pk,
+        dataset=dataset,
+        name="prop",
+        type="integer",
+        metadata_version=version
+    )
+    form = app.get(
+        reverse("enum-create", args=[dataset.pk, version.pk, model.name, prop.name])
     ).forms["enum-form"]
     form["value"] = 2
     form["source"] = 2
@@ -3999,25 +4330,25 @@ def test_manifest_export_openapi(app: DjangoTestApp):
 
     assert resp.status_code == 200
     assert resp.content_type == 'application/json'
-    
+
     openapi_spec = resp.json
-    
+
     expected_keys = ['openapi', 'info', 'externalDocs', 'servers', 'tags', 'components', 'paths']
     assert list(openapi_spec.keys()) == expected_keys, "OpenAPI spec missing required top-level fields"
-    
+
     info = openapi_spec['info']
     assert info['summary'] == structure.dataset.title, "Info summary should match dataset title"
     assert info['description'] == structure.dataset.description, "Info description should match dataset description"
     assert info['version'] == '1.0.0', "API version should be 1.0.0"
-    
+
     schemas = set(openapi_spec['components']['schemas'].keys())
     expected_schemas = {"Country", "CountryCollection", "CountryChange", "CountryChanges"}
     assert expected_schemas <= schemas, f"Missing required schemas: {expected_schemas - schemas}"
-    
+
     tag_names = {tag["name"] for tag in openapi_spec["tags"]}
     expected_tags = {"utility", "Country"}
     assert tag_names == expected_tags, f"Tags mismatch. Expected: {expected_tags}, Got: {tag_names}"
-    
+
     utility_paths = {"/version", "/health"}
     model_paths = {
         "/datasets/gov/ivpk/adp/Country",
@@ -4030,47 +4361,6 @@ def test_manifest_export_openapi(app: DjangoTestApp):
         f"Paths mismatch. Missing: {expected_paths - actual_paths}, "
         f"Extra: {actual_paths - expected_paths}"
     )
-       
-
-@pytest.mark.django_db
-def test_manifest_export_openapi_soap_params(app: DjangoTestApp):
-    """Test OpenAPI manifest export returns valid spec with correct metadata, schemas, tags, and paths."""
-    manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,rc_wsdl,,,,wsdl,,https://test-data.data.gov.lt/api/v1/rc/get-data/?wsdl,,,,,,,,,,\n'
-        ',,get_data,,,,soap,,Get.GetPort.GetPort.GetData,wsdl(rc_wsdl),,,,,,,,,\n'
-        ',,,,,,param,action_type,input/ActionType,,,,,,,,,,\n'
-        ',,,,Country,,,,,,,,,,,,,,\n'
-        ',,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
-        ',,,,,title,string,,,,5,,,private,dct:title,,,,\n'
-    )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
-    structure.dataset.current_structure = structure
-    structure.dataset.save()
-    create_structure_objects(structure)
-
-    ct = ContentType.objects.get_for_model(structure.dataset)
-    representative = RepresentativeFactory(
-        content_type=ct,
-        object_id=structure.dataset.pk,
-    )
-    app.set_user(representative.user)
-    resp = app.get(reverse('dataset-structure-export-openapi', args=[structure.dataset.pk]))
-
-    assert resp.status_code == 200
-    assert resp.content_type == 'application/json'
-    
-    openapi_spec = resp.json
-    
-    expected_keys = ['openapi', 'info', 'externalDocs', 'servers', 'tags', 'components', 'paths']
-    assert list(openapi_spec.keys()) == expected_keys, "OpenAPI spec missing required top-level fields"
-    
 
 @pytest.mark.django_db
 def test_imported_metadata_gets_develop_status(app: DjangoTestApp):
@@ -4096,26 +4386,66 @@ def test_imported_metadata_gets_develop_status(app: DjangoTestApp):
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure)
+    version = create_structure_objects(structure)
 
-    resp_models = app.get(reverse("model-structure", args=[structure.dataset.pk, "Country"]))
+    resp_models = app.get(reverse("model-structure", args=[structure.dataset.pk, version.pk, "Country"]))
     assert list(resp_models.context["models"].values_list("metadata__status__codename", flat=True)) == ["develop"]
     assert list(resp_models.context["props"].values_list("metadata__status__codename", flat=True)) == ["develop", "develop", "develop"]
 
-    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, "Country", "id"]))
+    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, version.pk, "Country", "id"]))
     assert list(resp_props.context["models"].values_list("metadata__status__codename", flat=True)) == ["develop"]
     assert resp_props.context["prop"].metadata.get().status.codename == "develop"
 
-    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, "Country", "title"]))
+    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, version.pk, "Country", "title"]))
     assert list(resp_props.context["models"].values_list("metadata__status__codename", flat=True)) == ["develop"]
     assert resp_props.context["prop"].metadata.get().status.codename == "develop"
 
-    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, "Country", "administration"]))
+    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, version.pk, "Country", "administration"]))
     assert list(resp_props.context["models"].values_list("metadata__status__codename", flat=True)) == ["develop"]
 
     prop = resp_props.context["prop"]
     for enum_item in prop.enums.first().enumitem_set.all():
         assert enum_item.metadata.first().status.codename == "develop"
+
+
+@pytest.mark.django_db
+def test_updating_metadata_in_not_draft_version_not_allowed(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+    manifest = (
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,Country,,,,,,,,,,,,,,\n"
+        ",,,,,id,integer,,,,5,discont,,open,dct:identifier,,Identifikatorius,,\n"
+        ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
+        ",,,,,administration,string,,,,5,,,open,dct:title,,,,\n"
+        ",,,,,,enum,small,,SMALL,,,,,,,,,\n"
+        ",,,,,,,,,,,,,,,,,,\n"
+    )
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(
+            file=FileField(filename="file.csv", data=manifest)
+        )
+    )
+    structure.dataset.current_structure = structure
+    structure.dataset.save()
+    version = create_structure_objects(structure)
+    version.status = VersionStatus.PRE_RELEASE
+    version.save()
+    enum_meta = Metadata.objects.filter(dataset=structure.dataset, name="small", metadata_version=version).first()
+
+    enum = enum_meta.object
+    enum_id = enum.id
+
+    model_form = app.get(reverse('model-update', args=[structure.dataset.pk, version.pk, "Country"]), expect_errors=True)
+    assert model_form.status_code == 404
+
+    property_form = app.get(reverse('property-update', args=[structure.dataset.pk, version.pk, "Country", "administration"]), expect_errors=True)
+    assert property_form.status_code == 404
+
+    enum_form = app.get(reverse('enum-update', args=[structure.dataset.pk, version.pk, "Country", "administration", enum_id]), expect_errors=True)
+    assert enum_form.status_code == 404
 
 
 @pytest.mark.django_db
@@ -4142,7 +4472,7 @@ def test_published_metadata_gets_completed_status(app: DjangoTestApp):
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure)
+    version = create_structure_objects(structure)
 
     metadata_ids = list(
         Metadata.objects.filter(
@@ -4151,25 +4481,27 @@ def test_published_metadata_gets_completed_status(app: DjangoTestApp):
         ).values_list('id', flat=True)
     )
 
-    form = app.get(reverse('version-create', args=[structure.dataset.pk])).forms['version-form']
+    form = app.get(reverse('version-create', args=[structure.dataset.pk, version.pk])).forms['version-form']
     form['released'] = datetime.date.today() + datetime.timedelta(days=15)
     form['version_type'] = "MAJOR"
     form['metadata'] = metadata_ids
     form.submit()
 
-    resp_models = app.get(reverse("model-structure", args=[structure.dataset.pk, "Country"]))
+    published_version = _Version.objects.exclude(status=VersionStatus.DRAFT).first()
+
+    resp_models = app.get(reverse("model-structure", args=[structure.dataset.pk, published_version.pk, "Country"]))
     assert list(resp_models.context["models"].values_list("metadata__status__codename", flat=True)) == ["completed"]
     assert list(resp_models.context["props"].values_list("metadata__status__codename", flat=True)) == ["completed", "completed", "completed"]
 
-    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, "Country", "id"]))
+    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, published_version.pk, "Country", "id"]))
     assert list(resp_props.context["models"].values_list("metadata__status__codename", flat=True)) == ["completed"]
     assert resp_props.context["prop"].metadata.get().status.codename == "completed"
 
-    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, "Country", "title"]))
+    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, published_version.pk, "Country", "title"]))
     assert list(resp_props.context["models"].values_list("metadata__status__codename", flat=True)) == ["completed"]
     assert resp_props.context["prop"].metadata.get().status.codename == "completed"
 
-    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, "Country", "administration"]))
+    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, published_version.pk, "Country", "administration"]))
     assert list(resp_props.context["models"].values_list("metadata__status__codename", flat=True)) == ["completed"]
 
     prop = resp_props.context["prop"]
@@ -4199,9 +4531,9 @@ def test_changed_metadata_keeps_status_after_publishing(app: DjangoTestApp):
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure)
+    version = create_structure_objects(structure)
 
-    enum_meta = Metadata.objects.filter(dataset=structure.dataset, name="small").first()
+    enum_meta = Metadata.objects.filter(dataset=structure.dataset, name="small", metadata_version=version).first()
 
     enum = enum_meta.object
     enum_id = enum.id
@@ -4210,116 +4542,46 @@ def test_changed_metadata_keeps_status_after_publishing(app: DjangoTestApp):
         Metadata.objects.filter(
             dataset=structure.dataset,
             draft=True,
+            metadata_version=version,
         ).values_list('id', flat=True)
     )
 
-    model_form = app.get(reverse('model-update', args=[structure.dataset.pk, "Country"])).forms['model-form']
+    model_form = app.get(reverse('model-update', args=[structure.dataset.pk, version.pk, "Country"])).forms['model-form']
     model_form['status'] = Status.objects.filter(codename="discont").first().id
     model_form.submit()
 
-    property_form = app.get(reverse('property-update', args=[structure.dataset.pk, "Country", "administration"])).forms['property-form']
+    property_form = app.get(reverse('property-update', args=[structure.dataset.pk, version.pk, "Country", "administration"])).forms['property-form']
     property_form['status'] = Status.objects.filter(codename="deprecated").first().id
     property_form.submit()
 
-    enum_form = app.get(reverse('enum-update', args=[structure.dataset.pk, "Country", "administration", enum_id])).forms['enum-form']
+    enum_form = app.get(reverse('enum-update', args=[structure.dataset.pk, version.pk, "Country", "administration", enum_id])).forms['enum-form']
     enum_form['status'] = Status.objects.filter(codename="withdrawn").first().id
     enum_form.submit()
 
-    form = app.get(reverse('version-create', args=[structure.dataset.pk])).forms['version-form']
+    form = app.get(reverse('version-create', args=[structure.dataset.pk, version.pk])).forms['version-form']
     form['released'] = datetime.date.today() + datetime.timedelta(days=15)
     form['version_type'] = "MAJOR"
     form['metadata'] = metadata_ids
     form.submit()
+    published_version = _Version.objects.exclude(status=VersionStatus.DRAFT).first()
 
-    resp_models = app.get(reverse("model-structure", args=[structure.dataset.pk, "Country"]))
+    resp_models = app.get(reverse("model-structure", args=[structure.dataset.pk, published_version.pk, "Country"]))
     assert list(resp_models.context["models"].values_list("metadata__status__codename", flat=True)) == ["discont"]
 
-    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, "Country", "id"]))
+    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, published_version.pk, "Country", "id"]))
     assert resp_props.context["prop"].metadata.get().status.codename == "discont"
 
-    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, "Country", "title"]))
+    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, published_version.pk, "Country", "title"]))
     assert resp_props.context["prop"].metadata.get().status.codename == "completed"
 
-    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, "Country", "administration"]))
+    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, published_version.pk, "Country", "administration"]))
     assert resp_props.context["prop"].metadata.get().status.codename == "deprecated"
 
-    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, "Country", "administration"]))
+    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, published_version.pk, "Country", "administration"]))
     prop = resp_props.context["prop"]
     for enum_item in prop.enums.first().enumitem_set.all():
         assert enum_item.metadata.first().status.codename == "withdrawn"
 
-@pytest.mark.django_db
-def test_published_metadata_defaults_to_develop_after_hard_change(app: DjangoTestApp):
-    user = UserFactory(is_staff=True)
-    app.set_user(user)
-    manifest = (
-        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
-        ",,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n"
-        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
-        ",,,,Country,,,,,,,,,,,,,,\n"
-        ",,,,,id,integer,,,,5,discont,,open,dct:identifier,,Identifikatorius,,\n"
-        ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
-        ",,,,,administration,string,,,,5,,,open,dct:title,,,,\n"
-        ",,,,,,enum,small,,SMALL,,,,,,,,,\n"
-        ",,,,,,,big,,BIG,,,,,,,,,\n"
-        ",,,,,,,,,,,,,,,,,,\n"
-    )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename="file.csv", data=manifest)
-        )
-    )
-    structure.dataset.current_structure = structure
-    structure.dataset.save()
-    create_structure_objects(structure)
-
-    metadata_ids = list(
-        Metadata.objects.filter(
-            dataset=structure.dataset,
-            draft=True,
-        ).values_list('id', flat=True)
-    )
-    publish_version_form = app.get(reverse('version-create', args=[structure.dataset.pk])).forms['version-form']
-    publish_version_form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    publish_version_form['version_type'] = "MAJOR"
-    publish_version_form['metadata'] = metadata_ids
-    publish_version_form.submit()
-
-    enum_meta = Metadata.objects.filter(dataset=structure.dataset, name="small").first()
-
-    enum = enum_meta.object
-    enum_id = enum.id
-    new_enum_name = "Largety"
-
-    model_form = app.get(reverse('model-update', args=[structure.dataset.pk, "Country"])).forms['model-form']
-    model_form['level'] = 3
-    model_form.submit()
-
-    property_form = app.get(reverse('property-update', args=[structure.dataset.pk, "Country", "administration"])).forms['property-form']
-    property_form['access'] = 2
-    property_form.submit()
-
-    enum_form = app.get(reverse('enum-update', args=[structure.dataset.pk, "Country", "administration", enum_id])).forms['enum-form']
-    enum_form['value'] = new_enum_name
-    enum_form.submit()
-
-    resp_models = app.get(reverse("model-structure", args=[structure.dataset.pk, "Country"]))
-    assert list(resp_models.context["models"].values_list("metadata__status__codename", flat=True)) == ["develop"]
-
-    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, "Country", "title"]))
-    assert resp_props.context["prop"].metadata.get().status.codename == "completed"
-
-    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, "Country", "administration"]))
-    assert resp_props.context["prop"].metadata.get().status.codename == "develop"
-
-    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, "Country", "administration"]))
-    prop = resp_props.context["prop"]
-    for enum_item in prop.enums.first().enumitem_set.all():
-        enum_metadata = enum_item.metadata.first()
-        if enum_metadata.name == new_enum_name:
-            assert enum_metadata.status.codename == "completed"
-        else:
-            assert enum_metadata.status.codename == "develop"
 
 @pytest.mark.django_db
 def test_draft_metadata_defaults_to_develop_after_hard_change(app: DjangoTestApp):
@@ -4344,33 +4606,33 @@ def test_draft_metadata_defaults_to_develop_after_hard_change(app: DjangoTestApp
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure)
+    version = create_structure_objects(structure)
 
-    enum_meta = Metadata.objects.filter(dataset=structure.dataset, name="small").first()
+    enum_meta = Metadata.objects.filter(dataset=structure.dataset, metadata_version=version, name="small").first()
 
     enum = enum_meta.object
     enum_id = enum.id
     new_enum_name = "Largety"
 
-    model_form = app.get(reverse('model-update', args=[structure.dataset.pk, "Country"])).forms['model-form']
+    model_form = app.get(reverse('model-update', args=[structure.dataset.pk, version.pk, "Country"])).forms['model-form']
     model_form['level'] = 3
     model_form.submit()
 
-    property_form = app.get(reverse('property-update', args=[structure.dataset.pk, "Country", "administration"])).forms['property-form']
+    property_form = app.get(reverse('property-update', args=[structure.dataset.pk, version.pk, "Country", "administration"])).forms['property-form']
     property_form['access'] = 2
     property_form.submit()
 
-    enum_form = app.get(reverse('enum-update', args=[structure.dataset.pk, "Country", "administration", enum_id])).forms['enum-form']
+    enum_form = app.get(reverse('enum-update', args=[structure.dataset.pk, version.pk, "Country", "administration", enum_id])).forms['enum-form']
     enum_form['value'] = new_enum_name
     enum_form.submit()
 
-    resp_models = app.get(reverse("model-structure", args=[structure.dataset.pk, "Country"]))
+    resp_models = app.get(reverse("model-structure", args=[structure.dataset.pk, version.pk, "Country"]))
     assert list(resp_models.context["models"].values_list("metadata__status__codename", flat=True)) == ["develop"]
 
-    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, "Country", "administration"]))
+    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, version.pk, "Country", "administration"]))
     assert resp_props.context["prop"].metadata.get().status.codename == "develop"
 
-    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, "Country", "administration"]))
+    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, version.pk, "Country", "administration"]))
     prop = resp_props.context["prop"]
     for enum_item in prop.enums.first().enumitem_set.all():
         enum_metadata = enum_item.metadata.first()
@@ -4399,36 +4661,36 @@ def test_changing_multiple_fields_in_draft_structure_respects_status(app: Django
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure)
+    version = create_structure_objects(structure)
 
-    enum_meta = Metadata.objects.filter(dataset=structure.dataset, name="small").first()
+    enum_meta = Metadata.objects.filter(dataset=structure.dataset, metadata_version=version, name="small").first()
 
     enum = enum_meta.object
     enum_id = enum.id
     new_enum_name = "Largety"
 
-    model_form = app.get(reverse('model-update', args=[structure.dataset.pk, "Country"])).forms['model-form']
+    model_form = app.get(reverse('model-update', args=[structure.dataset.pk, version.pk, "Country"])).forms['model-form']
     model_form['level'] = 2
     model_form["status"] = 5
     model_form.submit()
 
-    property_form = app.get(reverse('property-update', args=[structure.dataset.pk, "Country", "administration"])).forms['property-form']
+    property_form = app.get(reverse('property-update', args=[structure.dataset.pk, version.pk, "Country", "administration"])).forms['property-form']
     property_form['access'] = 2
     property_form["status"] = 5
     property_form.submit()
 
-    enum_form = app.get(reverse('enum-update', args=[structure.dataset.pk, "Country", "administration", enum_id])).forms['enum-form']
+    enum_form = app.get(reverse('enum-update', args=[structure.dataset.pk, version.pk, "Country", "administration", enum_id])).forms['enum-form']
     enum_form['value'] = new_enum_name
     enum_form["status"] = 5
     enum_form.submit()
 
-    resp_models = app.get(reverse("model-structure", args=[structure.dataset.pk, "Country"]))
+    resp_models = app.get(reverse("model-structure", args=[structure.dataset.pk, version.pk, "Country"]))
     assert list(resp_models.context["models"].values_list("metadata__status__codename", flat=True)) == ["deprecated"]
 
-    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, "Country", "administration"]))
+    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, version.pk, "Country", "administration"]))
     assert resp_props.context["prop"].metadata.get().status.codename == "deprecated"
 
-    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, "Country", "administration"]))
+    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, version.pk, "Country", "administration"]))
     prop = resp_props.context["prop"]
     for enum_item in prop.enums.first().enumitem_set.all():
         enum_metadata = enum_item.metadata.first()
@@ -4437,78 +4699,6 @@ def test_changing_multiple_fields_in_draft_structure_respects_status(app: Django
         else:
             assert enum_metadata.status.codename == "deprecated"
 
-@pytest.mark.django_db
-def test_changing_multiple_fields_in_published_structure_respects_status(app: DjangoTestApp):
-    user = UserFactory(is_staff=True)
-    app.set_user(user)
-    manifest = (
-        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
-        ",,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n"
-        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
-        ",,,,Country,,,,,,,,,,,,,,\n"
-        ",,,,,id,integer,,,,5,discont,,open,dct:identifier,,Identifikatorius,,\n"
-        ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
-        ",,,,,administration,string,,,,5,,,open,dct:title,,,,\n"
-        ",,,,,,enum,small,,SMALL,,,,,,,,,\n"
-        ",,,,,,,big,,BIG,,,,,,,,,\n"
-        ",,,,,,,,,,,,,,,,,,\n"
-    )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename="file.csv", data=manifest)
-        )
-    )
-    structure.dataset.current_structure = structure
-    structure.dataset.save()
-    create_structure_objects(structure)
-
-    metadata_ids = list(
-        Metadata.objects.filter(
-            dataset=structure.dataset,
-            draft=True,
-        ).values_list('id', flat=True)
-    )
-    publish_version_form = app.get(reverse('version-create', args=[structure.dataset.pk])).forms['version-form']
-    publish_version_form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    publish_version_form['version_type'] = "MAJOR"
-    publish_version_form['metadata'] = metadata_ids
-    publish_version_form.submit()
-
-    enum_meta = Metadata.objects.filter(dataset=structure.dataset, name="small").first()
-
-    enum = enum_meta.object
-    enum_id = enum.id
-    new_enum_name = "Largety"
-
-    model_form = app.get(reverse('model-update', args=[structure.dataset.pk, "Country"])).forms['model-form']
-    model_form['level'] = 2
-    model_form["status"] = 5
-    model_form.submit()
-
-    property_form = app.get(reverse('property-update', args=[structure.dataset.pk, "Country", "administration"])).forms['property-form']
-    property_form['access'] = 2
-    property_form["status"] = 5
-    property_form.submit()
-
-    enum_form = app.get(reverse('enum-update', args=[structure.dataset.pk, "Country", "administration", enum_id])).forms['enum-form']
-    enum_form['value'] = new_enum_name
-    enum_form["status"] = 5
-    enum_form.submit()
-
-    resp_models = app.get(reverse("model-structure", args=[structure.dataset.pk, "Country"]))
-    assert list(resp_models.context["models"].values_list("metadata__status__codename", flat=True)) == ["deprecated"]
-
-    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, "Country", "administration"]))
-    assert resp_props.context["prop"].metadata.get().status.codename == "deprecated"
-
-    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, "Country", "administration"]))
-    prop = resp_props.context["prop"]
-    for enum_item in prop.enums.first().enumitem_set.all():
-        enum_metadata = enum_item.metadata.first()
-        if enum_metadata.name == new_enum_name:
-            assert enum_metadata.status.codename == "completed"
-        else:
-            assert enum_metadata.status.codename == "deprecated"
 
 @pytest.mark.django_db
 def test_draft_metadata_form_does_not_change_status_is_kept(app: DjangoTestApp):
@@ -4533,118 +4723,58 @@ def test_draft_metadata_form_does_not_change_status_is_kept(app: DjangoTestApp):
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure)
+    version = create_structure_objects(structure)
 
-    enum_meta = Metadata.objects.filter(dataset=structure.dataset, name="small").first()
+    enum_meta = Metadata.objects.filter(dataset=structure.dataset, metadata_version=version, name="small").first()
 
     enum = enum_meta.object
     enum_id = enum.id
 
-    model_form = app.get(reverse('model-update', args=[structure.dataset.pk, "Country"])).forms['model-form']
+    model_form = app.get(reverse('model-update', args=[structure.dataset.pk, version.pk, "Country"])).forms['model-form']
     model_form.submit()
 
-    property_form = app.get(reverse('property-update', args=[structure.dataset.pk, "Country", "administration"])).forms['property-form']
+    property_form = app.get(reverse('property-update', args=[structure.dataset.pk, version.pk, "Country", "administration"])).forms['property-form']
     property_form.submit()
 
-    enum_form = app.get(reverse('enum-update', args=[structure.dataset.pk, "Country", "administration", enum_id])).forms['enum-form']
+    enum_form = app.get(reverse('enum-update', args=[structure.dataset.pk, version.pk, "Country", "administration", enum_id])).forms['enum-form']
     enum_form.submit()
 
-    resp_models = app.get(reverse("model-structure", args=[structure.dataset.pk, "Country"]))
+    resp_models = app.get(reverse("model-structure", args=[structure.dataset.pk, version.pk, "Country"]))
     assert list(resp_models.context["models"].values_list("metadata__status__codename", flat=True)) == ["develop"]
 
-    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, "Country", "administration"]))
+    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, version.pk, "Country", "administration"]))
     assert resp_props.context["prop"].metadata.get().status.codename == "develop"
 
-    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, "Country", "administration"]))
+    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, version.pk, "Country", "administration"]))
     prop = resp_props.context["prop"]
     for enum_item in prop.enums.first().enumitem_set.all():
         enum_metadata = enum_item.metadata.first()
         assert enum_metadata.status.codename == "develop"
 
-@pytest.mark.django_db
-def test_published_metadata_form_does_not_change_status_is_kept(app: DjangoTestApp):
-    user = UserFactory(is_staff=True)
-    app.set_user(user)
-    manifest = (
-        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
-        ",,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n"
-        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
-        ",,,,Country,,,,,,,,,,,,,,\n"
-        ",,,,,id,integer,,,,5,discont,,open,dct:identifier,,Identifikatorius,,\n"
-        ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
-        ",,,,,administration,string,,,,5,,,open,dct:title,,,,\n"
-        ",,,,,,enum,small,,SMALL,,,,,,,,,\n"
-        ",,,,,,,big,,BIG,,,,,,,,,\n"
-        ",,,,,,,,,,,,,,,,,,\n"
-    )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename="file.csv", data=manifest)
-        )
-    )
-    structure.dataset.current_structure = structure
-    structure.dataset.save()
-    create_structure_objects(structure)
-
-    metadata_ids = list(
-        Metadata.objects.filter(
-            dataset=structure.dataset,
-            draft=True,
-        ).values_list('id', flat=True)
-    )
-    publish_version_form = app.get(reverse('version-create', args=[structure.dataset.pk])).forms['version-form']
-    publish_version_form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    publish_version_form['version_type'] = "MAJOR"
-    publish_version_form['metadata'] = metadata_ids
-    publish_version_form.submit()
-
-    enum_meta = Metadata.objects.filter(dataset=structure.dataset, name="small").first()
-
-    enum = enum_meta.object
-    enum_id = enum.id
-
-    model_form = app.get(reverse('model-update', args=[structure.dataset.pk, "Country"])).forms['model-form']
-    model_form.submit()
-
-    property_form = app.get(reverse('property-update', args=[structure.dataset.pk, "Country", "administration"])).forms['property-form']
-    property_form.submit()
-
-    enum_form = app.get(reverse('enum-update', args=[structure.dataset.pk, "Country", "administration", enum_id])).forms['enum-form']
-    enum_form.submit()
-
-    resp_models = app.get(reverse("model-structure", args=[structure.dataset.pk, "Country"]))
-    assert list(resp_models.context["models"].values_list("metadata__status__codename", flat=True)) == ["completed"]
-
-    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, "Country", "administration"]))
-    assert resp_props.context["prop"].metadata.get().status.codename == "completed"
-
-    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, "Country", "administration"]))
-    prop = resp_props.context["prop"]
-    #TODO the status of enum should also be completed but because of a bug the name of the enum is changed even though nothing is submited. Change after bug fix
-    for enum_item in prop.enums.first().enumitem_set.all():
-        enum_metadata = enum_item.metadata.first()
-        assert enum_metadata.status.codename == "develop"
 
 @pytest.mark.django_db
 def test_props_metadata_rendering(app: DjangoTestApp) -> None:
-    model = ModelFactory()
-    dataset = model.dataset
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
 
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
+        metadata_version=version
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
         name="test/dataset",
+        metadata_version=version
     )
 
-    prop_1 = PropertyFactory(model=model)
-    prop_2 = PropertyFactory(model=model)
+    prop_1 = PropertyFactory(model=model, metadata_version=version)
+    prop_2 = PropertyFactory(model=model, metadata_version=version)
 
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop_1),
@@ -4653,6 +4783,7 @@ def test_props_metadata_rendering(app: DjangoTestApp) -> None:
         name="prop_1",
         type="string",
         eli="https://example.com/prop_1",
+        metadata_version=version
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop_2),
@@ -4661,121 +4792,173 @@ def test_props_metadata_rendering(app: DjangoTestApp) -> None:
         name="prop_2",
         type="integer",
         eli="https://example.com/prop_2",
+        metadata_version=version
     )
 
-    response = app.get(reverse("model-structure", kwargs={"pk": dataset.pk, "model": model.name}))
+    response = app.get(reverse("model-structure", kwargs={"pk": dataset.pk, "version_id": version.pk, "model": model.name}))
 
     assert response.status_code == 200
     assert 'href="https://example.com/prop_1"' in response.content.decode()
     assert 'href="https://example.com/prop_2"' in response.content.decode()
 
+
 @pytest.mark.django_db
 def test_only_major_version_allowed_when_new_metadata(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
-    dataset = DatasetFactory()
+    version = VersionFactory()
+    dataset = version.dataset
 
-    form = app.get(reverse("version-create", args=[dataset.pk])).forms["version-form"]
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
 
     assert form["version_type"].options[0][0] == "MAJOR"
+
 
 @pytest.mark.django_db
 def test_minor_version_available_if_major_exists(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
-    dataset = DatasetFactory()
+    version = VersionFactory()
+    dataset = version.dataset
+    dataset_metadata = MetadataFactory(
+        dataset=version.dataset,
+        metadata_version=version,
+        content_type=ContentType.objects.get_for_model(Dataset),
+        object_id=version.dataset.pk
+    )
 
-    form = app.get(reverse("version-create", args=[dataset.pk])).forms["version-form"]
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
     form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["metadata"] = [dataset_metadata.pk]
     form["version_type"] = "MAJOR"
     form.submit()
 
-    second_version_form = app.get(reverse("version-create", args=[dataset.pk])).forms["version-form"]
+    second_version_form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
 
     assert [opt[0] for opt in second_version_form["version_type"].options] == ["MAJOR", "MINOR", "PATCH"]
+
 
 @pytest.mark.django_db
 def test_patch_version_available_if_minor_exists(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
-    dataset = DatasetFactory()
-
-    major_version_form = app.get(reverse("version-create", args=[dataset.pk])).forms["version-form"]
+    version = VersionFactory()
+    dataset = version.dataset
+    dataset_metadata = MetadataFactory(
+        dataset=version.dataset,
+        metadata_version=version,
+        content_type=ContentType.objects.get_for_model(Dataset),
+        object_id=version.dataset.pk
+    )
+    major_version_form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
     major_version_form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    major_version_form["metadata"] = [dataset_metadata.pk]
     major_version_form["version_type"] = "MAJOR"
     major_version_form.submit()
 
     major_version = _Version.objects.get(dataset=dataset, version_type=VersionType.MAJOR)
 
-    minor_version_form = app.get(reverse("version-create", args=[dataset.pk])).forms["version-form"]
+    minor_version_form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
     minor_version_form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    minor_version_form["metadata"] = [dataset_metadata.pk]
     minor_version_form["version_type"] = "MINOR"
     minor_version_form["related_version"] = major_version.pk
     minor_version_form.submit()
 
-    patch_version_form = app.get(reverse("version-create", args=[dataset.pk])).forms["version-form"]
+    patch_version_form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
 
     assert [opt[0] for opt in patch_version_form["version_type"].options] == ["MAJOR", "MINOR", "PATCH"]
+
 
 @pytest.mark.django_db
 def test_form_errors_if_major_not_selected(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
-    dataset = DatasetFactory()
+    version = VersionFactory()
+    dataset = version.dataset
+    dataset_metadata = MetadataFactory(
+        dataset=version.dataset,
+        metadata_version=version,
+        content_type=ContentType.objects.get_for_model(Dataset),
+        object_id=version.dataset.pk
+    )
 
-    major_version_form = app.get(reverse("version-create", args=[dataset.pk])).forms["version-form"]
+    major_version_form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
     major_version_form["released"] = datetime.date.today() + datetime.timedelta(days=15)
     major_version_form["version_type"] = "MAJOR"
+    major_version_form["metadata"] = [dataset_metadata.pk]
     major_version_form.submit()
 
-    minor_version_form = app.get(reverse("version-create", args=[dataset.pk])).forms["version-form"]
+    minor_version_form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
     minor_version_form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    minor_version_form["metadata"] = [dataset_metadata.pk]
     minor_version_form["version_type"] = "MINOR"
 
     res = minor_version_form.submit(expect_errors=True)
 
     assert "Tėvinė versija turi būti pasirinkta" in res.text
 
+
 @pytest.mark.django_db
 def test_form_errors_if_minor_not_selected(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
-    dataset = DatasetFactory()
+    version = VersionFactory()
+    dataset = version.dataset
+    dataset_metadata = MetadataFactory(
+        dataset=version.dataset,
+        metadata_version=version,
+        content_type=ContentType.objects.get_for_model(Dataset),
+        object_id=version.dataset.pk
+    )
 
-    major_version_form = app.get(reverse("version-create", args=[dataset.pk])).forms["version-form"]
+    major_version_form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
     major_version_form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    major_version_form["metadata"] = [dataset_metadata.pk]
     major_version_form["version_type"] = "MAJOR"
     major_version_form.submit()
 
     major_version = _Version.objects.get(dataset=dataset, version_type=VersionType.MAJOR)
 
-    minor_version_form = app.get(reverse("version-create", args=[dataset.pk])).forms["version-form"]
+    minor_version_form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
     minor_version_form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    minor_version_form["metadata"] = [dataset_metadata.pk]
     minor_version_form["version_type"] = "MINOR"
     minor_version_form["related_version"] = major_version.pk
     minor_version_form.submit()
 
-    patch_version_form = app.get(reverse("version-create", args=[dataset.pk])).forms["version-form"]
+    patch_version_form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
     patch_version_form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    patch_version_form["metadata"] = [dataset_metadata.pk]
     patch_version_form["version_type"] = "PATCH"
 
     res = patch_version_form.submit(expect_errors=True)
 
     assert "Tėvinė versija turi būti pasirinkta" in res.text
 
+
 @pytest.mark.django_db
 def test_multiple_major_versions_increment_external_version(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
-    dataset = DatasetFactory()
+    version = VersionFactory()
+    dataset = version.dataset
+    dataset_metadata = MetadataFactory(
+        dataset=version.dataset,
+        metadata_version=version,
+        content_type=ContentType.objects.get_for_model(Dataset),
+        object_id=version.dataset.pk
+    )
 
-    major_version_form = app.get(reverse("version-create", args=[dataset.pk])).forms["version-form"]
+    major_version_form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
     major_version_form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    major_version_form["metadata"] = [dataset_metadata.pk]
     major_version_form["version_type"] = "MAJOR"
     major_version_form.submit()
 
-    major_version_form = app.get(reverse("version-create", args=[dataset.pk])).forms["version-form"]
+    major_version_form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
     major_version_form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    major_version_form["metadata"] = [dataset_metadata.pk]
     major_version_form["version_type"] = "MAJOR"
     major_version_form.submit()
 
@@ -4784,29 +4967,40 @@ def test_multiple_major_versions_increment_external_version(app: DjangoTestApp):
     assert major_versions[0].external_version == "1.0.0"
     assert major_versions[1].external_version == "2.0.0"
 
+
 @pytest.mark.django_db
 def test_multiple_minor_versions_increment_external_version(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
-    dataset = DatasetFactory()
+    version = VersionFactory()
+    dataset = version.dataset
+    dataset_metadata = MetadataFactory(
+        dataset=version.dataset,
+        metadata_version=version,
+        content_type=ContentType.objects.get_for_model(Dataset),
+        object_id=version.dataset.pk
+    )
 
-    major_version_form = app.get(reverse("version-create", args=[dataset.pk])).forms["version-form"]
+    major_version_form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
     major_version_form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    major_version_form["metadata"] = [dataset_metadata.pk]
     major_version_form["version_type"] = "MAJOR"
     major_version_form.submit()
 
     major_version = _Version.objects.get(dataset=dataset, version_type=VersionType.MAJOR)
 
-    minor_version_form = app.get(reverse("version-create", args=[dataset.pk])).forms["version-form"]
+    minor_version_form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
     minor_version_form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    minor_version_form["metadata"] = [dataset_metadata.pk]
     minor_version_form["version_type"] = "MINOR"
     minor_version_form["related_version"] = major_version.pk
     minor_version_form.submit()
 
     latest_version = _Version.objects.last()
 
-    minor_version_form = app.get(reverse("version-create", args=[dataset.pk])).forms["version-form"]
+    minor_version_form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
     minor_version_form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    minor_version_form["metadata"] = [dataset_metadata.pk]
     minor_version_form["version_type"] = "MINOR"
     minor_version_form["related_version"] = latest_version.pk
     minor_version_form.submit()
@@ -4816,37 +5010,49 @@ def test_multiple_minor_versions_increment_external_version(app: DjangoTestApp):
     assert minor_versions[0].external_version == "1.1.0"
     assert minor_versions[1].external_version == "1.2.0"
 
+
 @pytest.mark.django_db
 def test_multiple_patch_versions_increment_external_version(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
-    dataset = DatasetFactory()
+    version = VersionFactory()
+    dataset = version.dataset
+    dataset_metadata = MetadataFactory(
+        dataset=version.dataset,
+        metadata_version=version,
+        content_type=ContentType.objects.get_for_model(Dataset),
+        object_id=version.dataset.pk
+    )
 
-    major_version_form = app.get(reverse("version-create", args=[dataset.pk])).forms["version-form"]
+    major_version_form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
     major_version_form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    major_version_form["metadata"] = [dataset_metadata.pk]
     major_version_form["version_type"] = "MAJOR"
     major_version_form.submit()
 
     major_version = _Version.objects.get(dataset=dataset, version_type=VersionType.MAJOR)
 
-    minor_version_form = app.get(reverse("version-create", args=[dataset.pk])).forms["version-form"]
+    minor_version_form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
     minor_version_form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    minor_version_form["metadata"] = [dataset_metadata.pk]
     minor_version_form["version_type"] = "MINOR"
     minor_version_form["related_version"] = major_version.pk
     minor_version_form.submit()
 
     minor_version = _Version.objects.get(dataset=dataset, version_type=VersionType.MINOR)
 
-    patch_version_form = app.get(reverse("version-create", args=[dataset.pk])).forms["version-form"]
+    patch_version_form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
     patch_version_form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    patch_version_form["metadata"] = [dataset_metadata.pk]
     patch_version_form["related_version"] = minor_version.pk
     patch_version_form["version_type"] = "PATCH"
     patch_version_form.submit()
 
     latest_version = _Version.objects.last()
 
-    patch_version_form = app.get(reverse("version-create", args=[dataset.pk])).forms["version-form"]
+    patch_version_form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
     patch_version_form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    patch_version_form["metadata"] = [dataset_metadata.pk]
     patch_version_form["related_version"] = latest_version.pk
     patch_version_form["version_type"] = "PATCH"
     patch_version_form.submit()
@@ -4855,6 +5061,7 @@ def test_multiple_patch_versions_increment_external_version(app: DjangoTestApp):
 
     assert patch_versions[0].external_version == "1.1.1"
     assert patch_versions[1].external_version == "1.1.2"
+
 
 def test_publish_form_shows_all_metadata_rows_params(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
@@ -4879,10 +5086,11 @@ def test_publish_form_shows_all_metadata_rows_params(app: DjangoTestApp):
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure)
+    version = create_structure_objects(structure)
 
-    form = app.get(reverse("version-create", args=[structure.dataset.pk])).forms["version-form"]
+    form = app.get(reverse("version-create", args=[structure.dataset.pk, version.pk])).forms["version-form"]
     assert len(form.fields["metadata"]) == 11 # 10 fields from DSA + 1 for dataset_distribution
+
 
 def test_publish_form_shows_all_metadata_rows_base(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
@@ -4907,10 +5115,11 @@ def test_publish_form_shows_all_metadata_rows_base(app: DjangoTestApp):
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure)
+    version = create_structure_objects(structure)
 
-    form = app.get(reverse("version-create", args=[structure.dataset.pk])).forms["version-form"]
+    form = app.get(reverse("version-create", args=[structure.dataset.pk, version.pk])).forms["version-form"]
     assert len(form.fields["metadata"]) == 10 # 9 fields from DSA, because Base as City Base is not displayed + 1 for dataset_distribution
+
 
 def test_publish_form_shows_all_metadata_rows_enum(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
@@ -4936,10 +5145,11 @@ def test_publish_form_shows_all_metadata_rows_enum(app: DjangoTestApp):
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure)
+    version = create_structure_objects(structure)
 
-    form = app.get(reverse("version-create", args=[structure.dataset.pk])).forms["version-form"]
+    form = app.get(reverse("version-create", args=[structure.dataset.pk, version.pk])).forms["version-form"]
     assert len(form.fields["metadata"]) == 12 # 11 DSA rows + 1 dataset_distribution
+
 
 def test_publish_form_shows_all_metadata_rows_single_defined_resource(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
@@ -4964,10 +5174,11 @@ def test_publish_form_shows_all_metadata_rows_single_defined_resource(app: Djang
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure)
+    version = create_structure_objects(structure)
 
-    form = app.get(reverse("version-create", args=[structure.dataset.pk])).forms["version-form"]
+    form = app.get(reverse("version-create", args=[structure.dataset.pk, version.pk])).forms["version-form"]
     assert len(form.fields["metadata"]) == 9
+
 
 def test_publish_form_shows_all_metadata_rows_multiple_resources(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
@@ -4993,15 +5204,16 @@ def test_publish_form_shows_all_metadata_rows_multiple_resources(app: DjangoTest
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure)
+    version = create_structure_objects(structure)
 
     dataset_distributions = DatasetDistribution.objects.filter(dataset=structure.dataset)
 
-    form = app.get(reverse("version-create", args=[structure.dataset.pk])).forms["version-form"]
+    form = app.get(reverse("version-create", args=[structure.dataset.pk, version.pk])).forms["version-form"]
     assert len(form.fields["metadata"]) == 10
     assert len(dataset_distributions) == 2
     assert dataset_distributions.first().metadata.first().name == "resource1"
     assert dataset_distributions.last().metadata.first().name == "resource"
+
 
 def test_publish_form_shows_all_metadata_rows_denorm_props(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
@@ -5028,7 +5240,1123 @@ def test_publish_form_shows_all_metadata_rows_denorm_props(app: DjangoTestApp):
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure)
+    version = create_structure_objects(structure)
 
-    form = app.get(reverse("version-create", args=[structure.dataset.pk])).forms["version-form"]
+    form = app.get(reverse("version-create", args=[structure.dataset.pk, version.pk])).forms["version-form"]
     assert len(form.fields["metadata"]) == 12 # Denorm props create an additional property country.continent
+
+
+def test_publishing_dataset_duplicates_metadata_but_not_dataset(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+    version = VersionFactory()
+    dataset = version.dataset
+    dataset_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(dataset),
+        object_id=dataset.pk,
+        dataset=dataset,
+        name="test/dataset",
+        metadata_version=version
+    )
+
+    assert Metadata.objects.count() == 1
+    assert Dataset.objects.count() - 1 == 1
+    assert _Version.objects.count() == 1
+
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
+    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
+    form['version_type'] = "MAJOR"
+    form['metadata'] = dataset_meta.pk
+    form.submit()
+
+    assert Metadata.objects.count() == 2
+    assert Dataset.objects.count() - 1 == 1
+    assert _Version.objects.count() == 2
+
+
+def test_if_dataset_not_published_error(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+    version = VersionFactory()
+    dataset = version.dataset
+    model = ModelFactory(dataset=dataset, metadata_version=version)
+    model_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(Model),
+        object_id=model.pk,
+        dataset=dataset,
+        name="test/dataset",
+        metadata_version=version
+    )
+    assert Metadata.objects.count() == 1
+    assert Dataset.objects.count() - 1 == 1
+    assert _Version.objects.count() == 1
+
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
+    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
+    form['version_type'] = "MAJOR"
+    form['metadata'] = [model_meta]
+    response = form.submit()
+
+    assert response.status_code == 200
+    assert response.context['form'].errors
+    assert "Privalote publikuoti duomenų rinkinį." in response.context['form'].errors['__all__'][0]
+
+
+def test_publishing_model_duplicates_metadata_and_model(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
+    model_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(model),
+        object_id=model.pk,
+        dataset=dataset,
+        name="test/dataset/TestModel",
+        metadata_version=version
+    )
+    dataset_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(dataset),
+        object_id=dataset.pk,
+        dataset=dataset,
+        name="test/dataset",
+        metadata_version=version
+    )
+
+    assert Metadata.objects.count() == 2
+    assert Model.objects.count() == 1
+    assert _Version.objects.count() == 1
+
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
+    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
+    form['version_type'] = "MAJOR"
+    form['metadata'] = [dataset_meta.pk, model_meta.pk]
+    form.submit()
+
+    assert Metadata.objects.count() == 4
+    assert Model.objects.count() == 2
+    assert _Version.objects.count() == 2
+
+
+def test_publishing_model_duplicates_metadata_and_dataset_distribution(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+    version = VersionFactory()
+    distribution = DatasetDistributionFactory(is_parameterized=True, metadata_version=version)
+    model = ModelFactory(dataset=version.dataset, metadata_version=version, distribution=distribution)
+    dataset = version.dataset
+    model_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(model),
+        object_id=model.pk,
+        dataset=dataset,
+        name="test/dataset/TestModel",
+        metadata_version=version
+    )
+    distribution_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(distribution),
+        object_id=distribution.pk,
+        dataset=dataset,
+        name="test/dataset/TestDistribution",
+        metadata_version=version
+    )
+    dataset_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(dataset),
+        object_id=dataset.pk,
+        dataset=dataset,
+        name="test/dataset",
+        metadata_version=version
+    )
+
+    assert Metadata.objects.count() == 3
+    assert Model.objects.count() == 1
+    assert DatasetDistribution.objects.count() == 1
+    assert _Version.objects.count() == 1
+
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
+    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
+    form['version_type'] = "MAJOR"
+    form['metadata'] = [dataset_meta.pk, distribution_meta.pk, model_meta.pk]
+    response = form.submit()
+
+    assert Metadata.objects.count() == 6
+    assert Model.objects.count() == 2
+    assert DatasetDistribution.objects.count() == 2
+    assert _Version.objects.count() == 2
+
+
+def test_publishing_model_without_resource_error(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+    version = VersionFactory()
+    distribution = DatasetDistributionFactory(is_parameterized=True, metadata_version=version)
+    model = ModelFactory(dataset=version.dataset, metadata_version=version, distribution=distribution)
+    dataset = version.dataset
+    model_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(model),
+        object_id=model.pk,
+        dataset=dataset,
+        name="test/dataset/TestModel",
+        metadata_version=version
+    )
+    distribution_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(distribution),
+        object_id=distribution.pk,
+        dataset=dataset,
+        name="test/dataset/TestDistribution",
+        metadata_version=version
+    )
+    dataset_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(dataset),
+        object_id=dataset.pk,
+        dataset=dataset,
+        name="test/dataset",
+        metadata_version=version
+    )
+
+    assert Metadata.objects.count() == 3
+    assert Model.objects.count() == 1
+    assert DatasetDistribution.objects.count() == 1
+    assert _Version.objects.count() == 1
+
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
+    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
+    form['version_type'] = "MAJOR"
+    form['metadata'] = [dataset_meta.pk, model_meta.pk]
+    response = form.submit()
+
+    assert response.status_code == 200
+    assert response.context['form'].errors
+    assert "laukas TestModel turi nuorodą į jį" in response.context['form'].errors['__all__'][0]
+
+    assert Metadata.objects.count() == 3
+    assert Model.objects.count() == 1
+    assert DatasetDistribution.objects.count() == 1
+    assert _Version.objects.count() == 1
+
+
+def test_publishing_property_duplicates_metadata_and_property(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
+    model_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(model),
+        object_id=model.pk,
+        dataset=dataset,
+        name="test/dataset/TestModel",
+        metadata_version=version
+    )
+    prop = PropertyFactory(model=model, metadata_version=version)
+    prop_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(prop),
+        object_id=prop.pk,
+        dataset=dataset,
+        name='prop',
+        type='string',
+        metadata_version=version
+    )
+    dataset_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(dataset),
+        object_id=dataset.pk,
+        dataset=dataset,
+        name="test/dataset",
+        metadata_version=version
+    )
+
+    assert Metadata.objects.count() == 3
+    assert Property.objects.count() == 1
+    assert _Version.objects.count() == 1
+
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
+    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
+    form['version_type'] = "MAJOR"
+    form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
+    form.submit()
+
+    assert Metadata.objects.count() == 6
+    assert Property.objects.count() == 2
+    assert _Version.objects.count() == 2
+
+
+def test_publishing_property_without_model_error(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
+    model_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(model),
+        object_id=model.pk,
+        dataset=dataset,
+        name="test/dataset/TestModel",
+        metadata_version=version
+    )
+    prop = PropertyFactory(model=model, metadata_version=version)
+    prop_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(prop),
+        object_id=prop.pk,
+        dataset=dataset,
+        name='prop',
+        type='string',
+        metadata_version=version
+    )
+    dataset_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(dataset),
+        object_id=dataset.pk,
+        dataset=dataset,
+        name="test/dataset",
+        metadata_version=version
+    )
+
+    assert Metadata.objects.count() == 3
+    assert Property.objects.count() == 1
+    assert _Version.objects.count() == 1
+
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
+    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
+    form['version_type'] = "MAJOR"
+    form['metadata'] = [dataset_meta.pk, prop_meta.pk]
+    response = form.submit()
+
+    assert response.status_code == 200
+    assert response.context['form'].errors
+    assert "laukas prop turi nuorodą į jį" in response.context['form'].errors['__all__'][0]
+
+    assert Metadata.objects.count() == 3
+    assert Property.objects.count() == 1
+    assert _Version.objects.count() == 1
+
+
+def test_publishing_enum_duplicates_enum_item_and_enum(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
+    model_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(model),
+        object_id=model.pk,
+        dataset=dataset,
+        name="test/dataset/TestModel",
+        metadata_version=version,
+    )
+    prop = PropertyFactory(model=model, metadata_version=version,)
+    prop_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(prop),
+        object_id=prop.pk,
+        dataset=dataset,
+        name='prop',
+        type='string',
+        access=3,
+        metadata_version=version,
+    )
+    enum = EnumFactory(
+        content_type=ContentType.objects.get_for_model(prop),
+        object_id=prop.pk,
+        metadata_version=version,
+    )
+    enum_item = EnumItemFactory(enum=enum, metadata_version=version,)
+    enum_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(enum_item),
+        object_id=enum_item.pk,
+        dataset=dataset,
+        title='Test value',
+        description='For testing',
+        prepare='1',
+        access=Metadata.OPEN,
+        source="TEST",
+        metadata_version=version,
+    )
+    dataset_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(dataset),
+        object_id=dataset.pk,
+        dataset=dataset,
+        name="test/dataset",
+        metadata_version=version
+    )
+
+    assert Metadata.objects.count() == 4
+    assert EnumItem.objects.count() == 1
+    assert Enum.objects.count() == 1
+    assert _Version.objects.count() == 1
+
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
+    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
+    form['version_type'] = "MAJOR"
+    form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk, enum_meta.pk]
+    form.submit()
+
+    assert Metadata.objects.count() == 8
+    assert EnumItem.objects.count() == 2
+    assert Enum.objects.count() == 2
+    assert _Version.objects.count() == 2
+
+
+def test_publishing_enum_without_property_error(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
+    model_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(model),
+        object_id=model.pk,
+        dataset=dataset,
+        name="test/dataset/TestModel",
+        metadata_version=version,
+    )
+    prop = PropertyFactory(model=model, metadata_version=version,)
+    prop_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(prop),
+        object_id=prop.pk,
+        dataset=dataset,
+        name='prop',
+        type='string',
+        access=3,
+        metadata_version=version,
+    )
+    enum = EnumFactory(
+        content_type=ContentType.objects.get_for_model(prop),
+        object_id=prop.pk,
+        metadata_version=version,
+    )
+    enum_item = EnumItemFactory(enum=enum, metadata_version=version,)
+    enum_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(enum_item),
+        object_id=enum_item.pk,
+        dataset=dataset,
+        title='Test value',
+        description='For testing',
+        prepare='1',
+        access=Metadata.OPEN,
+        source="TEST",
+        metadata_version=version,
+    )
+    dataset_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(dataset),
+        object_id=dataset.pk,
+        dataset=dataset,
+        name="test/dataset",
+        metadata_version=version
+    )
+
+    assert Metadata.objects.count() == 4
+    assert EnumItem.objects.count() == 1
+    assert Enum.objects.count() == 1
+    assert _Version.objects.count() == 1
+
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
+    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
+    form['version_type'] = "MAJOR"
+    form['metadata'] = [dataset_meta.pk, enum_meta.pk]
+    response = form.submit()
+
+    assert response.status_code == 200
+    assert response.context['form'].errors
+    assert response.context['form'].errors['__all__'][0] == "Laukas 1 turi nuorodą į nepublikuojamą lauką tame pačiame duomenų ištekliuje."
+
+    assert Metadata.objects.count() == 4
+    assert EnumItem.objects.count() == 1
+    assert Enum.objects.count() == 1
+    assert _Version.objects.count() == 1
+
+
+def test_publishing_model_with_base_duplicates_model_and_base(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
+    model_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(model),
+        object_id=model.pk,
+        dataset=dataset,
+        name="test/dataset/TestModel",
+        uri="dcat:TestModel",
+        metadata_version=version
+    )
+    base_model = ModelFactory(dataset=dataset, metadata_version=version)
+    base_model_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(base_model),
+        object_id=base_model.pk,
+        dataset=dataset,
+        name="test/dataset/BaseModel",
+        metadata_version=version,
+    )
+    base = BaseFactory(model=base_model, metadata_version=version,)
+    base_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(base),
+        object_id=base.pk,
+        dataset=dataset,
+        name="test/dataset/BaseModel",
+        metadata_version=version,
+    )
+    dataset_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(dataset),
+        object_id=dataset.pk,
+        dataset=dataset,
+        name="test/dataset",
+        metadata_version=version
+    )
+
+    model.base = base
+    model.save()
+
+    assert Metadata.objects.count() == 4
+    assert Model.objects.count() == 2
+    assert Base.objects.count() == 1
+    assert _Version.objects.count() == 1
+
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
+    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
+    form['version_type'] = "MAJOR"
+    form['metadata'] = [dataset_meta.pk, base_model_meta.pk, model_meta.pk]
+    form.submit()
+
+    assert Metadata.objects.count() == 8
+    assert Model.objects.count() == 4
+    assert Base.objects.count() == 2
+    assert _Version.objects.count() == 2
+
+
+def test_publishing_model_with_without_base_error(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
+    model_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(model),
+        object_id=model.pk,
+        dataset=dataset,
+        name="test/dataset/TestModel",
+        uri="dcat:TestModel",
+        metadata_version=version
+    )
+    base_model = ModelFactory(dataset=dataset, metadata_version=version)
+    base_model_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(base_model),
+        object_id=base_model.pk,
+        dataset=dataset,
+        name="test/dataset/BaseModel",
+        metadata_version=version,
+    )
+    base = BaseFactory(model=base_model, metadata_version=version,)
+    base_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(base),
+        object_id=base.pk,
+        dataset=dataset,
+        name="test/dataset/BaseModel",
+        metadata_version=version,
+    )
+    dataset_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(dataset),
+        object_id=dataset.pk,
+        dataset=dataset,
+        name="test/dataset",
+        metadata_version=version
+    )
+
+    model.base = base
+    model.save()
+
+    assert Metadata.objects.count() == 4
+    assert Model.objects.count() == 2
+    assert Base.objects.count() == 1
+    assert _Version.objects.count() == 1
+
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
+    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
+    form['version_type'] = "MAJOR"
+    form['metadata'] = [dataset_meta.pk, model_meta.pk]
+    response = form.submit()
+
+    assert response.status_code == 200
+    assert response.context['form'].errors
+    assert "laukas test/dataset/BaseModel turi nuorodą į jį." in response.context['form'].errors['__all__'][0]
+
+    assert Metadata.objects.count() == 4
+    assert Model.objects.count() == 2
+    assert Base.objects.count() == 1
+    assert _Version.objects.count() == 1
+
+
+def test_publishing_property_with_ref_to_another_model(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+    manifest = (
+        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
+        '1,datasets/govsssss/ivpk/adp,,,,,,,,,,,,,,,,,\n'
+        '3,,,,City,,,,,,5,,,,,,,City,,\n'
+        '4,,,,,id,ref,Country,,,5,,,,,,,Id,,\n'
+        '8,,,,Country,,,,,,4,,,,,,,Country,,\n'
+    )
+
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(
+            file=FileField(filename='file.csv', data=manifest)
+        )
+    )
+    structure.dataset.current_structure = structure
+    structure.dataset.save()
+    version = create_structure_objects(structure)
+
+    assert Metadata.objects.count() == 5
+    assert Model.objects.count() == 2
+    assert DatasetDistribution.objects.count() == 1
+    assert Property.objects.count() == 1
+    assert _Version.objects.count() == 1
+
+    publish_metadata = list(
+        Metadata.objects.filter(dataset=structure.dataset, name__in=["datasets/govsssss/ivpk/adp", "adp", "datasets/govsssss/ivpk/adp/City", "id"]).values_list('pk', flat=True)
+    )
+    form = app.get(reverse('version-create', args=[structure.dataset.pk, version.pk])).forms['version-form']
+    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
+    form['version_type'] = "MAJOR"
+    form['metadata'] = publish_metadata
+    response = form.submit()
+
+    assert response.status_code == 200
+    assert response.context['form'].errors
+    assert response.context['form'].errors['__all__'][0] == "Laukas Country privalo būti publikuojamas, nes laukas id turi nuorodą į jį."
+
+    assert Metadata.objects.count() == 5
+    assert Model.objects.count() == 2
+    assert DatasetDistribution.objects.count() == 1
+    assert Property.objects.count() == 1
+    assert _Version.objects.count() == 1
+
+
+def test_publishing_property_with_ref_to_another_property(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+    manifest = (
+        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
+        '1,datasets/govsssss/ivpk/adp,,,,,,,,,,,,,,,,,\n'
+        '3,,,,City,,,,,,5,,,,,,,City,,\n'
+        '4,,,,,country,integer,Country,,,5,,,,,,,country_prop,,\n'
+        '5,,,,,country.id,integer,,,,5,,,,,,,country_id,,\n'
+        '8,,,,Country,,,,,,4,,,,,,,Country,,\n'
+    )
+
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(
+            file=FileField(filename='file.csv', data=manifest)
+        )
+    )
+    structure.dataset.current_structure = structure
+    structure.dataset.save()
+    version = create_structure_objects(structure)
+
+    assert Metadata.objects.count() == 6
+    assert Model.objects.count() == 2
+    assert DatasetDistribution.objects.count() == 1
+    assert Property.objects.count() == 2
+    assert _Version.objects.count() == 1
+
+    publish_metadata = list(
+        Metadata.objects.filter(dataset=structure.dataset, name__in=["datasets/govsssss/ivpk/adp", "adp", "datasets/govsssss/ivpk/adp/City", "datasets/govsssss/ivpk/adp/Country", "country.id"]).values_list('pk', flat=True)
+    )
+    form = app.get(reverse('version-create', args=[structure.dataset.pk, version.pk])).forms['version-form']
+    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
+    form['version_type'] = "MAJOR"
+    form['metadata'] = publish_metadata
+    response = form.submit()
+
+    assert response.status_code == 200
+    assert response.context['form'].errors
+    assert "Laukas country privalo būti publikuojamas, nes laukas country.id turi nuorodą į jį." in response.context['form'].errors['__all__'][0]
+
+
+def test_publishing_model_with_base_from_published_version_same_dataset(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+    manifest = (
+        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
+        '1,datasets/govsssss/ivpk/adp,,,,,,,,,,,,,,,,,\n'
+        '3,,,,City,,,,,,5,,,,,,,City,,\n'
+        '8,,,,Country,,,,,,4,,,,,,,Country,,\n'
+    )
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(
+            file=FileField(filename='file.csv', data=manifest)
+        )
+    )
+    structure.dataset.current_structure = structure
+    structure.dataset.save()
+    version = create_structure_objects(structure)
+
+    assert Metadata.objects.count() == 4
+    assert Model.objects.count() == 2
+    assert Base.objects.count() == 0
+
+    publish_metadata = list(
+        Metadata.objects.filter(dataset=structure.dataset, name__in=["datasets/govsssss/ivpk/adp", "adp", "datasets/govsssss/ivpk/adp/City"]).values_list('pk', flat=True)
+    )
+    form = app.get(reverse('version-create', args=[structure.dataset.pk, version.pk])).forms['version-form']
+    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
+    form['version_type'] = "MAJOR"
+    form['metadata'] = publish_metadata
+    form.submit()
+
+    assert Metadata.objects.count() == 7
+    assert Model.objects.count() == 3
+    assert Base.objects.count() == 0
+
+    published_version = _Version.objects.filter(dataset=structure.dataset).order_by("-created").first()
+    base_model = Model.objects.filter(dataset=structure.dataset, metadata_version=published_version).first()
+
+    form = app.get(reverse('model-update', args=[structure.dataset.pk, version.pk, "Country"])).forms['model-form']
+    form['base'].force_value(str(base_model.pk))
+    form.submit()
+
+    assert Metadata.objects.count() == 8
+    assert Base.objects.count() == 1
+
+    publish_metadata = list(
+        Metadata.objects.filter(dataset=structure.dataset, name__in=["datasets/govsssss/ivpk/adp", "adp", "datasets/govsssss/ivpk/adp/Country"]).values_list('pk', flat=True)
+    )
+
+    form = app.get(reverse('version-create', args=[structure.dataset.pk, version.pk])).forms['version-form']
+    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
+    form['version_type'] = "MAJOR"
+    form['metadata'] = publish_metadata
+    form.submit()
+    published_version = _Version.objects.filter(dataset=structure.dataset).order_by("-created").first()
+    published_model = Model.objects.filter(dataset=structure.dataset, metadata_version=published_version).first()
+
+    assert base_model.pk == published_model.base.model.pk
+    assert Metadata.objects.count() == 12
+    assert Model.objects.count() == 4
+    assert Base.objects.count() == 2
+
+
+def test_publishing_model_with_base_from_published_version_different_dataset(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+
+    first_version = VersionFactory()
+    first_model = ModelFactory(dataset=first_version.dataset, metadata_version=first_version)
+    first_dataset = first_version.dataset
+    first_dataset_meta = MetadataFactory(
+        dataset=first_dataset,
+        metadata_version=first_version,
+        content_type=ContentType.objects.get_for_model(Dataset),
+        object_id=first_dataset.pk
+    )
+    first_model_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(first_model),
+        object_id=first_model.pk,
+        dataset=first_dataset,
+        name="test/dataset/TestModel1",
+        metadata_version=first_version,
+    )
+
+    second_version = VersionFactory()
+    second_model = ModelFactory(dataset=second_version.dataset, metadata_version=second_version)
+    second_dataset = second_version.dataset
+    second_dataset_meta = MetadataFactory(
+        dataset=second_dataset,
+        metadata_version=second_version,
+        content_type=ContentType.objects.get_for_model(Dataset),
+        object_id=second_dataset.pk
+    )
+    second_model_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(second_model),
+        object_id=second_model.pk,
+        dataset=second_dataset,
+        name="test/dataset/TestModel2",
+        metadata_version=second_version,
+    )
+
+    assert Metadata.objects.count() == 4
+    assert Model.objects.count() == 2
+    assert _Version.objects.count() == 2
+    assert Base.objects.count() == 0
+
+    form = app.get(reverse('version-create', args=[first_dataset.pk, first_version.pk])).forms['version-form']
+    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
+    form['version_type'] = "MAJOR"
+    form['metadata'] = [first_dataset_meta.pk, first_model_meta.pk]
+    form.submit()
+
+    assert Metadata.objects.count() == 6
+    assert Model.objects.count() == 3
+    assert _Version.objects.count() == 3
+    assert Base.objects.count() == 0
+
+    first_published_version = _Version.objects.filter(dataset=first_dataset).order_by("-created").first()
+    first_published_model = Model.objects.filter(dataset=first_dataset, metadata_version=first_published_version).first()
+
+    form = app.get(reverse('model-update', args=[second_dataset.pk, second_version.pk, "TestModel2"])).forms['model-form']
+    form['base'].force_value(str(first_published_model.pk))
+    form.submit()
+
+    assert Metadata.objects.count() == 7
+    assert Model.objects.count() == 3
+    assert _Version.objects.count() == 3
+    assert Base.objects.count() == 1
+
+    form = app.get(reverse('version-create', args=[second_dataset.pk, second_version.pk])).forms['version-form']
+    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
+    form['version_type'] = "MAJOR"
+    form['metadata'] = [second_dataset_meta.pk, second_model_meta.pk]
+    form.submit()
+    published_version = _Version.objects.filter(dataset=second_dataset).order_by("-created").first()
+    published_model_with_base = Model.objects.filter(dataset=second_dataset, metadata_version=published_version).first()
+
+    assert first_published_model.pk == published_model_with_base.base.model.pk
+    assert Metadata.objects.count() == 10
+    assert Model.objects.count() == 4
+    assert _Version.objects.count() == 4
+    assert Base.objects.count() == 2
+
+
+def test_publishing_model_with_base_from_draft_version_different_dataset(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+    first_version = VersionFactory()
+    first_model = ModelFactory(dataset=first_version.dataset, metadata_version=first_version)
+    first_dataset = first_version.dataset
+    first_dataset_meta = MetadataFactory(
+        dataset=first_dataset,
+        metadata_version=first_version,
+        content_type=ContentType.objects.get_for_model(Dataset),
+        object_id=first_dataset.pk
+    )
+    first_model_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(first_model),
+        object_id=first_model.pk,
+        dataset=first_dataset,
+        name="test/dataset/TestModel1",
+        metadata_version=first_version,
+    )
+
+    second_version = VersionFactory()
+    second_model = ModelFactory(dataset=second_version.dataset, metadata_version=second_version)
+    second_dataset = second_version.dataset
+    second_dataset_meta = MetadataFactory(
+        dataset=second_dataset,
+        metadata_version=second_version,
+        content_type=ContentType.objects.get_for_model(Dataset),
+        object_id=second_dataset.pk
+    )
+    second_model_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(second_model),
+        object_id=second_model.pk,
+        dataset=second_dataset,
+        name="test/dataset/TestModel2",
+        metadata_version=second_version,
+    )
+    assert Metadata.objects.count() == 4
+    assert Model.objects.count() == 2
+    assert _Version.objects.count() == 2
+    assert Base.objects.count() == 0
+
+    form = app.get(reverse('model-update', args=[second_dataset.pk, second_version.pk, "TestModel2"])).forms['model-form']
+    form['base'].force_value(str(first_model.pk))
+    form.submit()
+    second_model.refresh_from_db()
+
+    assert Metadata.objects.count() == 5
+    assert Model.objects.count() == 2
+    assert _Version.objects.count() == 2
+    assert Base.objects.count() == 1
+
+    form = app.get(reverse('version-create', args=[second_dataset.pk, second_version.pk])).forms['version-form']
+    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
+    form['version_type'] = "MAJOR"
+    form['metadata'] = [second_dataset_meta.pk, second_model_meta.pk]
+    response = form.submit()
+
+    assert response.status_code == 200
+    assert response.context['form'].errors
+    assert response.context['form'].errors['__all__'][0] == "Laukas test/dataset/TestModel1 turi nuorodą į nepublikuotą lauką kitame duomenų ištekliuje."
+
+
+def test_publishing_property_with_published_model_ref_same_dataset(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+    version = VersionFactory()
+    first_model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
+    first_model_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(first_model),
+        object_id=first_model.pk,
+        dataset=dataset,
+        name="test/dataset/TestModel",
+        metadata_version=version,
+    )
+    dataset_meta = MetadataFactory(
+        dataset=dataset,
+        metadata_version=version,
+        content_type=ContentType.objects.get_for_model(Dataset),
+        object_id=dataset.pk
+    )
+    second_model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    second_model_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(second_model),
+        object_id=second_model.pk,
+        dataset=dataset,
+        name="test/dataset/TestModel2",
+        metadata_version=version,
+    )
+    prop = PropertyFactory(model=second_model, metadata_version=version,)
+    prop_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(prop),
+        object_id=prop.pk,
+        dataset=dataset,
+        name='prop2',
+        type='ref',
+        access=3,
+        metadata_version=version,
+    )
+
+    assert Metadata.objects.count() == 4
+    assert Property.objects.count() == 1
+    assert Model.objects.count() == 2
+
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
+    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
+    form['version_type'] = "MAJOR"
+    form['metadata'] = [dataset_meta.pk, first_model_meta.pk]
+    form.submit()
+    published_version = _Version.objects.filter(dataset=dataset).order_by("-created").first()
+    first_published_model = Model.objects.filter(metadata_version=published_version).first()
+
+    assert Metadata.objects.count() == 6
+    assert Property.objects.count() == 1
+    assert Model.objects.count() == 3
+
+    property_form = app.get(reverse('property-update', args=[dataset.pk, version.pk, "TestModel2", "prop2"])).forms['property-form']
+    property_form['ref'].force_value(str(first_published_model.pk))
+    property_form.submit()
+    prop.refresh_from_db()
+
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
+    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
+    form['version_type'] = "MAJOR"
+    form['metadata'] = [dataset_meta.pk, second_model_meta.pk, prop_meta.pk]
+    form.submit()
+
+    published_version = _Version.objects.filter(dataset=dataset).order_by("-created").first()
+    second_published_property = Property.objects.filter(metadata_version=published_version).first()
+
+    assert first_published_model.pk == second_published_property.ref_model_id
+    assert Metadata.objects.count() == 9
+    assert Property.objects.count() == 2
+    assert Model.objects.count() == 4
+
+
+def test_publishing_property_with_published_model_ref_different_dataset(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+    first_version = VersionFactory()
+    first_dataset = first_version.dataset
+    first_dataset_meta = MetadataFactory(
+        dataset=first_dataset,
+        metadata_version=first_version,
+        content_type=ContentType.objects.get_for_model(Dataset),
+        object_id=first_dataset.pk
+    )
+    first_model = ModelFactory(dataset=first_dataset, metadata_version=first_version)
+    first_model_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(first_model),
+        object_id=first_model.pk,
+        dataset=first_dataset,
+        name="test/dataset/TestModel",
+        metadata_version=first_version,
+    )
+
+    second_version = VersionFactory()
+    second_dataset = second_version.dataset
+    second_dataset_meta = MetadataFactory(
+        dataset=second_dataset,
+        metadata_version=second_version,
+        content_type=ContentType.objects.get_for_model(Dataset),
+        object_id=second_dataset.pk
+    )
+    second_model = ModelFactory(dataset=second_dataset, metadata_version=second_version)
+    second_model_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(second_model),
+        object_id=second_model.pk,
+        dataset=second_dataset,
+        name="test/dataset/TestModel2",
+        metadata_version=second_version,
+    )
+    prop = PropertyFactory(model=second_model, metadata_version=second_version,)
+    prop_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(prop),
+        object_id=prop.pk,
+        dataset=second_dataset,
+        name='prop2',
+        type='ref',
+        access=3,
+        metadata_version=second_version,
+    )
+
+    assert Metadata.objects.count() == 5
+    assert Property.objects.count() == 1
+    assert Model.objects.count() == 2
+
+    form = app.get(reverse('version-create', args=[first_dataset.pk, first_version.pk])).forms['version-form']
+    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
+    form['version_type'] = "MAJOR"
+    form['metadata'] = [first_dataset_meta.pk, first_model_meta.pk]
+    form.submit()
+    published_version = _Version.objects.filter(dataset=first_dataset).order_by("-created").first()
+    first_published_model = Model.objects.filter(metadata_version=published_version).first()
+
+    assert Metadata.objects.count() == 7
+    assert Property.objects.count() == 1
+    assert Model.objects.count() == 3
+
+    property_form = app.get(reverse('property-update', args=[second_dataset.pk, second_version.pk, "TestModel2", "prop2"])).forms['property-form']
+    property_form['ref'].force_value(str(first_published_model.pk))
+    property_form.submit()
+    prop.refresh_from_db()
+
+
+    form = app.get(reverse('version-create', args=[second_dataset.pk, second_version.pk])).forms['version-form']
+    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
+    form['version_type'] = "MAJOR"
+    form['metadata'] = [second_dataset_meta.pk, second_model_meta.pk, prop_meta.pk]
+    form.submit()
+
+    published_version = _Version.objects.filter(dataset=second_dataset).order_by("-created").first()
+    second_published_property = Property.objects.filter(metadata_version=published_version).first()
+
+    assert first_published_model.pk == second_published_property.ref_model_id
+    assert Metadata.objects.count() == 10
+    assert Property.objects.count() == 2
+    assert Model.objects.count() == 4
+
+
+def test_publishing_property_with_draft_model_ref_same_dataset(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+    version = VersionFactory()
+    dataset = version.dataset
+    dataset_meta = MetadataFactory(
+        dataset=dataset,
+        metadata_version=version,
+        content_type=ContentType.objects.get_for_model(Dataset),
+        object_id=dataset.pk
+    )
+    first_model = ModelFactory(dataset=dataset, metadata_version=version)
+    first_model_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(first_model),
+        object_id=first_model.pk,
+        dataset=dataset,
+        name="test/dataset/TestModel1",
+        metadata_version=version,
+    )
+
+    second_model = ModelFactory(dataset=dataset, metadata_version=version)
+    second_model_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(second_model),
+        object_id=second_model.pk,
+        dataset=dataset,
+        name="test/dataset/TestModel2",
+        metadata_version=version,
+    )
+    prop = PropertyFactory(model=second_model, metadata_version=version,)
+    prop_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(prop),
+        object_id=prop.pk,
+        dataset=dataset,
+        name='prop2',
+        type='ref',
+        access=3,
+        metadata_version=version,
+    )
+
+    assert Metadata.objects.count() == 4
+    assert Property.objects.count() == 1
+    assert Model.objects.count() == 2
+
+    property_form = app.get(reverse('property-update', args=[dataset.pk, version.pk, "TestModel2", "prop2"])).forms['property-form']
+    property_form['ref'].force_value(str(first_model.pk))
+    property_form.submit()
+    prop.refresh_from_db()
+
+
+    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
+    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
+    form['version_type'] = "MAJOR"
+    form['metadata'] = [dataset_meta.pk, second_model_meta.pk, prop_meta.pk]
+    response = form.submit()
+
+    assert response.status_code == 200
+    assert response.context['form'].errors
+    assert response.context['form'].errors['__all__'][0] == "Laukas TestModel1 privalo būti publikuojamas, nes laukas prop2 turi nuorodą į jį."
+
+
+def test_publishing_property_with_draft_model_ref_different_dataset(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+    first_version = VersionFactory()
+    first_dataset = first_version.dataset
+    first_dataset_meta = MetadataFactory(
+        dataset=first_dataset,
+        metadata_version=first_version,
+        content_type=ContentType.objects.get_for_model(Dataset),
+        object_id=first_dataset.pk
+    )
+    first_model = ModelFactory(dataset=first_dataset, metadata_version=first_version)
+    first_model_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(first_model),
+        object_id=first_model.pk,
+        dataset=first_dataset,
+        name="test/dataset/TestModel1",
+        metadata_version=first_version,
+    )
+
+    second_version = VersionFactory()
+    second_dataset = second_version.dataset
+    second_dataset_meta = MetadataFactory(
+        dataset=second_dataset,
+        metadata_version=second_version,
+        content_type=ContentType.objects.get_for_model(Dataset),
+        object_id=second_dataset.pk
+    )
+    second_model = ModelFactory(dataset=second_dataset, metadata_version=second_version)
+    second_model_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(second_model),
+        object_id=second_model.pk,
+        dataset=second_dataset,
+        name="test/dataset/TestModel2",
+        metadata_version=second_version,
+    )
+    prop = PropertyFactory(model=second_model, metadata_version=second_version, )
+    prop_meta = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(prop),
+        object_id=prop.pk,
+        dataset=second_dataset,
+        name='prop2',
+        type='ref',
+        access=3,
+        metadata_version=second_version,
+    )
+
+    assert Metadata.objects.count() == 5
+    assert Property.objects.count() == 1
+    assert Model.objects.count() == 2
+
+    property_form = app.get(reverse('property-update', args=[second_dataset.pk, second_version.pk, "TestModel2", "prop2"])).forms['property-form']
+    property_form['ref'].force_value(str(first_model.pk))
+    property_form.submit()
+    prop.refresh_from_db()
+
+    form = app.get(reverse('version-create', args=[second_dataset.pk, second_version.pk])).forms['version-form']
+    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
+    form['version_type'] = "MAJOR"
+    form['metadata'] = [second_dataset_meta.pk, second_model_meta.pk, prop_meta.pk]
+    response = form.submit()
+
+    assert response.status_code == 200
+    assert response.context['form'].errors
+    assert response.context['form'].errors['__all__'][0] == "Laukas prop2 turi nuorodą į nepublikuotą lauką kitame duomenų ištekliuje."

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -1799,20 +1799,19 @@ def test_property_enum_item_delete_in_pre_released_property(app: DjangoTestApp):
         metadata_version=version
     )
 
-    response = app.post(reverse('enum-delete', args=[
-        dataset.pk,
-        version.pk,
-        model.name,
-        prop.name,
-        enum_item.pk
-    ]), expect_errors=True)
+    response = app.post(
+        reverse("enum-delete", args=[dataset.pk, version.pk, model.name, prop.name, enum_item.pk]), expect_errors=True
+    )
 
-    assert response.status_code == 404
+    assert response.status_code == 302
+    assert response.location == prop.get_absolute_url()
     assert EnumItem.objects.filter(pk=enum_item.pk).count() == 1
-    assert Metadata.objects.filter(
-        content_type=ContentType.objects.get_for_model(enum_item),
-        object_id=enum_item.pk
-    ).count() == 1
+    assert (
+        Metadata.objects.filter(
+            content_type=ContentType.objects.get_for_model(enum_item), object_id=enum_item.pk
+        ).count()
+        == 1
+    )
 
 
 @pytest.mark.django_db
@@ -1828,18 +1827,17 @@ def test_model_create_with_lowercase_first_name_letter(app: DjangoTestApp):
         "Pirmas kodinio pavadinimo simbolis turi būti didžioji raidė."
     ]]
 
-@pytest.mark.parametrize(
-    "status",
-    [s for s in VersionStatus.values if s != VersionStatus.DRAFT]
-)
+
+@pytest.mark.parametrize("status", [s for s in VersionStatus.values if s != VersionStatus.DRAFT])
 @pytest.mark.django_db
 def test_model_create_with_in_not_draft_version(app: DjangoTestApp, status: str):
     user = UserFactory(is_staff=True)
     app.set_user(user)
     version = VersionFactory(status=status)
     dataset = version.dataset
-    form = app.get(reverse('model-create', args=[dataset.pk, version.pk]), expect_errors=True)
-    assert form.status_code == 404
+    form = app.get(reverse("model-create", args=[dataset.pk, version.pk]), expect_errors=True)
+    assert form.status_code == 302
+    assert form.location == dataset.get_absolute_url()
 
 
 @pytest.mark.django_db
@@ -2206,14 +2204,15 @@ def test_param_delete(app: DjangoTestApp):
     assert resp.url == distribution.get_absolute_url()
     assert distribution.params.first().paramitem_set.count() == 0
 
-
+@pytest.mark.parametrize("status", [s for s in VersionStatus.values if s != VersionStatus.DRAFT])
 @pytest.mark.django_db
-def test_new_version_when_chosen_version_not_draft(app: DjangoTestApp):
+def test_new_version_when_chosen_version_not_draft(app: DjangoTestApp, status: str):
     user = UserFactory(is_staff=True)
     app.set_user(user)
-    version = VersionFactory(status=VersionStatus.PRE_RELEASE)
-    form = app.get(reverse('version-create', args=[version.dataset.pk, version.pk]), expect_errors=True)
-    assert form.status_code == 404
+    version = VersionFactory(status=status)
+    form = app.get(reverse("version-create", args=[version.dataset.pk, version.pk]), expect_errors=True)
+    assert form.status_code == 302
+    assert form.location == version.dataset.get_absolute_url()
 
 
 @pytest.mark.django_db
@@ -4138,7 +4137,8 @@ def test_property_create_with_in_released_version(app: DjangoTestApp):
         metadata_version=version,
     )
     form = app.get(reverse("property-create", args=[dataset.pk, version.pk, model.name]), expect_errors=True)
-    assert form.status_code == 404
+    assert form.status_code == 302
+    assert form.location == model.get_absolute_url()
 
 
 @pytest.mark.django_db
@@ -4411,8 +4411,9 @@ def test_imported_metadata_gets_develop_status(app: DjangoTestApp):
         assert enum_item.metadata.first().status.codename == "develop"
 
 
+@pytest.mark.parametrize("status", [s for s in VersionStatus.values if s != VersionStatus.DRAFT])
 @pytest.mark.django_db
-def test_updating_metadata_in_not_draft_version_not_allowed(app: DjangoTestApp):
+def test_updating_metadata_in_not_draft_version_not_allowed(app: DjangoTestApp, status: str):
     user = UserFactory(is_staff=True)
     app.set_user(user)
     manifest = (
@@ -4426,29 +4427,46 @@ def test_updating_metadata_in_not_draft_version_not_allowed(app: DjangoTestApp):
         ",,,,,,enum,small,,SMALL,,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename="file.csv", data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
-    version.status = VersionStatus.PRE_RELEASE
+    version.status = status
     version.save()
     enum_meta = Metadata.objects.filter(dataset=structure.dataset, name="small", metadata_version=version).first()
 
     enum = enum_meta.object
     enum_id = enum.id
 
-    model_form = app.get(reverse('model-update', args=[structure.dataset.pk, version.pk, "Country"]), expect_errors=True)
-    assert model_form.status_code == 404
+    model_form = app.get(
+        reverse("model-update", args=[structure.dataset.pk, version.pk, "Country"]), expect_errors=True
+    )
+    assert model_form.status_code == 302
+    assert model_form.location == structure.dataset.get_absolute_url()
 
-    property_form = app.get(reverse('property-update', args=[structure.dataset.pk, version.pk, "Country", "administration"]), expect_errors=True)
-    assert property_form.status_code == 404
+    property_form = app.get(
+        reverse("property-update", args=[structure.dataset.pk, version.pk, "Country", "administration"]),
+        expect_errors=True,
+    )
+    assert property_form.status_code == 302
 
-    enum_form = app.get(reverse('enum-update', args=[structure.dataset.pk, version.pk, "Country", "administration", enum_id]), expect_errors=True)
-    assert enum_form.status_code == 404
+    expected_location = reverse(
+        "model-structure",
+        args=[structure.dataset.pk, version.pk, "Country"],
+    )
+    assert property_form.location == expected_location
+
+    enum_form = app.get(
+        reverse("enum-update", args=[structure.dataset.pk, version.pk, "Country", "administration", enum_id]),
+        expect_errors=True,
+    )
+    assert enum_form.status_code == 302
+
+    expected_location = reverse(
+        "property-structure", args=[structure.dataset.pk, version.pk, "Country", "administration"]
+    )
+
+    assert enum_form.location == expected_location
 
 
 @pytest.mark.django_db

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -1828,12 +1828,15 @@ def test_model_create_with_lowercase_first_name_letter(app: DjangoTestApp):
         "Pirmas kodinio pavadinimo simbolis turi būti didžioji raidė."
     ]]
 
-
+@pytest.mark.parametrize(
+    "status",
+    [s for s in VersionStatus.values if s != VersionStatus.DRAFT]
+)
 @pytest.mark.django_db
-def test_model_create_with_in_not_draft_version(app: DjangoTestApp):
+def test_model_create_with_in_not_draft_version(app: DjangoTestApp, status: str):
     user = UserFactory(is_staff=True)
     app.set_user(user)
-    version = VersionFactory(status=VersionStatus.PRE_RELEASE)
+    version = VersionFactory(status=status)
     dataset = version.dataset
     form = app.get(reverse('model-create', args=[dataset.pk, version.pk]), expect_errors=True)
     assert form.status_code == 404

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -1799,7 +1799,7 @@ def test_property_enum_item_delete_in_pre_released_property(app: DjangoTestApp):
         metadata_version=version
     )
 
-    resp = app.post(reverse('enum-delete', args=[
+    response = app.post(reverse('enum-delete', args=[
         dataset.pk,
         version.pk,
         model.name,
@@ -1807,7 +1807,7 @@ def test_property_enum_item_delete_in_pre_released_property(app: DjangoTestApp):
         enum_item.pk
     ]), expect_errors=True)
 
-    assert resp.status_code == 404
+    assert response.status_code == 404
     assert EnumItem.objects.filter(pk=enum_item.pk).count() == 1
     assert Metadata.objects.filter(
         content_type=ContentType.objects.get_for_model(enum_item),

--- a/vitrina/datasets/templates/vitrina/datasets/add_resource.html
+++ b/vitrina/datasets/templates/vitrina/datasets/add_resource.html
@@ -1,6 +1,17 @@
 {% load i18n %}
 {% if can_add_resource %}
-    <a href="{% url 'resource-add' pk=dataset.id %}" class="button is-primary is-normal is-size-6-mobile is-flex" id="add_resource">
-        {% translate "Naujas šaltinis" %}
-    </a>
+    {% if not selected_version.external_version %}
+        <a href="{% url 'resource-add' pk=dataset.id %}"
+           class="button is-primary is-normal is-size-6-mobile is-flex"
+           id="add_resource">
+            {% translate "Naujas šaltinis" %}
+        </a>
+    {% else %}
+        <a class="button is-primary is-normal is-size-6-mobile is-flex is-disabled"
+           style="pointer-events: none; opacity: 0.5;"
+           id="add_resource"
+           aria-disabled="true">
+            {% translate "Naujas šaltinis" %}
+        </a>
+    {% endif %}
 {% endif %}

--- a/vitrina/datasets/templates/vitrina/datasets/add_resource.html
+++ b/vitrina/datasets/templates/vitrina/datasets/add_resource.html
@@ -1,17 +1,17 @@
 {% load i18n %}
 {% if can_add_resource %}
-    {% if not selected_version.external_version %}
-        <a href="{% url 'resource-add' pk=dataset.id %}"
-           class="button is-primary is-normal is-size-6-mobile is-flex"
-           id="add_resource">
-            {% translate "Naujas šaltinis" %}
-        </a>
-    {% else %}
-        <a class="button is-primary is-normal is-size-6-mobile is-flex is-disabled"
-           style="pointer-events: none; opacity: 0.5;"
-           id="add_resource"
-           aria-disabled="true">
-            {% translate "Naujas šaltinis" %}
-        </a>
-    {% endif %}
+    <a
+        {% if not selected_version.external_version %}
+            href="{% url 'resource-add' pk=dataset.id %}"
+        {% endif %}
+        class="button is-primary is-normal is-size-6-mobile is-flex{% if selected_version.external_version %} is-disabled{% endif %}"
+        {% if selected_version.external_version %}
+            style="pointer-events: none; opacity: 0.5;"
+            aria-disabled="true"
+        {% endif %}
+        id="add_resource"
+    >
+        {% translate "Naujas šaltinis" %}
+    </a>
+
 {% endif %}

--- a/vitrina/datasets/templates/vitrina/datasets/datatable.html
+++ b/vitrina/datasets/templates/vitrina/datasets/datatable.html
@@ -91,14 +91,14 @@
             <td>
                 {% if r.metadata_version %}
                     <a
+                        class="button is-link is-small is-pulled-right{% if selected_version.external_version %} is-disabled{% endif %}"
                         {% if not selected_version.external_version %}
                             href="{% url 'resource-change' pk=r.id version_id=r.metadata_version.id %}"
-                        {% endif %}
-                        class="button is-link is-small is-pulled-right{% if selected_version.external_version %} is-disabled{% endif %}"
-                        id="change_resource"
-                        {% if selected_version.external_version %}
+                        {% else %}
+                            style="pointer-events: none; opacity: 0.5;"
                             aria-disabled="true"
                         {% endif %}
+                        id="change_resource"
                     >
                         {% translate "Redaguoti" %}
                     </a>

--- a/vitrina/datasets/templates/vitrina/datasets/datatable.html
+++ b/vitrina/datasets/templates/vitrina/datasets/datatable.html
@@ -118,22 +118,17 @@
                 {% endif %}
                     {% csrf_token %}
                     {% if r.metadata_version %}
-                        {% if not selected_version.external_version %}
-                            <button type="submit"
-                                    class="button is-link is-small is-pulled-right"
-                                    onclick="return confirm({% translate 'Ar jūs tikrai norite ištrinti šį šaltinį?' %})"
-                                    id="delete_resource">
+                        <button type="submit"
+                            class="button is-link is-small is-pulled-right {% if selected_version.external_version %}is-disabled{% endif %}"
+                            {% if selected_version.external_version %}
+                                style="pointer-events: none; opacity: 0.5;"
+                                aria-disabled="true"
+                            {% else %}
+                                onclick="return confirm({% translate 'Ar jūs tikrai norite ištrinti šį šaltinį?' %})"
+                            {% endif %}
+                            id="delete_resource">
                                 {% translate "Ištrinti" %}
-                            </button>
-                        {% else %}
-                            <button type="button"
-                                    class="button is-link is-small is-pulled-right is-disabled"
-                                    style="pointer-events: none; opacity: 0.5;"
-                                    id="delete_resource"
-                                    aria-disabled="true">
-                                {% translate "Ištrinti" %}
-                            </button>
-                        {% endif %}
+                        </button>
                     {% else %}
                         <button type="submit"
                                     class="button is-link is-small is-pulled-right"

--- a/vitrina/datasets/templates/vitrina/datasets/datatable.html
+++ b/vitrina/datasets/templates/vitrina/datasets/datatable.html
@@ -90,20 +90,19 @@
             {% if can_add_resource %}
             <td>
                 {% if r.metadata_version %}
-                    {% if not selected_version.external_version %}
-                        <a href="{% url 'resource-change' pk=r.id version_id=r.metadata_version.id %}"
-                           class="button is-link is-small is-pulled-right"
-                           id="change_resource">
-                            {% translate "Redaguoti" %}
-                        </a>
-                    {% else %}
-                        <a class="button is-link is-small is-pulled-right is-disabled"
-                           style="pointer-events: none; opacity: 0.5;"
-                           id="change_resource"
-                           aria-disabled="true">
-                            {% translate "Redaguoti" %}
-                        </a>
-                    {% endif %}
+                    <a
+                        {% if not selected_version.external_version %}
+                            href="{% url 'resource-change' pk=r.id version_id=r.metadata_version.id %}"
+                        {% endif %}
+                        class="button is-link is-small is-pulled-right{% if selected_version.external_version %} is-disabled{% endif %}"
+                        id="change_resource"
+                        {% if selected_version.external_version %}
+                            aria-disabled="true"
+                        {% endif %}
+                    >
+                        {% translate "Redaguoti" %}
+                    </a>
+
                 {% else %}
                     <a href="{% url 'resource-change-no-version' pk=r.id %}"
                        class="button is-link is-small is-pulled-right"

--- a/vitrina/datasets/templates/vitrina/datasets/datatable.html
+++ b/vitrina/datasets/templates/vitrina/datasets/datatable.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 <div class="buttons is-right m-t-md">
     {% include "version_picker.html" with version_as_query_param=True url_name="dataset-detail" dataset=dataset versions=versions selected_version=selected_version %}
-    {% include 'vitrina/datasets/add_resource.html' %}
+    {% include 'vitrina/datasets/add_resource.html' with selected_version=selected_version %}
 </div>
 <table class="table is-striped is-hoverable is-fullwidth no-margin-bottom table-smaller-padding" id="resource-table">
     <thead>
@@ -90,9 +90,20 @@
             {% if can_add_resource %}
             <td>
                 {% if r.metadata_version %}
-                    <a href="{% url 'resource-change' pk=r.id version_id=r.metadata_version.id %}"
-                       class="button is-link is-small is-pulled-right"
-                       id="change_resource">{% translate "Redaguoti" %}</a>
+                    {% if not selected_version.external_version %}
+                        <a href="{% url 'resource-change' pk=r.id version_id=r.metadata_version.id %}"
+                           class="button is-link is-small is-pulled-right"
+                           id="change_resource">
+                            {% translate "Redaguoti" %}
+                        </a>
+                    {% else %}
+                        <a class="button is-link is-small is-pulled-right is-disabled"
+                           style="pointer-events: none; opacity: 0.5;"
+                           id="change_resource"
+                           aria-disabled="true">
+                            {% translate "Redaguoti" %}
+                        </a>
+                    {% endif %}
                 {% else %}
                     <a href="{% url 'resource-change-no-version' pk=r.id %}"
                        class="button is-link is-small is-pulled-right"
@@ -106,12 +117,31 @@
                     <form method="post" action="{% url 'resource-delete-no-version' pk=r.id %}">
                 {% endif %}
                     {% csrf_token %}
-                    <button type="submit"
-                            class="button is-link is-small is-pulled-right"
-                            onclick="return confirm({% translate 'Ar jūs tikrai norite ištrinti šį šaltinį?' %})"
-                            id="delete_resource">
-                        {% translate "Ištrinti" %}
-                    </button>
+                    {% if r.metadata_version %}
+                        {% if not selected_version.external_version %}
+                            <button type="submit"
+                                    class="button is-link is-small is-pulled-right"
+                                    onclick="return confirm({% translate 'Ar jūs tikrai norite ištrinti šį šaltinį?' %})"
+                                    id="delete_resource">
+                                {% translate "Ištrinti" %}
+                            </button>
+                        {% else %}
+                            <button type="button"
+                                    class="button is-link is-small is-pulled-right is-disabled"
+                                    style="pointer-events: none; opacity: 0.5;"
+                                    id="delete_resource"
+                                    aria-disabled="true">
+                                {% translate "Ištrinti" %}
+                            </button>
+                        {% endif %}
+                    {% else %}
+                        <button type="submit"
+                                    class="button is-link is-small is-pulled-right"
+                                    onclick="return confirm({% translate 'Ar jūs tikrai norite ištrinti šį šaltinį?' %})"
+                                    id="delete_resource">
+                                {% translate "Ištrinti" %}
+                            </button>
+                    {% endif %}
                 </form>
             </td>
             {% endif %}

--- a/vitrina/datasets/views.py
+++ b/vitrina/datasets/views.py
@@ -1491,14 +1491,13 @@ class DatasetStructureImportView(
     def dispatch(self, request, *args, **kwargs):
         self.dataset = get_object_or_404(Dataset, pk=kwargs.get("pk"))
         if not self.has_permission():
-            if not request.user.is_authenticated:
-                return redirect(settings.LOGIN_URL)
-            raise PermissionDenied()
+            return self.handle_no_permission()
         if not (version_id := kwargs.get("version_id")):
             return super().dispatch(request, *args, **kwargs)
         self.metadata_version = get_object_or_404(_Version, pk=version_id, dataset=self.dataset)
         if not self.metadata_version.is_draft():
-            raise Http404("Only allowed on Draft version.")
+            messages.error(request, _("Negalima importuoti struktūros, kai versijos būsena nėra juodraštis."))
+            return redirect(self.dataset.get_absolute_url())
         return super().dispatch(request, *args, **kwargs)
 
     def has_permission(self):
@@ -1509,6 +1508,11 @@ class DatasetStructureImportView(
             DatasetStructure,
             self.dataset,
         )
+
+    def handle_no_permission(self):
+        if not self.request.user.is_authenticated:
+            return redirect(settings.LOGIN_URL)
+        return redirect(self.dataset)
 
     def get_context_data(self, **kwargs):
         return {

--- a/vitrina/datasets/views.py
+++ b/vitrina/datasets/views.py
@@ -16,14 +16,14 @@ from django.contrib.admin.options import get_content_type_for_model
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
 from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
+from django.core.exceptions import ObjectDoesNotExist
 from django.core.paginator import Paginator
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
 from django.db.models import QuerySet, Count, Max, Q, Avg, Sum, Func, F, Value, TextField
 from django.forms import BaseForm
 from django.http import JsonResponse, HttpResponseRedirect, HttpResponse
-from django.http.response import HttpResponsePermanentRedirect, Http404
+from django.http.response import HttpResponsePermanentRedirect
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.defaultfilters import date as _date
 from django.urls import reverse, reverse_lazy, resolve

--- a/vitrina/datasets/views.py
+++ b/vitrina/datasets/views.py
@@ -23,7 +23,7 @@ from django.db import models
 from django.db.models import QuerySet, Count, Max, Q, Avg, Sum, Func, F, Value, TextField
 from django.forms import BaseForm
 from django.http import JsonResponse, HttpResponseRedirect, HttpResponse
-from django.http.response import HttpResponsePermanentRedirect
+from django.http.response import HttpResponsePermanentRedirect, Http404
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.defaultfilters import date as _date
 from django.urls import reverse, reverse_lazy, resolve
@@ -1487,6 +1487,19 @@ class DatasetStructureImportView(
     detail_url_name = "dataset-detail"
     history_url_name = "dataset-structure-history"
     plan_url_name = "dataset-plans"
+
+    def dispatch(self, request, *args, **kwargs):
+        version_id = kwargs.get("version_id")
+        if version_id is not None:
+            self.metadata_version = get_object_or_404(
+                _Version, pk=version_id, dataset=get_object_or_404(Dataset, pk=kwargs.get("pk"))
+            )
+        else:
+            self.metadata_version = None
+
+        if self.metadata_version and self.metadata_version.status != VersionStatus.DRAFT:
+            raise Http404("Only allowed on Draft version.")
+        return super().dispatch(request, *args, **kwargs)
 
     def has_permission(self):
         subclass = self.dataset.subclass

--- a/vitrina/datasets/views.py
+++ b/vitrina/datasets/views.py
@@ -1489,15 +1489,13 @@ class DatasetStructureImportView(
     plan_url_name = "dataset-plans"
 
     def dispatch(self, request, *args, **kwargs):
-        version_id = kwargs.get("version_id")
-        if version_id is not None:
-            self.metadata_version = get_object_or_404(
-                _Version, pk=version_id, dataset=get_object_or_404(Dataset, pk=kwargs.get("pk"))
-            )
-        else:
-            self.metadata_version = None
+        if not (version_id := kwargs.get("version_id")):
+            return super().dispatch(request, *args, **kwargs)
 
-        if self.metadata_version and self.metadata_version.status != VersionStatus.DRAFT:
+        self.metadata_version = get_object_or_404(
+            _Version, pk=version_id, dataset=get_object_or_404(Dataset, pk=kwargs.get("pk"))
+        )
+        if not self.metadata_version.is_draft():
             raise Http404("Only allowed on Draft version.")
         return super().dispatch(request, *args, **kwargs)
 
@@ -1536,7 +1534,7 @@ class DatasetStructureImportView(
         self.object.save()
         self.object.dataset.current_structure = self.object
         self.object.dataset.save()
-        if self.metadata_version and self.metadata_version.status != VersionStatus.DRAFT:
+        if self.metadata_version and not self.metadata_version.is_draft():
             form.add_error("file", _("Negalima importuoti struktūros, kai versijos būsena nėra juodraštis."))
             return self.form_invalid(form)
 

--- a/vitrina/datasets/views.py
+++ b/vitrina/datasets/views.py
@@ -16,7 +16,7 @@ from django.contrib.admin.options import get_content_type_for_model
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
 from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.core.paginator import Paginator
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
@@ -1489,12 +1489,14 @@ class DatasetStructureImportView(
     plan_url_name = "dataset-plans"
 
     def dispatch(self, request, *args, **kwargs):
+        self.dataset = get_object_or_404(Dataset, pk=kwargs.get("pk"))
+        if not self.has_permission():
+            if not request.user.is_authenticated:
+                return redirect(settings.LOGIN_URL)
+            raise PermissionDenied()
         if not (version_id := kwargs.get("version_id")):
             return super().dispatch(request, *args, **kwargs)
-
-        self.metadata_version = get_object_or_404(
-            _Version, pk=version_id, dataset=get_object_or_404(Dataset, pk=kwargs.get("pk"))
-        )
+        self.metadata_version = get_object_or_404(_Version, pk=version_id, dataset=self.dataset)
         if not self.metadata_version.is_draft():
             raise Http404("Only allowed on Draft version.")
         return super().dispatch(request, *args, **kwargs)

--- a/vitrina/resources/templates/vitrina/resources/detail.html
+++ b/vitrina/resources/templates/vitrina/resources/detail.html
@@ -21,17 +21,14 @@
             {% if can_update %}
                 <div class="buttons is-right">
                     {% if resource.metadata_version %}
-                        {% if not is_disabled %}
-                            <a href="{% url 'resource-change' pk=resource.pk version_id=resource.metadata_version.pk %}" class="button is-primary is-normal m-t-md is-size-6-mobile">
-                                {% translate "Redaguoti" %}
-                            </a>
-                        {% else %}
-                            <a class="button is-primary is-disabled"
+                        <a href="{% url 'resource-change' pk=resource.pk version_id=resource.metadata_version.pk %}"
+                           class="button is-primary is-normal m-t-md is-size-6-mobile{% if is_disabled %} is-disabled{% endif %}"
+                           {% if is_disabled %}
                                style="pointer-events: none; opacity: 0.5;"
-                               aria-disabled="true">
+                               aria-disabled="true"
+                           {% endif %}>
                             {% translate "Redaguoti" %}
-                            </a>
-                        {% endif %}
+                        </a>
                     {% else %}
                         <a href="{% url 'resource-change-no-version' pk=resource.pk %}" class="button is-primary is-normal m-t-md is-size-6-mobile">
                             {% translate "Redaguoti" %}
@@ -264,18 +261,14 @@
                         {% endif %}
 
                         {% if resource.metadata_version %}
-                            {% if not is_disabled %}
-                                <a href="{% url 'resource-model-create' resource.dataset.pk resource.metadata_version.pk resource.pk %}"
-                                   class="button is-primary is-normal m-t-md is-size-6-mobile">
-                                    {% translate "Naujas modelis" %}
-                                </a>
-                                {% else %}
-                                <a class="button is-primary is-normal m-t-md is-size-6-mobile is-disabled"
+                            <a href="{% url 'resource-model-create' resource.dataset.pk resource.metadata_version.pk resource.pk %}"
+                               class="button is-primary is-normal m-t-md is-size-6-mobile{% if is_disabled %} is-disabled{% endif %}"
+                               {% if is_disabled %}
                                    style="pointer-events: none; opacity: 0.5;"
-                                   aria-disabled="true">
+                                   aria-disabled="true"
+                               {% endif %}>
                                 {% translate "Naujas modelis" %}
-                                </a>
-                            {% endif %}
+                            </a>
                         {% endif %}
                     </div>
                 {% endif %}

--- a/vitrina/resources/templates/vitrina/resources/detail.html
+++ b/vitrina/resources/templates/vitrina/resources/detail.html
@@ -21,9 +21,17 @@
             {% if can_update %}
                 <div class="buttons is-right">
                     {% if resource.metadata_version %}
-                        <a href="{% url 'resource-change' pk=resource.pk version_id=resource.metadata_version.pk %}" class="button is-primary is-normal m-t-md is-size-6-mobile">
+                        {% if not is_disabled %}
+                            <a href="{% url 'resource-change' pk=resource.pk version_id=resource.metadata_version.pk %}" class="button is-primary is-normal m-t-md is-size-6-mobile">
+                                {% translate "Redaguoti" %}
+                            </a>
+                        {% else %}
+                            <a class="button is-primary is-disabled"
+                               style="pointer-events: none; opacity: 0.5;"
+                               aria-disabled="true">
                             {% translate "Redaguoti" %}
-                        </a>
+                            </a>
+                        {% endif %}
                     {% else %}
                         <a href="{% url 'resource-change-no-version' pk=resource.pk %}" class="button is-primary is-normal m-t-md is-size-6-mobile">
                             {% translate "Redaguoti" %}
@@ -256,10 +264,18 @@
                         {% endif %}
 
                         {% if resource.metadata_version %}
-                            <a href="{% url 'resource-model-create' resource.dataset.pk resource.metadata_version.pk resource.pk %}"
-                               class="button is-primary is-normal m-t-md is-size-6-mobile">
+                            {% if not is_disabled %}
+                                <a href="{% url 'resource-model-create' resource.dataset.pk resource.metadata_version.pk resource.pk %}"
+                                   class="button is-primary is-normal m-t-md is-size-6-mobile">
+                                    {% translate "Naujas modelis" %}
+                                </a>
+                                {% else %}
+                                <a class="button is-primary is-normal m-t-md is-size-6-mobile is-disabled"
+                                   style="pointer-events: none; opacity: 0.5;"
+                                   aria-disabled="true">
                                 {% translate "Naujas modelis" %}
-                            </a>
+                                </a>
+                            {% endif %}
                         {% endif %}
                     </div>
                 {% endif %}

--- a/vitrina/resources/views.py
+++ b/vitrina/resources/views.py
@@ -174,12 +174,9 @@ class ResourceUpdateView(LoginRequiredMixin, PermissionRequiredMixin, Translatab
     form_class = DatasetResourceForm
 
     def dispatch(self, request, *args, **kwargs):
+        self.resource = get_object_or_404(DatasetDistribution, pk=kwargs["pk"])
         if not self.has_permission():
             return self.handle_no_permission()
-        self.resource = get_object_or_404(
-            DatasetDistribution,
-            pk=kwargs["pk"],
-        )
         self.metadata_version = None
         version_id = kwargs.get("version_id")
         if version_id is not None:
@@ -188,21 +185,18 @@ class ResourceUpdateView(LoginRequiredMixin, PermissionRequiredMixin, Translatab
                 pk=version_id,
             )
             if not self.metadata_version.is_draft():
-                if not self.metadata_version.is_draft():
-                    messages.error(request, _("Negalima redaguoti šaltinio, kai versijos būsena nėra juodraštis."))
-                    return redirect(self.resource.get_absolute_url())
+                messages.error(request, _("Negalima redaguoti šaltinio, kai versijos būsena nėra juodraštis."))
+                return redirect(self.resource.get_absolute_url())
         return super().dispatch(request, *args, **kwargs)
 
     def has_permission(self):
-        resource = get_object_or_404(DatasetDistribution, id=self.kwargs["pk"])
-        return has_perm(self.request.user, Action.UPDATE, resource)
+        return has_perm(self.request.user, Action.UPDATE, self.resource)
 
     def handle_no_permission(self):
         if not self.request.user.is_authenticated:
             return redirect(settings.LOGIN_URL)
         else:
-            resource = get_object_or_404(DatasetDistribution, id=self.kwargs["pk"])
-            return redirect(resource.dataset)
+            return redirect(self.resource.dataset)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -243,12 +237,9 @@ class ResourceDeleteView(LoginRequiredMixin, PermissionRequiredMixin, DeleteView
     model = DatasetDistribution
 
     def dispatch(self, request, *args, **kwargs):
+        self.resource = get_object_or_404(DatasetDistribution, pk=kwargs["pk"])
         if not self.has_permission():
             return self.handle_no_permission()
-        self.resource = get_object_or_404(
-            DatasetDistribution,
-            pk=kwargs["pk"],
-        )
         self.metadata_version = None
         version_id = kwargs.get("version_id")
         if version_id is not None:
@@ -262,18 +253,16 @@ class ResourceDeleteView(LoginRequiredMixin, PermissionRequiredMixin, DeleteView
         return super().dispatch(request, *args, **kwargs)
 
     def has_permission(self):
-        resource = get_object_or_404(DatasetDistribution, id=self.kwargs["pk"])
-        return has_perm(self.request.user, Action.DELETE, resource)
+        return has_perm(self.request.user, Action.DELETE, self.resource)
 
     def handle_no_permission(self):
         if not self.request.user.is_authenticated:
             return redirect(settings.LOGIN_URL)
-
-        resource = get_object_or_404(DatasetDistribution, id=self.kwargs["pk"])
-        if resource.metadata_version:
-            url = reverse("dataset-detail", kwargs={"pk": resource.dataset.pk})
-            return HttpResponseRedirect(f"{url}?resource_version={resource.metadata_version.pk}")
-        return redirect(resource.dataset)
+        else:
+            if self.resource.metadata_version:
+                url = reverse("dataset-detail", kwargs={"pk": self.resource.dataset.pk})
+                return HttpResponseRedirect(f"{url}?resource_version={self.resource.metadata_version.pk}")
+            return redirect(self.resource.dataset)
 
     def form_valid(self, form: BaseForm) -> HttpResponse:
         resource = get_object_or_404(DatasetDistribution, id=self.kwargs["pk"])

--- a/vitrina/resources/views.py
+++ b/vitrina/resources/views.py
@@ -1,3 +1,4 @@
+from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Exists, OuterRef
@@ -187,7 +188,9 @@ class ResourceUpdateView(LoginRequiredMixin, PermissionRequiredMixin, Translatab
                 pk=version_id,
             )
             if not self.metadata_version.is_draft():
-                raise Http404("Only allowed on Draft version.")
+                if not self.metadata_version.is_draft():
+                    messages.error(request, _("Negalima redaguoti šaltinio, kai versijos būsena nėra juodraštis."))
+                    return redirect(self.resource.get_absolute_url())
         return super().dispatch(request, *args, **kwargs)
 
     def has_permission(self):
@@ -254,7 +257,8 @@ class ResourceDeleteView(LoginRequiredMixin, PermissionRequiredMixin, DeleteView
                 pk=version_id,
             )
             if not self.metadata_version.is_draft():
-                raise Http404("Only allowed on Draft version.")
+                messages.error(request, _("Negalima trinti šaltinio, kai versijos būsena nėra juodraštis."))
+                return redirect(self.resource.get_absolute_url())
         return super().dispatch(request, *args, **kwargs)
 
     def has_permission(self):

--- a/vitrina/resources/views.py
+++ b/vitrina/resources/views.py
@@ -20,7 +20,6 @@ from vitrina.plans.models import Plan
 from vitrina.requests.models import Request
 from vitrina.resources.forms import DatasetResourceForm
 from vitrina.resources.models import DatasetDistribution
-from vitrina.structure import VersionStatus
 from vitrina.structure.models import Version
 from vitrina.structure.views import DatasetStructureMixin, ModelCreateView
 from vitrina.views import HistoryMixin
@@ -61,7 +60,7 @@ class ResourceDetailView(PermissionRequiredMixin, HistoryMixin, DatasetStructure
         context["params"] = self.object.params.all().order_by("name")
         context["models"] = self.object.model_set.all()
         context["is_disabled"] = (
-            self.object.metadata_version is not None and self.object.metadata_version.status != VersionStatus.DRAFT
+            self.object.metadata_version is not None and not self.object.metadata_version.is_draft()
         )
         return context
 
@@ -174,6 +173,8 @@ class ResourceUpdateView(LoginRequiredMixin, PermissionRequiredMixin, Translatab
     form_class = DatasetResourceForm
 
     def dispatch(self, request, *args, **kwargs):
+        if not self.has_permission():
+            return self.handle_no_permission()
         self.resource = get_object_or_404(
             DatasetDistribution,
             pk=kwargs["pk"],
@@ -185,7 +186,7 @@ class ResourceUpdateView(LoginRequiredMixin, PermissionRequiredMixin, Translatab
                 Version,
                 pk=version_id,
             )
-            if self.metadata_version.status != VersionStatus.DRAFT:
+            if not self.metadata_version.is_draft():
                 raise Http404("Only allowed on Draft version.")
         return super().dispatch(request, *args, **kwargs)
 
@@ -239,6 +240,8 @@ class ResourceDeleteView(LoginRequiredMixin, PermissionRequiredMixin, DeleteView
     model = DatasetDistribution
 
     def dispatch(self, request, *args, **kwargs):
+        if not self.has_permission():
+            return self.handle_no_permission()
         self.resource = get_object_or_404(
             DatasetDistribution,
             pk=kwargs["pk"],
@@ -250,7 +253,7 @@ class ResourceDeleteView(LoginRequiredMixin, PermissionRequiredMixin, DeleteView
                 Version,
                 pk=version_id,
             )
-            if self.metadata_version.status != VersionStatus.DRAFT:
+            if not self.metadata_version.is_draft():
                 raise Http404("Only allowed on Draft version.")
         return super().dispatch(request, *args, **kwargs)
 

--- a/vitrina/resources/views.py
+++ b/vitrina/resources/views.py
@@ -21,7 +21,7 @@ from vitrina.requests.models import Request
 from vitrina.resources.forms import DatasetResourceForm
 from vitrina.resources.models import DatasetDistribution
 from vitrina.structure import VersionStatus
-from vitrina.structure.models import Metadata, Version
+from vitrina.structure.models import Version
 from vitrina.structure.views import DatasetStructureMixin, ModelCreateView
 from vitrina.views import HistoryMixin
 

--- a/vitrina/resources/views.py
+++ b/vitrina/resources/views.py
@@ -20,7 +20,8 @@ from vitrina.plans.models import Plan
 from vitrina.requests.models import Request
 from vitrina.resources.forms import DatasetResourceForm
 from vitrina.resources.models import DatasetDistribution
-from vitrina.structure.models import Version
+from vitrina.structure import VersionStatus
+from vitrina.structure.models import Metadata, Version
 from vitrina.structure.views import DatasetStructureMixin, ModelCreateView
 from vitrina.views import HistoryMixin
 
@@ -59,6 +60,9 @@ class ResourceDetailView(PermissionRequiredMixin, HistoryMixin, DatasetStructure
         context["structure_acceptable"] = False
         context["params"] = self.object.params.all().order_by("name")
         context["models"] = self.object.model_set.all()
+        context["is_disabled"] = (
+            self.object.metadata_version is not None and self.object.metadata_version.status != VersionStatus.DRAFT
+        )
         return context
 
 
@@ -169,6 +173,22 @@ class ResourceUpdateView(LoginRequiredMixin, PermissionRequiredMixin, Translatab
     context_object_name = "datasetdistribution"
     form_class = DatasetResourceForm
 
+    def dispatch(self, request, *args, **kwargs):
+        self.resource = get_object_or_404(
+            DatasetDistribution,
+            pk=kwargs["pk"],
+        )
+        self.metadata_version = None
+        version_id = kwargs.get("version_id")
+        if version_id is not None:
+            self.metadata_version = get_object_or_404(
+                Version,
+                pk=version_id,
+            )
+            if self.metadata_version.status != VersionStatus.DRAFT:
+                raise Http404("Only allowed on Draft version.")
+        return super().dispatch(request, *args, **kwargs)
+
     def has_permission(self):
         resource = get_object_or_404(DatasetDistribution, id=self.kwargs["pk"])
         return has_perm(self.request.user, Action.UPDATE, resource)
@@ -217,6 +237,22 @@ class ResourceUpdateView(LoginRequiredMixin, PermissionRequiredMixin, Translatab
 
 class ResourceDeleteView(LoginRequiredMixin, PermissionRequiredMixin, DeleteView):
     model = DatasetDistribution
+
+    def dispatch(self, request, *args, **kwargs):
+        self.resource = get_object_or_404(
+            DatasetDistribution,
+            pk=kwargs["pk"],
+        )
+        self.metadata_version = None
+        version_id = kwargs.get("version_id")
+        if version_id is not None:
+            self.metadata_version = get_object_or_404(
+                Version,
+                pk=version_id,
+            )
+            if self.metadata_version.status != VersionStatus.DRAFT:
+                raise Http404("Only allowed on Draft version.")
+        return super().dispatch(request, *args, **kwargs)
 
     def has_permission(self):
         resource = get_object_or_404(DatasetDistribution, id=self.kwargs["pk"])

--- a/vitrina/structure/models.py
+++ b/vitrina/structure/models.py
@@ -552,6 +552,9 @@ class Version(models.Model):
     def get_absolute_url(self):
         return reverse("version-detail", kwargs={"pk": self.dataset.pk, "version_id": self.pk})
 
+    def is_draft(self) -> bool:
+        return self.status == VersionStatus.DRAFT
+
     def __str__(self):
         return f"v{self.version}"
 

--- a/vitrina/structure/templates/vitrina/structure/dataset_structure.html
+++ b/vitrina/structure/templates/vitrina/structure/dataset_structure.html
@@ -41,14 +41,31 @@
                 </a>
             {% endif %}
             {% if selected_version %}
-                <a class="button is-primary mb-5 ml-2" href="{% url 'dataset-structure-import' view.kwargs.pk selected_version.pk %}">
+                <a class="button mb-5 ml-2 is-primary {% if is_disabled %}is-disabled{% endif %}"
+                   {% if is_disabled %}
+                       style="pointer-events: none; opacity: 0.5;"
+                       aria-disabled="true"
+                   {% else %}
+                       href="{% url 'dataset-structure-import' view.kwargs.pk selected_version.pk %}"
+                   {% endif %}>
                     {% translate "Importuoti" %}
                 </a>
-                <a class="button is-primary mb-5 ml-2" href="{% url 'model-create' dataset.pk selected_version.pk %}">
+                <a class="button mb-5 ml-2 is-primary {% if is_disabled %}is-disabled{% endif %}"
+                   {% if is_disabled %}
+                       style="pointer-events: none; opacity: 0.5;"
+                       aria-disabled="true"
+                   {% else %}
+                       href="{% url 'model-create' dataset.pk selected_version.pk %}"
+                   {% endif %}>
                     {% translate "Naujas modelis" %}
                 </a>
-                <a class="button is-primary mb-5 ml-2"
-                   href="{% url 'version-create' dataset.pk selected_version.pk %}">
+                <a class="button mb-5 ml-2 is-primary {% if is_disabled %}is-disabled{% endif %}"
+                   {% if is_disabled %}
+                       style="pointer-events: none; opacity: 0.5;"
+                       aria-disabled="true"
+                   {% else %}
+                       href="{% url 'version-create' dataset.pk selected_version.pk %}"
+                   {% endif %}>
                     {% translate "Publikuoti versiją" %}
                 </a>
 

--- a/vitrina/structure/templates/vitrina/structure/model_structure.html
+++ b/vitrina/structure/templates/vitrina/structure/model_structure.html
@@ -136,9 +136,18 @@
         </div>
         {% if can_manage_structure and model.name %}
         <div class="buttons is-right">
-            <a href="{% url 'model-update' dataset.pk version_id model.name %}" class="button is-primary">
-                {% translate "Redaguoti" %}
-            </a>
+            {% if not is_disabled %}
+                <a href="{% url 'model-update' dataset.pk version_id model.name %}"
+                   class="button is-primary">
+                    {% translate "Redaguoti" %}
+                </a>
+            {% else %}
+                <a class="button is-primary is-disabled"
+                   style="pointer-events: none; opacity: 0.5;"
+                   aria-disabled="true">
+                    {% translate "Redaguoti" %}
+                </a>
+            {% endif %}
         </div>
         {% endif %}
         <div>
@@ -318,9 +327,18 @@
         </div>
         {% if can_manage_structure and model.name %}
         <div class="buttons is-right mt-5">
-            <a href="{% url 'property-create' dataset.pk version_id model.name %}" class="button is-primary">
-                {% translate "Naujas duomenų laukas" %}
-            </a>
+            {% if not is_disabled %}
+                <a href="{% url 'property-create' dataset.pk version_id model.name %}"
+                   class="button is-primary">
+                    {% translate "Naujas duomenų laukas" %}
+                </a>
+            {% else %}
+                <a class="button is-primary is-disabled"
+                   style="pointer-events: none; opacity: 0.5;"
+                   aria-disabled="true">
+                    {% translate "Naujas duomenų laukas" %}
+                </a>
+            {% endif %}
         </div>
         {% endif %}
         {% if model.base and base_props %}

--- a/vitrina/structure/templates/vitrina/structure/model_structure.html
+++ b/vitrina/structure/templates/vitrina/structure/model_structure.html
@@ -137,12 +137,12 @@
         {% if can_manage_structure and model.name %}
         <div class="buttons is-right">
             <a
-                {% if not is_disabled %}
-                    href="{% url 'model-update' dataset.pk version_id model.name %}"
-                {% endif %}
-                class="button is-primary{% if is_disabled %} is-disabled{% endif %}"
+                class="button is-primary {% if is_disabled %}is-disabled{% endif %}"
                 {% if is_disabled %}
+                    style="pointer-events: none; opacity: 0.5;"
                     aria-disabled="true"
+                {% else %}
+                    href="{% url 'model-update' dataset.pk version_id model.name %}"
                 {% endif %}
             >
                 {% translate "Redaguoti" %}

--- a/vitrina/structure/templates/vitrina/structure/model_structure.html
+++ b/vitrina/structure/templates/vitrina/structure/model_structure.html
@@ -136,18 +136,17 @@
         </div>
         {% if can_manage_structure and model.name %}
         <div class="buttons is-right">
-            {% if not is_disabled %}
-                <a href="{% url 'model-update' dataset.pk version_id model.name %}"
-                   class="button is-primary">
-                    {% translate "Redaguoti" %}
-                </a>
-            {% else %}
-                <a class="button is-primary is-disabled"
-                   style="pointer-events: none; opacity: 0.5;"
-                   aria-disabled="true">
-                    {% translate "Redaguoti" %}
-                </a>
-            {% endif %}
+            <a
+                {% if not is_disabled %}
+                    href="{% url 'model-update' dataset.pk version_id model.name %}"
+                {% endif %}
+                class="button is-primary{% if is_disabled %} is-disabled{% endif %}"
+                {% if is_disabled %}
+                    aria-disabled="true"
+                {% endif %}
+            >
+                {% translate "Redaguoti" %}
+            </a>
         </div>
         {% endif %}
         <div>

--- a/vitrina/structure/templates/vitrina/structure/property_structure.html
+++ b/vitrina/structure/templates/vitrina/structure/property_structure.html
@@ -173,11 +173,20 @@
         </div>
 
         {% if can_manage_structure and model.name and prop.name %}
-        <div class="buttons is-right">
-            <a href="{% url 'property-update' dataset.pk version_id.pk model.name prop.name %}" class="button is-primary">
-                {% translate "Redaguoti" %}
-            </a>
-        </div>
+           <div class="buttons is-right">
+                {% if not is_disabled %}
+                    <a href="{% url 'property-update' dataset.pk version_id.pk model.name prop.name %}"
+                       class="button is-primary">
+                        {% translate "Redaguoti" %}
+                    </a>
+                {% else %}
+                    <a class="button is-primary is-disabled"
+                       style="pointer-events: none; opacity: 0.5;"
+                       aria-disabled="true">
+                        {% translate "Redaguoti" %}
+                    </a>
+                {% endif %}
+            </div>
         {% endif %}
 
         {% if has_graph %}
@@ -303,16 +312,29 @@
                         <div class="column is-2">
                             {% if enum_meta.prepare or enum_meta.title %}
                                 {% if prop.name and model.name and can_manage_structure %}
-                                <div class="buttons is-right">
-                                    <a href="{% url 'enum-update' dataset.pk version_id.pk model.name prop.name enum_item.pk %}" class="button is-primary is-small">
+                                {% if not is_disabled %}
+                                    <a href="{% url 'enum-update' dataset.pk version_id.pk model.name prop.name enum_item.pk %}"
+                                       class="button is-primary is-small">
                                         {% translate "Keisti" %}
                                     </a>
                                     <a href="{% url 'enum-delete' dataset.pk version_id.pk model.name prop.name enum_item.pk %}"
                                        onclick="return confirm({% translate 'Ar jūs tikrai norite ištrinti?' %})"
                                        class="button is-link is-small"
-                                       id="delete_enum">{% translate "Ištrinti" %}
+                                       id="delete_enum">
+                                        {% translate "Ištrinti" %}
                                     </a>
-                                </div>
+                                {% else %}
+                                    <a class="button is-primary is-small is-disabled"
+                                       style="pointer-events: none; opacity: 0.5;"
+                                       aria-disabled="true">
+                                        {% translate "Keisti" %}
+                                    </a>
+                                    <a class="button is-link is-small is-disabled"
+                                       style="pointer-events: none; opacity: 0.5;"
+                                       aria-disabled="true">
+                                        {% translate "Ištrinti" %}
+                                    </a>
+                                {% endif %}
                                 {% endif %}
                             {% endif %}
                         </div>
@@ -326,9 +348,18 @@
             {% endif %}
             {% if model.name and prop.name and can_manage_structure %}
                 <div class="buttons is-right mt-5">
-                    <a href="{% url 'enum-create' dataset.pk version_id.pk model.name prop.name %}" class="button is-primary">
-                        {% translate "Nauja reikšmė" %}
-                    </a>
+                    {% if not is_disabled %}
+                        <a href="{% url 'enum-create' dataset.pk version_id.pk model.name prop.name %}"
+                           class="button is-primary">
+                            {% translate "Nauja reikšmė" %}
+                        </a>
+                    {% else %}
+                        <a class="button is-primary is-disabled"
+                           style="pointer-events: none; opacity: 0.5;"
+                           aria-disabled="true">
+                            {% translate "Nauja reikšmė" %}
+                        </a>
+                    {% endif %}
                 </div>
             {% endif %}
         </div>

--- a/vitrina/structure/views.py
+++ b/vitrina/structure/views.py
@@ -5,6 +5,7 @@ from typing import List, Union
 from urllib import parse
 from urllib.parse import unquote
 
+from django.contrib import messages
 from django.core.exceptions import ValidationError
 from django.db.models import Q, ForeignKey
 from django.conf import settings
@@ -1814,12 +1815,13 @@ class EnumCreateView(PermissionRequiredMixin, CreateView):
         )
         if not self.model_obj:
             raise Http404("No Model matches the given query.")
-        if self.metadata_version and not self.metadata_version.is_draft():
-            raise Http404("Only allowed on Draft version.")
         prop_name = kwargs.get("prop")
         self.property = get_object_or_404(
             Property, model=self.model_obj, metadata__name=prop_name, metadata_version=self.metadata_version
         )
+        if self.metadata_version and not self.metadata_version.is_draft():
+            messages.error(request, _("Negalima kurti naujos reikšmės, kai versijos būsena nėra juodraštis."))
+            return redirect(self.property.get_absolute_url())
         self.enum = self.property.enums.first()
         return super().dispatch(request, *args, **kwargs)
 
@@ -1941,8 +1943,6 @@ class EnumUpdateView(PermissionRequiredMixin, UpdateView):
         )
         if not self.model_obj:
             raise Http404("No Model matches the given query.")
-        if self.metadata_version and not self.metadata_version.is_draft():
-            raise Http404("Only allowed on Draft version.")
         prop_name = kwargs.get("prop")
         self.property = get_object_or_404(
             Property.objects.filter(visibility_filter_property),
@@ -1952,6 +1952,9 @@ class EnumUpdateView(PermissionRequiredMixin, UpdateView):
         )
         if not self.property:
             raise Http404("No Property matches the given query.")
+        if self.metadata_version and not self.metadata_version.is_draft():
+            messages.error(request, _("Negalima redaguoti reikšmės, kai versijos būsena nėra juodraštis."))
+            return redirect(self.property.get_absolute_url())
         return super().dispatch(request, *args, **kwargs)
 
     def has_permission(self):
@@ -2075,12 +2078,13 @@ class EnumDeleteView(PermissionRequiredMixin, DeleteView):
         )
         if not self.model:
             raise Http404("No Model matches the given query.")
-        if self.metadata_version and not self.metadata_version.is_draft():
-            raise Http404("Only allowed on Draft version.")
         prop_name = kwargs.get("prop")
         self.property = get_object_or_404(
             Property, model=self.model_obj, metadata__name=prop_name, metadata_version=self.metadata_version
         )
+        if self.metadata_version and not self.metadata_version.is_draft():
+            messages.error(request, _("Negalima trinti reikšmės, kai versijos būsena nėra juodraštis."))
+            return redirect(self.property.get_absolute_url())
         return super().dispatch(request, *args, **kwargs)
 
     def has_permission(self):
@@ -2155,7 +2159,8 @@ class ModelCreateView(PermissionRequiredMixin, CreateView):
             self.metadata_version = None
 
         if self.metadata_version and not self.metadata_version.is_draft():
-            raise Http404("Only allowed on Draft version.")
+            messages.error(request, _("Negalima kurti naujo modelio, kai versijos būsena nėra juodraštis."))
+            return redirect(self.dataset.get_absolute_url())
 
         # Filter by version?
         if has_perm(self.request.user, Action.STRUCTURE, Dataset, self.dataset):
@@ -2293,7 +2298,8 @@ class ModelUpdateView(DatasetBreadcrumbsMixin, PermissionRequiredMixin, UpdateVi
         self.dataset = get_object_or_404(Dataset, pk=kwargs.get("pk"))
         self.metadata_version = get_object_or_404(_Version, pk=kwargs.get("version_id"), dataset=self.dataset)
         if self.metadata_version and not self.metadata_version.is_draft():
-            raise Http404("Only allowed on Draft version.")
+            messages.error(request, _("Negalima redaguoti modelio, kai versijos būsena nėra juodraštis."))
+            return redirect(self.dataset.get_absolute_url())
         return super().dispatch(request, *args, **kwargs)
 
     def get_object(self, queryset=None):
@@ -2535,7 +2541,8 @@ class PropertyCreateView(DatasetBreadcrumbsMixin, PermissionRequiredMixin, Creat
         if not self.model_obj:
             raise Http404("No Model matches the given query.")
         if self.metadata_version and not self.metadata_version.is_draft():
-            raise Http404("Only allowed on Draft version.")
+            messages.error(request, _("Negalima kurti naujo duomenų lauko, kai versijos būsena nėra juodraštis."))
+            return redirect(self.model_obj.get_absolute_url())
         return super().dispatch(request, *args, **kwargs)
 
     def has_permission(self):
@@ -2644,7 +2651,8 @@ class PropertyUpdateView(DatasetBreadcrumbsMixin, PermissionRequiredMixin, Updat
         if not self.model_obj:
             raise Http404("No Model matches the given query.")
         if self.metadata_version and not self.metadata_version.is_draft():
-            raise Http404("Only allowed on Draft version.")
+            messages.error(request, _("Negalima redaguoti naujo duomenų lauko, kai versijos būsena nėra juodraštis."))
+            return redirect(self.model_obj.get_absolute_url())
         prop_name = kwargs.get("prop")
         self.property = get_object_or_404(
             Property.objects.filter(visibility_filter_property),
@@ -3463,7 +3471,8 @@ class PublishVersionView(PermissionRequiredMixin, CreateView):
         self.metadata_version = get_object_or_404(_Version, pk=kwargs.get("version_id"))
 
         if self.metadata_version and not self.metadata_version.is_draft():
-            raise Http404("Only allowed on Draft version.")
+            messages.error(request, _("Negalima publikuoti versijos, kai versijos būsena nėra juodraštis."))
+            return redirect(self.dataset.get_absolute_url())
 
         return super().dispatch(request, *args, **kwargs)
 
@@ -3483,7 +3492,7 @@ class PublishVersionView(PermissionRequiredMixin, CreateView):
         return context
 
     def form_valid(self, form: ModelCreateForm) -> HttpResponseRedirect:
-        if not self.metadata_version.status.is_draft():
+        if not self.metadata_version.is_draft():
             form.add_error(None, _("Publikuota versija negali būti publikuota dar kartą."))
             return self.form_invalid(form)
         self.new_version = form.save(commit=False)

--- a/vitrina/structure/views.py
+++ b/vitrina/structure/views.py
@@ -261,7 +261,7 @@ class DatasetStructureView(
         dataset = get_object_or_404(Dataset, pk=kwargs.get("pk"))
         structure = dataset.current_structure
         context["selected_version"] = self.metadata_version
-        context["is_disabled"] = self.metadata_version.status != VersionStatus.DRAFT
+        context["is_disabled"] = not self.metadata_version.is_draft()
         context["versions"] = _Version.objects.filter(dataset=dataset).order_by("version")
         context["errors"] = []
         context["manifest"] = None
@@ -435,9 +435,7 @@ class ModelStructureView(
             self.object,
         )
         context["can_manage_structure"] = self.can_manage_structure
-        context["is_disabled"] = (
-            self.metadata_version is not None and self.metadata_version.status != VersionStatus.DRAFT
-        )
+        context["is_disabled"] = self.metadata_version is not None and not self.metadata_version.is_draft()
         context["base_props"] = self.model.get_base_props()
         context["params"] = self.model.params.all().order_by("name")
         context["page_title"] = build_page_title_context(
@@ -738,9 +736,7 @@ class PropertyStructureView(
             self.object,
         )
         context["can_manage_structure"] = self.can_manage_structure
-        context["is_disabled"] = (
-            self.metadata_version is not None and self.metadata_version.status != VersionStatus.DRAFT
-        )
+        context["is_disabled"] = self.metadata_version is not None and not self.metadata_version.is_draft()
 
         allowed_enum_visibilities = get_allowed_visibilities(
             self.request.user, self.object, Action.VIEW, model_class=Enum
@@ -1818,7 +1814,7 @@ class EnumCreateView(PermissionRequiredMixin, CreateView):
         )
         if not self.model_obj:
             raise Http404("No Model matches the given query.")
-        if self.metadata_version and self.metadata_version.status != VersionStatus.DRAFT:
+        if self.metadata_version and not self.metadata_version.is_draft():
             raise Http404("Only allowed on Draft version.")
         prop_name = kwargs.get("prop")
         self.property = get_object_or_404(
@@ -1945,7 +1941,7 @@ class EnumUpdateView(PermissionRequiredMixin, UpdateView):
         )
         if not self.model_obj:
             raise Http404("No Model matches the given query.")
-        if self.metadata_version and self.metadata_version.status != VersionStatus.DRAFT:
+        if self.metadata_version and not self.metadata_version.is_draft():
             raise Http404("Only allowed on Draft version.")
         prop_name = kwargs.get("prop")
         self.property = get_object_or_404(
@@ -2079,7 +2075,7 @@ class EnumDeleteView(PermissionRequiredMixin, DeleteView):
         )
         if not self.model:
             raise Http404("No Model matches the given query.")
-        if self.metadata_version and self.metadata_version.status != VersionStatus.DRAFT:
+        if self.metadata_version and not self.metadata_version.is_draft():
             raise Http404("Only allowed on Draft version.")
         prop_name = kwargs.get("prop")
         self.property = get_object_or_404(
@@ -2158,7 +2154,7 @@ class ModelCreateView(PermissionRequiredMixin, CreateView):
         else:
             self.metadata_version = None
 
-        if self.metadata_version and self.metadata_version.status != VersionStatus.DRAFT:
+        if self.metadata_version and not self.metadata_version.is_draft():
             raise Http404("Only allowed on Draft version.")
 
         # Filter by version?
@@ -2296,7 +2292,7 @@ class ModelUpdateView(DatasetBreadcrumbsMixin, PermissionRequiredMixin, UpdateVi
     def dispatch(self, request, *args, **kwargs):
         self.dataset = get_object_or_404(Dataset, pk=kwargs.get("pk"))
         self.metadata_version = get_object_or_404(_Version, pk=kwargs.get("version_id"), dataset=self.dataset)
-        if self.metadata_version and self.metadata_version.status != VersionStatus.DRAFT:
+        if self.metadata_version and not self.metadata_version.is_draft():
             raise Http404("Only allowed on Draft version.")
         return super().dispatch(request, *args, **kwargs)
 
@@ -2538,7 +2534,7 @@ class PropertyCreateView(DatasetBreadcrumbsMixin, PermissionRequiredMixin, Creat
         )
         if not self.model_obj:
             raise Http404("No Model matches the given query.")
-        if self.metadata_version and self.metadata_version.status != VersionStatus.DRAFT:
+        if self.metadata_version and not self.metadata_version.is_draft():
             raise Http404("Only allowed on Draft version.")
         return super().dispatch(request, *args, **kwargs)
 
@@ -2647,7 +2643,7 @@ class PropertyUpdateView(DatasetBreadcrumbsMixin, PermissionRequiredMixin, Updat
         )
         if not self.model_obj:
             raise Http404("No Model matches the given query.")
-        if self.metadata_version and self.metadata_version != VersionStatus.DRAFT:
+        if self.metadata_version and not self.metadata_version.is_draft():
             raise Http404("Only allowed on Draft version.")
         prop_name = kwargs.get("prop")
         self.property = get_object_or_404(
@@ -3466,7 +3462,7 @@ class PublishVersionView(PermissionRequiredMixin, CreateView):
         self.dataset = get_object_or_404(Dataset, pk=kwargs.get("pk"))
         self.metadata_version = get_object_or_404(_Version, pk=kwargs.get("version_id"))
 
-        if self.metadata_version and self.metadata_version.status != VersionStatus.DRAFT:
+        if self.metadata_version and not self.metadata_version.is_draft():
             raise Http404("Only allowed on Draft version.")
 
         return super().dispatch(request, *args, **kwargs)
@@ -3487,7 +3483,7 @@ class PublishVersionView(PermissionRequiredMixin, CreateView):
         return context
 
     def form_valid(self, form: ModelCreateForm) -> HttpResponseRedirect:
-        if self.metadata_version.status != VersionStatus.DRAFT:
+        if not self.metadata_version.status.is_draft():
             form.add_error(None, _("Publikuota versija negali būti publikuota dar kartą."))
             return self.form_invalid(form)
         self.new_version = form.save(commit=False)

--- a/vitrina/structure/views.py
+++ b/vitrina/structure/views.py
@@ -261,6 +261,7 @@ class DatasetStructureView(
         dataset = get_object_or_404(Dataset, pk=kwargs.get("pk"))
         structure = dataset.current_structure
         context["selected_version"] = self.metadata_version
+        context["is_disabled"] = self.metadata_version.status != VersionStatus.DRAFT
         context["versions"] = _Version.objects.filter(dataset=dataset).order_by("version")
         context["errors"] = []
         context["manifest"] = None
@@ -434,6 +435,9 @@ class ModelStructureView(
             self.object,
         )
         context["can_manage_structure"] = self.can_manage_structure
+        context["is_disabled"] = (
+            self.metadata_version is not None and self.metadata_version.status != VersionStatus.DRAFT
+        )
         context["base_props"] = self.model.get_base_props()
         context["params"] = self.model.params.all().order_by("name")
         context["page_title"] = build_page_title_context(
@@ -734,6 +738,9 @@ class PropertyStructureView(
             self.object,
         )
         context["can_manage_structure"] = self.can_manage_structure
+        context["is_disabled"] = (
+            self.metadata_version is not None and self.metadata_version.status != VersionStatus.DRAFT
+        )
 
         allowed_enum_visibilities = get_allowed_visibilities(
             self.request.user, self.object, Action.VIEW, model_class=Enum
@@ -1811,6 +1818,8 @@ class EnumCreateView(PermissionRequiredMixin, CreateView):
         )
         if not self.model_obj:
             raise Http404("No Model matches the given query.")
+        if self.metadata_version and self.metadata_version.status != VersionStatus.DRAFT:
+            raise Http404("Only allowed on Draft version.")
         prop_name = kwargs.get("prop")
         self.property = get_object_or_404(
             Property, model=self.model_obj, metadata__name=prop_name, metadata_version=self.metadata_version
@@ -1936,6 +1945,8 @@ class EnumUpdateView(PermissionRequiredMixin, UpdateView):
         )
         if not self.model_obj:
             raise Http404("No Model matches the given query.")
+        if self.metadata_version and self.metadata_version.status != VersionStatus.DRAFT:
+            raise Http404("Only allowed on Draft version.")
         prop_name = kwargs.get("prop")
         self.property = get_object_or_404(
             Property.objects.filter(visibility_filter_property),
@@ -2068,6 +2079,8 @@ class EnumDeleteView(PermissionRequiredMixin, DeleteView):
         )
         if not self.model:
             raise Http404("No Model matches the given query.")
+        if self.metadata_version and self.metadata_version.status != VersionStatus.DRAFT:
+            raise Http404("Only allowed on Draft version.")
         prop_name = kwargs.get("prop")
         self.property = get_object_or_404(
             Property, model=self.model_obj, metadata__name=prop_name, metadata_version=self.metadata_version
@@ -2144,6 +2157,9 @@ class ModelCreateView(PermissionRequiredMixin, CreateView):
             )
         else:
             self.metadata_version = None
+
+        if self.metadata_version and self.metadata_version.status != VersionStatus.DRAFT:
+            raise Http404("Only allowed on Draft version.")
 
         # Filter by version?
         if has_perm(self.request.user, Action.STRUCTURE, Dataset, self.dataset):
@@ -2280,6 +2296,8 @@ class ModelUpdateView(DatasetBreadcrumbsMixin, PermissionRequiredMixin, UpdateVi
     def dispatch(self, request, *args, **kwargs):
         self.dataset = get_object_or_404(Dataset, pk=kwargs.get("pk"))
         self.metadata_version = get_object_or_404(_Version, pk=kwargs.get("version_id"), dataset=self.dataset)
+        if self.metadata_version and self.metadata_version.status != VersionStatus.DRAFT:
+            raise Http404("Only allowed on Draft version.")
         return super().dispatch(request, *args, **kwargs)
 
     def get_object(self, queryset=None):
@@ -2520,6 +2538,8 @@ class PropertyCreateView(DatasetBreadcrumbsMixin, PermissionRequiredMixin, Creat
         )
         if not self.model_obj:
             raise Http404("No Model matches the given query.")
+        if self.metadata_version and self.metadata_version.status != VersionStatus.DRAFT:
+            raise Http404("Only allowed on Draft version.")
         return super().dispatch(request, *args, **kwargs)
 
     def has_permission(self):
@@ -2627,6 +2647,8 @@ class PropertyUpdateView(DatasetBreadcrumbsMixin, PermissionRequiredMixin, Updat
         )
         if not self.model_obj:
             raise Http404("No Model matches the given query.")
+        if self.metadata_version and self.metadata_version != VersionStatus.DRAFT:
+            raise Http404("Only allowed on Draft version.")
         prop_name = kwargs.get("prop")
         self.property = get_object_or_404(
             Property.objects.filter(visibility_filter_property),
@@ -3443,6 +3465,10 @@ class PublishVersionView(PermissionRequiredMixin, CreateView):
     def dispatch(self, request, *args, **kwargs):
         self.dataset = get_object_or_404(Dataset, pk=kwargs.get("pk"))
         self.metadata_version = get_object_or_404(_Version, pk=kwargs.get("version_id"))
+
+        if self.metadata_version and self.metadata_version.status != VersionStatus.DRAFT:
+            raise Http404("Only allowed on Draft version.")
+
         return super().dispatch(request, *args, **kwargs)
 
     def has_permission(self):


### PR DESCRIPTION
Summary:
- Disabled create, update, and delete action buttons in HTML templates for non-draft versions.
- Added guards in view dispatch() methods to return Http404 when attempting to access metadata or resource modification views for non-draft versions.
