### PR TITLE
1656 Client/Agreement sync APIs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,7 +34,6 @@ https://github.com/atviriduomenys/katalogas/pull/2275
 
 - A number of changes regarding UAPI.
 
-
 https://github.com/atviriduomenys/katalogas/pull/2149
 
 - Structure tab navigation rewritten to accept version_id.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ https://github.com/atviriduomenys/katalogas/issues/1906
 
 - Export Dataset structure for a specific version.
 
+https://github.com/atviriduomenys/spinta/issues/1656
+
+- Add endpoints for Agreement and Client synchronization
+
 Bug fixes:
 
 https://github.com/atviriduomenys/katalogas/issues/2296
@@ -29,6 +33,7 @@ https://github.com/atviriduomenys/katalogas/issues/705
 https://github.com/atviriduomenys/katalogas/pull/2275
 
 - A number of changes regarding UAPI.
+
 
 https://github.com/atviriduomenys/katalogas/pull/2149
 

--- a/tests/smart_contracts/conftest.py
+++ b/tests/smart_contracts/conftest.py
@@ -8,6 +8,8 @@ from vitrina.datasets.factories import DatasetFactory
 from vitrina.datasets.models import Dataset
 from vitrina.orgs.factories import OrganizationFactory
 from vitrina.orgs.models import Organization
+from vitrina.smart_contracts.factories import AgreementFactory
+from vitrina.smart_contracts.models import Agreement
 from vitrina.smart_contracts.services import SAFE_PARSER, SIGNATURE_NAMESPACES
 
 
@@ -139,3 +141,8 @@ def certificate() -> x509.Certificate:
 @pytest.fixture
 def certificate_no_first_name() -> x509.Certificate:
     return x509.load_der_x509_certificate(b64decode(CERTIFICATE_ENCODED_NO_FIRST_NAME))
+
+
+@pytest.fixture
+def agreement() -> Agreement:
+    return AgreementFactory()

--- a/tests/smart_contracts/test_models.py
+++ b/tests/smart_contracts/test_models.py
@@ -4,7 +4,8 @@ import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.exceptions import ValidationError
 
-from vitrina.smart_contracts.models import SmartContractTemplate
+from vitrina.smart_contracts.factories import AgreementFileFactory
+from vitrina.smart_contracts.models import SmartContractTemplate, Agreement
 from vitrina.orgs.factories import OrganizationFactory
 
 
@@ -34,3 +35,22 @@ def test_invalid_file_extension_raises_validation_error():
     with pytest.raises(ValidationError) as exc_info:
         template.full_clean()
     assert "Failas turi būti Markdown formato (.md)." in str(exc_info.value)
+
+
+class TestAgreement:
+    def test_latest_agreement_adoc_return_only_adoc(self, agreement: Agreement):
+        agreement_file1 = AgreementFileFactory(agreement=agreement)
+        AgreementFileFactory(agreement=agreement, file_extension="md")
+
+        assert agreement.latest_agreement_adoc == agreement_file1
+
+    def test_latest_agreement_adoc_returns_latest_adoc(self, agreement: Agreement):
+        AgreementFileFactory(agreement=agreement)
+        agreement_file2 = AgreementFileFactory(agreement=agreement)
+
+        assert agreement.latest_agreement_adoc == agreement_file2
+
+    def test_latest_agreement_adoc_returns_none_if_no_adocs_exist(self, agreement: Agreement):
+        AgreementFileFactory(agreement=agreement, file_extension="md")
+
+        assert agreement.latest_agreement_adoc is None

--- a/tests/uapi/agreement/test_views.py
+++ b/tests/uapi/agreement/test_views.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
@@ -11,15 +12,24 @@ from rest_framework import status
 from django.conf import settings
 
 from tests.uapi.conftest import _generate_test_token
+from vitrina.datasets.factories import DatasetFactory
+from vitrina.datasets.models import Dataset
 from vitrina.orgs.factories import OrganizationFactory
 from vitrina.orgs.models import Organization
+from vitrina.projects.factories import ProjectFactory, UseCaseClientFactory
 from vitrina.projects.models import Project
 from vitrina.smart_contracts import AgreementStatuses
-from vitrina.smart_contracts.factories import AgreementFactory
+from vitrina.smart_contracts.exceptions import InvalidAdocError
+from vitrina.smart_contracts.factories import AgreementFactory, AgreementFileFactory
+from vitrina.uapi.models import Agent
 
 
 pytestmark = pytest.mark.django_db
 timezone = pytz.timezone(settings.TIME_ZONE)
+
+
+def agreement_url() -> str:
+    return reverse("uapi-agreement")
 
 
 class TestSyncDone:
@@ -29,7 +39,6 @@ class TestSyncDone:
             extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
             expect_errors=True,
         )
