### PR TITLE
2284: Overriding get_child_resources_url in Resources

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,11 @@ https://github.com/atviriduomenys/katalogas/pull/2275
 
 - A number of changes regarding UAPI.
 
+Bug fixes:
+
+https://github.com/atviriduomenys/katalogas/issues/2284
+
+- Fix child-resources url in resources tab
 
 v 1.12.1 (2026-01-19)
 ==================
@@ -24,10 +29,6 @@ Bug fixes:
 https://github.com/atviriduomenys/spinta/issues/1630
 
 - Fix import logic when resource params were imported as dataset params.
-
-https://github.com/atviriduomenys/katalogas/issues/2284
-
-- Fix child-resources url in resources tab
 
 v 1.12.0 (2026-01-15)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,10 @@ https://github.com/atviriduomenys/spinta/issues/1630
 
 - Fix import logic when resource params were imported as dataset params.
 
+https://github.com/atviriduomenys/katalogas/issues/2284
+
+- Fix child-resources url in resources tab
+
 v 1.12.0 (2026-01-15)
 ==================
 

--- a/tests/resources/test_views.py
+++ b/tests/resources/test_views.py
@@ -10,8 +10,12 @@ from vitrina.classifiers.factories import ApplicableLegislationFactory
 from vitrina.datasets.factories import DatasetFactory
 from vitrina.orgs.factories import RepresentativeFactory
 from vitrina.orgs.models import Representative
-from vitrina.resources.factories import DatasetDistributionFactory, FileFormat, CompressionFormatFactory, \
-    PackagingFormatFactory
+from vitrina.resources.factories import (
+    DatasetDistributionFactory,
+    FileFormat,
+    CompressionFormatFactory,
+    PackagingFormatFactory,
+)
 from vitrina.resources.models import DatasetDistribution
 from vitrina.settings import SPINTA_SERVER_URL
 from vitrina.structure.factories import MetadataFactory
@@ -216,6 +220,19 @@ def test_detail_tab_from_resource_detail_view(app: DjangoTestApp):
     resp = app.get(reverse('resource-detail', args=[resource.dataset.pk, resource.pk]))
     resp = resp.click(linkid='detail_tab')
     assert resp.request.path == resource.dataset.get_absolute_url()
+
+
+@pytest.mark.django_db
+def test_child_resources_tab_from_resource_detail_view_uses_dataset(
+    app: DjangoTestApp,
+):
+    resource = DatasetDistributionFactory()
+    response = app.get(reverse("resource-detail", args=[resource.dataset.pk, resource.pk]))
+    child_resources_response = response.click(linkid="child_resources_tab")
+    assert child_resources_response.request.path == reverse(
+        "dataset-child-resources",
+        args=[resource.dataset.pk],
+    )
 
 
 @pytest.mark.django_db

--- a/vitrina/requests/templates/vitrina/requests/datasets.html
+++ b/vitrina/requests/templates/vitrina/requests/datasets.html
@@ -22,9 +22,11 @@
         <div class="column">
             {% if show_edit_buttons %}
                 <div class="buttons is-right">
-                    <a id="add-new-dataset" class="button is-primary" href="{% url 'resource-subclass-add' pk=user.organization.id %}?next={% url 'request-datasets' pk=request_obj.pk %}">
-                        {% translate "Naujas rinkinys" %}
-                    </a>
+                    {% if user.organization %}
+                        <a id="add-new-dataset" class="button is-primary" href="{% url 'resource-subclass-add' pk=user.organization.id %}?next={% url 'request-datasets' pk=request_obj.pk %}">
+                            {% translate "Naujas rinkinys" %}
+                        </a>
+                    {% endif %}
                     <a id="add-dataset" class="button is-primary" href="{% url 'request-datasets-edit' pk=request_obj.pk %}">
                         {% translate "Priskirti rinkinį" %}
                     </a>

--- a/vitrina/resources/views.py
+++ b/vitrina/resources/views.py
@@ -45,7 +45,7 @@ class ResourceDetailView(PermissionRequiredMixin, HistoryMixin, DatasetStructure
     def get_detail_url(self):
         return self.object.dataset.get_absolute_url()
 
-    def get_child_resources_url(self):
+    def get_child_resources_url(self) -> str:
         return reverse(
             "dataset-child-resources",
             args=[self.object.dataset.pk],

--- a/vitrina/resources/views.py
+++ b/vitrina/resources/views.py
@@ -45,6 +45,12 @@ class ResourceDetailView(PermissionRequiredMixin, HistoryMixin, DatasetStructure
     def get_detail_url(self):
         return self.object.dataset.get_absolute_url()
 
+    def get_child_resources_url(self):
+        return reverse(
+            "dataset-child-resources",
+            args=[self.object.dataset.pk],
+        )
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["resource"] = self.object


### PR DESCRIPTION
Summary:
- Fixed navigation in Resource detail view so dataset-level tabs generate correct URLs.
- Overrode child resources URL generation in ResourceDetailView to use dataset.pk instead of resource.pk.

Ticket: https://github.com/atviriduomenys/katalogas/issues/2284