-
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert response.json == {
             "code": "not_found",
@@ -205,3 +214,369 @@ class TestSyncDone:
         assert response.status_code == status.HTTP_204_NO_CONTENT
         agreement.refresh_from_db()
         assert agreement.updated_at == creation_date
+
+
+class TestAgreementViewSetAuthorization:
+    def test_401_if_unauthorized(self, app: DjangoTestApp):
+        response = app.get(agreement_url(), expect_errors=True)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_403_if_token_has_no_organization(self, app: DjangoTestApp, organization: Organization, test_jwk: RSAKey):
+        token = _generate_test_token(test_jwk, organization=None, scopes=settings.OAUTH_AGENT_DEFAULT_SCOPES)
+        response = app.get(
+            agreement_url(),
+            extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"},
+            expect_errors=True,
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.parametrize(
+        "invalid_scopes", [
+            tuple(),
+            ("", ),
+            ("invalid_scope1", "invalid_scope2"),
+        ])
+    def test_403_if_list_authorized_with_incorrect_scopes(
+        self, app: DjangoTestApp, organization: Organization, test_jwk: RSAKey, invalid_scopes: tuple[str]
+    ):
+        token = _generate_test_token(test_jwk, organization=organization, scopes=invalid_scopes)
+        response = app.get(
+            agreement_url(),
+            extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"},
+            expect_errors=True,
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+class TestAgreementViewSetList:
+    def test_404_if_agreement_is_in_different_organization(
+        self, app: DjangoTestApp, organization: Organization, valid_token: str
+    ):
+        different_organization = OrganizationFactory()
+        agent = Agent.objects.get(organization=organization)
+        use_case = ProjectFactory(datasets=[agent.service])
+        AgreementFactory(project=use_case, assigner=different_organization, status=AgreementStatuses.SIGNED)
+        response = app.get(
+            agreement_url(),
+            extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+            expect_errors=True,
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_404_if_agreement_does_not_exist(
+        self, app: DjangoTestApp, organization: Organization, valid_token: str
+    ):
+        response = app.get(
+            agreement_url(),
+            extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+            expect_errors=True,
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.parametrize(
+        "incorrect_status", [
+            AgreementStatuses.CREATED,
+            AgreementStatuses.SUBMITTED,
+            AgreementStatuses.APPROVED,
+            AgreementStatuses.FORMED,
+            AgreementStatuses.INITIATED,
+            AgreementStatuses.TERMINATED,
+        ]
+    )
+    def test_404_if_agreement_with_incorrect_status(
+        self, app: DjangoTestApp, organization: Organization, valid_token: str, incorrect_status: AgreementStatuses
+    ):
+        agent = Agent.objects.get(organization=organization)
+        use_case = ProjectFactory(datasets=[agent.service])
+        AgreementFactory(project=use_case, assigner=organization, status=incorrect_status)
+        response = app.get(
+            agreement_url(),
+            extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+            expect_errors=True,
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_404_if_agreement_dataset_is_not_related_to_agent_service(
+        self, app: DjangoTestApp, organization: Organization, dataset: Dataset, valid_token: str
+    ):
+        use_case = ProjectFactory(datasets=[dataset])
+        AgreementFactory(project=use_case, assigner=organization, status=AgreementStatuses.SIGNED)
+        response = app.get(
+            agreement_url(),
+            extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+            expect_errors=True,
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.parametrize("correct_status", [
+        AgreementStatuses.SIGNED,
+        AgreementStatuses.ACTIVE
+    ])
+    def test_success(
+        self, app: DjangoTestApp, organization: Organization, valid_token: str, correct_status: AgreementStatuses
+    ):
+        agent = Agent.objects.get(organization=organization)
+        use_case = ProjectFactory(datasets=[agent.service])
+        agreement = AgreementFactory(project=use_case, assigner=organization, status=correct_status)
+        agreement_file = AgreementFileFactory(agreement=agreement)
+        use_case_client = UseCaseClientFactory(use_case=use_case)
+        response = app.get(
+            agreement_url(),
+            extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json == {
+            "_data": [
+                {
+                    "_type": "datasets/gov/vssa/ror/dcat/Agreement",
+                    "_id": str(agreement.uuid),
+                    "_revision": "",
+                    "_txn": "",
+                    "_created": agreement.created_at.astimezone(timezone).isoformat(),
+                    "_updated": agreement.updated_at.astimezone(timezone).isoformat(),
+                    "@context": "",
+                    "agreement_file_url": reverse(
+                        "uapi-agreement-file-download", kwargs={"agreement_file_uuid": agreement_file.uuid}
+                    ),
+                    "agreement_scopes": [
+                        "uapi:/datasets/gov/rc/ar/ws/Country/@resident/:getall",
+                        "uapi:/datasets/gov/rc/ar/ws/Country/@resident/:getone",
+                    ],
+                    "clients": [
+                        {
+                            # TODO: Fix this in https://github.com/atviriduomenys/katalogas/issues/2287.
+                            #  Should be: datasets/gov/vssa/isris/dcat/Client
+                            "_type": "",
+                            "_id": str(use_case_client.uuid),
+                            "_revision": "",
+                            "_txn": "",
+                            "_created": use_case_client.created_at.astimezone(timezone).isoformat(),
+                            "_updated": use_case_client.updated_at.astimezone(timezone).isoformat(),
+                            "@context": "",
+                        }
+                    ]
+                }
+            ]
+        }
+
+    def test_success_when_dataset_is_agent_service_child(
+        self, app: DjangoTestApp, organization: Organization, valid_token: str
+    ):
+        agent = Agent.objects.get(organization=organization)
+        child_dataset = DatasetFactory(organization=organization)
+        child_dataset.move(agent.service, pos="sorted-child")
+        use_case = ProjectFactory(datasets=[child_dataset])
+        agreement = AgreementFactory(project=use_case, assigner=organization, status=AgreementStatuses.SIGNED)
+        agreement_file = AgreementFileFactory(agreement=agreement)
+        response = app.get(
+            agreement_url(),
+            extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json == {
+            "_data": [
+                {
+                    "_type": "datasets/gov/vssa/ror/dcat/Agreement",
+                    "_id": str(agreement.uuid),
+                    "_revision": "",
+                    "_txn": "",
+                    "_created": agreement.created_at.astimezone(timezone).isoformat(),
+                    "_updated": agreement.updated_at.astimezone(timezone).isoformat(),
+                    "@context": "",
+                    "agreement_file_url": reverse(
+                        "uapi-agreement-file-download", kwargs={"agreement_file_uuid": agreement_file.uuid}
+                    ),
+                    "agreement_scopes": [
+                        "uapi:/datasets/gov/rc/ar/ws/Country/@resident/:getall",
+                        "uapi:/datasets/gov/rc/ar/ws/Country/@resident/:getone",
+                    ],
+                    "clients": [],
+                }
+            ]
+        }
+
+    def test_400_when_given_dataset_uuid_is_not_related_to_agent_service(
+        self, app: DjangoTestApp, organization: Organization, valid_token: str
+    ):
+        non_existig_dataset_uuid = str(uuid4())
+        agent = Agent.objects.get(organization=organization)
+        use_case = ProjectFactory(datasets=[agent.service])
+        AgreementFactory(project=use_case, assigner=organization, status=AgreementStatuses.SIGNED)
+        response = app.get(
+            f"{agreement_url()}?dataset._id={non_existig_dataset_uuid}",
+            extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+            expect_errors=True,
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json["message"] == f"dataset._id values: {non_existig_dataset_uuid} are invalid."
+
+    def test_filter_dataset_by_dataset_uuid(
+        self, app: DjangoTestApp, organization: Organization, valid_token: str
+    ):
+        agent = Agent.objects.get(organization=organization)
+        child_dataset = DatasetFactory(organization=organization)
+        child_dataset.move(agent.service, pos="sorted-child")
+
+        use_case = ProjectFactory(datasets=[agent.service])
+        use_case2 = ProjectFactory(datasets=[child_dataset])
+        agreement = AgreementFactory(project=use_case, assigner=organization, status=AgreementStatuses.SIGNED)
+        agreement2 = AgreementFactory(project=use_case2, assigner=organization, status=AgreementStatuses.SIGNED)
+        agreement_file = AgreementFileFactory(agreement=agreement)
+        AgreementFileFactory(agreement=agreement2)
+
+        response = app.get(
+            f"{agreement_url()}?dataset._id={agent.service.uuid}",
+            extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json == {
+            "_data": [
+                {
+                    "_type": "datasets/gov/vssa/ror/dcat/Agreement",
+                    "_id": str(agreement.uuid),
+                    "_revision": "",
+                    "_txn": "",
+                    "_created": agreement.created_at.astimezone(timezone).isoformat(),
+                    "_updated": agreement.updated_at.astimezone(timezone).isoformat(),
+                    "@context": "",
+                    "agreement_file_url": reverse(
+                        "uapi-agreement-file-download", kwargs={"agreement_file_uuid": agreement_file.uuid}
+                    ),
+                    "agreement_scopes": [
+                        "uapi:/datasets/gov/rc/ar/ws/Country/@resident/:getall",
+                        "uapi:/datasets/gov/rc/ar/ws/Country/@resident/:getone",
+                    ],
+                    "clients": [],
+                }
+            ]
+        }
+
+    def test_filter_dataset_by_multiple_dataset_uuids(
+        self, app: DjangoTestApp, organization: Organization, valid_token: str
+    ):
+        agent = Agent.objects.get(organization=organization)
+        child_dataset = DatasetFactory(organization=organization)
+        child_dataset2 = DatasetFactory(organization=organization)
+        child_dataset.move(agent.service, pos="sorted-child")
+        child_dataset.refresh_from_db()
+        child_dataset2.move(child_dataset, pos="sorted-child")
+        child_dataset2.refresh_from_db()
+
+        use_case = ProjectFactory(datasets=[agent.service])
+        use_case2 = ProjectFactory(datasets=[child_dataset])
+        use_case3 = ProjectFactory(datasets=[child_dataset])
+        agreement = AgreementFactory(project=use_case, assigner=organization, status=AgreementStatuses.SIGNED)
+        agreement2 = AgreementFactory(project=use_case2, assigner=organization, status=AgreementStatuses.SIGNED)
+        agreement3 = AgreementFactory(project=use_case3, assigner=organization, status=AgreementStatuses.SIGNED)
+        AgreementFileFactory(agreement=agreement)
+        agreement_file2 = AgreementFileFactory(agreement=agreement2)
+        agreement_file3 = AgreementFileFactory(agreement=agreement3)
+
+        response = app.get(
+            f"{agreement_url()}?dataset._id={child_dataset.uuid}&dataset._id={child_dataset2.uuid}",
+            extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json == {
+            "_data": [
+                {
+                    "_type": "datasets/gov/vssa/ror/dcat/Agreement",
+                    "_id": str(agreement3.uuid),
+                    "_revision": "",
+                    "_txn": "",
+                    "_created": agreement3.created_at.astimezone(timezone).isoformat(),
+                    "_updated": agreement3.updated_at.astimezone(timezone).isoformat(),
+                    "@context": "",
+                    "agreement_file_url": reverse(
+                        "uapi-agreement-file-download", kwargs={"agreement_file_uuid": agreement_file3.uuid}
+                    ),
+                    "agreement_scopes": [
+                        "uapi:/datasets/gov/rc/ar/ws/Country/@resident/:getall",
+                        "uapi:/datasets/gov/rc/ar/ws/Country/@resident/:getone",
+                    ],
+                    "clients": [],
+                },
+                {
+                    "_type": "datasets/gov/vssa/ror/dcat/Agreement",
+                    "_id": str(agreement2.uuid),
+                    "_revision": "",
+                    "_txn": "",
+                    "_created": agreement2.created_at.astimezone(timezone).isoformat(),
+                    "_updated": agreement2.updated_at.astimezone(timezone).isoformat(),
+                    "@context": "",
+                    "agreement_file_url": reverse(
+                        "uapi-agreement-file-download", kwargs={"agreement_file_uuid": agreement_file2.uuid}
+                    ),
+                    "agreement_scopes": [
+                        "uapi:/datasets/gov/rc/ar/ws/Country/@resident/:getall",
+                        "uapi:/datasets/gov/rc/ar/ws/Country/@resident/:getone",
+                    ],
+                    "clients": [],
+                },
+            ]
+        }
+
+    def test_returns_latest_agreement_adoc_file(self, app: DjangoTestApp, organization: Organization, valid_token: str):
+        agent = Agent.objects.get(organization=organization)
+        use_case = ProjectFactory(datasets=[agent.service])
+        agreement = AgreementFactory(project=use_case, assigner=organization, status=AgreementStatuses.SIGNED)
+        AgreementFileFactory(agreement=agreement)
+        agreement_file2 = AgreementFileFactory(agreement=agreement)
+        response = app.get(
+            agreement_url(),
+            extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json["_data"][0]["agreement_file_url"] == (
+            reverse("uapi-agreement-file-download", kwargs={"agreement_file_uuid": agreement_file2.uuid})
+        )
+
+    def test_400_if_agreement_file_scopes_cannot_be_extracted(
+        self, app: DjangoTestApp, organization: Organization, valid_token: str
+    ):
+        agent = Agent.objects.get(organization=organization)
+        use_case = ProjectFactory(datasets=[agent.service])
+        agreement = AgreementFactory(project=use_case, assigner=organization, status=AgreementStatuses.SIGNED)
+        agreement_file = AgreementFileFactory(agreement=agreement)
+
+        with patch(
+            "vitrina.uapi.views.agreement_views.extract_elements_from_adoc",
+            side_effect=InvalidAdocError("Test error")
+        ):
+            response = app.get(
+                agreement_url(),
+                extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+                expect_errors=True,
+            )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json["message"] == (
+            f"Scopes cannot be extracted from Agreement file (_id={agreement_file.uuid}). Error: Test error"
+        )
+
+    def test_returns_agreement_adoc_null_if_agreement_adoc_does_not_exist(
+        self, app: DjangoTestApp, organization: Organization, valid_token: str
+    ):
+        agent = Agent.objects.get(organization=organization)
+        use_case = ProjectFactory(datasets=[agent.service])
+        AgreementFactory(project=use_case, assigner=organization, status=AgreementStatuses.SIGNED)
+        response = app.get(
+            agreement_url(),
+            extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json["_data"][0]["agreement_file_url"] is None
+        assert response.json["_data"][0]["agreement_scopes"] is None

--- a/tests/uapi/agreement/test_views.py
+++ b/tests/uapi/agreement/test_views.py
@@ -22,7 +22,7 @@ from vitrina.smart_contracts import AgreementStatuses
 from vitrina.smart_contracts.exceptions import InvalidAdocError
 from vitrina.smart_contracts.factories import AgreementFactory, AgreementFileFactory
 from vitrina.uapi.models import Agent
-
+from vitrina.uapi.pagination import UAPIPagination
 
 pytestmark = pytest.mark.django_db
 timezone = pytz.timezone(settings.TIME_ZONE)
@@ -580,3 +580,32 @@ class TestAgreementViewSetList:
         assert response.status_code == status.HTTP_200_OK
         assert response.json["_data"][0]["agreement_file_url"] is None
         assert response.json["_data"][0]["agreement_scopes"] is None
+
+    def test_returns_paginated_response(self, app: DjangoTestApp, organization: Organization, valid_token: str):
+        agent = Agent.objects.get(organization=organization)
+        use_case = ProjectFactory(datasets=[agent.service])
+        agreement1 = AgreementFactory(project=use_case, assigner=organization, status=AgreementStatuses.SIGNED)
+        AgreementFactory(project=use_case, assigner=organization, status=AgreementStatuses.SIGNED)
+        response = app.get(
+            f"{agreement_url()}?_limit=1&_sort=_created",
+            extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json == {
+            "_data": [
+                {
+                    "_type": "datasets/gov/vssa/ror/dcat/Agreement",
+                    "_id": str(agreement1.uuid),
+                    "_revision": "",
+                    "_txn": "",
+                    "_created": agreement1.created_at.astimezone(timezone).isoformat(),
+                    "_updated": agreement1.updated_at.astimezone(timezone).isoformat(),
+                    "@context": "",
+                    "agreement_file_url": None,
+                    "agreement_scopes": None,
+                    "clients": [],
+                }
+            ],
+            "_next": UAPIPagination()._encode_uapi_urlsafe_base64(f'["{str(agreement1.created_at)}"]'),
+        }

--- a/tests/uapi/agreement/test_views.py
+++ b/tests/uapi/agreement/test_views.py
@@ -1,9 +1,9 @@
 from datetime import datetime
 from unittest.mock import patch
 from uuid import uuid4
+from zoneinfo import ZoneInfo
 
 import pytest
-import pytz
 from authlib.jose import RSAKey
 from django.urls import reverse
 from django_webtest import DjangoTestApp
@@ -25,11 +25,7 @@ from vitrina.uapi.models import Agent
 from vitrina.uapi.pagination import UAPIPagination
 
 pytestmark = pytest.mark.django_db
-timezone = pytz.timezone(settings.TIME_ZONE)
-
-
-def agreement_url() -> str:
-    return reverse("uapi-agreement")
+timezone = ZoneInfo(settings.TIME_ZONE)
 
 
 class TestSyncDone:
@@ -217,14 +213,16 @@ class TestSyncDone:
 
 
 class TestAgreementViewSetAuthorization:
-    def test_401_if_unauthorized(self, app: DjangoTestApp):
-        response = app.get(agreement_url(), expect_errors=True)
+    def test_401_if_unauthorized(self, app: DjangoTestApp, agreement_url: str):
+        response = app.get(agreement_url, expect_errors=True)
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
-    def test_403_if_token_has_no_organization(self, app: DjangoTestApp, organization: Organization, test_jwk: RSAKey):
+    def test_403_if_token_has_no_organization(
+        self, app: DjangoTestApp, organization: Organization, test_jwk: RSAKey, agreement_url: str
+    ):
         token = _generate_test_token(test_jwk, organization=None, scopes=settings.OAUTH_AGENT_DEFAULT_SCOPES)
         response = app.get(
-            agreement_url(),
+            agreement_url,
             extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"},
             expect_errors=True,
         )
@@ -240,11 +238,16 @@ class TestAgreementViewSetAuthorization:
         ],
     )
     def test_403_if_list_authorized_with_incorrect_scopes(
-        self, app: DjangoTestApp, organization: Organization, test_jwk: RSAKey, invalid_scopes: tuple[str]
+        self,
+        app: DjangoTestApp,
+        organization: Organization,
+        test_jwk: RSAKey,
+        agreement_url: str,
+        invalid_scopes: tuple[str],
     ):
         token = _generate_test_token(test_jwk, organization=organization, scopes=invalid_scopes)
         response = app.get(
-            agreement_url(),
+            agreement_url,
             extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"},
             expect_errors=True,
         )
@@ -253,29 +256,33 @@ class TestAgreementViewSetAuthorization:
 
 
 class TestAgreementViewSetList:
-    def test_404_if_agreement_is_in_different_organization(
-        self, app: DjangoTestApp, organization: Organization, valid_token: str
+    def test_return_agreements_only_from_agent_organization(
+        self, app: DjangoTestApp, organization: Organization, valid_token: str, agreement_url: str
     ):
         different_organization = OrganizationFactory()
         agent = Agent.objects.get(organization=organization)
         use_case = ProjectFactory(datasets=[agent.service])
         AgreementFactory(project=use_case, assigner=different_organization, status=AgreementStatuses.SIGNED)
         response = app.get(
-            agreement_url(),
+            agreement_url,
             extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
             expect_errors=True,
         )
 
-        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json == {"_data": []}
 
-    def test_404_if_agreement_does_not_exist(self, app: DjangoTestApp, organization: Organization, valid_token: str):
+    def test_return_empty_if_agreement_does_not_exist(
+        self, app: DjangoTestApp, organization: Organization, valid_token: str, agreement_url: str
+    ):
         response = app.get(
-            agreement_url(),
+            agreement_url,
             extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
             expect_errors=True,
         )
 
-        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json == {"_data": []}
 
     @pytest.mark.parametrize(
         "incorrect_status",
@@ -288,36 +295,48 @@ class TestAgreementViewSetList:
             AgreementStatuses.TERMINATED,
         ],
     )
-    def test_404_if_agreement_with_incorrect_status(
-        self, app: DjangoTestApp, organization: Organization, valid_token: str, incorrect_status: AgreementStatuses
+    def test_do_not_return_agreements_with_incorrect_status(
+        self,
+        app: DjangoTestApp,
+        organization: Organization,
+        valid_token: str,
+        agreement_url: str,
+        incorrect_status: AgreementStatuses,
     ):
         agent = Agent.objects.get(organization=organization)
         use_case = ProjectFactory(datasets=[agent.service])
         AgreementFactory(project=use_case, assigner=organization, status=incorrect_status)
         response = app.get(
-            agreement_url(),
+            agreement_url,
             extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
             expect_errors=True,
         )
 
-        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json == {"_data": []}
 
-    def test_404_if_agreement_dataset_is_not_related_to_agent_service(
-        self, app: DjangoTestApp, organization: Organization, dataset: Dataset, valid_token: str
+    def test_return_agreements_related_to_agent_service(
+        self, app: DjangoTestApp, organization: Organization, dataset: Dataset, valid_token: str, agreement_url: str
     ):
         use_case = ProjectFactory(datasets=[dataset])
         AgreementFactory(project=use_case, assigner=organization, status=AgreementStatuses.SIGNED)
         response = app.get(
-            agreement_url(),
+            agreement_url,
             extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
             expect_errors=True,
         )
 
-        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json == {"_data": []}
 
     @pytest.mark.parametrize("correct_status", [AgreementStatuses.SIGNED, AgreementStatuses.ACTIVE])
     def test_success(
-        self, app: DjangoTestApp, organization: Organization, valid_token: str, correct_status: AgreementStatuses
+        self,
+        app: DjangoTestApp,
+        organization: Organization,
+        valid_token: str,
+        agreement_url: str,
+        correct_status: AgreementStatuses,
     ):
         agent = Agent.objects.get(organization=organization)
         use_case = ProjectFactory(datasets=[agent.service])
@@ -325,7 +344,7 @@ class TestAgreementViewSetList:
         agreement_file = AgreementFileFactory(agreement=agreement)
         use_case_client = UseCaseClientFactory(use_case=use_case)
         response = app.get(
-            agreement_url(),
+            agreement_url,
             extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
         )
 
@@ -365,7 +384,7 @@ class TestAgreementViewSetList:
         }
 
     def test_success_when_dataset_is_agent_service_child(
-        self, app: DjangoTestApp, organization: Organization, valid_token: str
+        self, app: DjangoTestApp, organization: Organization, valid_token: str, agreement_url: str
     ):
         agent = Agent.objects.get(organization=organization)
         child_dataset = DatasetFactory(organization=organization)
@@ -374,7 +393,7 @@ class TestAgreementViewSetList:
         agreement = AgreementFactory(project=use_case, assigner=organization, status=AgreementStatuses.SIGNED)
         agreement_file = AgreementFileFactory(agreement=agreement)
         response = app.get(
-            agreement_url(),
+            agreement_url,
             extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
         )
 
@@ -402,22 +421,24 @@ class TestAgreementViewSetList:
         }
 
     def test_400_when_given_dataset_uuid_is_not_related_to_agent_service(
-        self, app: DjangoTestApp, organization: Organization, valid_token: str
+        self, app: DjangoTestApp, organization: Organization, valid_token: str, agreement_url: str
     ):
         non_existig_dataset_uuid = str(uuid4())
         agent = Agent.objects.get(organization=organization)
         use_case = ProjectFactory(datasets=[agent.service])
         AgreementFactory(project=use_case, assigner=organization, status=AgreementStatuses.SIGNED)
         response = app.get(
-            f"{agreement_url()}?dataset._id={non_existig_dataset_uuid}",
+            f"{agreement_url}?datasets._id={non_existig_dataset_uuid}",
             extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
             expect_errors=True,
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.json["message"] == f"dataset._id values: {non_existig_dataset_uuid} are invalid."
+        assert response.json["message"] == f"datasets._id values: {non_existig_dataset_uuid} are invalid."
 
-    def test_filter_dataset_by_dataset_uuid(self, app: DjangoTestApp, organization: Organization, valid_token: str):
+    def test_filter_dataset_by_dataset_uuid(
+        self, app: DjangoTestApp, organization: Organization, valid_token: str, agreement_url: str
+    ):
         agent = Agent.objects.get(organization=organization)
         child_dataset = DatasetFactory(organization=organization)
         child_dataset.move(agent.service, pos="sorted-child")
@@ -430,7 +451,7 @@ class TestAgreementViewSetList:
         AgreementFileFactory(agreement=agreement2)
 
         response = app.get(
-            f"{agreement_url()}?dataset._id={agent.service.uuid}",
+            f"{agreement_url}?datasets._id={agent.service.uuid}",
             extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
         )
 
@@ -458,7 +479,7 @@ class TestAgreementViewSetList:
         }
 
     def test_filter_dataset_by_multiple_dataset_uuids(
-        self, app: DjangoTestApp, organization: Organization, valid_token: str
+        self, app: DjangoTestApp, organization: Organization, valid_token: str, agreement_url: str
     ):
         agent = Agent.objects.get(organization=organization)
         child_dataset = DatasetFactory(organization=organization)
@@ -479,7 +500,7 @@ class TestAgreementViewSetList:
         agreement_file3 = AgreementFileFactory(agreement=agreement3)
 
         response = app.get(
-            f"{agreement_url()}?dataset._id={child_dataset.uuid}&dataset._id={child_dataset2.uuid}",
+            f"{agreement_url}?datasets._id={child_dataset.uuid}&datasets._id={child_dataset2.uuid}",
             extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
         )
 
@@ -523,14 +544,16 @@ class TestAgreementViewSetList:
             ]
         }
 
-    def test_returns_latest_agreement_adoc_file(self, app: DjangoTestApp, organization: Organization, valid_token: str):
+    def test_returns_latest_agreement_adoc_file(
+        self, app: DjangoTestApp, organization: Organization, valid_token: str, agreement_url: str
+    ):
         agent = Agent.objects.get(organization=organization)
         use_case = ProjectFactory(datasets=[agent.service])
         agreement = AgreementFactory(project=use_case, assigner=organization, status=AgreementStatuses.SIGNED)
         AgreementFileFactory(agreement=agreement)
         agreement_file2 = AgreementFileFactory(agreement=agreement)
         response = app.get(
-            agreement_url(),
+            agreement_url,
             extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
         )
 
@@ -540,7 +563,7 @@ class TestAgreementViewSetList:
         )
 
     def test_400_if_agreement_file_scopes_cannot_be_extracted(
-        self, app: DjangoTestApp, organization: Organization, valid_token: str
+        self, app: DjangoTestApp, organization: Organization, valid_token: str, agreement_url: str
     ):
         agent = Agent.objects.get(organization=organization)
         use_case = ProjectFactory(datasets=[agent.service])
@@ -551,7 +574,7 @@ class TestAgreementViewSetList:
             "vitrina.uapi.views.agreement_views.extract_elements_from_adoc", side_effect=InvalidAdocError("Test error")
         ):
             response = app.get(
-                agreement_url(),
+                agreement_url,
                 extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
                 expect_errors=True,
             )
@@ -561,28 +584,31 @@ class TestAgreementViewSetList:
             f"Scopes cannot be extracted from Agreement file (_id={agreement_file.uuid}). Error: Test error"
         )
 
-    def test_returns_agreement_adoc_null_if_agreement_adoc_does_not_exist(
-        self, app: DjangoTestApp, organization: Organization, valid_token: str
+    def test_400_if_agreement_adoc_does_not_exist(
+        self, app: DjangoTestApp, organization: Organization, valid_token: str, agreement_url: str
     ):
         agent = Agent.objects.get(organization=organization)
         use_case = ProjectFactory(datasets=[agent.service])
-        AgreementFactory(project=use_case, assigner=organization, status=AgreementStatuses.SIGNED)
+        agreement = AgreementFactory(project=use_case, assigner=organization, status=AgreementStatuses.SIGNED)
         response = app.get(
-            agreement_url(),
+            agreement_url,
             extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+            expect_errors=True,
         )
 
-        assert response.status_code == status.HTTP_200_OK
-        assert response.json["_data"][0]["agreement_file_url"] is None
-        assert response.json["_data"][0]["agreement_scopes"] is None
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json["message"] == (f"Agreement adoc file does not exist for agreement (_id={agreement.uuid})")
 
-    def test_returns_paginated_response(self, app: DjangoTestApp, organization: Organization, valid_token: str):
+    def test_returns_paginated_response(
+        self, app: DjangoTestApp, organization: Organization, valid_token: str, agreement_url: str
+    ):
         agent = Agent.objects.get(organization=organization)
         use_case = ProjectFactory(datasets=[agent.service])
         agreement1 = AgreementFactory(project=use_case, assigner=organization, status=AgreementStatuses.SIGNED)
+        agreement_file1 = AgreementFileFactory(agreement=agreement1)
         AgreementFactory(project=use_case, assigner=organization, status=AgreementStatuses.SIGNED)
         response = app.get(
-            f"{agreement_url()}?_limit=1&_sort=_created",
+            f"{agreement_url}?_limit=1&_sort=_created",
             extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
         )
 
@@ -597,8 +623,13 @@ class TestAgreementViewSetList:
                     "_created": agreement1.created_at.astimezone(timezone).isoformat(),
                     "_updated": agreement1.updated_at.astimezone(timezone).isoformat(),
                     "@context": "",
-                    "agreement_file_url": None,
-                    "agreement_scopes": None,
+                    "agreement_file_url": reverse(
+                        "uapi-agreement-file-download", kwargs={"agreement_file_uuid": agreement_file1.uuid}
+                    ),
+                    "agreement_scopes": [
+                        "uapi:/datasets/gov/rc/ar/ws/Country/@resident/:getall",
+                        "uapi:/datasets/gov/rc/ar/ws/Country/@resident/:getone",
+                    ],
                     "clients": [],
                 }
             ],

--- a/tests/uapi/agreement/test_views.py
+++ b/tests/uapi/agreement/test_views.py
@@ -232,11 +232,13 @@ class TestAgreementViewSetAuthorization:
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     @pytest.mark.parametrize(
-        "invalid_scopes", [
+        "invalid_scopes",
+        [
             tuple(),
-            ("", ),
+            ("",),
             ("invalid_scope1", "invalid_scope2"),
-        ])
+        ],
+    )
     def test_403_if_list_authorized_with_incorrect_scopes(
         self, app: DjangoTestApp, organization: Organization, test_jwk: RSAKey, invalid_scopes: tuple[str]
     ):
@@ -266,9 +268,7 @@ class TestAgreementViewSetList:
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
-    def test_404_if_agreement_does_not_exist(
-        self, app: DjangoTestApp, organization: Organization, valid_token: str
-    ):
+    def test_404_if_agreement_does_not_exist(self, app: DjangoTestApp, organization: Organization, valid_token: str):
         response = app.get(
             agreement_url(),
             extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
@@ -278,14 +278,15 @@ class TestAgreementViewSetList:
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     @pytest.mark.parametrize(
-        "incorrect_status", [
+        "incorrect_status",
+        [
             AgreementStatuses.CREATED,
             AgreementStatuses.SUBMITTED,
             AgreementStatuses.APPROVED,
             AgreementStatuses.FORMED,
             AgreementStatuses.INITIATED,
             AgreementStatuses.TERMINATED,
-        ]
+        ],
     )
     def test_404_if_agreement_with_incorrect_status(
         self, app: DjangoTestApp, organization: Organization, valid_token: str, incorrect_status: AgreementStatuses
@@ -314,10 +315,7 @@ class TestAgreementViewSetList:
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
-    @pytest.mark.parametrize("correct_status", [
-        AgreementStatuses.SIGNED,
-        AgreementStatuses.ACTIVE
-    ])
+    @pytest.mark.parametrize("correct_status", [AgreementStatuses.SIGNED, AgreementStatuses.ACTIVE])
     def test_success(
         self, app: DjangoTestApp, organization: Organization, valid_token: str, correct_status: AgreementStatuses
     ):
@@ -361,7 +359,7 @@ class TestAgreementViewSetList:
                             "_updated": use_case_client.updated_at.astimezone(timezone).isoformat(),
                             "@context": "",
                         }
-                    ]
+                    ],
                 }
             ]
         }
@@ -419,9 +417,7 @@ class TestAgreementViewSetList:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json["message"] == f"dataset._id values: {non_existig_dataset_uuid} are invalid."
 
-    def test_filter_dataset_by_dataset_uuid(
-        self, app: DjangoTestApp, organization: Organization, valid_token: str
-    ):
+    def test_filter_dataset_by_dataset_uuid(self, app: DjangoTestApp, organization: Organization, valid_token: str):
         agent = Agent.objects.get(organization=organization)
         child_dataset = DatasetFactory(organization=organization)
         child_dataset.move(agent.service, pos="sorted-child")
@@ -552,8 +548,7 @@ class TestAgreementViewSetList:
         agreement_file = AgreementFileFactory(agreement=agreement)
 
         with patch(
-            "vitrina.uapi.views.agreement_views.extract_elements_from_adoc",
-            side_effect=InvalidAdocError("Test error")
+            "vitrina.uapi.views.agreement_views.extract_elements_from_adoc", side_effect=InvalidAdocError("Test error")
         ):
             response = app.get(
                 agreement_url(),

--- a/tests/uapi/agreement_files/test_views.py
+++ b/tests/uapi/agreement_files/test_views.py
@@ -3,11 +3,10 @@ from uuid import UUID, uuid4
 import pytest
 from authlib.jose import RSAKey
 from django.conf import settings
-from django.urls import reverse
 from django_webtest import DjangoTestApp
 from rest_framework import status
 
-from tests.uapi.conftest import _generate_test_token
+from tests.uapi.conftest import _generate_test_token, _build_reverse_uapi_url
 from vitrina.datasets.models import Dataset
 from vitrina.orgs.factories import OrganizationFactory
 from vitrina.orgs.models import Organization
@@ -17,7 +16,7 @@ from vitrina.smart_contracts.factories import AgreementFileFactory, AgreementFac
 
 
 def agreement_file_url(agreement_file_uuid: UUID) -> str:
-    return reverse("uapi-agreement-file-download", kwargs={"agreement_file_uuid": agreement_file_uuid})
+    return _build_reverse_uapi_url("uapi-agreement-file-download", agreement_file_uuid=agreement_file_uuid)
 
 
 class TestAgreementFileDownloadUAPIView:

--- a/tests/uapi/agreement_files/test_views.py
+++ b/tests/uapi/agreement_files/test_views.py
@@ -36,11 +36,13 @@ class TestAgreementFileDownloadUAPIView:
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     @pytest.mark.parametrize(
-        "invalid_scopes", [
+        "invalid_scopes",
+        [
             tuple(),
             ("",),
             ("invalid_scope1", "invalid_scope2"),
-        ])
+        ],
+    )
     def test_403_if_list_authorized_with_incorrect_scopes(
         self, app: DjangoTestApp, organization: Organization, test_jwk: RSAKey, invalid_scopes: tuple[str]
     ):
@@ -70,14 +72,15 @@ class TestAgreementFileDownloadUAPIView:
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     @pytest.mark.parametrize(
-        "incorrect_status", [
+        "incorrect_status",
+        [
             AgreementStatuses.CREATED,
             AgreementStatuses.SUBMITTED,
             AgreementStatuses.APPROVED,
             AgreementStatuses.FORMED,
             AgreementStatuses.INITIATED,
             AgreementStatuses.TERMINATED,
-        ]
+        ],
     )
     def test_404_if_use_case_has_no_agreement_with_correct_status(
         self,
@@ -106,7 +109,7 @@ class TestAgreementFileDownloadUAPIView:
         agreement = AgreementFactory(project=use_case, assigner=organization, status=AgreementStatuses.SIGNED)
         agreement_file = AgreementFileFactory(
             agreement=agreement,
-            file_path=settings.BASE_DIR / "tests/smart_contracts/files/test_contracts/agreement.pdf"
+            file_path=settings.BASE_DIR / "tests/smart_contracts/files/test_contracts/agreement.pdf",
         )
 
         response = app.get(

--- a/tests/uapi/agreement_files/test_views.py
+++ b/tests/uapi/agreement_files/test_views.py
@@ -1,0 +1,148 @@
+from uuid import UUID, uuid4
+
+import pytest
+from authlib.jose import RSAKey
+from django.conf import settings
+from django.urls import reverse
+from django_webtest import DjangoTestApp
+from rest_framework import status
+
+from tests.uapi.conftest import _generate_test_token
+from vitrina.datasets.models import Dataset
+from vitrina.orgs.factories import OrganizationFactory
+from vitrina.orgs.models import Organization
+from vitrina.projects.factories import ProjectFactory
+from vitrina.smart_contracts import AgreementStatuses
+from vitrina.smart_contracts.factories import AgreementFileFactory, AgreementFactory
+
+
+def agreement_file_url(agreement_file_uuid: UUID) -> str:
+    return reverse("uapi-agreement-file-download", kwargs={"agreement_file_uuid": agreement_file_uuid})
+
+
+class TestAgreementFileDownloadUAPIView:
+    def test_403_if_unauthorized(self, app: DjangoTestApp):
+        response = app.get(agreement_file_url(agreement_file_uuid=uuid4()), expect_errors=True)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_403_if_token_has_no_organization(self, app: DjangoTestApp, organization: Organization, test_jwk: RSAKey):
+        token = _generate_test_token(test_jwk, organization=None, scopes=settings.OAUTH_AGENT_DEFAULT_SCOPES)
+        response = app.get(
+            agreement_file_url(agreement_file_uuid=uuid4()),
+            extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"},
+            expect_errors=True,
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.parametrize(
+        "invalid_scopes", [
+            tuple(),
+            ("",),
+            ("invalid_scope1", "invalid_scope2"),
+        ])
+    def test_403_if_list_authorized_with_incorrect_scopes(
+        self, app: DjangoTestApp, organization: Organization, test_jwk: RSAKey, invalid_scopes: tuple[str]
+    ):
+        token = _generate_test_token(test_jwk, organization=organization, scopes=invalid_scopes)
+        response = app.get(
+            agreement_file_url(agreement_file_uuid=uuid4()),
+            extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"},
+            expect_errors=True,
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_404_if_agreement_file_in_different_organization(
+        self, app: DjangoTestApp, organization: Organization, dataset: Dataset, valid_token: str
+    ):
+        different_organization = OrganizationFactory()
+        use_case = ProjectFactory(organization=different_organization, datasets=[dataset])
+        agreement = AgreementFactory(project=use_case, assigner=different_organization, status=AgreementStatuses.SIGNED)
+        agreement_file = AgreementFileFactory(agreement=agreement)
+
+        response = app.get(
+            agreement_file_url(agreement_file.uuid),
+            extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+            expect_errors=True,
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.parametrize(
+        "incorrect_status", [
+            AgreementStatuses.CREATED,
+            AgreementStatuses.SUBMITTED,
+            AgreementStatuses.APPROVED,
+            AgreementStatuses.FORMED,
+            AgreementStatuses.INITIATED,
+            AgreementStatuses.TERMINATED,
+        ]
+    )
+    def test_404_if_use_case_has_no_agreement_with_correct_status(
+        self,
+        app: DjangoTestApp,
+        organization: Organization,
+        dataset: Dataset,
+        valid_token: str,
+        incorrect_status: AgreementStatuses,
+    ):
+        use_case = ProjectFactory(organization=organization, datasets=[dataset])
+        agreement = AgreementFactory(project=use_case, assigner=organization, status=incorrect_status)
+        agreement_file = AgreementFileFactory(agreement=agreement)
+
+        response = app.get(
+            agreement_file_url(agreement_file.uuid),
+            extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+            expect_errors=True,
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_404_if_agreement_file_not_adoc(
+        self, app: DjangoTestApp, organization: Organization, dataset: Dataset, valid_token: str
+    ):
+        use_case = ProjectFactory(organization=organization, datasets=[dataset])
+        agreement = AgreementFactory(project=use_case, assigner=organization, status=AgreementStatuses.SIGNED)
+        agreement_file = AgreementFileFactory(
+            agreement=agreement,
+            file_path=settings.BASE_DIR / "tests/smart_contracts/files/test_contracts/agreement.pdf"
+        )
+
+        response = app.get(
+            agreement_file_url(agreement_file.uuid),
+            extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+            expect_errors=True,
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_404_if_agreement_file_with_given_uuid_does_not_exist(self, app: DjangoTestApp, valid_token: str):
+        response = app.get(
+            agreement_file_url(uuid4()),
+            extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+            expect_errors=True,
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.parametrize("correct_status", [AgreementStatuses.SIGNED, AgreementStatuses.ACTIVE])
+    def test_success(
+        self,
+        app: DjangoTestApp,
+        organization: Organization,
+        dataset: Dataset,
+        valid_token: str,
+        correct_status: AgreementStatuses,
+    ):
+        use_case = ProjectFactory(organization=organization, datasets=[dataset])
+        agreement = AgreementFactory(project=use_case, assigner=organization, status=correct_status)
+        agreement_file = AgreementFileFactory(agreement=agreement)
+
+        response = app.get(
+            agreement_file_url(agreement_file.uuid),
+            extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.headers.get("Content-Disposition") == f'attachment; filename="{agreement_file.uuid}.adoc"'

--- a/tests/uapi/conftest.py
+++ b/tests/uapi/conftest.py
@@ -180,6 +180,11 @@ def url_agent() -> str:
 
 
 @pytest.fixture
+def agreement_url() -> str:
+    return _build_reverse_uapi_url("uapi-agreement")
+
+
+@pytest.fixture
 def dsa() -> str:
     return """id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description
 ,test/dataset,,,,,,,,,,,,,,,,,

--- a/tests/uapi/dataset/test_views.py
+++ b/tests/uapi/dataset/test_views.py
@@ -1,9 +1,9 @@
 from typing import Iterable, Any
 from unittest.mock import patch, PropertyMock
 from urllib.parse import quote
+from zoneinfo import ZoneInfo
 
 import pytest
-import pytz
 from authlib.jose import RSAKey
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
@@ -27,7 +27,7 @@ from vitrina.uapi.serializers.uapi_serializers import TYPE_PREFIX_TO_REMOVE
 
 
 pytestmark = pytest.mark.django_db
-timezone = pytz.timezone(settings.TIME_ZONE)
+timezone = ZoneInfo(settings.TIME_ZONE)
 
 
 class TestCreate:

--- a/vitrina/datasets/factories.py
+++ b/vitrina/datasets/factories.py
@@ -73,6 +73,7 @@ class DatasetFactory(DjangoModelFactory):
         django_get_or_create = ("organization", "is_public")
 
     organization = factory.SubFactory(OrganizationFactory)
+    uuid = factory.Faker("uuid4")
     is_public = True
     version = 1
     will_be_financed = False

--- a/vitrina/settings.py
+++ b/vitrina/settings.py
@@ -72,6 +72,7 @@ OAUTH_CLIENTS_MANAGEMENT_SCOPE = env("OAUTH_CLIENTS_MANAGEMENT_SCOPE", default="
 OAUTH_AGENT_DEFAULT_SCOPES = (
     "uapi:/datasets/gov/vssa/dcat/Agent/:getall",
     "uapi:/datasets/gov/vssa/dcat/Agreement/:patch",
+    "uapi:/datasets/gov/vssa/dcat/AgreementFile/:getone",
     "uapi:/datasets/gov/vssa/dcat/Dataset/:getall",
     "uapi:/datasets/gov/vssa/dcat/Dataset/:create",
     "uapi:/datasets/gov/vssa/dcat/Distribution/:getall",

--- a/vitrina/settings.py
+++ b/vitrina/settings.py
@@ -71,6 +71,7 @@ OAUTH_CLIENT_SECRET_BASE64 = base64.b64encode(f"{OAUTH_CLIENT_NAME}:{OAUTH_CLIEN
 OAUTH_CLIENTS_MANAGEMENT_SCOPE = env("OAUTH_CLIENTS_MANAGEMENT_SCOPE", default="spinta_auth_clients")
 OAUTH_AGENT_DEFAULT_SCOPES = (
     "uapi:/datasets/gov/vssa/dcat/Agent/:getall",
+    "uapi:/datasets/gov/vssa/dcat/Agreement/:getall",
     "uapi:/datasets/gov/vssa/dcat/Agreement/:patch",
     "uapi:/datasets/gov/vssa/dcat/AgreementFile/:getone",
     "uapi:/datasets/gov/vssa/dcat/Dataset/:getall",

--- a/vitrina/smart_contracts/factories.py
+++ b/vitrina/smart_contracts/factories.py
@@ -1,8 +1,10 @@
+from django.conf import settings
 from factory import SubFactory, lazy_attribute
 from factory.django import DjangoModelFactory
 from django.core.files.uploadedfile import SimpleUploadedFile
 from pathlib import Path
 
+from vitrina.helpers import get_file_extension
 from vitrina.orgs.factories import OrganizationFactory
 from vitrina.projects.factories import ProjectFactory
 from vitrina.smart_contracts import AgreementStatuses
@@ -57,3 +59,31 @@ class AgreementJSONFileFactory(DjangoModelFactory):
             file_path = Path(self.json_path)
             return SimpleUploadedFile(file_path.name, file_path.read_bytes(), content_type="application/json")
         return SimpleUploadedFile("dummy.json", b"{}", content_type="application/json")
+
+
+class AgreementFileFactory(DjangoModelFactory):
+    class Meta:
+        model = AgreementFile
+
+    class Params:
+        file_path = None
+
+    agreement = SubFactory(AgreementFactory)
+
+    def _get_file_path(self) -> Path:
+        if self.file_path:
+            return Path(self.file_path)
+        return settings.BASE_DIR / "tests/smart_contracts/files/test_contracts/agreement_two_signers.adoc"
+
+    @lazy_attribute
+    def file(self) -> SimpleUploadedFile:
+        file_path = AgreementFileFactory._get_file_path(self)
+        return SimpleUploadedFile(file_path.name, file_path.read_bytes())
+
+    @lazy_attribute
+    def file_name(self) -> str:
+        return AgreementFileFactory._get_file_path(self).name
+
+    @lazy_attribute
+    def file_extension(self) -> str:
+        return get_file_extension(str(AgreementFileFactory._get_file_path(self)))

--- a/vitrina/smart_contracts/models.py
+++ b/vitrina/smart_contracts/models.py
@@ -1,6 +1,7 @@
 import json
 import os
 from datetime import datetime
+from functools import cached_property
 from io import BytesIO
 
 from django.core.files.base import ContentFile
@@ -251,6 +252,17 @@ class Agreement(UUIDBaseModel):
 
         json_file.file.seek(0)
         return json.loads(json_file.file.read())
+
+    @cached_property
+    def latest_agreement_adoc(self) -> "AgreementFile | None":
+        agreement_adocs = [
+            agreement_file
+            for agreement_file in self.files.all()
+            if agreement_file.file_extension == AgreementFile.AllowedFileTypes.ADOC
+        ]
+        agreement_adocs = sorted(agreement_adocs, key=lambda file: file.created_at, reverse=True)
+
+        return agreement_adocs[0] if agreement_adocs else None
 
 
 class AgreementScope(UUIDBaseModel):

--- a/vitrina/uapi/urls.py
+++ b/vitrina/uapi/urls.py
@@ -1,6 +1,8 @@
 from django.urls import path
 
 from vitrina.uapi.views.agreement_file_views import AgreementFileDownloadUAPIView
+from vitrina.uapi.views.agreement_views import AgreementViewSet
+
 from vitrina.uapi.views.template_views import (
     AgentDeleteView,
     AgentUpdateView,
@@ -72,6 +74,11 @@ urlpatterns = [
         f"{STATIC_UAPI_BASE_PATH}Distribution/",
         DistributionViewSet.as_view({"post": "create", "get": "list"}),
         name="uapi-distribution",
+    ),
+    path(
+        f"{STATIC_UAPI_BASE_PATH}Agreement/",
+        AgreementViewSet.as_view({"get": "list"}),
+        name="uapi-agreement",
     ),
     path(
         f"{STATIC_UAPI_BASE_PATH}Agreement/<uuid:agreement_id>/sync-done/",

--- a/vitrina/uapi/urls.py
+++ b/vitrina/uapi/urls.py
@@ -1,5 +1,6 @@
 from django.urls import path
 
+from vitrina.uapi.views.agreement_file_views import AgreementFileDownloadUAPIView
 from vitrina.uapi.views.template_views import (
     AgentDeleteView,
     AgentUpdateView,
@@ -86,5 +87,10 @@ urlpatterns = [
         f"{STATIC_UAPI_BASE_PATH}Agent/",
         AgentViewSet.as_view({"get": "list"}),
         name="uapi-agent",
+    ),
+    path(
+        f"{STATIC_UAPI_BASE_PATH}AgreementFile/<uuid:agreement_file_uuid>/file/",
+        AgreementFileDownloadUAPIView.as_view(),
+        name="uapi-agreement-file-download",
     ),
 ]

--- a/vitrina/uapi/views/agreement_file_views.py
+++ b/vitrina/uapi/views/agreement_file_views.py
@@ -13,9 +13,9 @@ from vitrina.uapi.views.mixins import AgentAuthViewSetMixin, UAPIExceptionHandle
 
 
 class AgreementFileDownloadUAPIView(UAPIExceptionHandlerMixin, AgentAuthViewSetMixin, APIView):
-    action = "get"
+    action = "retrieve"
     required_scopes = {
-        "get": ["uapi:/datasets/gov/vssa/dcat/AgreementFile/:getone"],
+        "retrieve": ["uapi:/datasets/gov/vssa/dcat/AgreementFile/:getone"],
     }
 
     def get(self, request: Request, *args: Any, **kwargs: Any) -> FileResponse:

--- a/vitrina/uapi/views/agreement_file_views.py
+++ b/vitrina/uapi/views/agreement_file_views.py
@@ -9,8 +9,7 @@ from rest_framework.views import APIView
 from vitrina.exceptions import UAPIException
 from vitrina.smart_contracts import AgreementStatuses
 from vitrina.smart_contracts.models import AgreementFile
-from vitrina.uapi.utils.views import UAPIExceptionHandlerMixin
-from vitrina.uapi.views.mixins import AgentAuthViewSetMixin
+from vitrina.uapi.views.mixins import AgentAuthViewSetMixin, UAPIExceptionHandlerMixin
 
 
 class AgreementFileDownloadUAPIView(UAPIExceptionHandlerMixin, AgentAuthViewSetMixin, APIView):

--- a/vitrina/uapi/views/agreement_file_views.py
+++ b/vitrina/uapi/views/agreement_file_views.py
@@ -1,0 +1,45 @@
+from typing import Any
+
+from django.db.models import Q
+from django.http import FileResponse
+from rest_framework import status
+from rest_framework.request import Request
+from rest_framework.views import APIView
+
+from vitrina.exceptions import UAPIException
+from vitrina.smart_contracts import AgreementStatuses
+from vitrina.smart_contracts.models import AgreementFile
+from vitrina.uapi.utils.views import UAPIExceptionHandlerMixin
+from vitrina.uapi.views.mixins import AgentAuthViewSetMixin
+
+
+class AgreementFileDownloadUAPIView(UAPIExceptionHandlerMixin, AgentAuthViewSetMixin, APIView):
+    action = "get"
+    required_scopes = {
+        "get": ["uapi:/datasets/gov/vssa/dcat/AgreementFile/:getone"],
+    }
+
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> FileResponse:
+        organization = getattr(request, "organization")
+
+        try:
+            agreement_file = AgreementFile.objects.get(
+                Q(agreement__assignee=organization) | Q(agreement__assigner=organization),
+                agreement__status__in=(AgreementStatuses.SIGNED, AgreementStatuses.ACTIVE),
+                file_extension=AgreementFile.AllowedFileTypes.ADOC,
+                uuid=self.kwargs.get("agreement_file_uuid"),
+            )
+        except AgreementFile.DoesNotExist:
+            raise UAPIException(
+                code="agreement_file_not_found",
+                type="AgreementFileNotFound",
+                template="The requested AgreementFile could not be found.",
+                message="No agreement file matched the provided query.",
+                status_code=status.HTTP_404_NOT_FOUND,
+            )
+
+        return FileResponse(
+            agreement_file.file.open("rb"),
+            as_attachment=True,
+            filename=f"{agreement_file.uuid}.{agreement_file.file_extension}",
+        )

--- a/vitrina/uapi/views/agreement_views.py
+++ b/vitrina/uapi/views/agreement_views.py
@@ -1,0 +1,152 @@
+from functools import cached_property
+from typing import Any
+from uuid import UUID
+
+from django.db.models import QuerySet
+from django.urls import reverse
+from rest_framework import viewsets, status, serializers
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from scripts.extract_elements_from_adoc import SCOPES_REGEX
+from vitrina.api.oauth import (
+    OAuthClientAuthenticator,
+)
+from vitrina.exceptions import UAPIException
+from vitrina.projects.models import UseCaseClient
+from vitrina.smart_contracts import AgreementStatuses
+from vitrina.smart_contracts.exceptions import InvalidAdocError
+from vitrina.smart_contracts.models import Agreement
+from vitrina.smart_contracts.services import extract_elements_from_adoc
+from vitrina.uapi.models import Agent
+from vitrina.uapi.serializers.uapi_serializers import BaseObjectListSerializer, BaseUUIDObjectMixin
+from vitrina.uapi.utils.utils import extract_type_from_url
+from vitrina.uapi.views.mixins import AgentAuthViewSetMixin, UAPIExceptionHandlerMixin
+
+
+class AgreementQueryParameterSerializer(serializers.Serializer):
+    dataset = serializers.ListField(child=serializers.UUIDField(), required=False)
+
+    def to_internal_value(self, data: dict) -> dict:
+        data = data.copy()
+        if "dataset._id" in data:
+            data.setlist("dataset", data.getlist("dataset._id"))
+        return super().to_internal_value(data)
+
+    def validate_dataset(self, dataset_uuids: list[UUID]) -> list[UUID]:
+        if not dataset_uuids:
+            return dataset_uuids
+
+        if non_agent_dataset_uuids := (set(dataset_uuids) - self.context["agent_dataset_uuids"]):
+            raise UAPIException(
+                code="invalid_agreement_query_filter",
+                type="InvalidAgreementQueryFilter",
+                template="Given query filter is invalid.",
+                message=f"dataset._id values: {', '.join(map(str, non_agent_dataset_uuids))} are invalid.",
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
+
+        return dataset_uuids
+
+
+class UAPIClientListSerializer(BaseUUIDObjectMixin, serializers.ModelSerializer):
+    class Meta:
+        model = UseCaseClient
+        fields = BaseUUIDObjectMixin.Meta.fields
+
+
+class UAPIAgreementListSerializer(BaseUUIDObjectMixin, serializers.ModelSerializer):
+    clients = serializers.SerializerMethodField()
+    agreement_file_url = serializers.SerializerMethodField()
+    agreement_scopes = serializers.SerializerMethodField()
+
+    def get_clients(self, obj: Agreement) -> list[dict]:
+        return UAPIClientListSerializer(obj.project.client_set.all(), many=True).data
+
+    def get_agreement_file_url(self, obj: Agreement) -> str | None:
+        if not (agreement_adoc := obj.latest_agreement_adoc):
+            return None
+        return reverse("uapi-agreement-file-download", kwargs={"agreement_file_uuid": agreement_adoc.uuid})
+
+    def get_agreement_scopes(self, obj: Agreement) -> list[str] | None:
+        if not (agreement_adoc := obj.latest_agreement_adoc):
+            return None
+        try:
+            scopes = extract_elements_from_adoc(agreement_adoc.file.path, SCOPES_REGEX)
+        except InvalidAdocError as error:
+            raise UAPIException(
+                code="scope_extraction_error",
+                type="CannotExtractAgreementScopes",
+                template="Agreement scopes cannot be extracted from.",
+                message=f"Scopes cannot be extracted from Agreement file (_id={agreement_adoc.uuid}). Error: {error}",
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
+
+        return scopes
+
+    class Meta:
+        model = Agreement
+        fields = (
+            "clients",
+            "agreement_file_url",
+            "agreement_scopes",
+        ) + BaseUUIDObjectMixin.Meta.fields
+
+
+class AgreementViewSet(UAPIExceptionHandlerMixin, AgentAuthViewSetMixin, viewsets.ModelViewSet):
+    required_scopes = {
+        "list": ["uapi:/datasets/gov/vssa/dcat/Agreement/:getall"],
+    }
+
+    @cached_property
+    def get_agent_dataset_uuids(self) -> set[str]:
+        agent = Agent.objects.select_related("service").get(
+            oauth_client_id=OAuthClientAuthenticator.resolve_client_id_from_token(self.request.auth)
+        )
+        agent_datasets_uuids = {agent.service.uuid}
+        agent_datasets_uuids.update(list(agent.service.get_descendants().values_list("uuid", flat=True)))
+
+        return agent_datasets_uuids
+
+    def get_queryset(self) -> QuerySet:
+        organization = getattr(self.request, "organization")
+
+        dataset_uuids = self.get_agent_dataset_uuids
+        if request_params := self.request.query_params:
+            query_parameter_serializer = AgreementQueryParameterSerializer(
+                data=request_params, context={"agent_dataset_uuids": self.get_agent_dataset_uuids}
+            )
+            query_parameter_serializer.is_valid(raise_exception=True)
+            if validated_dataset_uuids := query_parameter_serializer.validated_data.get("dataset"):
+                dataset_uuids = validated_dataset_uuids
+
+        queryset = (
+            Agreement.objects.filter(
+                assigner=organization,
+                status__in=(AgreementStatuses.SIGNED, AgreementStatuses.ACTIVE),
+                project__datasets__uuid__in=dataset_uuids,
+            )
+            .prefetch_related("project__client_set")
+            .order_by("-created_at")
+            .distinct()
+        )
+
+        return queryset
+
+    def list(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        if not (agreements := self.get_queryset()):
+            raise UAPIException(
+                code="agreement_not_found",
+                type="AgreementNotFound",
+                template="The requested Agreement could not be found.",
+                message="No agreement matched the provided query.",
+                status_code=status.HTTP_404_NOT_FOUND,
+            )
+
+        serializer = BaseObjectListSerializer(
+            instance=agreements,
+            context=self.get_serializer_context(),
+            data_serializer_class=UAPIAgreementListSerializer,
+            _type=extract_type_from_url(self.request.build_absolute_uri()),
+        )
+        return Response(serializer.data, status=status.HTTP_200_OK)

--- a/vitrina/uapi/views/agreement_views.py
+++ b/vitrina/uapi/views/agreement_views.py
@@ -26,15 +26,15 @@ from vitrina.uapi.views.mixins import AgentAuthViewSetMixin, UAPIExceptionHandle
 
 
 class AgreementQueryParameterSerializer(serializers.Serializer):
-    dataset = serializers.ListField(child=serializers.UUIDField(), required=False)
+    datasets = serializers.ListField(child=serializers.UUIDField(), required=False)
 
     def to_internal_value(self, data: dict) -> dict:
         data = data.copy()
-        if "dataset._id" in data:
-            data.setlist("dataset", data.getlist("dataset._id"))
+        if "datasets._id" in data:
+            data.setlist("datasets", data.getlist("datasets._id"))
         return super().to_internal_value(data)
 
-    def validate_dataset(self, dataset_uuids: list[UUID]) -> list[UUID]:
+    def validate_datasets(self, dataset_uuids: list[UUID]) -> list[UUID]:
         if not dataset_uuids:
             return dataset_uuids
 
@@ -43,7 +43,7 @@ class AgreementQueryParameterSerializer(serializers.Serializer):
                 code="invalid_agreement_query_filter",
                 type="InvalidAgreementQueryFilter",
                 template="Given query filter is invalid.",
-                message=f"dataset._id values: {', '.join(map(str, non_agent_dataset_uuids))} are invalid.",
+                message=f"datasets._id values: {', '.join(map(str, non_agent_dataset_uuids))} are invalid.",
                 status_code=status.HTTP_400_BAD_REQUEST,
             )
 
@@ -64,14 +64,28 @@ class UAPIAgreementListSerializer(BaseUUIDObjectMixin, serializers.ModelSerializ
     def get_clients(self, obj: Agreement) -> list[dict]:
         return UAPIClientListSerializer(obj.project.client_set.all(), many=True).data
 
-    def get_agreement_file_url(self, obj: Agreement) -> str | None:
+    def get_agreement_file_url(self, obj: Agreement) -> str:
         if not (agreement_adoc := obj.latest_agreement_adoc):
-            return None
+            raise UAPIException(
+                code="agreement_file_does_not_exist",
+                type="AgreementFileDoesNotExist",
+                template="Agreement file does not exist.",
+                message=f"Agreement adoc file does not exist for agreement (_id={obj.uuid})",
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
+
         return reverse("uapi-agreement-file-download", kwargs={"agreement_file_uuid": agreement_adoc.uuid})
 
-    def get_agreement_scopes(self, obj: Agreement) -> list[str] | None:
+    def get_agreement_scopes(self, obj: Agreement) -> list[str]:
         if not (agreement_adoc := obj.latest_agreement_adoc):
-            return None
+            raise UAPIException(
+                code="agreement_file_does_not_exist",
+                type="AgreementFileDoesNotExist",
+                template="Agreement file does not exist.",
+                message=f"Agreement adoc file does not exist for agreement (_id={obj.uuid})",
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
+
         try:
             scopes = extract_elements_from_adoc(agreement_adoc.file.path, SCOPES_REGEX)
         except InvalidAdocError as error:
@@ -119,7 +133,7 @@ class AgreementViewSet(UAPIExceptionHandlerMixin, AgentAuthViewSetMixin, viewset
                 data=request_params, context={"agent_dataset_uuids": self.get_agent_dataset_uuids}
             )
             query_parameter_serializer.is_valid(raise_exception=True)
-            if validated_dataset_uuids := query_parameter_serializer.validated_data.get("dataset"):
+            if validated_dataset_uuids := query_parameter_serializer.validated_data.get("datasets"):
                 dataset_uuids = validated_dataset_uuids
 
         queryset = (
@@ -136,17 +150,8 @@ class AgreementViewSet(UAPIExceptionHandlerMixin, AgentAuthViewSetMixin, viewset
         return queryset
 
     def list(self, request: Request, *args: Any, **kwargs: Any) -> Response:
-        if not (agreements := self.get_queryset()):
-            raise UAPIException(
-                code="agreement_not_found",
-                type="AgreementNotFound",
-                template="The requested Agreement could not be found.",
-                message="No agreement matched the provided query.",
-                status_code=status.HTTP_404_NOT_FOUND,
-            )
-
         serializer = BaseObjectListSerializer(
-            instance=self.paginate_queryset(agreements),
+            instance=self.paginate_queryset(self.get_queryset()),
             context=self.get_serializer_context(),
             data_serializer_class=UAPIAgreementListSerializer,
             _type=extract_type_from_url(self.request.build_absolute_uri()),

--- a/vitrina/uapi/views/agreement_views.py
+++ b/vitrina/uapi/views/agreement_views.py
@@ -19,6 +19,7 @@ from vitrina.smart_contracts.exceptions import InvalidAdocError
 from vitrina.smart_contracts.models import Agreement
 from vitrina.smart_contracts.services import extract_elements_from_adoc
 from vitrina.uapi.models import Agent
+from vitrina.uapi.pagination import UAPIPagination
 from vitrina.uapi.serializers.uapi_serializers import BaseObjectListSerializer, BaseUUIDObjectMixin
 from vitrina.uapi.utils.utils import extract_type_from_url
 from vitrina.uapi.views.mixins import AgentAuthViewSetMixin, UAPIExceptionHandlerMixin
@@ -94,6 +95,7 @@ class UAPIAgreementListSerializer(BaseUUIDObjectMixin, serializers.ModelSerializ
 
 
 class AgreementViewSet(UAPIExceptionHandlerMixin, AgentAuthViewSetMixin, viewsets.ModelViewSet):
+    pagination_class = UAPIPagination
     required_scopes = {
         "list": ["uapi:/datasets/gov/vssa/dcat/Agreement/:getall"],
     }
@@ -144,9 +146,9 @@ class AgreementViewSet(UAPIExceptionHandlerMixin, AgentAuthViewSetMixin, viewset
             )
 
         serializer = BaseObjectListSerializer(
-            instance=agreements,
+            instance=self.paginate_queryset(agreements),
             context=self.get_serializer_context(),
             data_serializer_class=UAPIAgreementListSerializer,
             _type=extract_type_from_url(self.request.build_absolute_uri()),
         )
-        return Response(serializer.data, status=status.HTTP_200_OK)
+        return self.get_paginated_response(serializer.data)


### PR DESCRIPTION
**Summary:**
Adds 2 new UAPI endpoints: 
  - `AgreementViewSet` - returns list of agreements, together with agreement adoc URL and scopes extracted from agreement adoc. It also has pagination.
  - `AgreementFileDownloadUAPIView` - returns agreement adoc file.

These endpoints will be called from Agent during Agreement and Contract sync.

**Ticket:**
https://github.com/atviriduomenys/spinta/issues/1656