### PR TITLE
Run ruff on tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.ruff]
 include = [
-    "vitrina/*.py",
+    "vitrina/*.py", "tests/*.py"
 ]
 exclude = [
     "**/migrations/*.py",

--- a/tests/api/test_views.py
+++ b/tests/api/test_views.py
@@ -16,8 +16,13 @@ from vitrina.api.factories import APIKeyFactory
 from vitrina.api.models import ApiKey
 from vitrina.catalogs.factories import CatalogFactory
 from vitrina.classifiers.factories import CategoryFactory
-from vitrina.datasets.factories import DatasetFactory, DatasetStructureFactory, DatasetGroupFactory, \
-    DCATResourceSubclassFactory, DatasetGroupCategoryUriFactory
+from vitrina.datasets.factories import (
+    DatasetFactory,
+    DatasetStructureFactory,
+    DatasetGroupFactory,
+    DCATResourceSubclassFactory,
+    DatasetGroupCategoryUriFactory,
+)
 from vitrina.datasets.models import Dataset
 from vitrina.orgs.factories import RepresentativeFactory, OrganizationFactory
 from vitrina.resources.factories import DatasetDistributionFactory
@@ -43,13 +48,8 @@ def test_retrieve_catalog_list_with_disabled_api_key(app: DjangoTestApp):
         content_type=ct,
         object_id=organization.pk,
     )
-    APIKeyFactory(
-        representative=representative,
-        enabled=False
-    )
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
+    APIKeyFactory(representative=representative, enabled=False)
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
     res = app.get(reverse("api-catalog-list"), expect_errors=True)
     assert res.status_code == 403
 
@@ -62,13 +62,8 @@ def test_retrieve_catalog_list_with_expired_api_key(app: DjangoTestApp):
         content_type=ct,
         object_id=organization.pk,
     )
-    APIKeyFactory(
-        representative=representative,
-        expires=timezone.make_aware(datetime(2000, 12, 24))
-    )
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
+    APIKeyFactory(representative=representative, expires=timezone.make_aware(datetime(2000, 12, 24)))
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
     res = app.get(reverse("api-catalog-list"), expect_errors=True)
     assert res.status_code == 403
 
@@ -83,17 +78,11 @@ def test_retrieve_catalog_list_with_duplicate_api_key(app: DjangoTestApp):
         object_id=organization.pk,
     )
     key = secrets.token_urlsafe()
-    APIKeyFactory(
-        api_key=f"{ApiKey.DUPLICATE}-0-{key}",
-        representative=representative,
-        enabled=False
-    )
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': f'ApiKey {key}'
-    })
+    APIKeyFactory(api_key=f"{ApiKey.DUPLICATE}-0-{key}", representative=representative, enabled=False)
+    app.extra_environ.update({"HTTP_AUTHORIZATION": f"ApiKey {key}"})
     res = app.get(reverse("api-catalog-list"), expect_errors=True)
     assert res.status_code == 403
-    assert res.json['detail'] == DuplicateAPIKeyException.default_detail.format(
+    assert res.json["detail"] == DuplicateAPIKeyException.default_detail.format(
         url=f"http://{domain}{reverse('organization-members', args=[organization.pk])}"
     )
 
@@ -108,20 +97,20 @@ def test_retrieve_catalog_list_with_correct_api_key(app: DjangoTestApp):
         object_id=organization.pk,
     )
     APIKeyFactory(representative=representative)
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
     res = app.get(reverse("api-catalog-list"), expect_errors=True)
-    assert res.json == [{
-        'description': catalog.description,
-        'id': str(catalog.identifier),
-        'licence': {
-            'description': catalog.licence.description,
-            'id': str(catalog.licence.identifier),
-            'title': catalog.licence.title
-        },
-        'title': catalog.title
-    }]
+    assert res.json == [
+        {
+            "description": catalog.description,
+            "id": str(catalog.identifier),
+            "licence": {
+                "description": catalog.licence.description,
+                "id": str(catalog.licence.identifier),
+                "title": catalog.licence.title,
+            },
+            "title": catalog.title,
+        }
+    ]
 
 
 @pytest.mark.django_db
@@ -138,13 +127,8 @@ def test_retrieve_category_list_with_disabled_api_key(app: DjangoTestApp):
         content_type=ct,
         object_id=organization.pk,
     )
-    APIKeyFactory(
-        representative=representative,
-        enabled=False
-    )
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
+    APIKeyFactory(representative=representative, enabled=False)
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
     res = app.get(reverse("api-category-list"), expect_errors=True)
     assert res.status_code == 403
 
@@ -157,13 +141,8 @@ def test_retrieve_category_list_with_expired_api_key(app: DjangoTestApp):
         content_type=ct,
         object_id=organization.pk,
     )
-    APIKeyFactory(
-        representative=representative,
-        expires=timezone.make_aware(datetime(2000, 12, 24))
-    )
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
+    APIKeyFactory(representative=representative, expires=timezone.make_aware(datetime(2000, 12, 24)))
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
     res = app.get(reverse("api-category-list"), expect_errors=True)
     assert res.status_code == 403
 
@@ -178,17 +157,11 @@ def test_retrieve_category_list_with_duplicate_api_key(app: DjangoTestApp):
         object_id=organization.pk,
     )
     key = secrets.token_urlsafe()
-    APIKeyFactory(
-        api_key=f"{ApiKey.DUPLICATE}-0-{key}",
-        representative=representative,
-        enabled=False
-    )
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': f'ApiKey {key}'
-    })
+    APIKeyFactory(api_key=f"{ApiKey.DUPLICATE}-0-{key}", representative=representative, enabled=False)
+    app.extra_environ.update({"HTTP_AUTHORIZATION": f"ApiKey {key}"})
     res = app.get(reverse("api-category-list"), expect_errors=True)
     assert res.status_code == 403
-    assert res.json['detail'] == DuplicateAPIKeyException.default_detail.format(
+    assert res.json["detail"] == DuplicateAPIKeyException.default_detail.format(
         url=f"http://{domain}{reverse('organization-members', args=[organization.pk])}"
     )
 
@@ -203,15 +176,9 @@ def test_retrieve_category_list_with_correct_api_key(app: DjangoTestApp):
         object_id=organization.pk,
     )
     APIKeyFactory(representative=representative)
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
     res = app.get(reverse("api-category-list"), expect_errors=True)
-    assert res.json == [{
-        'description': category.description,
-        'id': str(category.pk),
-        'title': category.title
-    }]
+    assert res.json == [{"description": category.description, "id": str(category.pk), "title": category.title}]
 
 
 @pytest.mark.django_db
@@ -228,13 +195,8 @@ def test_licence_licence_list_with_disabled_api_key(app: DjangoTestApp):
         content_type=ct,
         object_id=organization.pk,
     )
-    APIKeyFactory(
-        representative=representative,
-        enabled=False
-    )
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
+    APIKeyFactory(representative=representative, enabled=False)
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
     res = app.get(reverse("api-licence-list"), expect_errors=True)
     assert res.status_code == 403
 
@@ -247,13 +209,8 @@ def test_licence_licence_list_with_expired_api_key(app: DjangoTestApp):
         content_type=ct,
         object_id=organization.pk,
     )
-    APIKeyFactory(
-        representative=representative,
-        expires=timezone.make_aware(datetime(2000, 12, 24))
-    )
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
+    APIKeyFactory(representative=representative, expires=timezone.make_aware(datetime(2000, 12, 24)))
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
     res = app.get(reverse("api-licence-list"), expect_errors=True)
     assert res.status_code == 403
 
@@ -268,17 +225,11 @@ def test_retrieve_licence_list_with_duplicate_api_key(app: DjangoTestApp):
         object_id=organization.pk,
     )
     key = secrets.token_urlsafe()
-    APIKeyFactory(
-        api_key=f"{ApiKey.DUPLICATE}-0-{key}",
-        representative=representative,
-        enabled=False
-    )
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': f'ApiKey {key}'
-    })
+    APIKeyFactory(api_key=f"{ApiKey.DUPLICATE}-0-{key}", representative=representative, enabled=False)
+    app.extra_environ.update({"HTTP_AUTHORIZATION": f"ApiKey {key}"})
     res = app.get(reverse("api-licence-list"), expect_errors=True)
     assert res.status_code == 403
-    assert res.json['detail'] == DuplicateAPIKeyException.default_detail.format(
+    assert res.json["detail"] == DuplicateAPIKeyException.default_detail.format(
         url=f"http://{domain}{reverse('organization-members', args=[organization.pk])}"
     )
 
@@ -293,16 +244,10 @@ def test_retrieve_licence_list_with_correct_api_key(app: DjangoTestApp):
         object_id=organization.pk,
     )
     APIKeyFactory(representative=representative)
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
     res = app.get(reverse("api-licence-list"), expect_errors=True)
     data = [licence_obj for licence_obj in res.json if licence_obj["id"] == str(licence.identifier)]
-    assert data == [{
-        'description': licence.description,
-        'id': str(licence.identifier),
-        'title': licence.title
-    }]
+    assert data == [{"description": licence.description, "id": str(licence.identifier), "title": licence.title}]
 
 
 @pytest.mark.django_db
@@ -325,38 +270,36 @@ def test_get_all_datasets(app: DjangoTestApp):
         object_id=dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
     res = app.get(reverse("api-dataset"))
     dataset.refresh_from_db()
-    assert res.json == [{
-        "created": timezone.localtime(dataset.created).isoformat(),
-        "id": str(dataset.pk),
-        "internalId": dataset.internal_id,
-        "origin": dataset.origin,
-        "title": dataset.title,
-        "description": dataset.description,
-        "modified": timezone.localtime(dataset.modified).isoformat(),
-        'organization_id': dataset.organization.id,
-        'organization_title': dataset.organization.title,
-        "temporalCoverage": dataset.temporal_coverage,
-        "language": dataset.language_array,
-        "publisher": None,
-        "spatial": dataset.spatial_coverage,
-        "periodicity": dataset.frequency.title,
-        "keyword": dataset.tag_name_array,
-        "landingPage": f"http://{domain}{dataset.get_absolute_url()}",
-        "theme": [category.title]
-    }]
+    assert res.json == [
+        {
+            "created": timezone.localtime(dataset.created).isoformat(),
+            "id": str(dataset.pk),
+            "internalId": dataset.internal_id,
+            "origin": dataset.origin,
+            "title": dataset.title,
+            "description": dataset.description,
+            "modified": timezone.localtime(dataset.modified).isoformat(),
+            "organization_id": dataset.organization.id,
+            "organization_title": dataset.organization.title,
+            "temporalCoverage": dataset.temporal_coverage,
+            "language": dataset.language_array,
+            "publisher": None,
+            "spatial": dataset.spatial_coverage,
+            "periodicity": dataset.frequency.title,
+            "keyword": dataset.tag_name_array,
+            "landingPage": f"http://{domain}{dataset.get_absolute_url()}",
+            "theme": [category.title],
+        }
+    ]
 
 
 @pytest.mark.django_db
 def test_get_dataset_without_api_key(app: DjangoTestApp):
     dataset = DatasetFactory()
-    res = app.get(reverse("api-single-dataset", kwargs={
-        'datasetId': dataset.pk
-    }), expect_errors=True)
+    res = app.get(reverse("api-single-dataset", kwargs={"datasetId": dataset.pk}), expect_errors=True)
     assert res.status_code == 403
 
 
@@ -370,12 +313,8 @@ def test_get_dataset_from_different_organization(app: DjangoTestApp):
         object_id=organization.pk,
     )
     APIKeyFactory(representative=representative)
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
-    res = app.get(reverse("api-single-dataset", kwargs={
-        'datasetId': dataset.pk
-    }), expect_errors=True)
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
+    res = app.get(reverse("api-single-dataset", kwargs={"datasetId": dataset.pk}), expect_errors=True)
     assert res.status_code == 404
 
 
@@ -391,12 +330,8 @@ def test_get_dataset_with_dataset_id(app: DjangoTestApp):
         object_id=dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
-    res = app.get(reverse("api-single-dataset", kwargs={
-        'datasetId': dataset.pk
-    }))
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
+    res = app.get(reverse("api-single-dataset", kwargs={"datasetId": dataset.pk}))
     dataset.refresh_from_db()
     assert res.json == {
         "created": timezone.localtime(dataset.created).isoformat(),
@@ -406,8 +341,8 @@ def test_get_dataset_with_dataset_id(app: DjangoTestApp):
         "title": dataset.title,
         "description": dataset.description,
         "modified": timezone.localtime(dataset.modified).isoformat(),
-        'organization_id': dataset.organization.id,
-        'organization_title': dataset.organization.title,
+        "organization_id": dataset.organization.id,
+        "organization_title": dataset.organization.title,
         "temporalCoverage": dataset.temporal_coverage,
         "language": dataset.language_array,
         "publisher": None,
@@ -415,7 +350,7 @@ def test_get_dataset_with_dataset_id(app: DjangoTestApp):
         "periodicity": dataset.frequency.title,
         "keyword": dataset.tag_name_array,
         "landingPage": f"http://{domain}{dataset.get_absolute_url()}",
-        "theme": [category.title]
+        "theme": [category.title],
     }
 
 
@@ -428,12 +363,8 @@ def test_get_dataset_with_wrong_internal_id(app: DjangoTestApp):
         object_id=dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
-    res = app.get(reverse("api-single-dataset-internal", kwargs={
-        'internalId': "wrong"
-    }), expect_errors=True)
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
+    res = app.get(reverse("api-single-dataset-internal", kwargs={"internalId": "wrong"}), expect_errors=True)
     assert res.status_code == 404
 
 
@@ -449,12 +380,8 @@ def test_get_dataset_with_internal_id(app: DjangoTestApp):
         object_id=dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
-    res = app.get(reverse("api-single-dataset-internal", kwargs={
-        'internalId': dataset.internal_id
-    }))
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
+    res = app.get(reverse("api-single-dataset-internal", kwargs={"internalId": dataset.internal_id}))
     dataset.refresh_from_db()
     assert res.json == {
         "created": timezone.localtime(dataset.created).isoformat(),
@@ -464,8 +391,8 @@ def test_get_dataset_with_internal_id(app: DjangoTestApp):
         "title": dataset.title,
         "description": dataset.description,
         "modified": timezone.localtime(dataset.modified).isoformat(),
-        'organization_id': dataset.organization.id,
-        'organization_title': dataset.organization.title,
+        "organization_id": dataset.organization.id,
+        "organization_title": dataset.organization.title,
         "temporalCoverage": dataset.temporal_coverage,
         "language": dataset.language_array,
         "publisher": None,
@@ -473,15 +400,13 @@ def test_get_dataset_with_internal_id(app: DjangoTestApp):
         "periodicity": dataset.frequency.title,
         "keyword": dataset.tag_name_array,
         "landingPage": f"http://{domain}{dataset.get_absolute_url()}",
-        "theme": [category.title]
+        "theme": [category.title],
     }
 
 
 @pytest.mark.django_db
 def test_create_dataset_without_api_key(app: DjangoTestApp):
-    res = app.post(reverse("api-dataset"), {
-        'title': "New dataset"
-    }, expect_errors=True)
+    res = app.post(reverse("api-dataset"), {"title": "New dataset"}, expect_errors=True)
     assert res.status_code == 403
 
 
@@ -494,13 +419,11 @@ def test_create_dataset_with_errors(app: DjangoTestApp):
         object_id=dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
     res = app.post(reverse("api-dataset"), expect_errors=True)
     assert res.status_code == 400
-    assert 'title' in res.json
-    assert 'description' in res.json
+    assert "title" in res.json
+    assert "description" in res.json
 
 
 @pytest.mark.django_db
@@ -515,38 +438,28 @@ def test_create_dataset(app: DjangoTestApp):
         object_id=organization.pk,
     )
     APIKeyFactory(representative=representative)
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
     url = reverse("api-dataset")
     revision_comment = RevisionComment(
-        source=RevisionSource.VIEW,
-        action="api-dataset",
-        http_method="POST",
-        path=url,
-        args=[],
-        kwargs={}
+        source=RevisionSource.VIEW, action="api-dataset", http_method="POST", path=url, args=[], kwargs={}
     )
-    res = app.post(url, {
-        'title': 'Test dataset',
-        'description': 'Test dataset',
-        'language': [
-            'en',
-            'lt'
-        ],
-        'keyword': [
-            'tag1',
-            'tag2'
-        ],
-        'periodicity': frequency.title,
-        'theme': [category.title]
-    })
+    res = app.post(
+        url,
+        {
+            "title": "Test dataset",
+            "description": "Test dataset",
+            "language": ["en", "lt"],
+            "keyword": ["tag1", "tag2"],
+            "periodicity": frequency.title,
+            "theme": [category.title],
+        },
+    )
     dataset_objects = Dataset.objects.exclude(id=1)
 
     assert dataset_objects.count() == 1
     dataset = dataset_objects.first()
     assert dataset.language == "en lt"
-    assert list(dataset.tags.all()) == ['tag1', 'tag2']
+    assert list(dataset.tags.all()) == ["tag1", "tag2"]
     assert dataset.frequency == frequency
     assert list(dataset.category.all()) == [category]
     assert dataset.organization == organization
@@ -562,25 +475,23 @@ def test_create_dataset(app: DjangoTestApp):
         "title": dataset.title,
         "description": dataset.description,
         "modified": timezone.localtime(dataset.modified).isoformat(),
-        'organization_id': dataset.organization.id,
-        'organization_title': dataset.organization.title,
+        "organization_id": dataset.organization.id,
+        "organization_title": dataset.organization.title,
         "temporalCoverage": dataset.temporal_coverage,
-        "language": ['en', 'lt'],
+        "language": ["en", "lt"],
         "publisher": None,
         "spatial": dataset.spatial_coverage,
         "periodicity": dataset.frequency.title,
-        "keyword": ['tag1', 'tag2'],
+        "keyword": ["tag1", "tag2"],
         "landingPage": f"http://{domain}{dataset.get_absolute_url()}",
-        "theme": [category.title]
+        "theme": [category.title],
     }
 
 
 @pytest.mark.django_db
 def test_update_dataset_without_api_key(app: DjangoTestApp):
     dataset = DatasetFactory()
-    res = app.patch(reverse("api-single-dataset", kwargs={
-        'datasetId': dataset.pk
-    }), expect_errors=True)
+    res = app.patch(reverse("api-single-dataset", kwargs={"datasetId": dataset.pk}), expect_errors=True)
     assert res.status_code == 403
 
 
@@ -594,13 +505,12 @@ def test_update_dataset_from_different_organization(app: DjangoTestApp):
         object_id=organization.pk,
     )
     APIKeyFactory(representative=representative)
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
-    res = app.patch(reverse("api-single-dataset", kwargs={'datasetId': dataset.pk}), {
-        'title': "Updated title",
-        'description': "Updated description"
-    }, expect_errors=True)
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
+    res = app.patch(
+        reverse("api-single-dataset", kwargs={"datasetId": dataset.pk}),
+        {"title": "Updated title", "description": "Updated description"},
+        expect_errors=True,
+    )
     assert res.status_code == 404
 
 
@@ -616,22 +526,17 @@ def test_update_dataset_with_dataset_id(app: DjangoTestApp):
         object_id=dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
-    url = reverse("api-single-dataset", kwargs={'datasetId': dataset.pk})
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
+    url = reverse("api-single-dataset", kwargs={"datasetId": dataset.pk})
     revision_comment = RevisionComment(
         source=RevisionSource.VIEW,
         action="api-single-dataset",
         http_method="PATCH",
         path=url,
         args=[],
-        kwargs={'datasetId': dataset.pk}
+        kwargs={"datasetId": dataset.pk},
     )
-    res = app.patch(url, {
-        'title': "Updated title",
-        'description': "Updated description"
-    })
+    res = app.patch(url, {"title": "Updated title", "description": "Updated description"})
     dataset.refresh_from_db()
     assert Version.objects.get_for_object(dataset).count() == 1
     version = Version.objects.get_for_object(dataset).first()
@@ -645,8 +550,8 @@ def test_update_dataset_with_dataset_id(app: DjangoTestApp):
         "title": "Updated title",
         "description": "Updated description",
         "modified": timezone.localtime(dataset.modified).isoformat(),
-        'organization_id': dataset.organization.id,
-        'organization_title': dataset.organization.title,
+        "organization_id": dataset.organization.id,
+        "organization_title": dataset.organization.title,
         "temporalCoverage": dataset.temporal_coverage,
         "language": dataset.language_array,
         "publisher": None,
@@ -654,7 +559,7 @@ def test_update_dataset_with_dataset_id(app: DjangoTestApp):
         "periodicity": dataset.frequency.title,
         "keyword": dataset.tag_name_array,
         "landingPage": f"http://{domain}{dataset.get_absolute_url()}",
-        "theme": [category.title]
+        "theme": [category.title],
     }
 
 
@@ -670,22 +575,17 @@ def test_update_dataset_with_internal_id(app: DjangoTestApp):
         object_id=dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
-    url = reverse("api-single-dataset-internal", kwargs={'internalId': dataset.internal_id})
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
+    url = reverse("api-single-dataset-internal", kwargs={"internalId": dataset.internal_id})
     revision_comment = RevisionComment(
         source=RevisionSource.VIEW,
         action="api-single-dataset-internal",
         http_method="PATCH",
         path=url,
         args=[],
-        kwargs={'internalId': dataset.internal_id}
+        kwargs={"internalId": dataset.internal_id},
     )
-    res = app.patch(url, {
-        'title': "Updated title",
-        'description': "Updated description"
-    })
+    res = app.patch(url, {"title": "Updated title", "description": "Updated description"})
     dataset.refresh_from_db()
     assert Version.objects.get_for_object(dataset).count() == 1
     version = Version.objects.get_for_object(dataset).select_related("revision").first()
@@ -699,8 +599,8 @@ def test_update_dataset_with_internal_id(app: DjangoTestApp):
         "title": "Updated title",
         "description": "Updated description",
         "modified": timezone.localtime(dataset.modified).isoformat(),
-        'organization_id': dataset.organization.id,
-        'organization_title': dataset.organization.title,
+        "organization_id": dataset.organization.id,
+        "organization_title": dataset.organization.title,
         "temporalCoverage": dataset.temporal_coverage,
         "language": dataset.language_array,
         "publisher": None,
@@ -708,16 +608,14 @@ def test_update_dataset_with_internal_id(app: DjangoTestApp):
         "periodicity": dataset.frequency.title,
         "keyword": dataset.tag_name_array,
         "landingPage": f"http://{domain}{dataset.get_absolute_url()}",
-        "theme": [category.title]
+        "theme": [category.title],
     }
 
 
 @pytest.mark.django_db
 def test_delete_dataset_without_api_key(app: DjangoTestApp):
     dataset = DatasetFactory()
-    res = app.delete(reverse('api-single-dataset', kwargs={
-        'datasetId': dataset.pk
-    }), expect_errors=True)
+    res = app.delete(reverse("api-single-dataset", kwargs={"datasetId": dataset.pk}), expect_errors=True)
     assert res.status_code == 403
 
 
@@ -731,38 +629,29 @@ def test_delete_dataset_from_different_organization(app: DjangoTestApp):
         object_id=organization.pk,
     )
     APIKeyFactory(representative=representative)
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
-    res = app.delete(reverse('api-single-dataset', kwargs={
-        'datasetId': dataset.pk
-    }), expect_errors=True)
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
+    res = app.delete(reverse("api-single-dataset", kwargs={"datasetId": dataset.pk}), expect_errors=True)
     assert res.status_code == 404
 
 
 @pytest.mark.django_db
 def test_delete_dataset_with_dataset_id(app: DjangoTestApp):
-    dataset = DatasetFactory(
-        internal_id="test",
-        slug="test"
-    )
+    dataset = DatasetFactory(internal_id="test", slug="test")
     ct = ContentType.objects.get_for_model(dataset.organization)
     representative = RepresentativeFactory(
         content_type=ct,
         object_id=dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
-    url = reverse('api-single-dataset', kwargs={'datasetId': dataset.pk})
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
+    url = reverse("api-single-dataset", kwargs={"datasetId": dataset.pk})
     revision_comment = RevisionComment(
         source=RevisionSource.VIEW,
         action="api-single-dataset",
         http_method="DELETE",
         path=url,
         args=[],
-        kwargs={'datasetId': dataset.pk}
+        kwargs={"datasetId": dataset.pk},
     )
     app.delete(url)
     dataset.refresh_from_db()
@@ -778,28 +667,23 @@ def test_delete_dataset_with_dataset_id(app: DjangoTestApp):
 
 @pytest.mark.django_db
 def test_delete_dataset_with_internal_id(app: DjangoTestApp):
-    dataset = DatasetFactory(
-        internal_id="test",
-        slug="test"
-    )
+    dataset = DatasetFactory(internal_id="test", slug="test")
     ct = ContentType.objects.get_for_model(dataset.organization)
     representative = RepresentativeFactory(
         content_type=ct,
         object_id=dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
-    kwargs_dict = {'internalId': dataset.internal_id}
-    url = reverse('api-single-dataset-internal', kwargs=kwargs_dict)
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
+    kwargs_dict = {"internalId": dataset.internal_id}
+    url = reverse("api-single-dataset-internal", kwargs=kwargs_dict)
     revision_comment = RevisionComment(
         source=RevisionSource.VIEW,
         action="api-single-dataset-internal",
         http_method="DELETE",
         path=url,
         args=[],
-        kwargs=kwargs_dict
+        kwargs=kwargs_dict,
     )
     app.delete(url)
     dataset.refresh_from_db()
@@ -816,9 +700,7 @@ def test_delete_dataset_with_internal_id(app: DjangoTestApp):
 @pytest.mark.django_db
 def test_get_all_dataset_distributions_without_api_key(app: DjangoTestApp):
     dataset = DatasetFactory()
-    res = app.get(reverse('api-distribution', kwargs={
-        'datasetId': dataset.pk
-    }), expect_errors=True)
+    res = app.get(reverse("api-distribution", kwargs={"datasetId": dataset.pk}), expect_errors=True)
     assert res.status_code == 403
 
 
@@ -833,26 +715,24 @@ def test_get_all_dataset_distributions_with_dataset_id(app: DjangoTestApp):
         object_id=distribution.dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
-    res = app.get(reverse('api-distribution', kwargs={
-        'datasetId': distribution.dataset.pk
-    }))
-    assert res.json == [{
-        'description': distribution.description,
-        'file': distribution.filename_without_path(),
-        'geo_location': distribution.geo_location,
-        'id': distribution.pk,
-        'issued': distribution.issued,
-        'periodEnd': str(distribution.period_end),
-        'periodStart': str(distribution.period_start),
-        'title': distribution.title,
-        'type': distribution.type,
-        'url': f"http://{domain}{distribution.dataset.get_absolute_url()}",
-        'version': distribution.distribution_version,
-        'upload_to_storage': distribution.upload_to_storage,
-    }]
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
+    res = app.get(reverse("api-distribution", kwargs={"datasetId": distribution.dataset.pk}))
+    assert res.json == [
+        {
+            "description": distribution.description,
+            "file": distribution.filename_without_path(),
+            "geo_location": distribution.geo_location,
+            "id": distribution.pk,
+            "issued": distribution.issued,
+            "periodEnd": str(distribution.period_end),
+            "periodStart": str(distribution.period_start),
+            "title": distribution.title,
+            "type": distribution.type,
+            "url": f"http://{domain}{distribution.dataset.get_absolute_url()}",
+            "version": distribution.distribution_version,
+            "upload_to_storage": distribution.upload_to_storage,
+        }
+    ]
 
 
 @pytest.mark.django_db
@@ -867,26 +747,24 @@ def test_get_all_dataset_distributions_with_internal_id(app: DjangoTestApp):
         object_id=dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
-    res = app.get(reverse('api-distribution-internal', kwargs={
-        'internalId': dataset.internal_id
-    }))
-    assert res.json == [{
-        'description': distribution.description,
-        'file': distribution.filename_without_path(),
-        'geo_location': distribution.geo_location,
-        'id': distribution.pk,
-        'issued': distribution.issued,
-        'periodEnd': str(distribution.period_end),
-        'periodStart': str(distribution.period_start),
-        'title': distribution.title,
-        'type': distribution.type,
-        'url': f"http://{domain}{dataset.get_absolute_url()}",
-        'version': distribution.distribution_version,
-        'upload_to_storage': distribution.upload_to_storage,
-    }]
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
+    res = app.get(reverse("api-distribution-internal", kwargs={"internalId": dataset.internal_id}))
+    assert res.json == [
+        {
+            "description": distribution.description,
+            "file": distribution.filename_without_path(),
+            "geo_location": distribution.geo_location,
+            "id": distribution.pk,
+            "issued": distribution.issued,
+            "periodEnd": str(distribution.period_end),
+            "periodStart": str(distribution.period_start),
+            "title": distribution.title,
+            "type": distribution.type,
+            "url": f"http://{domain}{dataset.get_absolute_url()}",
+            "version": distribution.distribution_version,
+            "upload_to_storage": distribution.upload_to_storage,
+        }
+    ]
 
 
 @pytest.mark.django_db
@@ -901,35 +779,33 @@ def test_get_all_distributions(app: DjangoTestApp):
         object_id=dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
-    res = app.get(reverse('api-all-distributions-upload-to-storage'))
-    assert res.json == [{
-        'dataset_id': distribution.dataset.id,
-        'description': distribution.description,
-        'file': distribution.filename_without_path(),
-        'geo_location': distribution.geo_location,
-        'id': distribution.pk,
-        'issued': distribution.issued,
-        'organization_id': distribution.dataset.organization.id,
-        'periodEnd': str(distribution.period_end),
-        'periodStart': str(distribution.period_start),
-        'title': distribution.title,
-        'type': distribution.type,
-        'update_interval': distribution.dataset.frequency.hours,
-        'url': f"http://{domain}{dataset.get_absolute_url()}",
-        'version': distribution.distribution_version,
-        'upload_to_storage': distribution.upload_to_storage,
-    }]
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
+    res = app.get(reverse("api-all-distributions-upload-to-storage"))
+    assert res.json == [
+        {
+            "dataset_id": distribution.dataset.id,
+            "description": distribution.description,
+            "file": distribution.filename_without_path(),
+            "geo_location": distribution.geo_location,
+            "id": distribution.pk,
+            "issued": distribution.issued,
+            "organization_id": distribution.dataset.organization.id,
+            "periodEnd": str(distribution.period_end),
+            "periodStart": str(distribution.period_start),
+            "title": distribution.title,
+            "type": distribution.type,
+            "update_interval": distribution.dataset.frequency.hours,
+            "url": f"http://{domain}{dataset.get_absolute_url()}",
+            "version": distribution.distribution_version,
+            "upload_to_storage": distribution.upload_to_storage,
+        }
+    ]
 
 
 @pytest.mark.django_db
 def test_create_dataset_distribution_without_api_key(app: DjangoTestApp):
     dataset = DatasetFactory()
-    res = app.post(reverse('api-distribution', kwargs={
-        'datasetId': dataset.pk
-    }), expect_errors=True)
+    res = app.post(reverse("api-distribution", kwargs={"datasetId": dataset.pk}), expect_errors=True)
     assert res.status_code == 403
 
 
@@ -942,19 +818,12 @@ def test_create_dataset_distribution_without_file_and_url(app: DjangoTestApp):
         object_id=dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    content_type, params = app.encode_multipart(params=[
-        ('title', "Test distribution")
-    ], files=[])
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test',
-        'CONTENT_TYPE': content_type
-    })
-    res = app.post(reverse('api-distribution', kwargs={
-        'datasetId': dataset.pk
-    }), params, expect_errors=True)
+    content_type, params = app.encode_multipart(params=[("title", "Test distribution")], files=[])
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test", "CONTENT_TYPE": content_type})
+    res = app.post(reverse("api-distribution", kwargs={"datasetId": dataset.pk}), params, expect_errors=True)
     assert res.status_code == 400
-    assert 'file' in res.json
-    assert 'url' in res.json
+    assert "file" in res.json
+    assert "url" in res.json
 
 
 @pytest.mark.django_db
@@ -966,20 +835,14 @@ def test_create_dataset_distribution_with_both_file_and_url(app: DjangoTestApp):
         object_id=dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    content_type, params = app.encode_multipart(params=[
-        ('title', "Test distribution"),
-        ('url', "https://test.com/")
-    ], files=[('file', 'file.csv', b'Test')])
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test',
-        'CONTENT_TYPE': content_type
-    })
-    res = app.post(reverse('api-distribution', kwargs={
-        'datasetId': dataset.pk
-    }), params, expect_errors=True)
+    content_type, params = app.encode_multipart(
+        params=[("title", "Test distribution"), ("url", "https://test.com/")], files=[("file", "file.csv", b"Test")]
+    )
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test", "CONTENT_TYPE": content_type})
+    res = app.post(reverse("api-distribution", kwargs={"datasetId": dataset.pk}), params, expect_errors=True)
     assert res.status_code == 400
-    assert 'file' in res.json
-    assert 'url' in res.json
+    assert "file" in res.json
+    assert "url" in res.json
 
 
 @pytest.mark.django_db
@@ -991,19 +854,13 @@ def test_create_dataset_distribution_with_empty_file(app: DjangoTestApp):
         object_id=dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    content_type, params = app.encode_multipart(params=[
-        ('title', "Test distribution"),
-        ('url', "https://test.com/")
-    ], files=[('file', 'file.csv', b'')])
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test',
-        'CONTENT_TYPE': content_type
-    })
-    res = app.post(reverse('api-distribution', kwargs={
-        'datasetId': dataset.pk
-    }), params, expect_errors=True)
+    content_type, params = app.encode_multipart(
+        params=[("title", "Test distribution"), ("url", "https://test.com/")], files=[("file", "file.csv", b"")]
+    )
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test", "CONTENT_TYPE": content_type})
+    res = app.post(reverse("api-distribution", kwargs={"datasetId": dataset.pk}), params, expect_errors=True)
     assert res.status_code == 400
-    assert 'file' in res.json
+    assert "file" in res.json
 
 
 @pytest.mark.django_db
@@ -1016,35 +873,33 @@ def test_create_dataset_distribution_with_file(app: DjangoTestApp):
         object_id=dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    content_type, params = app.encode_multipart(params=[
-        ('title', "Test distribution"),
-        ('region', 'Geo'),
-        ('municipality', 'Location'),
-        ('periodStart', "2022-10-12")
-    ], files=[('file', 'file.csv', b'Test')])
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test',
-        'CONTENT_TYPE': content_type
-    })
-    res = app.post(reverse('api-distribution', kwargs={
-        'datasetId': dataset.pk
-    }), params)
+    content_type, params = app.encode_multipart(
+        params=[
+            ("title", "Test distribution"),
+            ("region", "Geo"),
+            ("municipality", "Location"),
+            ("periodStart", "2022-10-12"),
+        ],
+        files=[("file", "file.csv", b"Test")],
+    )
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test", "CONTENT_TYPE": content_type})
+    res = app.post(reverse("api-distribution", kwargs={"datasetId": dataset.pk}), params)
     assert dataset.datasetdistribution_set.count() == 1
     distribution = dataset.datasetdistribution_set.first()
     distribution.set_current_language("lt")
     assert res.json == {
-        'description': distribution.description,
-        'file': distribution.filename_without_path(),
-        'id': distribution.pk,
-        'issued': distribution.issued,
-        'periodEnd': None,
-        'periodStart': str(distribution.period_start),
-        'geo_location': "Geo Location",
-        'title': "Test distribution",
-        'type': "FILE",
-        'url': f"http://{domain}{dataset.get_absolute_url()}",
-        'version': distribution.distribution_version,
-        'upload_to_storage': distribution.upload_to_storage,
+        "description": distribution.description,
+        "file": distribution.filename_without_path(),
+        "id": distribution.pk,
+        "issued": distribution.issued,
+        "periodEnd": None,
+        "periodStart": str(distribution.period_start),
+        "geo_location": "Geo Location",
+        "title": "Test distribution",
+        "type": "FILE",
+        "url": f"http://{domain}{dataset.get_absolute_url()}",
+        "version": distribution.distribution_version,
+        "upload_to_storage": distribution.upload_to_storage,
     }
 
 
@@ -1057,36 +912,34 @@ def test_create_dataset_distribution_with_url(app: DjangoTestApp):
         object_id=dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    content_type, params = app.encode_multipart(params=[
-        ('title', "Test distribution"),
-        ('region', 'Geo'),
-        ('municipality', 'Location'),
-        ('periodStart', "2022-10-12"),
-        ('url', "http://test.com/")
-    ], files=[])
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test',
-        'CONTENT_TYPE': content_type
-    })
-    res = app.post(reverse('api-distribution', kwargs={
-        'datasetId': dataset.pk
-    }), params)
+    content_type, params = app.encode_multipart(
+        params=[
+            ("title", "Test distribution"),
+            ("region", "Geo"),
+            ("municipality", "Location"),
+            ("periodStart", "2022-10-12"),
+            ("url", "http://test.com/"),
+        ],
+        files=[],
+    )
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test", "CONTENT_TYPE": content_type})
+    res = app.post(reverse("api-distribution", kwargs={"datasetId": dataset.pk}), params)
     assert dataset.datasetdistribution_set.count() == 1
     distribution = dataset.datasetdistribution_set.first()
     distribution.set_current_language("lt")
     assert res.json == {
-        'description': distribution.description,
-        'file': "",
-        'id': distribution.pk,
-        'issued': distribution.issued,
-        'periodEnd': None,
-        'periodStart': str(distribution.period_start),
-        'geo_location': "Geo Location",
-        'title': "Test distribution",
-        'type': "URL",
-        'url': "http://test.com/",
-        'version': distribution.distribution_version,
-        'upload_to_storage': distribution.upload_to_storage,
+        "description": distribution.description,
+        "file": "",
+        "id": distribution.pk,
+        "issued": distribution.issued,
+        "periodEnd": None,
+        "periodStart": str(distribution.period_start),
+        "geo_location": "Geo Location",
+        "title": "Test distribution",
+        "type": "URL",
+        "url": "http://test.com/",
+        "version": distribution.distribution_version,
+        "upload_to_storage": distribution.upload_to_storage,
     }
 
 
@@ -1100,36 +953,34 @@ def test_create_dataset_distribution_with_overwrite(app: DjangoTestApp):
         object_id=distribution.dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    content_type, params = app.encode_multipart(params=[
-        ('title', "Test distribution"),
-        ('region', 'Geo'),
-        ('municipality', 'Location'),
-        ('periodStart', "2022-10-12"),
-        ('overwrite', True)
-    ], files=[('file', distribution.filename_without_path(), b'Test')])
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test',
-        'CONTENT_TYPE': content_type
-    })
-    res = app.post(reverse('api-distribution', kwargs={
-        'datasetId': distribution.dataset.pk
-    }), params)
+    content_type, params = app.encode_multipart(
+        params=[
+            ("title", "Test distribution"),
+            ("region", "Geo"),
+            ("municipality", "Location"),
+            ("periodStart", "2022-10-12"),
+            ("overwrite", True),
+        ],
+        files=[("file", distribution.filename_without_path(), b"Test")],
+    )
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test", "CONTENT_TYPE": content_type})
+    res = app.post(reverse("api-distribution", kwargs={"datasetId": distribution.dataset.pk}), params)
     assert distribution.dataset.datasetdistribution_set.count() == 1
     distribution = distribution.dataset.datasetdistribution_set.first()
     distribution.set_current_language("lt")
     assert res.json == {
-        'description': distribution.description,
-        'file': distribution.filename_without_path(),
-        'id': distribution.pk,
-        'issued': distribution.issued,
-        'periodEnd': str(distribution.period_end),
-        'periodStart': str(distribution.period_start),
-        'geo_location': "Geo Location",
-        'title': "Test distribution",
-        'type': "FILE",
-        'url': f"http://{domain}{distribution.dataset.get_absolute_url()}",
-        'version': distribution.distribution_version,
-        'upload_to_storage': distribution.upload_to_storage,
+        "description": distribution.description,
+        "file": distribution.filename_without_path(),
+        "id": distribution.pk,
+        "issued": distribution.issued,
+        "periodEnd": str(distribution.period_end),
+        "periodStart": str(distribution.period_start),
+        "geo_location": "Geo Location",
+        "title": "Test distribution",
+        "type": "FILE",
+        "url": f"http://{domain}{distribution.dataset.get_absolute_url()}",
+        "version": distribution.distribution_version,
+        "upload_to_storage": distribution.upload_to_storage,
     }
 
 
@@ -1142,45 +993,41 @@ def test_create_dataset_distribution_with_internal_id(app: DjangoTestApp):
         object_id=dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    content_type, params = app.encode_multipart(params=[
-        ('title', "Test distribution"),
-        ('region', 'Geo'),
-        ('municipality', 'Location'),
-        ('periodStart', "2022-10-12"),
-        ('url', "http://test.com/")
-    ], files=[])
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test',
-        'CONTENT_TYPE': content_type
-    })
-    res = app.post(reverse('api-distribution-internal', kwargs={
-        'internalId': dataset.internal_id
-    }), params)
+    content_type, params = app.encode_multipart(
+        params=[
+            ("title", "Test distribution"),
+            ("region", "Geo"),
+            ("municipality", "Location"),
+            ("periodStart", "2022-10-12"),
+            ("url", "http://test.com/"),
+        ],
+        files=[],
+    )
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test", "CONTENT_TYPE": content_type})
+    res = app.post(reverse("api-distribution-internal", kwargs={"internalId": dataset.internal_id}), params)
     assert dataset.datasetdistribution_set.count() == 1
     distribution = dataset.datasetdistribution_set.first()
     distribution.set_current_language("lt")
     assert res.json == {
-        'description': distribution.description,
-        'file': "",
-        'id': distribution.pk,
-        'issued': distribution.issued,
-        'periodEnd': None,
-        'periodStart': str(distribution.period_start),
-        'geo_location': "Geo Location",
-        'title': "Test distribution",
-        'type': "URL",
-        'url': "http://test.com/",
-        'version': distribution.distribution_version,
-        'upload_to_storage': distribution.upload_to_storage,
+        "description": distribution.description,
+        "file": "",
+        "id": distribution.pk,
+        "issued": distribution.issued,
+        "periodEnd": None,
+        "periodStart": str(distribution.period_start),
+        "geo_location": "Geo Location",
+        "title": "Test distribution",
+        "type": "URL",
+        "url": "http://test.com/",
+        "version": distribution.distribution_version,
+        "upload_to_storage": distribution.upload_to_storage,
     }
 
 
 @pytest.mark.django_db
 def test_put_create_dataset_distribution_without_api_key(app: DjangoTestApp):
     dataset = DatasetFactory()
-    res = app.put(reverse('api-distribution', kwargs={
-        'datasetId': dataset.pk
-    }), expect_errors=True)
+    res = app.put(reverse("api-distribution", kwargs={"datasetId": dataset.pk}), expect_errors=True)
     assert res.status_code == 403
 
 
@@ -1193,19 +1040,12 @@ def test_put_create_dataset_distribution_without_file_and_url(app: DjangoTestApp
         object_id=dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    content_type, params = app.encode_multipart(params=[
-        ('title', "Test distribution")
-    ], files=[])
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test',
-        'CONTENT_TYPE': content_type
-    })
-    res = app.put(reverse('api-distribution', kwargs={
-        'datasetId': dataset.pk
-    }), params, expect_errors=True)
+    content_type, params = app.encode_multipart(params=[("title", "Test distribution")], files=[])
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test", "CONTENT_TYPE": content_type})
+    res = app.put(reverse("api-distribution", kwargs={"datasetId": dataset.pk}), params, expect_errors=True)
     assert res.status_code == 400
-    assert 'file' in res.json
-    assert 'url' in res.json
+    assert "file" in res.json
+    assert "url" in res.json
 
 
 @pytest.mark.django_db
@@ -1217,20 +1057,14 @@ def test_put_create_dataset_distribution_with_both_file_and_url(app: DjangoTestA
         object_id=dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    content_type, params = app.encode_multipart(params=[
-        ('title', "Test distribution"),
-        ('url', "https://test.com/")
-    ], files=[('file', 'file.csv', b'Test')])
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test',
-        'CONTENT_TYPE': content_type
-    })
-    res = app.put(reverse('api-distribution', kwargs={
-        'datasetId': dataset.pk
-    }), params, expect_errors=True)
+    content_type, params = app.encode_multipart(
+        params=[("title", "Test distribution"), ("url", "https://test.com/")], files=[("file", "file.csv", b"Test")]
+    )
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test", "CONTENT_TYPE": content_type})
+    res = app.put(reverse("api-distribution", kwargs={"datasetId": dataset.pk}), params, expect_errors=True)
     assert res.status_code == 400
-    assert 'file' in res.json
-    assert 'url' in res.json
+    assert "file" in res.json
+    assert "url" in res.json
 
 
 @pytest.mark.django_db
@@ -1242,19 +1076,13 @@ def test_put_create_dataset_distribution_with_empty_file(app: DjangoTestApp):
         object_id=dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    content_type, params = app.encode_multipart(params=[
-        ('title', "Test distribution"),
-        ('url', "https://test.com/")
-    ], files=[('file', 'file.csv', b'')])
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test',
-        'CONTENT_TYPE': content_type
-    })
-    res = app.put(reverse('api-distribution', kwargs={
-        'datasetId': dataset.pk
-    }), params, expect_errors=True)
+    content_type, params = app.encode_multipart(
+        params=[("title", "Test distribution"), ("url", "https://test.com/")], files=[("file", "file.csv", b"")]
+    )
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test", "CONTENT_TYPE": content_type})
+    res = app.put(reverse("api-distribution", kwargs={"datasetId": dataset.pk}), params, expect_errors=True)
     assert res.status_code == 400
-    assert 'file' in res.json
+    assert "file" in res.json
 
 
 @pytest.mark.django_db
@@ -1267,35 +1095,33 @@ def test_put_create_dataset_distribution_with_file(app: DjangoTestApp):
         object_id=dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    content_type, params = app.encode_multipart(params=[
-        ('title', "Test distribution"),
-        ('region', 'Geo'),
-        ('municipality', 'Location'),
-        ('periodStart', "2022-10-12")
-    ], files=[('file', 'file.csv', b'Test')])
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test',
-        'CONTENT_TYPE': content_type
-    })
-    res = app.put(reverse('api-distribution', kwargs={
-        'datasetId': dataset.pk
-    }), params)
+    content_type, params = app.encode_multipart(
+        params=[
+            ("title", "Test distribution"),
+            ("region", "Geo"),
+            ("municipality", "Location"),
+            ("periodStart", "2022-10-12"),
+        ],
+        files=[("file", "file.csv", b"Test")],
+    )
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test", "CONTENT_TYPE": content_type})
+    res = app.put(reverse("api-distribution", kwargs={"datasetId": dataset.pk}), params)
     assert dataset.datasetdistribution_set.count() == 1
     distribution = dataset.datasetdistribution_set.first()
     distribution.set_current_language("lt")
     assert res.json == {
-        'description': distribution.description,
-        'file': distribution.filename_without_path(),
-        'id': distribution.pk,
-        'issued': distribution.issued,
-        'periodEnd': None,
-        'periodStart': str(distribution.period_start),
-        'geo_location': "Geo Location",
-        'title': "Test distribution",
-        'type': "FILE",
-        'url': f"http://{domain}{dataset.get_absolute_url()}",
-        'version': distribution.distribution_version,
-        'upload_to_storage': distribution.upload_to_storage,
+        "description": distribution.description,
+        "file": distribution.filename_without_path(),
+        "id": distribution.pk,
+        "issued": distribution.issued,
+        "periodEnd": None,
+        "periodStart": str(distribution.period_start),
+        "geo_location": "Geo Location",
+        "title": "Test distribution",
+        "type": "FILE",
+        "url": f"http://{domain}{dataset.get_absolute_url()}",
+        "version": distribution.distribution_version,
+        "upload_to_storage": distribution.upload_to_storage,
     }
 
 
@@ -1308,36 +1134,34 @@ def test_put_create_dataset_distribution_with_url(app: DjangoTestApp):
         object_id=dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    content_type, params = app.encode_multipart(params=[
-        ('title', "Test distribution"),
-        ('region', 'Geo'),
-        ('municipality', 'Location'),
-        ('periodStart', "2022-10-12"),
-        ('url', "http://test.com/")
-    ], files=[])
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test',
-        'CONTENT_TYPE': content_type
-    })
-    res = app.put(reverse('api-distribution', kwargs={
-        'datasetId': dataset.pk
-    }), params)
+    content_type, params = app.encode_multipart(
+        params=[
+            ("title", "Test distribution"),
+            ("region", "Geo"),
+            ("municipality", "Location"),
+            ("periodStart", "2022-10-12"),
+            ("url", "http://test.com/"),
+        ],
+        files=[],
+    )
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test", "CONTENT_TYPE": content_type})
+    res = app.put(reverse("api-distribution", kwargs={"datasetId": dataset.pk}), params)
     assert dataset.datasetdistribution_set.count() == 1
     distribution = dataset.datasetdistribution_set.first()
     distribution.set_current_language("lt")
     assert res.json == {
-        'description': distribution.description,
-        'file': "",
-        'id': distribution.pk,
-        'issued': distribution.issued,
-        'periodEnd': None,
-        'periodStart': str(distribution.period_start),
-        'geo_location': "Geo Location",
-        'title': "Test distribution",
-        'type': "URL",
-        'url': "http://test.com/",
-        'version': distribution.distribution_version,
-        'upload_to_storage': distribution.upload_to_storage,
+        "description": distribution.description,
+        "file": "",
+        "id": distribution.pk,
+        "issued": distribution.issued,
+        "periodEnd": None,
+        "periodStart": str(distribution.period_start),
+        "geo_location": "Geo Location",
+        "title": "Test distribution",
+        "type": "URL",
+        "url": "http://test.com/",
+        "version": distribution.distribution_version,
+        "upload_to_storage": distribution.upload_to_storage,
     }
 
 
@@ -1350,46 +1174,46 @@ def test_put_create_dataset_distribution_with_internal_id(app: DjangoTestApp):
         object_id=dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    content_type, params = app.encode_multipart(params=[
-        ('title', "Test distribution"),
-        ('region', 'Geo'),
-        ('municipality', 'Location'),
-        ('periodStart', "2022-10-12"),
-        ('url', "http://test.com/")
-    ], files=[])
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test',
-        'CONTENT_TYPE': content_type
-    })
-    res = app.put(reverse('api-distribution-internal', kwargs={
-        'internalId': dataset.internal_id
-    }), params)
+    content_type, params = app.encode_multipart(
+        params=[
+            ("title", "Test distribution"),
+            ("region", "Geo"),
+            ("municipality", "Location"),
+            ("periodStart", "2022-10-12"),
+            ("url", "http://test.com/"),
+        ],
+        files=[],
+    )
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test", "CONTENT_TYPE": content_type})
+    res = app.put(reverse("api-distribution-internal", kwargs={"internalId": dataset.internal_id}), params)
     assert dataset.datasetdistribution_set.count() == 1
     distribution = dataset.datasetdistribution_set.first()
     distribution.set_current_language("lt")
     assert res.json == {
-        'description': distribution.description,
-        'file': "",
-        'id': distribution.pk,
-        'issued': distribution.issued,
-        'periodEnd': None,
-        'periodStart': str(distribution.period_start),
-        'geo_location': "Geo Location",
-        'title': "Test distribution",
-        'type': "URL",
-        'url': "http://test.com/",
-        'version': distribution.distribution_version,
-        'upload_to_storage': distribution.upload_to_storage,
+        "description": distribution.description,
+        "file": "",
+        "id": distribution.pk,
+        "issued": distribution.issued,
+        "periodEnd": None,
+        "periodStart": str(distribution.period_start),
+        "geo_location": "Geo Location",
+        "title": "Test distribution",
+        "type": "URL",
+        "url": "http://test.com/",
+        "version": distribution.distribution_version,
+        "upload_to_storage": distribution.upload_to_storage,
     }
 
 
 @pytest.mark.django_db
 def test_update_dataset_distribution_without_api_key(app: DjangoTestApp):
     distribution = DatasetDistributionFactory()
-    res = app.patch(reverse('api-single-distribution', kwargs={
-        'datasetId': distribution.dataset.pk,
-        'distributionId': distribution.pk
-    }), expect_errors=True)
+    res = app.patch(
+        reverse(
+            "api-single-distribution", kwargs={"datasetId": distribution.dataset.pk, "distributionId": distribution.pk}
+        ),
+        expect_errors=True,
+    )
     assert res.status_code == 403
 
 
@@ -1403,13 +1227,11 @@ def test_update_dataset_distribution_with_wrong_dataset_id(app: DjangoTestApp):
         object_id=distribution.dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
-    res = app.patch(reverse('api-single-distribution', kwargs={
-        'datasetId': another_dataset.pk,
-        'distributionId': distribution.pk
-    }), expect_errors=True)
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
+    res = app.patch(
+        reverse("api-single-distribution", kwargs={"datasetId": another_dataset.pk, "distributionId": distribution.pk}),
+        expect_errors=True,
+    )
     assert res.status_code == 404
 
 
@@ -1423,13 +1245,14 @@ def test_update_dataset_distribution_with_wrong_internal_id(app: DjangoTestApp):
         object_id=distribution.dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
-    res = app.patch(reverse('api-single-distribution-internal', kwargs={
-        'internalId': another_dataset.internal_id,
-        'distributionId': distribution.pk
-    }), expect_errors=True)
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
+    res = app.patch(
+        reverse(
+            "api-single-distribution-internal",
+            kwargs={"internalId": another_dataset.internal_id, "distributionId": distribution.pk},
+        ),
+        expect_errors=True,
+    )
     assert res.status_code == 404
 
 
@@ -1442,21 +1265,20 @@ def test_update_dataset_distribution_with_both_file_and_url(app: DjangoTestApp):
         object_id=distribution.dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    content_type, params = app.encode_multipart(params=[
-        ('title', "Test distribution"),
-        ('url', 'http://example.com/')
-    ], files=[('file', 'file.csv', b'Test')])
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test',
-        'CONTENT_TYPE': content_type
-    })
-    res = app.patch(reverse('api-single-distribution', kwargs={
-        'datasetId': distribution.dataset.pk,
-        'distributionId': distribution.pk
-    }), params, expect_errors=True)
+    content_type, params = app.encode_multipart(
+        params=[("title", "Test distribution"), ("url", "http://example.com/")], files=[("file", "file.csv", b"Test")]
+    )
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test", "CONTENT_TYPE": content_type})
+    res = app.patch(
+        reverse(
+            "api-single-distribution", kwargs={"datasetId": distribution.dataset.pk, "distributionId": distribution.pk}
+        ),
+        params,
+        expect_errors=True,
+    )
     assert res.status_code == 400
-    assert 'file' in res.json
-    assert 'url' in res.json
+    assert "file" in res.json
+    assert "url" in res.json
 
 
 @pytest.mark.django_db
@@ -1468,19 +1290,22 @@ def test_update_dataset_distribution_with_empty_file(app: DjangoTestApp):
         object_id=distribution.dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    content_type, params = app.encode_multipart(params=[
-        ('title', "Test distribution"),
-    ], files=[('file', 'file.csv', b'')])
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test',
-        'CONTENT_TYPE': content_type
-    })
-    res = app.patch(reverse('api-single-distribution', kwargs={
-        'datasetId': distribution.dataset.pk,
-        'distributionId': distribution.pk
-    }), params, expect_errors=True)
+    content_type, params = app.encode_multipart(
+        params=[
+            ("title", "Test distribution"),
+        ],
+        files=[("file", "file.csv", b"")],
+    )
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test", "CONTENT_TYPE": content_type})
+    res = app.patch(
+        reverse(
+            "api-single-distribution", kwargs={"datasetId": distribution.dataset.pk, "distributionId": distribution.pk}
+        ),
+        params,
+        expect_errors=True,
+    )
     assert res.status_code == 400
-    assert 'file' in res.json
+    assert "file" in res.json
 
 
 @pytest.mark.django_db
@@ -1492,21 +1317,24 @@ def test_update_dataset_distribution_with_not_allowed_file(app: DjangoTestApp):
         object_id=distribution.dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    content_type, params = app.encode_multipart(params=[
-        ('title', "Updated title"),
-        ('description', "Updated description"),
-        ('region', 'Geo'),
-        ('municipality', 'Location'),
-    ], files=[('file', 'updated_file.html', b'test')])
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test',
-        'CONTENT_TYPE': content_type
-    })
-    res = app.patch(reverse('api-single-distribution', kwargs={
-        'datasetId': distribution.dataset.pk,
-        'distributionId': distribution.pk
-    }), params, expect_errors=True)
-    assert 'file' in res.json
+    content_type, params = app.encode_multipart(
+        params=[
+            ("title", "Updated title"),
+            ("description", "Updated description"),
+            ("region", "Geo"),
+            ("municipality", "Location"),
+        ],
+        files=[("file", "updated_file.html", b"test")],
+    )
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test", "CONTENT_TYPE": content_type})
+    res = app.patch(
+        reverse(
+            "api-single-distribution", kwargs={"datasetId": distribution.dataset.pk, "distributionId": distribution.pk}
+        ),
+        params,
+        expect_errors=True,
+    )
+    assert "file" in res.json
 
 
 @pytest.mark.django_db
@@ -1519,35 +1347,37 @@ def test_update_dataset_distribution_with_file(app: DjangoTestApp):
         object_id=distribution.dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    content_type, params = app.encode_multipart(params=[
-        ('title', "Updated title"),
-        ('description', "Updated description"),
-        ('region', 'Geo'),
-        ('municipality', 'Location'),
-    ], files=[('file', 'updated_file.csv', b'test')])
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test',
-        'CONTENT_TYPE': content_type
-    })
-    res = app.patch(reverse('api-single-distribution', kwargs={
-        'datasetId': distribution.dataset.pk,
-        'distributionId': distribution.pk
-    }), params)
+    content_type, params = app.encode_multipart(
+        params=[
+            ("title", "Updated title"),
+            ("description", "Updated description"),
+            ("region", "Geo"),
+            ("municipality", "Location"),
+        ],
+        files=[("file", "updated_file.csv", b"test")],
+    )
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test", "CONTENT_TYPE": content_type})
+    res = app.patch(
+        reverse(
+            "api-single-distribution", kwargs={"datasetId": distribution.dataset.pk, "distributionId": distribution.pk}
+        ),
+        params,
+    )
     distribution.refresh_from_db()
     distribution.set_current_language("lt")
     assert res.json == {
-        'description': "Updated description",
-        'file': distribution.filename_without_path(),
-        'id': distribution.pk,
-        'issued': distribution.issued,
-        'periodEnd': str(distribution.period_end),
-        'periodStart': str(distribution.period_start),
-        'geo_location': "Geo Location",
-        'title': "Updated title",
-        'type': "FILE",
-        'url': f"http://{domain}{distribution.dataset.get_absolute_url()}",
-        'version': distribution.distribution_version,
-        'upload_to_storage': distribution.upload_to_storage,
+        "description": "Updated description",
+        "file": distribution.filename_without_path(),
+        "id": distribution.pk,
+        "issued": distribution.issued,
+        "periodEnd": str(distribution.period_end),
+        "periodStart": str(distribution.period_start),
+        "geo_location": "Geo Location",
+        "title": "Updated title",
+        "type": "FILE",
+        "url": f"http://{domain}{distribution.dataset.get_absolute_url()}",
+        "version": distribution.distribution_version,
+        "upload_to_storage": distribution.upload_to_storage,
     }
 
 
@@ -1560,35 +1390,37 @@ def test_update_dataset_distribution_with_url(app: DjangoTestApp):
         object_id=distribution.dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    content_type, params = app.encode_multipart(params=[
-        ('title', "Updated title"),
-        ('description', "Updated description"),
-        ('region', 'Geo'),
-        ('municipality', 'Location'),
-        ('url', "http://example.com/")
-    ], files=[])
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test',
-        'CONTENT_TYPE': content_type
-    })
-    res = app.patch(reverse('api-single-distribution', kwargs={
-        'datasetId': distribution.dataset.pk,
-        'distributionId': distribution.pk
-    }), params)
+    content_type, params = app.encode_multipart(
+        params=[
+            ("title", "Updated title"),
+            ("description", "Updated description"),
+            ("region", "Geo"),
+            ("municipality", "Location"),
+            ("url", "http://example.com/"),
+        ],
+        files=[],
+    )
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test", "CONTENT_TYPE": content_type})
+    res = app.patch(
+        reverse(
+            "api-single-distribution", kwargs={"datasetId": distribution.dataset.pk, "distributionId": distribution.pk}
+        ),
+        params,
+    )
     distribution.set_current_language("lt")
     assert res.json == {
-        'description': "Updated description",
-        'file': "",
-        'id': distribution.pk,
-        'issued': distribution.issued,
-        'periodEnd': str(distribution.period_end),
-        'periodStart': str(distribution.period_start),
-        'geo_location': "Geo Location",
-        'title': "Updated title",
-        'type': "URL",
-        'url': "http://example.com/",
-        'version': distribution.distribution_version,
-        'upload_to_storage': distribution.upload_to_storage,
+        "description": "Updated description",
+        "file": "",
+        "id": distribution.pk,
+        "issued": distribution.issued,
+        "periodEnd": str(distribution.period_end),
+        "periodStart": str(distribution.period_start),
+        "geo_location": "Geo Location",
+        "title": "Updated title",
+        "type": "URL",
+        "url": "http://example.com/",
+        "version": distribution.distribution_version,
+        "upload_to_storage": distribution.upload_to_storage,
     }
 
 
@@ -1603,45 +1435,50 @@ def test_update_dataset_distribution_with_internal_id(app: DjangoTestApp):
         object_id=dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    content_type, params = app.encode_multipart(params=[
-        ('title', "Updated title"),
-        ('description', "Updated description"),
-        ('region', 'Geo'),
-        ('municipality', 'Location'),
-    ], files=[('file', 'updated_file.csv', b'test')])
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test',
-        'CONTENT_TYPE': content_type
-    })
-    res = app.patch(reverse('api-single-distribution-internal', kwargs={
-        'internalId': dataset.internal_id,
-        'distributionId': distribution.pk
-    }), params)
+    content_type, params = app.encode_multipart(
+        params=[
+            ("title", "Updated title"),
+            ("description", "Updated description"),
+            ("region", "Geo"),
+            ("municipality", "Location"),
+        ],
+        files=[("file", "updated_file.csv", b"test")],
+    )
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test", "CONTENT_TYPE": content_type})
+    res = app.patch(
+        reverse(
+            "api-single-distribution-internal",
+            kwargs={"internalId": dataset.internal_id, "distributionId": distribution.pk},
+        ),
+        params,
+    )
     distribution.refresh_from_db()
     distribution.set_current_language("lt")
     assert res.json == {
-        'description': "Updated description",
-        'file': distribution.filename_without_path(),
-        'id': distribution.pk,
-        'issued': distribution.issued,
-        'periodEnd': str(distribution.period_end),
-        'periodStart': str(distribution.period_start),
-        'geo_location': "Geo Location",
-        'title': "Updated title",
-        'type': "FILE",
-        'url': f"http://{domain}{dataset.get_absolute_url()}",
-        'version': distribution.distribution_version,
-        'upload_to_storage': distribution.upload_to_storage,
+        "description": "Updated description",
+        "file": distribution.filename_without_path(),
+        "id": distribution.pk,
+        "issued": distribution.issued,
+        "periodEnd": str(distribution.period_end),
+        "periodStart": str(distribution.period_start),
+        "geo_location": "Geo Location",
+        "title": "Updated title",
+        "type": "FILE",
+        "url": f"http://{domain}{dataset.get_absolute_url()}",
+        "version": distribution.distribution_version,
+        "upload_to_storage": distribution.upload_to_storage,
     }
 
 
 @pytest.mark.django_db
 def test_delete_dataset_distribution_without_api_key(app: DjangoTestApp):
     distribution = DatasetDistributionFactory()
-    res = app.delete(reverse('api-single-distribution', kwargs={
-        'datasetId': distribution.dataset.pk,
-        'distributionId': distribution.pk
-    }), expect_errors=True)
+    res = app.delete(
+        reverse(
+            "api-single-distribution", kwargs={"datasetId": distribution.dataset.pk, "distributionId": distribution.pk}
+        ),
+        expect_errors=True,
+    )
     assert res.status_code == 403
 
 
@@ -1655,13 +1492,11 @@ def test_delete_dataset_distribution_with_wrong_dataset_id(app: DjangoTestApp):
         object_id=distribution.dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
-    res = app.delete(reverse('api-single-distribution', kwargs={
-        'datasetId': another_dataset.pk,
-        'distributionId': distribution.pk
-    }), expect_errors=True)
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
+    res = app.delete(
+        reverse("api-single-distribution", kwargs={"datasetId": another_dataset.pk, "distributionId": distribution.pk}),
+        expect_errors=True,
+    )
     assert res.status_code == 404
 
 
@@ -1675,13 +1510,14 @@ def test_delete_dataset_distribution_with_wrong_internal_id(app: DjangoTestApp):
         object_id=distribution.dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
-    res = app.delete(reverse('api-single-distribution-internal', kwargs={
-        'internalId': another_dataset.internal_id,
-        'distributionId': distribution.pk
-    }), expect_errors=True)
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
+    res = app.delete(
+        reverse(
+            "api-single-distribution-internal",
+            kwargs={"internalId": another_dataset.internal_id, "distributionId": distribution.pk},
+        ),
+        expect_errors=True,
+    )
     assert res.status_code == 404
 
 
@@ -1695,13 +1531,8 @@ def test_delete_dataset_distribution_with_dataset_id(app: DjangoTestApp):
         object_id=dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
-    app.delete(reverse('api-single-distribution', kwargs={
-        'datasetId': dataset.pk,
-        'distributionId': distribution.pk
-    }))
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
+    app.delete(reverse("api-single-distribution", kwargs={"datasetId": dataset.pk, "distributionId": distribution.pk}))
     assert dataset.datasetdistribution_set.count() == 0
 
 
@@ -1715,22 +1546,20 @@ def test_delete_dataset_distribution_with_internal_id(app: DjangoTestApp):
         object_id=dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
-    app.delete(reverse('api-single-distribution-internal', kwargs={
-        'internalId': dataset.internal_id,
-        'distributionId': distribution.pk
-    }))
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
+    app.delete(
+        reverse(
+            "api-single-distribution-internal",
+            kwargs={"internalId": dataset.internal_id, "distributionId": distribution.pk},
+        )
+    )
     assert dataset.datasetdistribution_set.count() == 0
 
 
 @pytest.mark.django_db
 def test_get_dataset_structures_without_api_key(app: DjangoTestApp):
     structure = DatasetStructureFactory()
-    res = app.get(reverse('api-structure', kwargs={
-        'datasetId': structure.dataset.pk
-    }), expect_errors=True)
+    res = app.get(reverse("api-structure", kwargs={"datasetId": structure.dataset.pk}), expect_errors=True)
     assert res.status_code == 403
 
 
@@ -1744,19 +1573,17 @@ def test_get_dataset_structures_with_dataset_id(app: DjangoTestApp):
         object_id=structure.dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
-    res = app.get(reverse('api-structure', kwargs={
-        'datasetId': structure.dataset.pk
-    }))
-    assert res.json == [{
-        'created': timezone.localtime(structure.created).isoformat(),
-        'filename': structure.filename_without_path(),
-        'id': structure.pk,
-        'size': structure.size,
-        'title': structure.title
-    }]
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
+    res = app.get(reverse("api-structure", kwargs={"datasetId": structure.dataset.pk}))
+    assert res.json == [
+        {
+            "created": timezone.localtime(structure.created).isoformat(),
+            "filename": structure.filename_without_path(),
+            "id": structure.pk,
+            "size": structure.size,
+            "title": structure.title,
+        }
+    ]
 
 
 @pytest.mark.django_db
@@ -1770,27 +1597,23 @@ def test_get_dataset_structures_with_internal_id(app: DjangoTestApp):
         object_id=dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
-    res = app.get(reverse('api-structure-internal', kwargs={
-        'internalId': dataset.internal_id
-    }))
-    assert res.json == [{
-        'created': timezone.localtime(structure.created).isoformat(),
-        'filename': structure.filename_without_path(),
-        'id': structure.pk,
-        'size': structure.size,
-        'title': structure.title
-    }]
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
+    res = app.get(reverse("api-structure-internal", kwargs={"internalId": dataset.internal_id}))
+    assert res.json == [
+        {
+            "created": timezone.localtime(structure.created).isoformat(),
+            "filename": structure.filename_without_path(),
+            "id": structure.pk,
+            "size": structure.size,
+            "title": structure.title,
+        }
+    ]
 
 
 @pytest.mark.django_db
 def test_create_dataset_structures_without_api_key(app: DjangoTestApp):
     dataset = DatasetFactory()
-    res = app.post(reverse('api-structure', kwargs={
-        'datasetId': dataset.pk
-    }), expect_errors=True)
+    res = app.post(reverse("api-structure", kwargs={"datasetId": dataset.pk}), expect_errors=True)
     assert res.status_code == 403
 
 
@@ -1803,15 +1626,11 @@ def test_create_dataset_structure_with_errors(app: DjangoTestApp):
         object_id=dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
-    res = app.post(reverse('api-structure', kwargs={
-        'datasetId': dataset.pk
-    }), expect_errors=True)
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
+    res = app.post(reverse("api-structure", kwargs={"datasetId": dataset.pk}), expect_errors=True)
     assert dataset.datasetstructure_set.count() == 0
-    assert 'file' in res.json
-    assert 'title' in res.json
+    assert "file" in res.json
+    assert "title" in res.json
 
 
 @pytest.mark.django_db
@@ -1823,17 +1642,12 @@ def test_create_dataset_structure_with_not_allowed_file(app: DjangoTestApp):
         object_id=dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    content_type, params = app.encode_multipart(params=[
-        ('title', "Test structure")
-    ], files=[('file', 'file.svg', b'test')])
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test',
-        'CONTENT_TYPE': content_type
-    })
-    res = app.post(reverse('api-structure', kwargs={
-        'datasetId': dataset.pk
-    }), params, expect_errors=True)
-    assert 'file' in res.json
+    content_type, params = app.encode_multipart(
+        params=[("title", "Test structure")], files=[("file", "file.svg", b"test")]
+    )
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test", "CONTENT_TYPE": content_type})
+    res = app.post(reverse("api-structure", kwargs={"datasetId": dataset.pk}), params, expect_errors=True)
+    assert "file" in res.json
 
 
 @pytest.mark.django_db
@@ -1845,26 +1659,21 @@ def test_create_dataset_structure_with_dataset_id(app: DjangoTestApp):
         object_id=dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    content_type, params = app.encode_multipart(params=[
-        ('title', "Test structure")
-    ], files=[('file', 'file.csv', b'test')])
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test',
-        'CONTENT_TYPE': content_type
-    })
-    res = app.post(reverse('api-structure', kwargs={
-        'datasetId': dataset.pk
-    }), params)
+    content_type, params = app.encode_multipart(
+        params=[("title", "Test structure")], files=[("file", "file.csv", b"test")]
+    )
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test", "CONTENT_TYPE": content_type})
+    res = app.post(reverse("api-structure", kwargs={"datasetId": dataset.pk}), params)
     dataset.refresh_from_db()
     assert dataset.datasetstructure_set.count() == 1
     structure = dataset.datasetstructure_set.first()
     assert dataset.current_structure == structure
     assert res.json == {
-        'created': timezone.localtime(structure.created).isoformat(),
-        'filename': structure.filename_without_path(),
-        'id': structure.pk,
-        'size': structure.size,
-        'title': structure.title
+        "created": timezone.localtime(structure.created).isoformat(),
+        "filename": structure.filename_without_path(),
+        "id": structure.pk,
+        "size": structure.size,
+        "title": structure.title,
     }
 
 
@@ -1877,36 +1686,31 @@ def test_create_dataset_structure_with_internal_id(app: DjangoTestApp):
         object_id=dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    content_type, params = app.encode_multipart(params=[
-        ('title', "Test structure")
-    ], files=[('file', 'file.csv', b'test')])
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test',
-        'CONTENT_TYPE': content_type
-    })
-    res = app.post(reverse('api-structure-internal', kwargs={
-        'internalId': dataset.internal_id
-    }), params)
+    content_type, params = app.encode_multipart(
+        params=[("title", "Test structure")], files=[("file", "file.csv", b"test")]
+    )
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test", "CONTENT_TYPE": content_type})
+    res = app.post(reverse("api-structure-internal", kwargs={"internalId": dataset.internal_id}), params)
     dataset.refresh_from_db()
     assert dataset.datasetstructure_set.count() == 1
     structure = dataset.datasetstructure_set.first()
     assert dataset.current_structure == structure
     assert res.json == {
-        'created': timezone.localtime(structure.created).isoformat(),
-        'filename': structure.filename_without_path(),
-        'id': structure.pk,
-        'size': structure.size,
-        'title': structure.title
+        "created": timezone.localtime(structure.created).isoformat(),
+        "filename": structure.filename_without_path(),
+        "id": structure.pk,
+        "size": structure.size,
+        "title": structure.title,
     }
 
 
 @pytest.mark.django_db
 def test_delete_dataset_structures_without_api_key(app: DjangoTestApp):
     structure = DatasetStructureFactory()
-    res = app.delete(reverse('api-single-structure', kwargs={
-        'datasetId': structure.dataset.pk,
-        'structureId': structure.pk
-    }), expect_errors=True)
+    res = app.delete(
+        reverse("api-single-structure", kwargs={"datasetId": structure.dataset.pk, "structureId": structure.pk}),
+        expect_errors=True,
+    )
     assert res.status_code == 403
 
 
@@ -1920,13 +1724,11 @@ def test_delete_dataset_structure_with_wrong_dataset_id(app: DjangoTestApp):
         object_id=structure.dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
-    res = app.delete(reverse('api-single-structure', kwargs={
-        'datasetId': another_dataset.pk,
-        'structureId': structure.pk
-    }), expect_errors=True)
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
+    res = app.delete(
+        reverse("api-single-structure", kwargs={"datasetId": another_dataset.pk, "structureId": structure.pk}),
+        expect_errors=True,
+    )
     assert res.status_code == 404
 
 
@@ -1940,13 +1742,14 @@ def test_delete_dataset_structure_with_wrong_internal_id(app: DjangoTestApp):
         object_id=structure.dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
-    res = app.delete(reverse('api-single-structure-internal', kwargs={
-        'internalId': another_dataset.internal_id,
-        'structureId': structure.pk
-    }), expect_errors=True)
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
+    res = app.delete(
+        reverse(
+            "api-single-structure-internal",
+            kwargs={"internalId": another_dataset.internal_id, "structureId": structure.pk},
+        ),
+        expect_errors=True,
+    )
     assert res.status_code == 404
 
 
@@ -1960,13 +1763,8 @@ def test_delete_dataset_structure_with_dataset_id(app: DjangoTestApp):
         object_id=dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
-    app.delete(reverse('api-single-structure', kwargs={
-        'datasetId': dataset.pk,
-        'structureId': structure.pk
-    }))
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
+    app.delete(reverse("api-single-structure", kwargs={"datasetId": dataset.pk, "structureId": structure.pk}))
     assert dataset.datasetstructure_set.count() == 0
 
 
@@ -1980,13 +1778,12 @@ def test_delete_dataset_structure_with_internal_id(app: DjangoTestApp):
         object_id=structure.dataset.organization.pk,
     )
     APIKeyFactory(representative=representative)
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
-    app.delete(reverse('api-single-structure-internal', kwargs={
-        'internalId': dataset.internal_id,
-        'structureId': structure.pk
-    }))
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
+    app.delete(
+        reverse(
+            "api-single-structure-internal", kwargs={"internalId": dataset.internal_id, "structureId": structure.pk}
+        )
+    )
     assert dataset.datasetstructure_set.count() == 0
 
 
@@ -1994,63 +1791,59 @@ def test_delete_dataset_structure_with_internal_id(app: DjangoTestApp):
 def test_create_model_statistics(app: DjangoTestApp):
     organization = OrganizationFactory()
     ct = ContentType.objects.get_for_model(organization)
-    user = UserFactory(
-        is_staff=True
-    )
-    representative = RepresentativeFactory(
-        content_type=ct,
-        object_id=organization.pk,
-        user=user
-    )
+    user = UserFactory(is_staff=True)
+    representative = RepresentativeFactory(content_type=ct, object_id=organization.pk, user=user)
     APIKeyFactory(representative=representative)
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
-    res = app.post(reverse('api-download-stats-internal'), {
-        'source': 'get.data.gov.lt',
-        'model': 'naujas_modelis',
-        'format': 'excel',
-        'time': datetime.now(),
-        'requests': 100,
-        'objects': 10
-    }, expect_errors=False)
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
+    res = app.post(
+        reverse("api-download-stats-internal"),
+        {
+            "source": "get.data.gov.lt",
+            "model": "naujas_modelis",
+            "format": "excel",
+            "time": datetime.now(),
+            "requests": 100,
+            "objects": 10,
+        },
+        expect_errors=False,
+    )
     assert res.json == {
         "source": "get.data.gov.lt",
         "model": "naujas_modelis",
         "format": "excel",
         "time": timezone.localtime(ModelDownloadStats.objects.first().created).isoformat(),
         "requests": 100,
-        "objects": 10
+        "objects": 10,
     }
 
 
 @pytest.mark.django_db
 def test_edp_dcat_ap_rdf(app: DjangoTestApp):
     Dataset.objects.all().delete()
-    iana = 'http://www.iana.org/assignments'
-    po = 'http://publications.europa.eu/resource/authority'
+    iana = "http://www.iana.org/assignments"
+    po = "http://publications.europa.eu/resource/authority"
 
     dataset = DatasetFactory(
         title={
-            'lt': 'Testas1',
-            'en': 'Test1',
+            "lt": "Testas1",
+            "en": "Test1",
         },
         description={
-            'lt': 'Duomenų rinkinio aprašymas.',
-            'en': 'Dataset description.',
+            "lt": "Duomenų rinkinio aprašymas.",
+            "en": "Dataset description.",
         },
         published=datetime(2016, 8, 1),
-        frequency=FrequencyFactory(uri=f'{po}/frequency/IRREG'),
+        frequency=FrequencyFactory(uri=f"{po}/frequency/IRREG"),
         category=[
-            CategoryFactory(title='Energy'),
+            CategoryFactory(title="Energy"),
             CategoryFactory(
-                title='Environment',
-                uri=f'{po}/data-theme/ENVI',
+                title="Environment",
+                uri=f"{po}/data-theme/ENVI",
             ),
         ],
         organization=OrganizationFactory(
-            title='Data Enterprise',
-            email='data@example.com',
+            title="Data Enterprise",
+            email="data@example.com",
         ),
         access_rights=Dataset.PUBLIC,
     )
@@ -2059,10 +1852,10 @@ def test_edp_dcat_ap_rdf(app: DjangoTestApp):
         title="CSV failas",
         description="Atviras duomenų šaltinis.",
         format=FileFormat(
-            uri=f'{po}/file-type/CSV',
-            media_type_uri=f'{iana}/media-types/text/csv',
+            uri=f"{po}/file-type/CSV",
+            media_type_uri=f"{iana}/media-types/text/csv",
         ),
-        licence=LicenceFactory(url=f'{po}/licence/CC_BY_4_0'),
+        licence=LicenceFactory(url=f"{po}/licence/CC_BY_4_0"),
         conditions="platinimo sąlygos",
     )
     dist2 = DatasetDistributionFactory(
@@ -2070,19 +1863,21 @@ def test_edp_dcat_ap_rdf(app: DjangoTestApp):
         title="Duomenų teikimo paslauga",
         description="Universali duomenų teikimo paslauga.",
         format=FileFormat(
-            extension='UAPI',
-            uri=f'{po}/file-type/JSON',
-            media_type_uri=f'{iana}/media-types/application/json',
+            extension="UAPI",
+            uri=f"{po}/file-type/JSON",
+            media_type_uri=f"{iana}/media-types/application/json",
         ),
-        licence=LicenceFactory(url=f'{po}/licence/CC_BY_4_0'),
+        licence=LicenceFactory(url=f"{po}/licence/CC_BY_4_0"),
         conditions="platinimo sąlygos",
     )
 
-    res = app.get('/edp/dcat-ap.rdf')
+    res = app.get("/edp/dcat-ap.rdf")
 
     assert res.status_code == 200
-    assert res.headers['Content-Type'] == 'application/rdf+xml'
-    assert strip_empty_lines(res.text) == f'''\
+    assert res.headers["Content-Type"] == "application/rdf+xml"
+    assert (
+        strip_empty_lines(res.text)
+        == f"""\
 <?xml version="1.0"?>
 <rdf:RDF
     xml:base="http://localhost"
@@ -2177,7 +1972,8 @@ def test_edp_dcat_ap_rdf(app: DjangoTestApp):
             </dcat:Distribution>
         </dcat:distribution>
     </dcat:Dataset>
-</rdf:RDF>'''
+</rdf:RDF>"""
+    )
 
 
 @pytest.mark.django_db
@@ -2187,21 +1983,14 @@ def test_get_all_datasets_publisher_exclusive(app: DjangoTestApp):
     get all should be forbidden
     """
     org = OrganizationFactory()
-    publisher_org = OrganizationFactory(publisher = True)
+    publisher_org = OrganizationFactory(publisher=True)
     dataset = DatasetFactory(is_public=False, organization=org)
     DatasetFactory(organization=org)
     DatasetFactory(organization=org)
     ct = ContentType.objects.get_for_model(dataset)
-    representative = RepresentativeFactory(
-        content_type=ct,
-        object_id=dataset.pk,
-        user = None,
-        organization = publisher_org
-    )
+    representative = RepresentativeFactory(content_type=ct, object_id=dataset.pk, user=None, organization=publisher_org)
     APIKeyFactory(representative=representative)
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
     res = app.get(reverse("api-dataset"), expect_errors=True)
     dataset.refresh_from_db()
     assert res.status_code == 403
@@ -2214,24 +2003,17 @@ def test_get_all_datasets_publisher(app: DjangoTestApp):
     get all should return all the datasets from that organization
     """
     org = OrganizationFactory()
-    publisher_org = OrganizationFactory(publisher = True)
+    publisher_org = OrganizationFactory(publisher=True)
     ds1 = DatasetFactory(is_public=False, organization=org)
     ds2 = DatasetFactory(organization=org)
     DatasetFactory()
     ct = ContentType.objects.get_for_model(org)
-    representative = RepresentativeFactory(
-        content_type=ct,
-        object_id=org.pk,
-        user = None,
-        organization = publisher_org
-    )
+    representative = RepresentativeFactory(content_type=ct, object_id=org.pk, user=None, organization=publisher_org)
     APIKeyFactory(representative=representative)
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
     res = app.get(reverse("api-dataset"), expect_errors=True)
     assert len(res.json) == 2
-    assert {int(ds['id']) for ds in res.json} == {ds1.pk, ds2.pk}
+    assert {int(ds["id"]) for ds in res.json} == {ds1.pk, ds2.pk}
 
 
 @pytest.mark.django_db
@@ -2241,29 +2023,18 @@ def test_get_dataset_publisher(app: DjangoTestApp):
     access should only be granted to that dataset.
     """
     org = OrganizationFactory()
-    publisher_org = OrganizationFactory(publisher = True)
+    publisher_org = OrganizationFactory(publisher=True)
     ds1 = DatasetFactory(is_public=False, organization=org)
     ds2 = DatasetFactory(organization=org)
     ct = ContentType.objects.get_for_model(ds1)
-    representative = RepresentativeFactory(
-        content_type=ct,
-        object_id=ds1.pk,
-        user = None,
-        organization = publisher_org
-    )
+    representative = RepresentativeFactory(content_type=ct, object_id=ds1.pk, user=None, organization=publisher_org)
     APIKeyFactory(representative=representative)
-    app.extra_environ.update({
-        'HTTP_AUTHORIZATION': 'ApiKey test'
-    })
-    res = app.delete(reverse('api-single-dataset', kwargs={
-        'datasetId': ds2.pk
-    }), expect_errors=True)
+    app.extra_environ.update({"HTTP_AUTHORIZATION": "ApiKey test"})
+    res = app.delete(reverse("api-single-dataset", kwargs={"datasetId": ds2.pk}), expect_errors=True)
     assert res.status_code == 403
 
-    res = app.get(reverse("api-single-dataset", kwargs={
-        'datasetId': ds1.pk
-    }))
-    assert int(res.json['id']) == ds1.pk
+    res = app.get(reverse("api-single-dataset", kwargs={"datasetId": ds1.pk}))
+    assert int(res.json["id"]) == ds1.pk
 
 
 class EdpDcatApRestrictedRdfTests(TestCase):
@@ -2338,7 +2109,9 @@ class EdpDcatApPublicRdfTests(TestCase):
         self.assertNotIn(b"Restricted Dataset", response.content)
 
     def test_edp_dcat_ap_rdf_homepage_for_information_system_subclass(self):
-        DatasetFactory(subclass=DCATResourceSubclassFactory(name="information_system"), landing_page="https://example.com")
+        DatasetFactory(
+            subclass=DCATResourceSubclassFactory(name="information_system"), landing_page="https://example.com"
+        )
 
         response = self.client.get(reverse("edp-dcat-ap-rdf"))
 
@@ -2357,44 +2130,42 @@ def test_edp_dcat_ap_rdf_hvd_dataset(app: DjangoTestApp):
     hvd_group.save()
     parent_category = CategoryFactory(
         title="Environment",
-        uri='http://publications.europa.eu/resource/authority/data-theme/ENVI',
+        uri="http://publications.europa.eu/resource/authority/data-theme/ENVI",
     )
     hvd_category = parent_category.add_child(
         instance=CategoryFactory.build(
             title="Earth observation and environment",
         )
     )
-    DatasetGroupCategoryUriFactory(
-        group=hvd_group,
-        category=hvd_category,
-        uri="http://data.europa.eu/bna/c_dd313021"
-    )
+    DatasetGroupCategoryUriFactory(group=hvd_group, category=hvd_category, uri="http://data.europa.eu/bna/c_dd313021")
 
     dataset = DatasetFactory(
         title={
-            'lt': 'Testas1',
-            'en': 'Test1',
+            "lt": "Testas1",
+            "en": "Test1",
         },
         description={
-            'lt': 'Duomenų rinkinio aprašymas.',
-            'en': 'Dataset description.',
+            "lt": "Duomenų rinkinio aprašymas.",
+            "en": "Dataset description.",
         },
         published=datetime(2016, 8, 1),
-        frequency=FrequencyFactory(uri='http://publications.europa.eu/resource/authority/frequency/IRREG'),
+        frequency=FrequencyFactory(uri="http://publications.europa.eu/resource/authority/frequency/IRREG"),
         category=[hvd_category],
         organization=OrganizationFactory(
-            title='Data Enterprise',
-            email='data@example.com',
+            title="Data Enterprise",
+            email="data@example.com",
         ),
         access_rights=Dataset.PUBLIC,
         is_hvd=True,
     )
 
-    res = app.get('/edp/dcat-ap.rdf')
+    res = app.get("/edp/dcat-ap.rdf")
 
     assert res.status_code == 200
-    assert res.headers['Content-Type'] == 'application/rdf+xml'
-    assert strip_empty_lines(res.text) == f'''\
+    assert res.headers["Content-Type"] == "application/rdf+xml"
+    assert (
+        strip_empty_lines(res.text)
+        == f"""\
 <?xml version="1.0"?>
 <rdf:RDF
     xml:base="http://localhost"
@@ -2444,4 +2215,5 @@ def test_edp_dcat_ap_rdf_hvd_dataset(app: DjangoTestApp):
             </vcard:Kind>
         </dcat:contactPoint>
     </dcat:Dataset>
-</rdf:RDF>'''
+</rdf:RDF>"""
+    )

--- a/tests/api/test_views.py
+++ b/tests/api/test_views.py
@@ -43,7 +43,7 @@ def test_retrieve_catalog_list_with_disabled_api_key(app: DjangoTestApp):
         content_type=ct,
         object_id=organization.pk,
     )
-    api_key = APIKeyFactory(
+    APIKeyFactory(
         representative=representative,
         enabled=False
     )
@@ -62,7 +62,7 @@ def test_retrieve_catalog_list_with_expired_api_key(app: DjangoTestApp):
         content_type=ct,
         object_id=organization.pk,
     )
-    api_key = APIKeyFactory(
+    APIKeyFactory(
         representative=representative,
         expires=timezone.make_aware(datetime(2000, 12, 24))
     )
@@ -107,7 +107,7 @@ def test_retrieve_catalog_list_with_correct_api_key(app: DjangoTestApp):
         content_type=ct,
         object_id=organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     app.extra_environ.update({
         'HTTP_AUTHORIZATION': 'ApiKey test'
     })
@@ -138,7 +138,7 @@ def test_retrieve_category_list_with_disabled_api_key(app: DjangoTestApp):
         content_type=ct,
         object_id=organization.pk,
     )
-    api_key = APIKeyFactory(
+    APIKeyFactory(
         representative=representative,
         enabled=False
     )
@@ -157,7 +157,7 @@ def test_retrieve_category_list_with_expired_api_key(app: DjangoTestApp):
         content_type=ct,
         object_id=organization.pk,
     )
-    api_key = APIKeyFactory(
+    APIKeyFactory(
         representative=representative,
         expires=timezone.make_aware(datetime(2000, 12, 24))
     )
@@ -202,7 +202,7 @@ def test_retrieve_category_list_with_correct_api_key(app: DjangoTestApp):
         content_type=ct,
         object_id=organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     app.extra_environ.update({
         'HTTP_AUTHORIZATION': 'ApiKey test'
     })
@@ -228,7 +228,7 @@ def test_licence_licence_list_with_disabled_api_key(app: DjangoTestApp):
         content_type=ct,
         object_id=organization.pk,
     )
-    api_key = APIKeyFactory(
+    APIKeyFactory(
         representative=representative,
         enabled=False
     )
@@ -247,7 +247,7 @@ def test_licence_licence_list_with_expired_api_key(app: DjangoTestApp):
         content_type=ct,
         object_id=organization.pk,
     )
-    api_key = APIKeyFactory(
+    APIKeyFactory(
         representative=representative,
         expires=timezone.make_aware(datetime(2000, 12, 24))
     )
@@ -292,7 +292,7 @@ def test_retrieve_licence_list_with_correct_api_key(app: DjangoTestApp):
         content_type=ct,
         object_id=organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     app.extra_environ.update({
         'HTTP_AUTHORIZATION': 'ApiKey test'
     })
@@ -345,7 +345,6 @@ def test_get_all_datasets(app: DjangoTestApp):
         "publisher": None,
         "spatial": dataset.spatial_coverage,
         "periodicity": dataset.frequency.title,
-        'publisher': None,
         "keyword": dataset.tag_name_array,
         "landingPage": f"http://{domain}{dataset.get_absolute_url()}",
         "theme": [category.title]
@@ -370,7 +369,7 @@ def test_get_dataset_from_different_organization(app: DjangoTestApp):
         content_type=ct,
         object_id=organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     app.extra_environ.update({
         'HTTP_AUTHORIZATION': 'ApiKey test'
     })
@@ -391,7 +390,7 @@ def test_get_dataset_with_dataset_id(app: DjangoTestApp):
         content_type=ct,
         object_id=dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     app.extra_environ.update({
         'HTTP_AUTHORIZATION': 'ApiKey test'
     })
@@ -414,7 +413,6 @@ def test_get_dataset_with_dataset_id(app: DjangoTestApp):
         "publisher": None,
         "spatial": dataset.spatial_coverage,
         "periodicity": dataset.frequency.title,
-        'publisher': None,
         "keyword": dataset.tag_name_array,
         "landingPage": f"http://{domain}{dataset.get_absolute_url()}",
         "theme": [category.title]
@@ -429,7 +427,7 @@ def test_get_dataset_with_wrong_internal_id(app: DjangoTestApp):
         content_type=ct,
         object_id=dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     app.extra_environ.update({
         'HTTP_AUTHORIZATION': 'ApiKey test'
     })
@@ -450,7 +448,7 @@ def test_get_dataset_with_internal_id(app: DjangoTestApp):
         content_type=ct,
         object_id=dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     app.extra_environ.update({
         'HTTP_AUTHORIZATION': 'ApiKey test'
     })
@@ -473,7 +471,6 @@ def test_get_dataset_with_internal_id(app: DjangoTestApp):
         "publisher": None,
         "spatial": dataset.spatial_coverage,
         "periodicity": dataset.frequency.title,
-        'publisher': None,
         "keyword": dataset.tag_name_array,
         "landingPage": f"http://{domain}{dataset.get_absolute_url()}",
         "theme": [category.title]
@@ -496,7 +493,7 @@ def test_create_dataset_with_errors(app: DjangoTestApp):
         content_type=ct,
         object_id=dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     app.extra_environ.update({
         'HTTP_AUTHORIZATION': 'ApiKey test'
     })
@@ -517,7 +514,7 @@ def test_create_dataset(app: DjangoTestApp):
         content_type=ct,
         object_id=organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     app.extra_environ.update({
         'HTTP_AUTHORIZATION': 'ApiKey test'
     })
@@ -572,7 +569,6 @@ def test_create_dataset(app: DjangoTestApp):
         "publisher": None,
         "spatial": dataset.spatial_coverage,
         "periodicity": dataset.frequency.title,
-        'publisher': None,
         "keyword": ['tag1', 'tag2'],
         "landingPage": f"http://{domain}{dataset.get_absolute_url()}",
         "theme": [category.title]
@@ -597,7 +593,7 @@ def test_update_dataset_from_different_organization(app: DjangoTestApp):
         content_type=ct,
         object_id=organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     app.extra_environ.update({
         'HTTP_AUTHORIZATION': 'ApiKey test'
     })
@@ -619,7 +615,7 @@ def test_update_dataset_with_dataset_id(app: DjangoTestApp):
         content_type=ct,
         object_id=dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     app.extra_environ.update({
         'HTTP_AUTHORIZATION': 'ApiKey test'
     })
@@ -656,7 +652,6 @@ def test_update_dataset_with_dataset_id(app: DjangoTestApp):
         "publisher": None,
         "spatial": dataset.spatial_coverage,
         "periodicity": dataset.frequency.title,
-        'publisher': None,
         "keyword": dataset.tag_name_array,
         "landingPage": f"http://{domain}{dataset.get_absolute_url()}",
         "theme": [category.title]
@@ -674,7 +669,7 @@ def test_update_dataset_with_internal_id(app: DjangoTestApp):
         content_type=ct,
         object_id=dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     app.extra_environ.update({
         'HTTP_AUTHORIZATION': 'ApiKey test'
     })
@@ -711,7 +706,6 @@ def test_update_dataset_with_internal_id(app: DjangoTestApp):
         "publisher": None,
         "spatial": dataset.spatial_coverage,
         "periodicity": dataset.frequency.title,
-        'publisher': None,
         "keyword": dataset.tag_name_array,
         "landingPage": f"http://{domain}{dataset.get_absolute_url()}",
         "theme": [category.title]
@@ -736,7 +730,7 @@ def test_delete_dataset_from_different_organization(app: DjangoTestApp):
         content_type=ct,
         object_id=organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     app.extra_environ.update({
         'HTTP_AUTHORIZATION': 'ApiKey test'
     })
@@ -757,7 +751,7 @@ def test_delete_dataset_with_dataset_id(app: DjangoTestApp):
         content_type=ct,
         object_id=dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     app.extra_environ.update({
         'HTTP_AUTHORIZATION': 'ApiKey test'
     })
@@ -793,7 +787,7 @@ def test_delete_dataset_with_internal_id(app: DjangoTestApp):
         content_type=ct,
         object_id=dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     app.extra_environ.update({
         'HTTP_AUTHORIZATION': 'ApiKey test'
     })
@@ -838,7 +832,7 @@ def test_get_all_dataset_distributions_with_dataset_id(app: DjangoTestApp):
         content_type=ct,
         object_id=distribution.dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     app.extra_environ.update({
         'HTTP_AUTHORIZATION': 'ApiKey test'
     })
@@ -872,7 +866,7 @@ def test_get_all_dataset_distributions_with_internal_id(app: DjangoTestApp):
         content_type=ct,
         object_id=dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     app.extra_environ.update({
         'HTTP_AUTHORIZATION': 'ApiKey test'
     })
@@ -906,7 +900,7 @@ def test_get_all_distributions(app: DjangoTestApp):
         content_type=ct,
         object_id=dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     app.extra_environ.update({
         'HTTP_AUTHORIZATION': 'ApiKey test'
     })
@@ -947,7 +941,7 @@ def test_create_dataset_distribution_without_file_and_url(app: DjangoTestApp):
         content_type=ct,
         object_id=dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     content_type, params = app.encode_multipart(params=[
         ('title', "Test distribution")
     ], files=[])
@@ -971,7 +965,7 @@ def test_create_dataset_distribution_with_both_file_and_url(app: DjangoTestApp):
         content_type=ct,
         object_id=dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     content_type, params = app.encode_multipart(params=[
         ('title', "Test distribution"),
         ('url', "https://test.com/")
@@ -996,7 +990,7 @@ def test_create_dataset_distribution_with_empty_file(app: DjangoTestApp):
         content_type=ct,
         object_id=dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     content_type, params = app.encode_multipart(params=[
         ('title', "Test distribution"),
         ('url', "https://test.com/")
@@ -1021,7 +1015,7 @@ def test_create_dataset_distribution_with_file(app: DjangoTestApp):
         content_type=ct,
         object_id=dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     content_type, params = app.encode_multipart(params=[
         ('title', "Test distribution"),
         ('region', 'Geo'),
@@ -1062,7 +1056,7 @@ def test_create_dataset_distribution_with_url(app: DjangoTestApp):
         content_type=ct,
         object_id=dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     content_type, params = app.encode_multipart(params=[
         ('title', "Test distribution"),
         ('region', 'Geo'),
@@ -1105,7 +1099,7 @@ def test_create_dataset_distribution_with_overwrite(app: DjangoTestApp):
         content_type=ct,
         object_id=distribution.dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     content_type, params = app.encode_multipart(params=[
         ('title', "Test distribution"),
         ('region', 'Geo'),
@@ -1147,7 +1141,7 @@ def test_create_dataset_distribution_with_internal_id(app: DjangoTestApp):
         content_type=ct,
         object_id=dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     content_type, params = app.encode_multipart(params=[
         ('title', "Test distribution"),
         ('region', 'Geo'),
@@ -1198,7 +1192,7 @@ def test_put_create_dataset_distribution_without_file_and_url(app: DjangoTestApp
         content_type=ct,
         object_id=dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     content_type, params = app.encode_multipart(params=[
         ('title', "Test distribution")
     ], files=[])
@@ -1222,7 +1216,7 @@ def test_put_create_dataset_distribution_with_both_file_and_url(app: DjangoTestA
         content_type=ct,
         object_id=dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     content_type, params = app.encode_multipart(params=[
         ('title', "Test distribution"),
         ('url', "https://test.com/")
@@ -1247,7 +1241,7 @@ def test_put_create_dataset_distribution_with_empty_file(app: DjangoTestApp):
         content_type=ct,
         object_id=dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     content_type, params = app.encode_multipart(params=[
         ('title', "Test distribution"),
         ('url', "https://test.com/")
@@ -1272,7 +1266,7 @@ def test_put_create_dataset_distribution_with_file(app: DjangoTestApp):
         content_type=ct,
         object_id=dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     content_type, params = app.encode_multipart(params=[
         ('title', "Test distribution"),
         ('region', 'Geo'),
@@ -1313,7 +1307,7 @@ def test_put_create_dataset_distribution_with_url(app: DjangoTestApp):
         content_type=ct,
         object_id=dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     content_type, params = app.encode_multipart(params=[
         ('title', "Test distribution"),
         ('region', 'Geo'),
@@ -1355,7 +1349,7 @@ def test_put_create_dataset_distribution_with_internal_id(app: DjangoTestApp):
         content_type=ct,
         object_id=dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     content_type, params = app.encode_multipart(params=[
         ('title', "Test distribution"),
         ('region', 'Geo'),
@@ -1408,7 +1402,7 @@ def test_update_dataset_distribution_with_wrong_dataset_id(app: DjangoTestApp):
         content_type=ct,
         object_id=distribution.dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     app.extra_environ.update({
         'HTTP_AUTHORIZATION': 'ApiKey test'
     })
@@ -1428,7 +1422,7 @@ def test_update_dataset_distribution_with_wrong_internal_id(app: DjangoTestApp):
         content_type=ct,
         object_id=distribution.dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     app.extra_environ.update({
         'HTTP_AUTHORIZATION': 'ApiKey test'
     })
@@ -1447,7 +1441,7 @@ def test_update_dataset_distribution_with_both_file_and_url(app: DjangoTestApp):
         content_type=ct,
         object_id=distribution.dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     content_type, params = app.encode_multipart(params=[
         ('title', "Test distribution"),
         ('url', 'http://example.com/')
@@ -1473,7 +1467,7 @@ def test_update_dataset_distribution_with_empty_file(app: DjangoTestApp):
         content_type=ct,
         object_id=distribution.dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     content_type, params = app.encode_multipart(params=[
         ('title', "Test distribution"),
     ], files=[('file', 'file.csv', b'')])
@@ -1491,14 +1485,13 @@ def test_update_dataset_distribution_with_empty_file(app: DjangoTestApp):
 
 @pytest.mark.django_db
 def test_update_dataset_distribution_with_not_allowed_file(app: DjangoTestApp):
-    domain = Site.objects.get_current().domain
     distribution = DatasetDistributionFactory()
     ct = ContentType.objects.get_for_model(distribution.dataset.organization)
     representative = RepresentativeFactory(
         content_type=ct,
         object_id=distribution.dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     content_type, params = app.encode_multipart(params=[
         ('title', "Updated title"),
         ('description', "Updated description"),
@@ -1525,7 +1518,7 @@ def test_update_dataset_distribution_with_file(app: DjangoTestApp):
         content_type=ct,
         object_id=distribution.dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     content_type, params = app.encode_multipart(params=[
         ('title', "Updated title"),
         ('description', "Updated description"),
@@ -1566,7 +1559,7 @@ def test_update_dataset_distribution_with_url(app: DjangoTestApp):
         content_type=ct,
         object_id=distribution.dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     content_type, params = app.encode_multipart(params=[
         ('title', "Updated title"),
         ('description', "Updated description"),
@@ -1609,7 +1602,7 @@ def test_update_dataset_distribution_with_internal_id(app: DjangoTestApp):
         content_type=ct,
         object_id=dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     content_type, params = app.encode_multipart(params=[
         ('title', "Updated title"),
         ('description', "Updated description"),
@@ -1661,7 +1654,7 @@ def test_delete_dataset_distribution_with_wrong_dataset_id(app: DjangoTestApp):
         content_type=ct,
         object_id=distribution.dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     app.extra_environ.update({
         'HTTP_AUTHORIZATION': 'ApiKey test'
     })
@@ -1681,7 +1674,7 @@ def test_delete_dataset_distribution_with_wrong_internal_id(app: DjangoTestApp):
         content_type=ct,
         object_id=distribution.dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     app.extra_environ.update({
         'HTTP_AUTHORIZATION': 'ApiKey test'
     })
@@ -1701,7 +1694,7 @@ def test_delete_dataset_distribution_with_dataset_id(app: DjangoTestApp):
         content_type=ct,
         object_id=dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     app.extra_environ.update({
         'HTTP_AUTHORIZATION': 'ApiKey test'
     })
@@ -1721,7 +1714,7 @@ def test_delete_dataset_distribution_with_internal_id(app: DjangoTestApp):
         content_type=ct,
         object_id=dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     app.extra_environ.update({
         'HTTP_AUTHORIZATION': 'ApiKey test'
     })
@@ -1750,7 +1743,7 @@ def test_get_dataset_structures_with_dataset_id(app: DjangoTestApp):
         content_type=ct,
         object_id=structure.dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     app.extra_environ.update({
         'HTTP_AUTHORIZATION': 'ApiKey test'
     })
@@ -1776,7 +1769,7 @@ def test_get_dataset_structures_with_internal_id(app: DjangoTestApp):
         content_type=ct,
         object_id=dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     app.extra_environ.update({
         'HTTP_AUTHORIZATION': 'ApiKey test'
     })
@@ -1809,7 +1802,7 @@ def test_create_dataset_structure_with_errors(app: DjangoTestApp):
         content_type=ct,
         object_id=dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     app.extra_environ.update({
         'HTTP_AUTHORIZATION': 'ApiKey test'
     })
@@ -1829,7 +1822,7 @@ def test_create_dataset_structure_with_not_allowed_file(app: DjangoTestApp):
         content_type=ct,
         object_id=dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     content_type, params = app.encode_multipart(params=[
         ('title', "Test structure")
     ], files=[('file', 'file.svg', b'test')])
@@ -1851,7 +1844,7 @@ def test_create_dataset_structure_with_dataset_id(app: DjangoTestApp):
         content_type=ct,
         object_id=dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     content_type, params = app.encode_multipart(params=[
         ('title', "Test structure")
     ], files=[('file', 'file.csv', b'test')])
@@ -1883,7 +1876,7 @@ def test_create_dataset_structure_with_internal_id(app: DjangoTestApp):
         content_type=ct,
         object_id=dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     content_type, params = app.encode_multipart(params=[
         ('title', "Test structure")
     ], files=[('file', 'file.csv', b'test')])
@@ -1926,7 +1919,7 @@ def test_delete_dataset_structure_with_wrong_dataset_id(app: DjangoTestApp):
         content_type=ct,
         object_id=structure.dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     app.extra_environ.update({
         'HTTP_AUTHORIZATION': 'ApiKey test'
     })
@@ -1946,7 +1939,7 @@ def test_delete_dataset_structure_with_wrong_internal_id(app: DjangoTestApp):
         content_type=ct,
         object_id=structure.dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     app.extra_environ.update({
         'HTTP_AUTHORIZATION': 'ApiKey test'
     })
@@ -1966,7 +1959,7 @@ def test_delete_dataset_structure_with_dataset_id(app: DjangoTestApp):
         content_type=ct,
         object_id=dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     app.extra_environ.update({
         'HTTP_AUTHORIZATION': 'ApiKey test'
     })
@@ -1986,7 +1979,7 @@ def test_delete_dataset_structure_with_internal_id(app: DjangoTestApp):
         content_type=ct,
         object_id=structure.dataset.organization.pk,
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     app.extra_environ.update({
         'HTTP_AUTHORIZATION': 'ApiKey test'
     })
@@ -2009,7 +2002,7 @@ def test_create_model_statistics(app: DjangoTestApp):
         object_id=organization.pk,
         user=user
     )
-    api_key = APIKeyFactory(representative=representative)
+    APIKeyFactory(representative=representative)
     app.extra_environ.update({
         'HTTP_AUTHORIZATION': 'ApiKey test'
     })
@@ -2364,7 +2357,7 @@ def test_edp_dcat_ap_rdf_hvd_dataset(app: DjangoTestApp):
     hvd_group.save()
     parent_category = CategoryFactory(
         title="Environment",
-        uri=f'http://publications.europa.eu/resource/authority/data-theme/ENVI',
+        uri='http://publications.europa.eu/resource/authority/data-theme/ENVI',
     )
     hvd_category = parent_category.add_child(
         instance=CategoryFactory.build(
@@ -2387,7 +2380,7 @@ def test_edp_dcat_ap_rdf_hvd_dataset(app: DjangoTestApp):
             'en': 'Dataset description.',
         },
         published=datetime(2016, 8, 1),
-        frequency=FrequencyFactory(uri=f'http://publications.europa.eu/resource/authority/frequency/IRREG'),
+        frequency=FrequencyFactory(uri='http://publications.europa.eu/resource/authority/frequency/IRREG'),
         category=[hvd_category],
         organization=OrganizationFactory(
             title='Data Enterprise',

--- a/tests/classifiers/test_admin.py
+++ b/tests/classifiers/test_admin.py
@@ -14,7 +14,7 @@ from vitrina.users.models import User
 @pytest.mark.django_db
 def test_change_default_licence(app: DjangoTestApp):
     admin = User.objects.create_superuser(email="admin@gmail.com", password="test123")
-    default_licence = LicenceFactory(is_default=True)
+    LicenceFactory(is_default=True)
     another_licence = LicenceFactory(is_default=False)
     app.set_user(admin)
     form = app.get(reverse('admin:vitrina_classifiers_licence_change', args=[another_licence.pk])).forms['licence_form']
@@ -26,7 +26,7 @@ def test_change_default_licence(app: DjangoTestApp):
 @pytest.mark.django_db
 def test_change_default_frequency(app: DjangoTestApp):
     admin = User.objects.create_superuser(email="admin@gmail.com", password="test123")
-    default_frequency = FrequencyFactory(is_default=True)
+    FrequencyFactory(is_default=True)
     another_frequency = FrequencyFactory(is_default=False)
     app.set_user(admin)
     form = app.get(reverse('admin:vitrina_classifiers_frequency_change',

--- a/tests/classifiers/test_admin.py
+++ b/tests/classifiers/test_admin.py
@@ -17,8 +17,8 @@ def test_change_default_licence(app: DjangoTestApp):
     LicenceFactory(is_default=True)
     another_licence = LicenceFactory(is_default=False)
     app.set_user(admin)
-    form = app.get(reverse('admin:vitrina_classifiers_licence_change', args=[another_licence.pk])).forms['licence_form']
-    form['is_default'] = True
+    form = app.get(reverse("admin:vitrina_classifiers_licence_change", args=[another_licence.pk])).forms["licence_form"]
+    form["is_default"] = True
     form.submit()
     assert list(Licence.objects.filter(is_default=True)) == [another_licence]
 
@@ -29,9 +29,10 @@ def test_change_default_frequency(app: DjangoTestApp):
     FrequencyFactory(is_default=True)
     another_frequency = FrequencyFactory(is_default=False)
     app.set_user(admin)
-    form = app.get(reverse('admin:vitrina_classifiers_frequency_change',
-                           args=[another_frequency.pk])).forms['frequency_form']
-    form['is_default'] = True
+    form = app.get(reverse("admin:vitrina_classifiers_frequency_change", args=[another_frequency.pk])).forms[
+        "frequency_form"
+    ]
+    form["is_default"] = True
     form.submit()
     assert list(Frequency.objects.filter(is_default=True)) == [another_frequency]
 
@@ -39,30 +40,28 @@ def test_change_default_frequency(app: DjangoTestApp):
 @pytest.mark.django_db
 def test_change_default_status(app: DjangoTestApp):
     """
-        Test that changing the default status via the Django admin form works correctly.
+    Test that changing the default status via the Django admin form works correctly.
 
-        This test verifies that when an existing status is updated to be the new default
-        (`is_default=True`), the previous default status is automatically unset
-        (`is_default=False`). It simulates an admin user modifying a status through
-        the admin interface.
+    This test verifies that when an existing status is updated to be the new default
+    (`is_default=True`), the previous default status is automatically unset
+    (`is_default=False`). It simulates an admin user modifying a status through
+    the admin interface.
 
-        Steps:
-            - Create an admin user and two status instances (one default, one not).
-            - Authenticate as the admin user.
-            - Submit a change form to make the non-default status the new default.
-            - Assert that the new default is updated correctly, and the old default is unset.
+    Steps:
+        - Create an admin user and two status instances (one default, one not).
+        - Authenticate as the admin user.
+        - Submit a change form to make the non-default status the new default.
+        - Assert that the new default is updated correctly, and the old default is unset.
 
-        Args:
-            app (DjangoTestApp): A test app instance from `pytest-django` or `WebTest`
-                configured to simulate requests to the Django app.
-        """
+    Args:
+        app (DjangoTestApp): A test app instance from `pytest-django` or `WebTest`
+            configured to simulate requests to the Django app.
+    """
     admin = User.objects.create_superuser(email="admin@gmail.com", password="test123")
     default_status = StatusFactory(is_default=True)
     another_status = StatusFactory(is_default=False)
     app.set_user(admin)
-    form = app.get(
-        reverse("admin:vitrina_classifiers_status_change", args=[another_status.pk])
-    ).forms["status_form"]
+    form = app.get(reverse("admin:vitrina_classifiers_status_change", args=[another_status.pk])).forms["status_form"]
     form["is_default"] = True
     form["name"] = "Test"
 

--- a/tests/comments/test_services.py
+++ b/tests/comments/test_services.py
@@ -8,7 +8,6 @@ from vitrina.orgs.factories import RepresentativeFactory
 from vitrina.orgs.models import Representative
 from vitrina.projects.factories import ProjectFactory
 from vitrina.requests.factories import RequestFactory, RequestAssignmentFactory
-from vitrina.orgs.factories import OrganizationFactory
 from vitrina.users.factories import UserFactory
 
 

--- a/tests/comments/test_views.py
+++ b/tests/comments/test_views.py
@@ -1,5 +1,3 @@
-import json
-from unittest.mock import patch, Mock
 
 import pytest
 from django.contrib.contenttypes.models import ContentType

--- a/tests/comments/test_views.py
+++ b/tests/comments/test_views.py
@@ -1,4 +1,3 @@
-
 import pytest
 from django.contrib.contenttypes.models import ContentType
 from django.core import mail
@@ -42,7 +41,7 @@ def test_comment_is_not_public_user_staff(app: DjangoTestApp):
     form = app.get(dataset.get_absolute_url()).follow().forms["comment-form"]
     form["is_public"] = False
     form["body"] = "Test comment"
-    resp = form.submit().follow().follow() # comment form → dataset view → versioned dataset view
+    resp = form.submit().follow().follow()  # comment form → dataset view → versioned dataset view
     created_comment = Comment.objects.filter(content_type=ct, object_id=dataset.pk)
     assert Comment.objects.filter(content_type=ct, object_id=dataset.pk).count() == 1
     assert created_comment.first() in list(resp.context["comments"])[0]
@@ -57,7 +56,7 @@ def test_comment_is_public(app: DjangoTestApp):
     form = app.get(dataset.get_absolute_url()).follow().forms["comment-form"]
     form["is_public"] = True
     form["body"] = "Test comment"
-    resp = form.submit().follow().follow() # comment form → dataset view → versioned dataset view
+    resp = form.submit().follow().follow()  # comment form → dataset view → versioned dataset view
     created_comment = Comment.objects.filter(content_type=ct, object_id=dataset.pk)
     assert created_comment.count() == 1
     assert created_comment.first() in list(resp.context["comments"])[0]
@@ -79,14 +78,14 @@ def test_dataset_comment_with_register_request(app: DjangoTestApp):
         http_method="POST",
         path=form.action,
         args=list(match.args),
-        kwargs=match.kwargs
+        kwargs=match.kwargs,
     )
     form["is_public"] = True
     form["register_request"] = True
     form["increase_frequency"] = frequency
     form["request_title"] = "Test request title"
     form["body"] = "Test comment"
-    resp = form.submit().follow().follow() # comment form → dataset view → versioned dataset view
+    resp = form.submit().follow().follow()  # comment form → dataset view → versioned dataset view
     created_request = Request.objects.filter(requestobject__object_id=dataset.pk, requestobject__content_type=ct)
     created_comment = Comment.objects.filter(content_type=ct, object_id=dataset.pk)
 
@@ -102,7 +101,9 @@ def test_dataset_comment_with_register_request(app: DjangoTestApp):
     assert created_request.first().requestassignment_set.first().organization == dataset.organization
     assert created_request.first().periodicity == frequency.title
     assert Version.objects.get_for_object(created_request.first()).count() == 1
-    assert Version.objects.get_for_object(created_request.first()).first().revision.comment == revision_comment.to_json()
+    assert (
+        Version.objects.get_for_object(created_request.first()).first().revision.comment == revision_comment.to_json()
+    )
 
 
 @pytest.mark.django_db
@@ -162,7 +163,7 @@ def test_reply_is_public(app: DjangoTestApp):
     form = app.get(comment.content_object.get_absolute_url()).follow().forms[f"reply-form-{comment.pk}"]
     form["is_public"] = True
     form["body"] = "Test comment"
-    resp = form.submit().follow().follow() # comment form → dataset view → versioned dataset view
+    resp = form.submit().follow().follow()  # comment form → dataset view → versioned dataset view
     comments = Comment.objects.filter(content_type=comment.content_type, object_id=comment.object_id)
     reply = Comment.objects.filter(content_type=comment.content_type, parent=comment).first()
     assert comments.count() == 2
@@ -216,7 +217,7 @@ def test_model_comment_with_register_request(app: DjangoTestApp):
         http_method="POST",
         path=form.action,
         args=list(match.args),
-        kwargs=match.kwargs
+        kwargs=match.kwargs,
     )
     form["is_public"] = True
     form["register_request"] = True
@@ -235,7 +236,9 @@ def test_model_comment_with_register_request(app: DjangoTestApp):
     assert created_request.first().title == model.title
     assert created_request.first().description == created_comment.first().body
     assert Version.objects.get_for_object(created_request.first()).count() == 1
-    assert Version.objects.get_for_object(created_request.first()).first().revision.comment == revision_comment.to_json()
+    assert (
+        Version.objects.get_for_object(created_request.first()).first().revision.comment == revision_comment.to_json()
+    )
 
 
 @pytest.mark.django_db
@@ -274,7 +277,7 @@ def test_property_comment_with_register_request(app: DjangoTestApp):
         http_method="POST",
         path=form.action,
         args=list(match.args),
-        kwargs=match.kwargs
+        kwargs=match.kwargs,
     )
     form["is_public"] = True
     form["register_request"] = True
@@ -293,7 +296,9 @@ def test_property_comment_with_register_request(app: DjangoTestApp):
     assert created_request.first().title == prop.title
     assert created_request.first().description == created_comment.first().body
     assert Version.objects.get_for_object(created_request.first()).count() == 1
-    assert Version.objects.get_for_object(created_request.first()).first().revision.comment == revision_comment.to_json()
+    assert (
+        Version.objects.get_for_object(created_request.first()).first().revision.comment == revision_comment.to_json()
+    )
 
 
 @pytest.mark.django_db
@@ -308,7 +313,7 @@ def test_object_data_comment_with_register_request(app: DjangoTestApp):
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        metadata_version=metadata_version
+        metadata_version=metadata_version,
     )
     prop = PropertyFactory(model=model, metadata_version=metadata_version)
     MetadataFactory(
@@ -317,7 +322,7 @@ def test_object_data_comment_with_register_request(app: DjangoTestApp):
         dataset=dataset,
         name="prop",
         type="string",
-        metadata_version=metadata_version
+        metadata_version=metadata_version,
     )
 
     form = app.get(
@@ -330,15 +335,13 @@ def test_object_data_comment_with_register_request(app: DjangoTestApp):
         http_method="POST",
         path=form.action,
         args=list(match.args),
-        kwargs=match.kwargs
+        kwargs=match.kwargs,
     )
     form["is_public"] = True
     form["register_request"] = True
     form["body"] = "Test comment"
     resp = form.submit().follow()
-    created_request = Request.objects.filter(
-        requestobject__external_object_id=model_metadata.uuid
-    )
+    created_request = Request.objects.filter(requestobject__external_object_id=model_metadata.uuid)
     created_comment = Comment.objects.filter(external_object_id=model_metadata.uuid)
 
     assert created_comment.count() == 1
@@ -351,7 +354,9 @@ def test_object_data_comment_with_register_request(app: DjangoTestApp):
     assert created_request.first().title == str(model_metadata.uuid)
     assert created_request.first().description == created_comment.first().body
     assert Version.objects.get_for_object(created_request.first()).count() == 1
-    assert Version.objects.get_for_object(created_request.first()).first().revision.comment == revision_comment.to_json()
+    assert (
+        Version.objects.get_for_object(created_request.first()).first().revision.comment == revision_comment.to_json()
+    )
 
 
 @pytest.mark.django_db
@@ -475,7 +480,7 @@ def test_view_author_comment_not_public(app: DjangoTestApp):
     form = app.get(dataset.get_absolute_url()).follow().forms["comment-form"]
     form["is_public"] = False
     form["body"] = "Test comment"
-    resp = form.submit().follow().follow() # comment form → dataset view → versioned dataset view
+    resp = form.submit().follow().follow()  # comment form → dataset view → versioned dataset view
     comments = Comment.objects.filter(content_type=ct, object_id=dataset.pk, user=user)
     assert comments.count() == 1
     assert [comment for comment, _, _ in resp.context["comments"]] == list(comments)
@@ -551,7 +556,7 @@ def test_view_reply_to_comment_not_public_without_permission(app: DjangoTestApp)
     [
         (Representative.OPEN_DATA_MANAGER),
         (Representative.RESOURCE_MANAGER),
-    ]
+    ],
 )
 def test_view_reply_to_comment_not_public_with_resource_permission(app: DjangoTestApp, role: str):
     dataset = DatasetFactory()
@@ -662,7 +667,7 @@ def test_subscription_about_comment(app: DjangoTestApp):
     form = app.get(dataset.get_absolute_url()).follow().forms["comment-form"]
     form["is_public"] = False
     form["body"] = "Test comment"
-    resp = form.submit().follow().follow() # comment form → dataset view → versioned dataset view
+    resp = form.submit().follow().follow()  # comment form → dataset view → versioned dataset view
     comments = Comment.objects.filter(content_type=ct, object_id=dataset.pk)
     assert comments.count() == 1
     assert [comment for comment, _, _ in resp.context["comments"]] == [comments.first()]
@@ -895,10 +900,10 @@ def test_edit_comment_wrong_http_method(client):
 @pytest.mark.parametrize(
     "access_rights, expected_status_code",
     (
-        (Dataset.PUBLIC, 302), # Allow
-        (Dataset.RESTRICTED, 302), # Allow
-        (Dataset.NON_PUBLIC, 403), # Disallow
-        (Dataset.CONFIDENTIAL, 403), # Disallow
+        (Dataset.PUBLIC, 302),  # Allow
+        (Dataset.RESTRICTED, 302),  # Allow
+        (Dataset.NON_PUBLIC, 403),  # Disallow
+        (Dataset.CONFIDENTIAL, 403),  # Disallow
     ),
 )
 def test_comment_based_on_access_rights(app: DjangoTestApp, access_rights, expected_status_code):
@@ -907,20 +912,14 @@ def test_comment_based_on_access_rights(app: DjangoTestApp, access_rights, expec
 
     org2 = OrganizationFactory()
     dataset2 = DatasetFactory(organization=org2, access_rights=access_rights)
-    RepresentativeFactory(
-        user=user2,
-        content_type=ContentType.objects.get_for_model(dataset2),
-        object_id=dataset2.pk
-    )
+    RepresentativeFactory(user=user2, content_type=ContentType.objects.get_for_model(dataset2), object_id=dataset2.pk)
 
     ct = ContentType.objects.get_for_model(dataset2)
 
     # User1 (not owner) tries to comment
     app.set_user(user1)
     resp = app.post(
-        reverse("comment", args=[ct.pk, dataset2.pk]),
-        {"is_public": True, "body": "Test comment"},
-        expect_errors=True
+        reverse("comment", args=[ct.pk, dataset2.pk]), {"is_public": True, "body": "Test comment"}, expect_errors=True
     )
 
     assert resp.status_code == expected_status_code
@@ -935,9 +934,7 @@ def test_comment_nonexistent_dataset(app: DjangoTestApp):
     ct = ContentType.objects.get_for_model(Dataset)
 
     resp = app.post(
-        reverse("comment", args=[ct.pk, 99999]),
-        {"is_public": True, "body": "IDOR test"},
-        expect_errors=True
+        reverse("comment", args=[ct.pk, 99999]), {"is_public": True, "body": "IDOR test"}, expect_errors=True
     )
 
     assert resp.status_code == 404
@@ -956,13 +953,12 @@ def test_comment_on_private_dataset_model(app: DjangoTestApp):
 
     app.set_user(user1)
     resp = app.post(
-        reverse("comment", args=[ct.pk, model.pk]),
-        {"is_public": True, "body": "IDOR test"},
-        expect_errors=True
+        reverse("comment", args=[ct.pk, model.pk]), {"is_public": True, "body": "IDOR test"}, expect_errors=True
     )
 
     assert resp.status_code == 403
     assert Comment.objects.filter(object_id=model.pk).count() == 0
+
 
 @pytest.mark.django_db
 def test_comment_on_non_public_project(app: DjangoTestApp):
@@ -977,9 +973,7 @@ def test_comment_on_non_public_project(app: DjangoTestApp):
     # User1 tries to comment
     app.set_user(user1)
     resp = app.post(
-        reverse("comment", args=[ct.pk, project.pk]),
-        {"is_public": True, "body": "IDOR test"},
-        expect_errors=True
+        reverse("comment", args=[ct.pk, project.pk]), {"is_public": True, "body": "IDOR test"}, expect_errors=True
     )
 
     assert resp.status_code == 403
@@ -1019,13 +1013,12 @@ def test_comment_on_private_dataset_property(app: DjangoTestApp):
     # User1 tries to comment on the property
     app.set_user(user1)
     resp = app.post(
-        reverse("comment", args=[ct.pk, prop.pk]),
-        {"is_public": True, "body": "IDOR test"},
-        expect_errors=True
+        reverse("comment", args=[ct.pk, prop.pk]), {"is_public": True, "body": "IDOR test"}, expect_errors=True
     )
 
     assert resp.status_code == 403
     assert Comment.objects.filter(object_id=prop.pk).count() == 0
+
 
 @pytest.mark.django_db
 def test_comment_on_unapproved_project(app: DjangoTestApp):
@@ -1038,9 +1031,7 @@ def test_comment_on_unapproved_project(app: DjangoTestApp):
 
     app.set_user(user1)
     resp = app.post(
-        reverse("comment", args=[ct.pk, project.pk]),
-        {"is_public": True, "body": "Test"},
-        expect_errors=True
+        reverse("comment", args=[ct.pk, project.pk]), {"is_public": True, "body": "Test"}, expect_errors=True
     )
 
     assert resp.status_code == 403

--- a/tests/compat/test_redirections.py
+++ b/tests/compat/test_redirections.py
@@ -6,7 +6,7 @@ from vitrina.users.models import User
 
 @pytest.mark.django_db
 def test_redirection_doesnt_exist(app: DjangoTestApp):
-    response = app.get('/neegzistuoja/', expect_errors=True)
+    response = app.get("/neegzistuoja/", expect_errors=True)
     assert response.status_code == 404
 
 
@@ -14,10 +14,10 @@ def test_redirection_doesnt_exist(app: DjangoTestApp):
 def test_redirection_exists_has_new_path(app: DjangoTestApp):
     Redirect.objects.create(
         site_id=1,
-        old_path='/labas/',
-        new_path='/labas_naujas/',
+        old_path="/labas/",
+        new_path="/labas_naujas/",
     )
-    response = app.get('/labas/')
+    response = app.get("/labas/")
     assert response.status_code == 301
 
 
@@ -25,170 +25,185 @@ def test_redirection_exists_has_new_path(app: DjangoTestApp):
 def test_redirection_exists_no_new_path(app: DjangoTestApp):
     Redirect.objects.create(
         site_id=1,
-        old_path='/labas/',
+        old_path="/labas/",
     )
-    response = app.get('/labas/', expect_errors=True)
+    response = app.get("/labas/", expect_errors=True)
     assert response.status_code == 410
+
 
 @pytest.mark.django_db
 def test_dataset_has_new_path(app: DjangoTestApp):
     Redirect.objects.get(
         site_id=1,
-        old_path='/dataset/',
-        new_path='/datasets/',
+        old_path="/dataset/",
+        new_path="/datasets/",
     )
-    response = app.get('/dataset/')
-    assert response.status_code == 301 and response.location == '/datasets/'
+    response = app.get("/dataset/")
+    assert response.status_code == 301 and response.location == "/datasets/"
+
 
 @pytest.mark.django_db
 def test_usecases_examples_has_new_path(app: DjangoTestApp):
     Redirect.objects.get(
         site_id=1,
-        old_path='/usecases/examples/',
-        new_path='/projects/',
+        old_path="/usecases/examples/",
+        new_path="/projects/",
     )
-    response = app.get('/usecases/examples/')
-    assert response.status_code == 301 and response.location == '/projects/'
+    response = app.get("/usecases/examples/")
+    assert response.status_code == 301 and response.location == "/projects/"
+
 
 @pytest.mark.django_db
 def test_usecases_applications_has_new_path(app: DjangoTestApp):
     Redirect.objects.get(
         site_id=1,
-        old_path='/usecases/applications/',
-        new_path='/projects/',
+        old_path="/usecases/applications/",
+        new_path="/projects/",
     )
-    response = app.get('/usecases/applications/')
-    assert response.status_code == 301 and response.location == '/projects/'
+    response = app.get("/usecases/applications/")
+    assert response.status_code == 301 and response.location == "/projects/"
+
 
 @pytest.mark.django_db
 def test_usecase_has_new_path(app: DjangoTestApp):
-    user1 = User.objects.create_user(email='user1@test.com', password='12345')
+    user1 = User.objects.create_user(email="user1@test.com", password="12345")
     app.set_user(user1)
     Redirect.objects.get(
         site_id=1,
-        old_path='/usecase/',
-        new_path='/projects/add/',
-    )   
-    response = app.get('/usecase/')
-    assert response.status_code == 301 and response.location == '/projects/add/'
+        old_path="/usecase/",
+        new_path="/projects/add/",
+    )
+    response = app.get("/usecase/")
+    assert response.status_code == 301 and response.location == "/projects/add/"
+
 
 @pytest.mark.django_db
 def test_policy_has_new_path(app: DjangoTestApp):
     Redirect.objects.get(
         site_id=1,
-        old_path='/page/regulation/',
-        new_path='/more/regulation/',
+        old_path="/page/regulation/",
+        new_path="/more/regulation/",
     )
-    response = app.get('/page/regulation/')
-    assert response.status_code == 301 and response.location == '/more/regulation/'
+    response = app.get("/page/regulation/")
+    assert response.status_code == 301 and response.location == "/more/regulation/"
 
 
 @pytest.mark.django_db
 def test_links_have_new_path(app: DjangoTestApp):
     Redirect.objects.get(
         site_id=1,
-        old_path='/page/nuorodos/',
-        new_path='/more/nuorodos/',
-    ) 
-    response = app.get('/page/nuorodos/')
-    assert response.status_code == 301 and response.location == '/more/nuorodos/'
+        old_path="/page/nuorodos/",
+        new_path="/more/nuorodos/",
+    )
+    response = app.get("/page/nuorodos/")
+    assert response.status_code == 301 and response.location == "/more/nuorodos/"
+
 
 @pytest.mark.django_db
 def test_notions_have_new_path(app: DjangoTestApp):
     Redirect.objects.get(
         site_id=1,
-        old_path='/page/savokos/',
-        new_path='/more/savokos/',
-    ) 
-    response = app.get('/page/savokos/')
-    assert response.status_code == 301 and response.location == '/more/savokos/'
+        old_path="/page/savokos/",
+        new_path="/more/savokos/",
+    )
+    response = app.get("/page/savokos/")
+    assert response.status_code == 301 and response.location == "/more/savokos/"
+
 
 @pytest.mark.django_db
 def test_about_has_new_path(app: DjangoTestApp):
     Redirect.objects.get(
         site_id=1,
-        old_path='/page/apie/',
-        new_path='/more/apie/',
-    ) 
-    response = app.get('/page/apie/')
-    assert response.status_code == 301 and response.location == '/more/apie/'
+        old_path="/page/apie/",
+        new_path="/more/apie/",
+    )
+    response = app.get("/page/apie/")
+    assert response.status_code == 301 and response.location == "/more/apie/"
+
 
 @pytest.mark.django_db
 def test_contacts_has_new_path(app: DjangoTestApp):
     Redirect.objects.get(
         site_id=1,
-        old_path='/page/contacts/',
-        new_path='/more/contacts/',
-    ) 
-    response = app.get('/page/contacts/')
-    assert response.status_code == 301 and response.location == '/more/contacts/'
+        old_path="/page/contacts/",
+        new_path="/more/contacts/",
+    )
+    response = app.get("/page/contacts/")
+    assert response.status_code == 301 and response.location == "/more/contacts/"
+
 
 @pytest.mark.django_db
 def test_templates_has_new_path(app: DjangoTestApp):
     Redirect.objects.get(
         site_id=1,
-        old_path='/page/templates/',
-        new_path='/more/templates/',
-    )    
-    response = app.get('/page/templates/')
-    assert response.status_code == 301 and response.location == '/more/templates/'
+        old_path="/page/templates/",
+        new_path="/more/templates/",
+    )
+    response = app.get("/page/templates/")
+    assert response.status_code == 301 and response.location == "/more/templates/"
+
 
 @pytest.mark.django_db
 def test_storage_has_new_path(app: DjangoTestApp):
     Redirect.objects.get(
         site_id=1,
-        old_path='/page/saugykla/',
-        new_path='/opening-tips/saugykla/',
+        old_path="/page/saugykla/",
+        new_path="/opening-tips/saugykla/",
     )
-    response = app.get('/page/saugykla/')
-    assert response.status_code == 301 and response.location == '/opening-tips/saugykla/'
+    response = app.get("/page/saugykla/")
+    assert response.status_code == 301 and response.location == "/opening-tips/saugykla/"
+
 
 @pytest.mark.django_db
 def test_guide_has_new_path(app: DjangoTestApp):
     Redirect.objects.get(
         site_id=1,
-        old_path='/page/vadovas/',
-        new_path='/opening-tips/vadovas/',
+        old_path="/page/vadovas/",
+        new_path="/opening-tips/vadovas/",
     )
-    response = app.get('/page/vadovas/')
-    assert response.status_code == 301 and response.location == '/opening-tips/vadovas/'
+    response = app.get("/page/vadovas/")
+    assert response.status_code == 301 and response.location == "/opening-tips/vadovas/"
+
 
 @pytest.mark.django_db
 def test_summary_has_new_path(app: DjangoTestApp):
     Redirect.objects.get(
         site_id=1,
-        old_path='/page/aprasas/',
-        new_path='/opening-tips/aprasas/',
+        old_path="/page/aprasas/",
+        new_path="/opening-tips/aprasas/",
     )
-    response = app.get('/page/aprasas/')
-    assert response.status_code == 301 and response.location == '/opening-tips/aprasas/'
+    response = app.get("/page/aprasas/")
+    assert response.status_code == 301 and response.location == "/opening-tips/aprasas/"
+
 
 @pytest.mark.django_db
 def test_data_opening_tools_have_new_path(app: DjangoTestApp):
     Redirect.objects.get(
         site_id=1,
-        old_path='/page/data-opening-tools/',
-        new_path='/opening-tips/data-opening-tools/',
+        old_path="/page/data-opening-tools/",
+        new_path="/opening-tips/data-opening-tools/",
     )
-    response = app.get('/page/data-opening-tools/')
-    assert response.status_code == 301 and response.location == '/opening-tips/data-opening-tools/'
+    response = app.get("/page/data-opening-tools/")
+    assert response.status_code == 301 and response.location == "/opening-tips/data-opening-tools/"
+
 
 @pytest.mark.django_db
 def test_learning_material_has_new_path(app: DjangoTestApp):
     Redirect.objects.get(
         site_id=1,
-        old_path='/opening/learningmaterial/',
-        new_path='/opening-tips/opening/learningmaterial/',
+        old_path="/opening/learningmaterial/",
+        new_path="/opening-tips/opening/learningmaterial/",
     )
-    response = app.get('/opening/learningmaterial/')
-    assert response.status_code == 301 and response.location == '/opening-tips/opening/learningmaterial/'
+    response = app.get("/opening/learningmaterial/")
+    assert response.status_code == 301 and response.location == "/opening-tips/opening/learningmaterial/"
+
 
 @pytest.mark.django_db
 def test_faq_has_new_path(app: DjangoTestApp):
     Redirect.objects.get(
         site_id=1,
-        old_path='/page/opening_faq/',
-        new_path='/opening-tips/opening_faq/',
+        old_path="/page/opening_faq/",
+        new_path="/opening-tips/opening_faq/",
     )
-    response = app.get('/page/opening_faq/')
-    assert response.status_code == 301 and response.location == '/opening-tips/opening_faq/'
+    response = app.get("/page/opening_faq/")
+    assert response.status_code == 301 and response.location == "/opening-tips/opening_faq/"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import builtins
 import csv
 import io
-from unittest.mock import patch, Mock
+from unittest.mock import patch
 
 import pytest
 from django.apps import apps
@@ -113,7 +113,6 @@ def organization(db):
 @pytest.fixture
 def dataset(db, organization):
     """Create test dataset."""
-    from vitrina.datasets.models import Dataset
     dataset = DatasetFactory.create(title="Test Dataset", organization=organization)
     return dataset
 

--- a/tests/datasets/test_breadcrumbs.py
+++ b/tests/datasets/test_breadcrumbs.py
@@ -1,7 +1,6 @@
 import pytest
-from django.urls import reverse
 
-from vitrina.datasets.factories import DatasetFactory, DCATResourceSubclassFactory, OrganizationFactory
+from vitrina.datasets.factories import DatasetFactory, OrganizationFactory
 from vitrina.datasets.views import DatasetDetailView, ResourceSubclassCreateView
 from vitrina.datasets.mixins import Crumb
 

--- a/tests/datasets/test_managers.py
+++ b/tests/datasets/test_managers.py
@@ -90,7 +90,6 @@ class TestDatasetViewPermissions:
             ("data_set_representative", "grandchild", False, "PUBLIC", "dataset", True),
             ("parent_representative", "grandchild", False, "PUBLIC", "dataset", True),
             ("global_representative", "grandchild", False, "PUBLIC", "dataset", True),
-
             # public datasets
             ("regular_user", "grandchild", True, "PUBLIC", "dataset", True),
             ("random_org_representative", "grandchild", True, "PUBLIC", "dataset", True),
@@ -99,7 +98,6 @@ class TestDatasetViewPermissions:
             ("parent_representative", "grandchild", True, "PUBLIC", "dataset", True),
             ("global_representative", "grandchild", True, "PUBLIC", "dataset", True),
             ("grandpa_rep", "grandchild", True, "PUBLIC", "dataset", True),
-
             # restricted
             ("regular_user", "grandchild", True, "RESTRICTED", "dataset", True),
             ("random_org_representative", "grandchild", True, "RESTRICTED", "dataset", True),
@@ -107,7 +105,6 @@ class TestDatasetViewPermissions:
             ("data_set_representative", "grandchild", True, "RESTRICTED", "dataset", True),
             ("parent_representative", "grandchild", True, "RESTRICTED", "dataset", True),
             ("global_representative", "grandchild", True, "RESTRICTED", "dataset", True),
-
             # non-public
             ("regular_user", "grandchild", True, "NON_PUBLIC", "dataset", False),
             ("random_org_representative", "grandchild", True, "NON_PUBLIC", "dataset", False),
@@ -115,7 +112,6 @@ class TestDatasetViewPermissions:
             ("data_set_representative", "grandchild", True, "NON_PUBLIC", "dataset", False),
             ("parent_representative", "grandchild", True, "NON_PUBLIC", "dataset", False),
             ("global_representative", "grandchild", True, "NON_PUBLIC", "dataset", True),
-
             # confidential
             ("regular_user", "grandchild", True, "CONFIDENTIAL", "dataset", False),
             ("random_org_representative", "grandchild", True, "CONFIDENTIAL", "dataset", False),
@@ -123,17 +119,16 @@ class TestDatasetViewPermissions:
             ("data_set_representative", "grandchild", True, "CONFIDENTIAL", "dataset", False),
             ("parent_representative", "grandchild", True, "CONFIDENTIAL", "dataset", False),
             ("global_representative", "grandchild", True, "CONFIDENTIAL", "dataset", True),
-
         ],
     )
     def test_view_permissions_open_data_managers(
-            self,
-            user_attributes: str,
-            dataset_attributes: str,
-            is_public: bool,
-            access_rights: str,
-            subclass: str,
-            expected: bool,
+        self,
+        user_attributes: str,
+        dataset_attributes: str,
+        is_public: bool,
+        access_rights: str,
+        subclass: str,
+        expected: bool,
     ):
         user = getattr(self, user_attributes)
         dataset = getattr(self, dataset_attributes)
@@ -158,7 +153,6 @@ class TestDatasetViewPermissions:
             ("data_set_representative", "grandchild", False, "PUBLIC", "dataset", True),
             ("parent_representative", "grandchild", False, "PUBLIC", "dataset", True),
             ("global_representative", "grandchild", False, "PUBLIC", "dataset", True),
-
             # public datasets
             ("regular_user", "grandchild", True, "PUBLIC", "dataset", True),
             ("random_org_representative", "grandchild", True, "PUBLIC", "dataset", True),
@@ -167,7 +161,6 @@ class TestDatasetViewPermissions:
             ("parent_representative", "grandchild", True, "PUBLIC", "dataset", True),
             ("global_representative", "grandchild", True, "PUBLIC", "dataset", True),
             ("grandpa_rep", "grandchild", True, "PUBLIC", "dataset", True),
-
             # restricted
             ("regular_user", "grandchild", True, "RESTRICTED", "dataset", True),
             ("random_org_representative", "grandchild", True, "RESTRICTED", "dataset", True),
@@ -175,7 +168,6 @@ class TestDatasetViewPermissions:
             ("data_set_representative", "grandchild", True, "RESTRICTED", "dataset", True),
             ("parent_representative", "grandchild", True, "RESTRICTED", "dataset", True),
             ("global_representative", "grandchild", True, "RESTRICTED", "dataset", True),
-
             # non-public
             ("regular_user", "grandchild", True, "NON_PUBLIC", "dataset", False),
             ("random_org_representative", "grandchild", True, "NON_PUBLIC", "dataset", True),
@@ -183,7 +175,6 @@ class TestDatasetViewPermissions:
             ("data_set_representative", "grandchild", True, "NON_PUBLIC", "dataset", True),
             ("parent_representative", "grandchild", True, "NON_PUBLIC", "dataset", True),
             ("global_representative", "grandchild", True, "NON_PUBLIC", "dataset", True),
-
             # confidential
             ("regular_user", "grandchild", True, "CONFIDENTIAL", "dataset", False),
             ("random_org_representative", "grandchild", True, "CONFIDENTIAL", "dataset", False),
@@ -191,24 +182,23 @@ class TestDatasetViewPermissions:
             ("data_set_representative", "grandchild", True, "CONFIDENTIAL", "dataset", True),
             ("parent_representative", "grandchild", True, "CONFIDENTIAL", "dataset", True),
             ("global_representative", "grandchild", True, "CONFIDENTIAL", "dataset", True),
-
         ],
     )
     def test_view_permissions_resource_managers(
-            self,
-            user_attributes: str,
-            dataset_attributes: str,
-            is_public: bool,
-            access_rights: str,
-            subclass: str,
-            expected: bool,
+        self,
+        user_attributes: str,
+        dataset_attributes: str,
+        is_public: bool,
+        access_rights: str,
+        subclass: str,
+        expected: bool,
     ):
         for repr_ in (
-                self.repr_random_org,
-                self.repr_org,
-                self.repr_ds,
-                self.repr_parent,
-                self.repr_grand_org,
+            self.repr_random_org,
+            self.repr_org,
+            self.repr_ds,
+            self.repr_parent,
+            self.repr_grand_org,
         ):
             repr_.role = Representative.RESOURCE_MANAGER
             repr_.save(update_fields=["role"])

--- a/tests/datasets/test_models.py
+++ b/tests/datasets/test_models.py
@@ -108,4 +108,3 @@ class TestDCATResourceSubclass:
     def test_is_catalog(self, name: str, result: bool) -> None:
         subclass = DCATResourceSubclassFactory(name=name)
         assert subclass.is_catalog is result
-

--- a/tests/datasets/test_models.py
+++ b/tests/datasets/test_models.py
@@ -4,12 +4,10 @@ import pytest
 import pytz
 from django.conf import settings
 
-from django.contrib.contenttypes.models import ContentType
 
 from vitrina.classifiers.factories import ConceptFactory
-from vitrina.datasets.factories import ContactFactory, DatasetFactory, DCATResourceSubclassFactory
+from vitrina.datasets.factories import DatasetFactory, DCATResourceSubclassFactory
 from vitrina.datasets.models import DCATResourceSubclass, Dataset
-from vitrina.datasets.models import Contact
 from vitrina.orgs.factories import OrganizationFactory
 
 pytestmark = pytest.mark.django_db

--- a/tests/datasets/test_scripts.py
+++ b/tests/datasets/test_scripts.py
@@ -37,8 +37,8 @@ from vitrina.users.models import User
 
 @pytest.mark.django_db
 def test_geoportal_import__title_and_description_create(app: DjangoTestApp):
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -55,9 +55,9 @@ def test_geoportal_import__title_and_description_create(app: DjangoTestApp):
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -70,7 +70,7 @@ def test_geoportal_import__title_and_description_create(app: DjangoTestApp):
                 </gmd:abstract>
             </gmd:identificationInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -94,8 +94,8 @@ def test_geoportal_import__title_and_description_create(app: DjangoTestApp):
 def test_geoportal_import__title_and_description_update(app: DjangoTestApp):
     dataset = DatasetFactory(geoportal_id="1")
 
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -112,9 +112,9 @@ def test_geoportal_import__title_and_description_update(app: DjangoTestApp):
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -127,7 +127,7 @@ def test_geoportal_import__title_and_description_update(app: DjangoTestApp):
                 </gmd:abstract>
             </gmd:identificationInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -146,7 +146,7 @@ def test_geoportal_import__title_and_description_update(app: DjangoTestApp):
 
 @pytest.mark.django_db
 def test_geoportal_import__title_and_description_create_without_translation(app: DjangoTestApp):
-    get_all = '''
+    get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -163,8 +163,8 @@ def test_geoportal_import__title_and_description_create_without_translation(app:
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-    '''
-    get_one = '''
+    """
+    get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -175,12 +175,12 @@ def test_geoportal_import__title_and_description_create_without_translation(app:
                 </gmd:abstract>
             </gmd:identificationInfo>
         </gmd:MD_Metadata>
-    '''
+    """
     get_all_mock = Mock(content=get_all)
     get_one_mock = Mock(content=get_one)
     get_conditions_mock = None
 
-    with patch('scripts.geoportal_import.requests.get') as get_data, patch('vitrina.utils.requests.post') as post_mock:
+    with patch("scripts.geoportal_import.requests.get") as get_data, patch("vitrina.utils.requests.post") as post_mock:
         get_data.side_effect = [get_all_mock, get_conditions_mock, get_one_mock]
         post_mock.side_effect = requests.exceptions.Timeout
         geoportal_import()
@@ -200,8 +200,8 @@ def test_geoportal_import__title_and_description_create_without_translation(app:
 
 @pytest.mark.django_db
 def test_geoportal_import__tags_create(app: DjangoTestApp):
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -218,9 +218,9 @@ def test_geoportal_import__tags_create(app: DjangoTestApp):
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -247,7 +247,7 @@ def test_geoportal_import__tags_create(app: DjangoTestApp):
                 </gmd:descriptiveKeywords> 
             </gmd:identificationInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -259,15 +259,15 @@ def test_geoportal_import__tags_create(app: DjangoTestApp):
     assert dataset_objects.count() == 1
     dataset = dataset_objects.first()
     assert dataset.geoportal_id == "1"
-    assert sorted(list(dataset.tags.values_list('name', flat=True))) == ['žymė1', 'žymė2', 'žymė3']
+    assert sorted(list(dataset.tags.values_list("name", flat=True))) == ["žymė1", "žymė2", "žymė3"]
 
 
 @pytest.mark.django_db
 def test_geoportal_import__tags_update(app: DjangoTestApp):
-    dataset = DatasetFactory(geoportal_id="1", tags=('žymė1', 'test'))
+    dataset = DatasetFactory(geoportal_id="1", tags=("žymė1", "test"))
 
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -284,9 +284,9 @@ def test_geoportal_import__tags_update(app: DjangoTestApp):
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -313,7 +313,7 @@ def test_geoportal_import__tags_update(app: DjangoTestApp):
                 </gmd:descriptiveKeywords> 
             </gmd:identificationInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -322,16 +322,16 @@ def test_geoportal_import__tags_update(app: DjangoTestApp):
 
     dataset.refresh_from_db()
     assert Dataset.objects.exclude(id=1).count() == 1
-    assert sorted(list(dataset.tags.values_list('name', flat=True))) == ['žymė1', 'žymė2', 'žymė3']
+    assert sorted(list(dataset.tags.values_list("name", flat=True))) == ["žymė1", "žymė2", "žymė3"]
 
 
 @pytest.mark.django_db
 def test_geoportal_import__frequency_create_with_existing_value(app: DjangoTestApp):
     frequency = FrequencyFactory(title="Neapibrėžtu periodiškumu")
-    GeoportalFrequencyFactory(title='asNeeded', frequency=frequency)
+    GeoportalFrequencyFactory(title="asNeeded", frequency=frequency)
 
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -348,9 +348,9 @@ def test_geoportal_import__frequency_create_with_existing_value(app: DjangoTestA
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -366,7 +366,7 @@ def test_geoportal_import__frequency_create_with_existing_value(app: DjangoTestA
                 </gmd:resourceMaintenance>
             </gmd:identificationInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -383,8 +383,8 @@ def test_geoportal_import__frequency_create_with_existing_value(app: DjangoTestA
 @pytest.mark.django_db
 def test_geoportal_import__frequency_create_with_not_existing_value(app: DjangoTestApp):
     UserFactory(is_superuser=True)
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -401,9 +401,9 @@ def test_geoportal_import__frequency_create_with_not_existing_value(app: DjangoT
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -419,7 +419,7 @@ def test_geoportal_import__frequency_create_with_not_existing_value(app: DjangoT
                 </gmd:resourceMaintenance>
             </gmd:identificationInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -443,8 +443,8 @@ def test_geoportal_import__frequency_update(app: DjangoTestApp):
     frequency = FrequencyFactory(title="Neapibrėžtu periodiškumu")
     GeoportalFrequencyFactory(title="asNeeded", frequency=frequency)
 
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -461,9 +461,9 @@ def test_geoportal_import__frequency_update(app: DjangoTestApp):
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -479,7 +479,7 @@ def test_geoportal_import__frequency_update(app: DjangoTestApp):
                 </gmd:resourceMaintenance>
             </gmd:identificationInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -493,8 +493,8 @@ def test_geoportal_import__frequency_update(app: DjangoTestApp):
 
 @pytest.mark.django_db
 def test_geoportal_import__access_rights_public(app: DjangoTestApp):
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -511,9 +511,9 @@ def test_geoportal_import__access_rights_public(app: DjangoTestApp):
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -531,7 +531,7 @@ def test_geoportal_import__access_rights_public(app: DjangoTestApp):
                 </gmd:descriptiveKeywords>
             </gmd:identificationInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -548,8 +548,8 @@ def test_geoportal_import__access_rights_public(app: DjangoTestApp):
 
 @pytest.mark.django_db
 def test_geoportal_import__access_rights_restricted(app: DjangoTestApp):
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -566,9 +566,9 @@ def test_geoportal_import__access_rights_restricted(app: DjangoTestApp):
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -581,7 +581,7 @@ def test_geoportal_import__access_rights_restricted(app: DjangoTestApp):
                 </gmd:abstract>
             </gmd:identificationInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -600,8 +600,8 @@ def test_geoportal_import__access_rights_restricted(app: DjangoTestApp):
 def test_geoportal_import__access_rights_public_update(app: DjangoTestApp):
     dataset = DatasetFactory(geoportal_id="1", access_rights=Dataset.RESTRICTED)
 
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -618,9 +618,9 @@ def test_geoportal_import__access_rights_public_update(app: DjangoTestApp):
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -638,7 +638,7 @@ def test_geoportal_import__access_rights_public_update(app: DjangoTestApp):
                 </gmd:descriptiveKeywords>
             </gmd:identificationInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -654,8 +654,8 @@ def test_geoportal_import__access_rights_public_update(app: DjangoTestApp):
 def test_geoportal_import__access_rights_restricted_update(app: DjangoTestApp):
     dataset = DatasetFactory(geoportal_id="1", access_rights=Dataset.PUBLIC)
 
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -672,9 +672,9 @@ def test_geoportal_import__access_rights_restricted_update(app: DjangoTestApp):
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -687,7 +687,7 @@ def test_geoportal_import__access_rights_restricted_update(app: DjangoTestApp):
                 </gmd:abstract>
             </gmd:identificationInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -701,7 +701,7 @@ def test_geoportal_import__access_rights_restricted_update(app: DjangoTestApp):
 
 @pytest.mark.django_db
 def test_geoportal_import__distribution_conditions_create():
-    get_all = '''
+    get_all = """
     <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
         xmlns:dct="http://purl.org/dc/terms/"
         xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -714,9 +714,9 @@ def test_geoportal_import__distribution_conditions_create():
             </csw:Record>
         </csw:SearchResults>
     </csw:GetRecordsResponse>              
-    '''
+    """
 
-    get_one = '''
+    get_one = """
     <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
         <gmd:identificationInfo>
             <gmd:title>
@@ -753,9 +753,9 @@ def test_geoportal_import__distribution_conditions_create():
             </gmd:transferOptions>
         </gmd:distributionInfo>
     </gmd:MD_Metadata>
-    '''
+    """
 
-    get_conditions = '''
+    get_conditions = """
     <CT_CodelistCatalogue xmlns="http://www.isotc211.org/2005/gmx"  xmlns:gml="http://www.opengis.net/gml/3.2">
         <CodeListDictionary gml:id="MD_RestrictionCode">
             <CodeDefinition gml:id="MD_RestrictionCode_copyright">
@@ -772,11 +772,11 @@ def test_geoportal_import__distribution_conditions_create():
             </CodeDefinition>
         </CodeListDictionary>
     </CT_CodelistCatalogue>
-    '''
+    """
 
     with (
         patch("scripts.geoportal_import.requests.get") as get_data,
-        patch("scripts.geoportal_import.translate_text") as mock_translate
+        patch("scripts.geoportal_import.translate_text") as mock_translate,
     ):
         mock_translate.side_effect = lambda text, field_name=None: text
 
@@ -806,12 +806,10 @@ def test_geoportal_import__distribution_conditions_create():
 def test_geoportal_import__distribution_conditions_update():
     dataset = Dataset.objects.create(geoportal_id="1", title="Old title")
     distribution = DatasetDistribution.objects.create(
-        dataset=dataset,
-        download_url="https://example.com/file.csv",
-        conditions="old conditions"
+        dataset=dataset, download_url="https://example.com/file.csv", conditions="old conditions"
     )
 
-    get_all_response = '''<csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
+    get_all_response = """<csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
         xmlns:dct="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/">
         <csw:SearchResults numberOfRecordsMatched="1">
             <csw:Record>
@@ -820,9 +818,9 @@ def test_geoportal_import__distribution_conditions_update():
                 <dct:references scheme="urn:x-esri:specification:ServiceType:ArcIMS:Metadata:Document">https://www.metadata.com</dct:references>
             </csw:Record>
         </csw:SearchResults>
-    </csw:GetRecordsResponse>'''
+    </csw:GetRecordsResponse>"""
 
-    get_conditions_response = '''<CT_CodelistCatalogue xmlns="http://www.isotc211.org/2005/gmx"  xmlns:gml="http://www.opengis.net/gml/3.2">
+    get_conditions_response = """<CT_CodelistCatalogue xmlns="http://www.isotc211.org/2005/gmx"  xmlns:gml="http://www.opengis.net/gml/3.2">
         <CodeListDictionary gml:id="MD_RestrictionCode">
             <CodeDefinition gml:id="MD_RestrictionCode_copyright">
                 <gml:description>Copyright</gml:description>
@@ -837,9 +835,9 @@ def test_geoportal_import__distribution_conditions_update():
                 <gml:identifier codeSpace="ISOTC211/19115">restricted</gml:identifier>
             </CodeDefinition>
         </CodeListDictionary>
-    </CT_CodelistCatalogue>'''
+    </CT_CodelistCatalogue>"""
 
-    get_one_response = '''<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
+    get_one_response = """<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
         <gmd:identificationInfo>
             <gmd:title>
                 <gco:CharacterString>Naujas duomenų rinkinys</gco:CharacterString>
@@ -860,10 +858,9 @@ def test_geoportal_import__distribution_conditions_update():
             <gmd:distributionFormat><gmd:MD_Format_GC>CSV</gmd:MD_Format_GC></gmd:distributionFormat>
             <gmd:transferOptions><gmd:CI_OnlineResource><gmd:URL>https://example.com/file.csv</gmd:URL></gmd:CI_OnlineResource></gmd:transferOptions>
         </gmd:distributionInfo>
-    </gmd:MD_Metadata>'''
+    </gmd:MD_Metadata>"""
 
     with patch("scripts.geoportal_import.requests.get") as mock_get:
-
         mock_get.side_effect = [
             Mock(content=get_all_response.encode()),
             Mock(content=get_conditions_response.encode()),
@@ -892,15 +889,14 @@ def test_geoportal_import__distribution_conditions_update():
 )
 def test_geoportal_import__existing_publisher(app: DjangoTestApp, role: str):
     organization = OrganizationFactory(
-        title="Viešoji įstaiga Statybos sektoriaus vystymo agentūra",
-        company_code="305997589"
+        title="Viešoji įstaiga Statybos sektoriaus vystymo agentūra", company_code="305997589"
     )
     coordinator = RepresentativeFactory(
         role=role, content_type=ContentType.objects.get_for_model(organization), object_id=organization.pk
     )
 
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -917,9 +913,9 @@ def test_geoportal_import__existing_publisher(app: DjangoTestApp, role: str):
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -932,7 +928,7 @@ def test_geoportal_import__existing_publisher(app: DjangoTestApp, role: str):
                 </gmd:abstract>
             </gmd:identificationInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -952,8 +948,8 @@ def test_geoportal_import__existing_publisher(app: DjangoTestApp, role: str):
 def test_geoportal_import__not_existing_publisher(app: DjangoTestApp):
     UserFactory(is_superuser=True)
 
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -970,9 +966,9 @@ def test_geoportal_import__not_existing_publisher(app: DjangoTestApp):
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -985,7 +981,7 @@ def test_geoportal_import__not_existing_publisher(app: DjangoTestApp):
                 </gmd:abstract>
             </gmd:identificationInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -1007,8 +1003,8 @@ def test_geoportal_import__not_existing_publisher(app: DjangoTestApp):
 def test_geoportal_import__existing_creator(app: DjangoTestApp):
     organization = OrganizationFactory(title="VšĮ Statybos sektoriaus vystymo agentūra")
 
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -1025,9 +1021,9 @@ def test_geoportal_import__existing_creator(app: DjangoTestApp):
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -1045,7 +1041,7 @@ def test_geoportal_import__existing_creator(app: DjangoTestApp):
                 </gmd:pointOfContact>
             </gmd:identificationInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -1063,8 +1059,8 @@ def test_geoportal_import__existing_creator(app: DjangoTestApp):
 def test_geoportal_import__existing_creator_municipality(app: DjangoTestApp):
     organization = OrganizationFactory(title="Jonavos rajono savivaldybės administracija")
 
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -1081,9 +1077,9 @@ def test_geoportal_import__existing_creator_municipality(app: DjangoTestApp):
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -1101,7 +1097,7 @@ def test_geoportal_import__existing_creator_municipality(app: DjangoTestApp):
                 </gmd:pointOfContact>
             </gmd:identificationInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -1118,12 +1114,11 @@ def test_geoportal_import__existing_creator_municipality(app: DjangoTestApp):
 @pytest.mark.django_db
 def test_geoportal_import__existing_creator_alternative_title(app: DjangoTestApp):
     organization = OrganizationFactory(
-        title="Jonavos rajono savivaldybės administracija",
-        alternative_titles="Jonavos rajonas"
+        title="Jonavos rajono savivaldybės administracija", alternative_titles="Jonavos rajonas"
     )
 
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -1140,9 +1135,9 @@ def test_geoportal_import__existing_creator_alternative_title(app: DjangoTestApp
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -1160,7 +1155,7 @@ def test_geoportal_import__existing_creator_alternative_title(app: DjangoTestApp
                 </gmd:pointOfContact>
             </gmd:identificationInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -1178,8 +1173,8 @@ def test_geoportal_import__existing_creator_alternative_title(app: DjangoTestApp
 def test_geoportal_import__not_existing_creator(app: DjangoTestApp):
     UserFactory(is_superuser=True)
 
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -1196,9 +1191,9 @@ def test_geoportal_import__not_existing_creator(app: DjangoTestApp):
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -1216,7 +1211,7 @@ def test_geoportal_import__not_existing_creator(app: DjangoTestApp):
                 </gmd:pointOfContact>
             </gmd:identificationInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -1241,8 +1236,8 @@ def test_geoportal_import__distribution_create_with_url(app: DjangoTestApp):
     geo_frm = GeoportalFormatFactory(format=frm)
     GeoportalFormatValueFactory(geoportal_format=geo_frm, value="csv")
 
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -1255,9 +1250,9 @@ def test_geoportal_import__distribution_create_with_url(app: DjangoTestApp):
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -1280,7 +1275,7 @@ def test_geoportal_import__distribution_create_with_url(app: DjangoTestApp):
                 </gmd:transferOptions>
             </gmd:distributionInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -1302,8 +1297,8 @@ def test_geoportal_import__distribution_create_with_url(app: DjangoTestApp):
 
 @pytest.mark.django_db
 def test_geoportal_import__distribution_create_without_url(app: DjangoTestApp):
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -1317,9 +1312,9 @@ def test_geoportal_import__distribution_create_without_url(app: DjangoTestApp):
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -1336,7 +1331,7 @@ def test_geoportal_import__distribution_create_without_url(app: DjangoTestApp):
                 </gmd:transferOptions>
             </gmd:distributionInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -1358,8 +1353,8 @@ def test_geoportal_import__distribution_create_without_url(app: DjangoTestApp):
 def test_geoportal_import__distribution_create_with_not_existing_format(app: DjangoTestApp):
     UserFactory(is_superuser=True)
 
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -1372,9 +1367,9 @@ def test_geoportal_import__distribution_create_with_not_existing_format(app: Dja
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -1397,7 +1392,7 @@ def test_geoportal_import__distribution_create_with_not_existing_format(app: Dja
                 </gmd:transferOptions>
             </gmd:distributionInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -1421,7 +1416,6 @@ def test_geoportal_import__distribution_create_with_not_existing_format(app: Dja
     assert 'Nerastas formatas: "CSV"' in task.description
 
 
-
 @pytest.mark.django_db
 def test_geoportal_import__distribution_create_with_multiple_formats(app: DjangoTestApp):
     frm1 = FileFormat(extension="CSV")
@@ -1432,8 +1426,8 @@ def test_geoportal_import__distribution_create_with_multiple_formats(app: Django
     geo_frm2 = GeoportalFormatFactory(format=frm2)
     GeoportalFormatValueFactory(geoportal_format=geo_frm2, value="json")
 
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -1446,9 +1440,9 @@ def test_geoportal_import__distribution_create_with_multiple_formats(app: Django
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -1471,7 +1465,7 @@ def test_geoportal_import__distribution_create_with_multiple_formats(app: Django
                 </gmd:transferOptions>
             </gmd:distributionInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -1483,14 +1477,12 @@ def test_geoportal_import__distribution_create_with_multiple_formats(app: Django
     assert dataset_objects.count() == 1
     dataset = dataset_objects.first()
     assert dataset.datasetdistribution_set.count() == 2
-    assert sorted(list(dataset.datasetdistribution_set.values_list('download_url', flat=True))) == sorted([
-        "https://example.com/file.zip",
-        "https://example.com/file.zip"
-    ])
-    assert sorted(list(dataset.datasetdistribution_set.values_list('format__pk', flat=True))) == sorted([
-        frm1.pk,
-        frm2.pk
-    ])
+    assert sorted(list(dataset.datasetdistribution_set.values_list("download_url", flat=True))) == sorted(
+        ["https://example.com/file.zip", "https://example.com/file.zip"]
+    )
+    assert sorted(list(dataset.datasetdistribution_set.values_list("format__pk", flat=True))) == sorted(
+        [frm1.pk, frm2.pk]
+    )
     assert dataset.status == Dataset.HAS_DATA
     assert dataset.comments.count() == 1
     assert dataset.comments.first().type == Comment.STATUS
@@ -1505,8 +1497,8 @@ def test_geoportal_import__distribution_update_with_url(app: DjangoTestApp):
 
     dataset = DatasetFactory(geoportal_id="1")
 
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -1519,9 +1511,9 @@ def test_geoportal_import__distribution_update_with_url(app: DjangoTestApp):
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -1544,7 +1536,7 @@ def test_geoportal_import__distribution_update_with_url(app: DjangoTestApp):
                 </gmd:transferOptions>
             </gmd:distributionInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -1571,8 +1563,8 @@ def test_geoportal_import__distribution_update_with_format(app: DjangoTestApp):
 
     dataset = DatasetFactory(geoportal_id="1")
 
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -1585,9 +1577,9 @@ def test_geoportal_import__distribution_update_with_format(app: DjangoTestApp):
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -1610,7 +1602,7 @@ def test_geoportal_import__distribution_update_with_format(app: DjangoTestApp):
                 </gmd:transferOptions>
             </gmd:distributionInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -1634,8 +1626,8 @@ def test_geoportal_import__distribution_update_with_not_existing_format(app: Dja
     UserFactory(is_superuser=True)
     dataset = DatasetFactory(geoportal_id="1")
 
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -1648,9 +1640,9 @@ def test_geoportal_import__distribution_update_with_not_existing_format(app: Dja
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -1673,7 +1665,7 @@ def test_geoportal_import__distribution_update_with_not_existing_format(app: Dja
                 </gmd:transferOptions>
             </gmd:distributionInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -1707,14 +1699,10 @@ def test_geoportal_import__distribution_update_with_multiple_formats(app: Django
     GeoportalFormatValueFactory(geoportal_format=geo_frm2, value="json")
 
     dataset = DatasetFactory(geoportal_id="1")
-    DatasetDistributionFactory(
-        dataset=dataset,
-        download_url="https://example.com/file.zip",
-        format=frm1
-    )
+    DatasetDistributionFactory(dataset=dataset, download_url="https://example.com/file.zip", format=frm1)
 
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -1727,9 +1715,9 @@ def test_geoportal_import__distribution_update_with_multiple_formats(app: Django
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -1752,7 +1740,7 @@ def test_geoportal_import__distribution_update_with_multiple_formats(app: Django
                 </gmd:transferOptions>
             </gmd:distributionInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -1762,14 +1750,12 @@ def test_geoportal_import__distribution_update_with_multiple_formats(app: Django
     assert Dataset.objects.exclude(id=1).count() == 1
     # dataset = Dataset.objects.first()
     assert dataset.datasetdistribution_set.count() == 2
-    assert sorted(list(dataset.datasetdistribution_set.values_list('download_url', flat=True))) == sorted([
-        "https://example.com/file.zip",
-        "https://example.com/file.zip"
-    ])
-    assert sorted(list(dataset.datasetdistribution_set.values_list('format__pk', flat=True))) == sorted([
-        frm1.pk,
-        frm2.pk
-    ])
+    assert sorted(list(dataset.datasetdistribution_set.values_list("download_url", flat=True))) == sorted(
+        ["https://example.com/file.zip", "https://example.com/file.zip"]
+    )
+    assert sorted(list(dataset.datasetdistribution_set.values_list("format__pk", flat=True))) == sorted(
+        [frm1.pk, frm2.pk]
+    )
     assert dataset.status == Dataset.HAS_DATA
     assert dataset.comments.count() == 1
     assert dataset.comments.first().type == Comment.STATUS
@@ -1782,8 +1768,8 @@ def test_geoportal_import__service_create_with_url(app: DjangoTestApp):
     geo_service_type = GeoportalFormatFactory(format=service_type)
     GeoportalFormatValueFactory(geoportal_format=geo_service_type, value="wms")
 
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -1796,9 +1782,9 @@ def test_geoportal_import__service_create_with_url(app: DjangoTestApp):
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:hierarchyLevel>
                 <gmd:MD_ScopeCode>service</gmd:MD_ScopeCode>
@@ -1824,7 +1810,7 @@ def test_geoportal_import__service_create_with_url(app: DjangoTestApp):
                 </gmd:transferOptions>
             </gmd:distributionInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -1848,8 +1834,8 @@ def test_geoportal_import__service_create_with_url(app: DjangoTestApp):
 
 @pytest.mark.django_db
 def test_geoportal_import__service_create_without_url(app: DjangoTestApp):
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -1863,9 +1849,9 @@ def test_geoportal_import__service_create_without_url(app: DjangoTestApp):
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:hierarchyLevel>
                 <gmd:MD_ScopeCode>service</gmd:MD_ScopeCode>
@@ -1885,13 +1871,12 @@ def test_geoportal_import__service_create_without_url(app: DjangoTestApp):
                 </gmd:transferOptions>
             </gmd:distributionInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
         get_data.side_effect = [get_all_mock, get_conditions_mock, get_one_mock]
         geoportal_import()
-
 
     dataset_objects = Dataset.objects.exclude(id=1)
 
@@ -1911,8 +1896,8 @@ def test_geoportal_import__service_create_without_url(app: DjangoTestApp):
 def test_geoportal_import__service_create_with_not_existing_format(app: DjangoTestApp):
     UserFactory(is_superuser=True)
 
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -1925,9 +1910,9 @@ def test_geoportal_import__service_create_with_not_existing_format(app: DjangoTe
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:hierarchyLevel>
                 <gmd:MD_ScopeCode>service</gmd:MD_ScopeCode>
@@ -1953,7 +1938,7 @@ def test_geoportal_import__service_create_with_not_existing_format(app: DjangoTe
                 </gmd:transferOptions>
             </gmd:distributionInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -1984,14 +1969,10 @@ def test_geoportal_import__service_update_with_url(app: DjangoTestApp):
     geo_service_type = GeoportalFormatFactory(format=service_type)
     GeoportalFormatValueFactory(geoportal_format=geo_service_type, value="wms")
 
-    dataset = DatasetFactory(
-        geoportal_id="1",
-        endpoint_url="https://test.com",
-        endpoint_type=service_type
-    )
+    dataset = DatasetFactory(geoportal_id="1", endpoint_url="https://test.com", endpoint_type=service_type)
 
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -2004,9 +1985,9 @@ def test_geoportal_import__service_update_with_url(app: DjangoTestApp):
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:hierarchyLevel>
                 <gmd:MD_ScopeCode>service</gmd:MD_ScopeCode>
@@ -2032,7 +2013,7 @@ def test_geoportal_import__service_update_with_url(app: DjangoTestApp):
                 </gmd:transferOptions>
             </gmd:distributionInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -2063,8 +2044,8 @@ def test_geoportal_import__service_update_with_format(app: DjangoTestApp):
         endpoint_url="https://test.com",
     )
 
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -2077,9 +2058,9 @@ def test_geoportal_import__service_update_with_format(app: DjangoTestApp):
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:hierarchyLevel>
                 <gmd:MD_ScopeCode>service</gmd:MD_ScopeCode>
@@ -2105,7 +2086,7 @@ def test_geoportal_import__service_update_with_format(app: DjangoTestApp):
                 </gmd:transferOptions>
             </gmd:distributionInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -2130,8 +2111,8 @@ def test_geoportal_import__service_update_with_not_existing_format(app: DjangoTe
     UserFactory(is_superuser=True)
     dataset = DatasetFactory(geoportal_id="1")
 
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -2144,9 +2125,9 @@ def test_geoportal_import__service_update_with_not_existing_format(app: DjangoTe
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:hierarchyLevel>
                 <gmd:MD_ScopeCode>service</gmd:MD_ScopeCode>
@@ -2172,7 +2153,7 @@ def test_geoportal_import__service_update_with_not_existing_format(app: DjangoTe
                 </gmd:transferOptions>
             </gmd:distributionInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -2208,8 +2189,8 @@ def test_geoportal_import__categories_create_existing_values(app: DjangoTestApp)
     mapping2.categories.add(category2)
     mapping2.categories.add(category3)
 
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -2226,9 +2207,9 @@ def test_geoportal_import__categories_create_existing_values(app: DjangoTestApp)
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -2247,7 +2228,7 @@ def test_geoportal_import__categories_create_existing_values(app: DjangoTestApp)
                 </gmd:topicCategory>
             </gmd:identificationInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -2258,10 +2239,10 @@ def test_geoportal_import__categories_create_existing_values(app: DjangoTestApp)
     assert dataset_objects.count() == 1
     dataset = dataset_objects.first()
     assert dataset.category.count() == 3
-    assert sorted(list(dataset.category.values_list('title', flat=True))) == [
-        'Energetika',
-        'Flora ir fauna',
-        'Transportas ir ryšiai'
+    assert sorted(list(dataset.category.values_list("title", flat=True))) == [
+        "Energetika",
+        "Flora ir fauna",
+        "Transportas ir ryšiai",
     ]
 
 
@@ -2272,8 +2253,8 @@ def test_geoportal_import__categories_create_not_existing_values(app: DjangoTest
     mapping = GeoportalCategoryFactory(title="utilitiesCommunication")
     mapping.categories.add(category)
 
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -2290,9 +2271,9 @@ def test_geoportal_import__categories_create_not_existing_values(app: DjangoTest
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -2311,7 +2292,7 @@ def test_geoportal_import__categories_create_not_existing_values(app: DjangoTest
                 </gmd:topicCategory>
             </gmd:identificationInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -2323,7 +2304,7 @@ def test_geoportal_import__categories_create_not_existing_values(app: DjangoTest
     assert dataset_objects.count() == 1
     dataset = dataset_objects.first()
     assert dataset.category.count() == 1
-    assert sorted(list(dataset.category.values_list('title', flat=True))) == ['Energetika']
+    assert sorted(list(dataset.category.values_list("title", flat=True))) == ["Energetika"]
 
     assert Task.objects.count() == 1
     task = Task.objects.first()
@@ -2345,8 +2326,8 @@ def test_geoportal_import__categories_update(app: DjangoTestApp):
     mapping2.categories.add(category2)
     mapping2.categories.add(category3)
 
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -2363,9 +2344,9 @@ def test_geoportal_import__categories_update(app: DjangoTestApp):
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -2384,7 +2365,7 @@ def test_geoportal_import__categories_update(app: DjangoTestApp):
                 </gmd:topicCategory>
             </gmd:identificationInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -2394,10 +2375,10 @@ def test_geoportal_import__categories_update(app: DjangoTestApp):
     dataset.refresh_from_db()
     assert Dataset.objects.exclude(id=1).count() == 1
     assert dataset.category.count() == 3
-    assert sorted(list(dataset.category.values_list('title', flat=True))) == [
-        'Energetika',
-        'Flora ir fauna',
-        'Transportas ir ryšiai'
+    assert sorted(list(dataset.category.values_list("title", flat=True))) == [
+        "Energetika",
+        "Flora ir fauna",
+        "Transportas ir ryšiai",
     ]
 
 
@@ -2418,8 +2399,8 @@ def test_geoportal_import__removed_categories_update(app: DjangoTestApp):
     dataset.category.add(category2)
     dataset.category.add(category3)
 
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -2436,9 +2417,9 @@ def test_geoportal_import__removed_categories_update(app: DjangoTestApp):
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -2454,7 +2435,7 @@ def test_geoportal_import__removed_categories_update(app: DjangoTestApp):
                 </gmd:topicCategory>
             </gmd:identificationInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -2464,9 +2445,7 @@ def test_geoportal_import__removed_categories_update(app: DjangoTestApp):
     dataset.refresh_from_db()
     assert Dataset.objects.exclude(id=1).count() == 1
     assert dataset.category.count() == 1
-    assert sorted(list(dataset.category.values_list('title', flat=True))) == [
-        'Flora ir fauna'
-    ]
+    assert sorted(list(dataset.category.values_list("title", flat=True))) == ["Flora ir fauna"]
 
 
 @pytest.mark.django_db
@@ -2474,8 +2453,8 @@ def test_geoportal_import__recurring_error_message(app: DjangoTestApp):
     user = UserFactory(is_superuser=True)
     dataset = DatasetFactory(geoportal_id="1")
 
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -2492,9 +2471,9 @@ def test_geoportal_import__recurring_error_message(app: DjangoTestApp):
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -2510,7 +2489,7 @@ def test_geoportal_import__recurring_error_message(app: DjangoTestApp):
                 </gmd:topicCategory>
             </gmd:identificationInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -2540,8 +2519,8 @@ def test_geoportal_import__different_error_message(app: DjangoTestApp):
     user = UserFactory(is_superuser=True)
     dataset = DatasetFactory(geoportal_id="1")
 
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -2558,9 +2537,9 @@ def test_geoportal_import__different_error_message(app: DjangoTestApp):
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -2576,14 +2555,14 @@ def test_geoportal_import__different_error_message(app: DjangoTestApp):
                 </gmd:topicCategory>
             </gmd:identificationInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
         get_data.side_effect = [get_all_mock, get_conditions_mock, get_one_mock]
         geoportal_import()
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -2599,7 +2578,7 @@ def test_geoportal_import__different_error_message(app: DjangoTestApp):
                 </gmd:topicCategory>
             </gmd:identificationInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -2610,9 +2589,9 @@ def test_geoportal_import__different_error_message(app: DjangoTestApp):
     assert dataset.category.count() == 0
 
     assert Task.objects.count() == 2
-    task1 = Task.objects.order_by('pk')[0]
+    task1 = Task.objects.order_by("pk")[0]
     assert 'Nerasta kategorija: "test"' in task1.description
-    task2 = Task.objects.order_by('pk')[1]
+    task2 = Task.objects.order_by("pk")[1]
     assert 'Nerasta kategorija: "test2"' in task2.description
 
     assert len(mail.outbox) == 2
@@ -2641,8 +2620,8 @@ def test_geoportal_import__subscription_create(app: DjangoTestApp, role: str):
         dataset_update_sub=True,
     )
 
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -2659,9 +2638,9 @@ def test_geoportal_import__subscription_create(app: DjangoTestApp, role: str):
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -2679,7 +2658,7 @@ def test_geoportal_import__subscription_create(app: DjangoTestApp, role: str):
                 </gmd:pointOfContact>
             </gmd:identificationInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -2714,8 +2693,8 @@ def test_geoportal_import__subscription_update(app: DjangoTestApp, role: str):
     )
     DatasetFactory(geoportal_id="1", organization=organization)
 
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -2732,9 +2711,9 @@ def test_geoportal_import__subscription_update(app: DjangoTestApp, role: str):
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -2752,7 +2731,7 @@ def test_geoportal_import__subscription_update(app: DjangoTestApp, role: str):
                 </gmd:pointOfContact>
             </gmd:identificationInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -2794,8 +2773,8 @@ def test_geoportal_import__subscription_update_no_changes(app: DjangoTestApp, ro
     dataset.description = "New dataset description"
     dataset.save()
 
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -2809,9 +2788,9 @@ def test_geoportal_import__subscription_update_no_changes(app: DjangoTestApp, ro
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -2829,7 +2808,7 @@ def test_geoportal_import__subscription_update_no_changes(app: DjangoTestApp, ro
                 </gmd:pointOfContact>
             </gmd:identificationInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -2843,8 +2822,8 @@ def test_geoportal_import__subscription_update_no_changes(app: DjangoTestApp, ro
 
 @pytest.mark.django_db
 def test_geoportal_import__history_create(app: DjangoTestApp):
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -2861,9 +2840,9 @@ def test_geoportal_import__history_create(app: DjangoTestApp):
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -2876,7 +2855,7 @@ def test_geoportal_import__history_create(app: DjangoTestApp):
                 </gmd:abstract>
             </gmd:identificationInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -2896,8 +2875,8 @@ def test_geoportal_import__history_create(app: DjangoTestApp):
 def test_geoportal_import__history_update(app: DjangoTestApp):
     dataset = DatasetFactory(geoportal_id="1")
 
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -2914,9 +2893,9 @@ def test_geoportal_import__history_update(app: DjangoTestApp):
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -2929,7 +2908,7 @@ def test_geoportal_import__history_update(app: DjangoTestApp):
                 </gmd:abstract>
             </gmd:identificationInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -2956,8 +2935,8 @@ def test_geoportal_import__history_update_no_changes(app: DjangoTestApp):
     dataset.description = "New dataset description"
     dataset.save()
 
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -2971,9 +2950,9 @@ def test_geoportal_import__history_update_no_changes(app: DjangoTestApp):
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -2986,7 +2965,7 @@ def test_geoportal_import__history_update_no_changes(app: DjangoTestApp):
                 </gmd:abstract>
             </gmd:identificationInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -3003,8 +2982,8 @@ def test_geoportal_import__add_to_geoportal_catalog(app: DjangoTestApp):
     relation = RelationFactory(name=Relation.CATALOG)
     geoportal_catalog = DatasetFactory(title="Lietuvos erdvinės informacijos portalas")
 
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
         <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
             xmlns:dct="http://purl.org/dc/terms/"
             xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -3021,9 +3000,9 @@ def test_geoportal_import__add_to_geoportal_catalog(app: DjangoTestApp):
                 </csw:Record>
             </csw:SearchResults>
         </csw:GetRecordsResponse>              
-        '''
+        """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -3036,7 +3015,7 @@ def test_geoportal_import__add_to_geoportal_catalog(app: DjangoTestApp):
                 </gmd:abstract>
             </gmd:identificationInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None
@@ -3057,8 +3036,8 @@ def test_geoportal_import__deleted_dataset(app: DjangoTestApp):
     dataset = DatasetFactory(geoportal_id="1", access_rights=Dataset.RESTRICTED)
     OrganizationFactory(title="VšĮ Statybos sektoriaus vystymo agentūra")
 
-    with patch('scripts.geoportal_import.requests.get') as get_data:
-        get_all = '''
+    with patch("scripts.geoportal_import.requests.get") as get_data:
+        get_all = """
             <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
                 xmlns:dct="http://purl.org/dc/terms/"
                 xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -3075,9 +3054,9 @@ def test_geoportal_import__deleted_dataset(app: DjangoTestApp):
                     </csw:Record>
                 </csw:SearchResults>
             </csw:GetRecordsResponse>              
-            '''
+            """
 
-        get_one = '''
+        get_one = """
         <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
             <gmd:identificationInfo>
                 <gmd:title>
@@ -3095,7 +3074,7 @@ def test_geoportal_import__deleted_dataset(app: DjangoTestApp):
                 </gmd:pointOfContact>
             </gmd:identificationInfo>
         </gmd:MD_Metadata>
-        '''
+        """
         get_all_mock = Mock(content=get_all)
         get_one_mock = Mock(content=get_one)
         get_conditions_mock = None

--- a/tests/datasets/test_scripts.py
+++ b/tests/datasets/test_scripts.py
@@ -11,7 +11,6 @@ from scripts.geoportal_import import main as geoportal_import
 from vitrina import settings
 from vitrina.classifiers.factories import (
     FrequencyFactory,
-    LicenceFactory,
     CategoryFactory,
     GeoportalCategoryFactory,
     GeoportalFrequencyFactory,
@@ -2713,7 +2712,7 @@ def test_geoportal_import__subscription_update(app: DjangoTestApp, role: str):
         object_id=organization.pk,
         dataset_update_sub=True,
     )
-    dataset = DatasetFactory(geoportal_id="1", organization=organization)
+    DatasetFactory(geoportal_id="1", organization=organization)
 
     with patch('scripts.geoportal_import.requests.get') as get_data:
         get_all = '''

--- a/tests/datasets/test_structure.py
+++ b/tests/datasets/test_structure.py
@@ -10,22 +10,28 @@ from vitrina.datasets.structure import precedes
 from vitrina.datasets.structure import read
 
 
-@pytest.mark.parametrize('content, errors_expected', [
-    (b'id,dataset,resource,base,model,property,type,ref,source,prepare,level,access,uri,title,description', False),
-    (b'id ,dataset,resource,base,model,property,type,ref,source,prepare,level,access,uri,title,description', True),
-    (b'id,DATASET,resource,base,model,property,type,ref,source,prepare,level,access,uri,title,description', True),
-    (b'id,DATASET ,resource,base,model,property,type,ref,source,prepare,level,access,uri,title,description', True),
-    (b'id,datast,resource,base,model,property,type,ref,source,prepare,level,access,uri,title,description', True),
-    (b'id,dataset,resource,base,model,property,type,ref,source,prepare,level,access,uri,title,description;;;', True),
-    (b'', True),
-    (bytes.fromhex('00010203ff'), True),
-])
+@pytest.mark.parametrize(
+    "content, errors_expected",
+    [
+        (b"id,dataset,resource,base,model,property,type,ref,source,prepare,level,access,uri,title,description", False),
+        (b"id ,dataset,resource,base,model,property,type,ref,source,prepare,level,access,uri,title,description", True),
+        (b"id,DATASET,resource,base,model,property,type,ref,source,prepare,level,access,uri,title,description", True),
+        (b"id,DATASET ,resource,base,model,property,type,ref,source,prepare,level,access,uri,title,description", True),
+        (b"id,datast,resource,base,model,property,type,ref,source,prepare,level,access,uri,title,description", True),
+        (
+            b"id,dataset,resource,base,model,property,type,ref,source,prepare,level,access,uri,title,description;;;",
+            True,
+        ),
+        (b"", True),
+        (bytes.fromhex("00010203ff"), True),
+    ],
+)
 def test_detect_read_errors(
     content: bytes,
     errors_expected: bool,
     tmp_path: pathlib.Path,
 ):
-    path = tmp_path / 'manifest.csv'
+    path = tmp_path / "manifest.csv"
     path.write_bytes(content)
     if errors_expected:
         assert detect_read_errors(path) != []
@@ -33,15 +39,18 @@ def test_detect_read_errors(
         assert detect_read_errors(path) == []
 
 
-@pytest.mark.parametrize('a, b, res', [
-    ('manifest', 'manifest', True),
-    ('comment', 'manifest', False),
-    ('model', 'dataset', False),
-    ('dataset', 'comment', True),
-    ('property', 'comment', True),
-    ('comment', 'enum', False),
-    ('enum', 'comment', True),
-])
+@pytest.mark.parametrize(
+    "a, b, res",
+    [
+        ("manifest", "manifest", True),
+        ("comment", "manifest", False),
+        ("model", "dataset", False),
+        ("dataset", "comment", True),
+        ("property", "comment", True),
+        ("comment", "enum", False),
+        ("enum", "comment", True),
+    ],
+)
 def test_precedence(a: str, b: str, res: bool):
     assert precedes(a, b) is res
 
@@ -53,31 +62,31 @@ def test_read_structure_table():
     assert state.errors == []
 
     manifest = state.manifest
-    dataset = 'datasets/gov/ivpk/adk'
-    model = f'{dataset}/Dataset'
+    dataset = "datasets/gov/ivpk/adk"
+    model = f"{dataset}/Dataset"
 
     assert list(manifest.datasets) == [dataset]
     assert list(manifest.models) == [
-        f'{dataset}/Dataset',
-        f'{dataset}/Licence',
+        f"{dataset}/Dataset",
+        f"{dataset}/Licence",
     ]
 
     assert list(manifest.datasets[dataset].prefixes) == [
-        'dcat',
-        'dct',
-        'spinta',
+        "dcat",
+        "dct",
+        "spinta",
     ]
 
     props = manifest.models[model].properties
     assert list(props) == [
-        'id',
-        'title',
-        'description',
-        'licence',
+        "id",
+        "title",
+        "description",
+        "licence",
     ]
 
-    assert props['id'].type == 'integer'
-    assert len(props['description'].comments) == 1
+    assert props["id"].type == "integer"
+    assert len(props["description"].comments) == 1
 
 
 def test_read_structure_table_not_mandatory_columns():
@@ -107,28 +116,28 @@ id,dataset,resource,base,model,property,type,ref,source,prepare,level,access,uri
     state = read(reader)
     assert state.errors == []
     manifest = state.manifest
-    dataset = 'datasets/gov/ivpk/adk'
-    model = f'{dataset}/Dataset'
+    dataset = "datasets/gov/ivpk/adk"
+    model = f"{dataset}/Dataset"
 
     assert list(manifest.datasets) == [dataset]
     assert list(manifest.models) == [
-        f'{dataset}/Dataset',
-        f'{dataset}/Licence',
+        f"{dataset}/Dataset",
+        f"{dataset}/Licence",
     ]
 
     assert list(manifest.datasets[dataset].prefixes) == [
-        'dcat',
-        'dct',
-        'spinta',
+        "dcat",
+        "dct",
+        "spinta",
     ]
 
     props = manifest.models[model].properties
     assert list(props) == [
-        'id',
-        'title',
-        'description',
-        'licence',
+        "id",
+        "title",
+        "description",
+        "licence",
     ]
 
-    assert props['id'].type == 'integer'
-    assert len(props['description'].comments) == 1
+    assert props["id"].type == "integer"
+    assert len(props["description"].comments) == 1

--- a/tests/datasets/test_views.py
+++ b/tests/datasets/test_views.py
@@ -48,7 +48,7 @@ from vitrina.datasets.forms import (
     DatasetResourceForm,
     CatalogResourceForm,
 )
-from vitrina.datasets.models import Dataset, DatasetStructure, Contact, Type, Relation
+from vitrina.datasets.models import Dataset, DatasetStructure, Type, Relation
 from vitrina.messages.models import Subscription
 from vitrina.orgs.factories import OrganizationFactory
 from vitrina.orgs.factories import RepresentativeFactory
@@ -62,11 +62,10 @@ from vitrina.resources.factories import DatasetDistributionFactory, FileFormat
 from vitrina.settings import SPINTA_SERVER_URL
 from vitrina.structure.factories import ModelFactory, MetadataFactory, VersionFactory
 from vitrina.structure import VersionStatus
-from vitrina.structure.factories import ModelFactory, MetadataFactory, VersionFactory
 from vitrina.testing.templates import strip_empty_lines
 from vitrina.users.factories import UserFactory, ManagerFactory
 from vitrina.users.models import User
-from vitrina.identifiers.factories import AgencyFactory, IdentifierFactory
+from vitrina.identifiers.factories import IdentifierFactory
 from vitrina.identifiers.models import Identifier, Agency
 from vitrina.smart_contracts.factories import AgreementFactory
 from vitrina.utils import RevisionComment, RevisionSource
@@ -588,8 +587,8 @@ class TestDatasetListView:
         dataset2 = DatasetFactory(organization=org2)
         ct = ContentType.objects.get_for_model(Organization)
         user = User.objects.create_user(email="test@test.com", password="test123")
-        rep = RepresentativeFactory(content_type=ct, object_id=org.pk, role=role, user=user)
-        rep2 = RepresentativeFactory(content_type=ct, object_id=org2.pk, role=role, user=user)
+        RepresentativeFactory(content_type=ct, object_id=org.pk, role=role, user=user)
+        RepresentativeFactory(content_type=ct, object_id=org2.pk, role=role, user=user)
         app.set_user(user)
         resp = app.get(reverse("dataset-list"))
         resp = resp.click(linkid="manager-dataset-url")
@@ -1331,7 +1330,7 @@ class TestDatasetUpdateView:
 
         response = app.get(reverse("dataset-change", kwargs={"pk": dataset.id}))
 
-        assert type(response.context.get("form")) == form_class
+        assert type(response.context.get("form")) is form_class
 
     def test_dataset_update_information_system(self, app: DjangoTestApp) -> None:
         organization = OrganizationFactory()
@@ -1713,7 +1712,7 @@ class TestDatasetCreateView:
         app.set_user(user)
         response = app.get(reverse("dataset-add", kwargs={"pk": organization.id, "subclass_uuid": subclass.pk}))
 
-        assert type(response.context.get("form")) == form_class
+        assert type(response.context.get("form")) is form_class
 
     def test_dataset_create_information_system(self, app: DjangoTestApp):
         organization = OrganizationFactory()
@@ -2179,9 +2178,9 @@ class TestDatasetCreateView:
         user = UserFactory(is_staff=True, organization=org)
         app.set_user(user)
         dataset1 = DatasetFactory(organization=org, title="Test Dataset", metadata=f"{org.name}test-dataset")
-        metadata_version1 = VersionFactory(dataset=dataset1)
+        VersionFactory(dataset=dataset1)
         dataset2 = DatasetFactory(organization=org, title="Second Test Dataset", metadata=f"{org.name}test-dataset_3")
-        metadata_version2 = VersionFactory(dataset=dataset2)
+        VersionFactory(dataset=dataset2)
 
         form = app.get(reverse("dataset-add", kwargs={"pk": org.id, "subclass_uuid": subclass.pk})).forms[
             "dataset-form"
@@ -3659,7 +3658,7 @@ def test_delete_non_last_distribution_from_dataset(app: DjangoTestApp):
     user = UserFactory(is_staff=True, organization=organization)
     app.set_user(user)
     dataset = DatasetFactory(organization=organization, status=Dataset.HAS_DATA)
-    resource1 = DatasetDistributionFactory(dataset=dataset)
+    DatasetDistributionFactory(dataset=dataset)
     resource2 = DatasetDistributionFactory(dataset=dataset)
     ModelFactory(dataset=resource2.dataset, distribution=resource2)
 

--- a/tests/datasets/test_views.py
+++ b/tests/datasets/test_views.py
@@ -1115,7 +1115,7 @@ class TestDatasetUpdateView:
             http_method="POST",
             path=url,
             args=(),
-            kwargs={"pk": dataset.id}
+            kwargs={"pk": dataset.id},
         )
         form = app.get(url).forms["dataset-form"]
         form["title"] = "Edited title"
@@ -1654,11 +1654,9 @@ class TestDatasetCreateView:
             http_method="POST",
             path=url,
             args=(),
-            kwargs={"pk": org.id, "subclass_uuid": subclass.pk}
+            kwargs={"pk": org.id, "subclass_uuid": subclass.pk},
         )
-        form = app.get(url).forms[
-            "dataset-form"
-        ]
+        form = app.get(url).forms["dataset-form"]
         form["title"] = "Added title"
         form["description"] = "Added new dataset description"
         form["tags"] = ["test tag"]
@@ -2360,9 +2358,9 @@ class TestDatasetMembers:
         ],
     )
     def test_dataset_members_create_member_in_information_system_forbidden_for_roles(
-            self,
-            app: DjangoTestApp,
-            role: str,
+        self,
+        app: DjangoTestApp,
+        role: str,
     ):
         subclass = DCATResourceSubclassFactory(name="information_system")
         dataset = DatasetFactory(subclass=subclass)
@@ -2574,8 +2572,9 @@ class TestDatasetMembers:
 
             target_rep.refresh_from_db()
             assert target_rep.role == new_role
-            assert target_rep.user.organization == original_org, \
+            assert target_rep.user.organization == original_org, (
                 "User's organization should not change during role update"
+            )
         else:
             assert len(update_links) == 0
 
@@ -2584,39 +2583,39 @@ class TestDatasetMembers:
         "coordinator_role,target_role,new_role,can_update",
         [
             (
-                    Representative.OPEN_DATA_COORDINATOR,
-                    Representative.OPEN_DATA_MANAGER,
-                    Representative.OPEN_DATA_MANAGER,
-                    False,
+                Representative.OPEN_DATA_COORDINATOR,
+                Representative.OPEN_DATA_MANAGER,
+                Representative.OPEN_DATA_MANAGER,
+                False,
             ),
             (
-                    Representative.OPEN_DATA_COORDINATOR,
-                    Representative.RESOURCE_MANAGER,
-                    Representative.RESOURCE_MANAGER,
-                    False,
+                Representative.OPEN_DATA_COORDINATOR,
+                Representative.RESOURCE_MANAGER,
+                Representative.RESOURCE_MANAGER,
+                False,
             ),
             (
-                    Representative.RESOURCE_COORDINATOR,
-                    Representative.OPEN_DATA_MANAGER,
-                    Representative.OPEN_DATA_MANAGER,
-                    True,
+                Representative.RESOURCE_COORDINATOR,
+                Representative.OPEN_DATA_MANAGER,
+                Representative.OPEN_DATA_MANAGER,
+                True,
             ),
             (
-                    Representative.RESOURCE_COORDINATOR,
-                    Representative.RESOURCE_MANAGER,
-                    Representative.RESOURCE_MANAGER,
-                    True,
+                Representative.RESOURCE_COORDINATOR,
+                Representative.RESOURCE_MANAGER,
+                Representative.RESOURCE_MANAGER,
+                True,
             ),
             (
-                    Representative.RESOURCE_MANAGER,
-                    Representative.RESOURCE_MANAGER,
-                    Representative.OPEN_DATA_MANAGER,
-                    False,
+                Representative.RESOURCE_MANAGER,
+                Representative.RESOURCE_MANAGER,
+                Representative.OPEN_DATA_MANAGER,
+                False,
             ),
         ],
     )
     def test_dataset_members_update_member_subclass_information_system(
-            self, app: DjangoTestApp, coordinator_role, target_role, new_role, can_update
+        self, app: DjangoTestApp, coordinator_role, target_role, new_role, can_update
     ):
         subclass = DCATResourceSubclassFactory(name="information_system")
         dataset = DatasetFactory(subclass=subclass)
@@ -2653,8 +2652,9 @@ class TestDatasetMembers:
 
             target_rep.refresh_from_db()
             assert target_rep.role == new_role
-            assert target_rep.user.organization == original_org, \
+            assert target_rep.user.organization == original_org, (
                 "User's organization should not change during role update"
+            )
         else:
             assert len(update_links) == 0
 
@@ -2734,7 +2734,9 @@ class TestDatasetMembers:
             (Representative.RESOURCE_MANAGER, Representative.OPEN_DATA_MANAGER, False),
         ],
     )
-    def test_dataset_members_delete_member_subclass_information_system(self, app: DjangoTestApp, coordinator_role, target_role, can_delete):
+    def test_dataset_members_delete_member_subclass_information_system(
+        self, app: DjangoTestApp, coordinator_role, target_role, can_delete
+    ):
         subclass = DCATResourceSubclassFactory(name="information_system")
         dataset = DatasetFactory(subclass=subclass)
         ct = ContentType.objects.get_for_model(Dataset)
@@ -2882,7 +2884,6 @@ class TestDatasetMembers:
         coordinator.refresh_from_db()
         assert coordinator.phone == "061234567"
 
-
     def test_create_representative_with_organization_email_coordinator_role_fails(self, app: DjangoTestApp):
         dataset = DatasetFactory()
         ct = ContentType.objects.get_for_model(Dataset)
@@ -2907,7 +2908,6 @@ class TestDatasetMembers:
         assert resp.status_code == 200
         assert "Organizacijai gali būti suteikta tik tvarkytojo rolė" in resp.text
         assert not Representative.objects.filter(email=org.email).exists()
-
 
     def test_create_representative_with_organization_email_manager_role_succeeds(self, app: DjangoTestApp):
         dataset = DatasetFactory()
@@ -3419,7 +3419,7 @@ def test_dataset_history_view_with_permission(app: DjangoTestApp):
         http_method="POST",
         path=url,
         args=[],
-        kwargs={"pk": dataset.pk}
+        kwargs={"pk": dataset.pk},
     )
     form = app.get(url).forms["dataset-form"]
     form["title"] = "Updated title"
@@ -3443,6 +3443,7 @@ def test_dataset_structure_import_without_permission(app: DjangoTestApp):
     resp = app.get(url, expect_errors=True)
 
     assert resp.status_code == 403
+
 
 @pytest.mark.parametrize("status", [s for s in VersionStatus.values if s != VersionStatus.DRAFT])
 def test_dataset_import_in_not_draft_version(app: DjangoTestApp, status: str):
@@ -3832,7 +3833,7 @@ def test_dataset_dynamic_resources_multiple_models(app: DjangoTestApp):
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         name="TestModel",
-        metadata_version=metadata_version
+        metadata_version=metadata_version,
     )
     model2 = ModelFactory(dataset=dataset, metadata_version=metadata_version)
     MetadataFactory(
@@ -3840,7 +3841,7 @@ def test_dataset_dynamic_resources_multiple_models(app: DjangoTestApp):
         content_type=ContentType.objects.get_for_model(model2),
         object_id=model2.pk,
         name="TestModel2",
-        metadata_version=metadata_version
+        metadata_version=metadata_version,
     )
     model3 = ModelFactory(dataset=dataset, metadata_version=metadata_version)
     MetadataFactory(
@@ -3848,7 +3849,7 @@ def test_dataset_dynamic_resources_multiple_models(app: DjangoTestApp):
         content_type=ContentType.objects.get_for_model(model3),
         object_id=model3.pk,
         name="TestModel3",
-        metadata_version=metadata_version
+        metadata_version=metadata_version,
     )
 
     response = app.get(reverse("dataset-detail", args=[resource.dataset.pk])).follow()
@@ -4319,7 +4320,7 @@ def test_dataset_rdf_download__dataset_with_spinta_data(app: DjangoTestApp):
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         name="test/dataset/TestModel",
-        metadata_version=dataset.metadata.first().metadata_version
+        metadata_version=dataset.metadata.first().metadata_version,
     )
     (
         FileFormat(
@@ -4651,21 +4652,21 @@ class TestDatasetMemberCreate:
         # Add new coordinator to dataset
         url = reverse("dataset-representative-create", args=[dataset.pk])
         resp = app.get(url)
-        form = resp.forms['representative-form']
-        form['email'] = 'new.coordinator@test.com'
+        form = resp.forms["representative-form"]
+        form["email"] = "new.coordinator@test.com"
         form.submit()
 
         # Coordinator representative should be created for the DATASET
         coordinator_rep = Representative.objects.get(
-            email='new.coordinator@test.com',
+            email="new.coordinator@test.com",
             content_type=ContentType.objects.get_for_model(dataset.__class__),
-            object_id=dataset.pk
+            object_id=dataset.pk,
         )
         assert coordinator_rep.role == Representative.RESOURCE_COORDINATOR
 
         # User doesn't exist yet (will be created when they register)
         # But if they existed, they should NOT have org assigned
-        assert not User.objects.filter(email='new.coordinator@test.com').exists()
+        assert not User.objects.filter(email="new.coordinator@test.com").exists()
 
     def test_existing_user_assigned_as_coordinator_keeps_no_org(self, app: DjangoTestApp):
         org = OrganizationFactory()
@@ -4676,16 +4677,17 @@ class TestDatasetMemberCreate:
 
         url = reverse("dataset-representative-create", args=[dataset.pk])
         resp = app.get(url)
-        form = resp.forms['representative-form']
-        form['email'] = existing_user.email
-        form['role'] = Representative.OPEN_DATA_COORDINATOR
+        form = resp.forms["representative-form"]
+        form["email"] = existing_user.email
+        form["role"] = Representative.OPEN_DATA_COORDINATOR
         form.submit()
 
         existing_user.refresh_from_db()
 
         # User should still have NO organization
-        assert existing_user.organization is None, \
+        assert existing_user.organization is None, (
             f"User should not be added to dataset's organization, but has {existing_user.organization}"
+        )
 
     def test_existing_user_from_different_org_not_changed(self, app: DjangoTestApp):
         org_a = OrganizationFactory(title="Org A")
@@ -4700,15 +4702,16 @@ class TestDatasetMemberCreate:
 
         url = reverse("dataset-representative-create", args=[dataset_in_org_a.pk])
         resp = app.get(url)
-        form = resp.forms['representative-form']
-        form['email'] = user_from_org_b.email
+        form = resp.forms["representative-form"]
+        form["email"] = user_from_org_b.email
         form.submit()
 
         user_from_org_b.refresh_from_db()
 
         # User should still belong to Org B, NOT Org A
-        assert user_from_org_b.organization == original_org, \
+        assert user_from_org_b.organization == original_org, (
             f"User's organization should not be changed from {original_org} to {user_from_org_b.organization}"
+        )
         assert user_from_org_b.organization != org_a
 
     def test_coordinator_has_representative_for_dataset_not_org(self, app: DjangoTestApp):
@@ -4721,25 +4724,21 @@ class TestDatasetMemberCreate:
 
         url = reverse("dataset-representative-create", args=[dataset.pk])
         resp = app.get(url)
-        form = resp.forms['representative-form']
-        form['email'] = user.email
+        form = resp.forms["representative-form"]
+        form["email"] = user.email
         form.submit()
 
         user.refresh_from_db()
 
         # Should have representative for DATASET
         dataset_reps = Representative.objects.filter(
-            user=user,
-            content_type=ContentType.objects.get_for_model(dataset.__class__),
-            object_id=dataset.pk
+            user=user, content_type=ContentType.objects.get_for_model(dataset.__class__), object_id=dataset.pk
         )
         assert dataset_reps.exists(), "User should have representative for dataset"
 
         # Should NOT have representative for ORGANIZATION
         org_reps = Representative.objects.filter(
-            user=user,
-            content_type=ContentType.objects.get_for_model(org.__class__),
-            object_id=org.pk
+            user=user, content_type=ContentType.objects.get_for_model(org.__class__), object_id=org.pk
         )
         assert not org_reps.exists(), "User should NOT have representative for organization"
 
@@ -4754,9 +4753,9 @@ class TestDatasetMemberCreate:
 
         url = reverse("dataset-representative-create", args=[dataset.pk])
         resp = app.get(url)
-        form = resp.forms['representative-form']
-        form['email'] = existing_user.email
-        form['role'] = Representative.OPEN_DATA_MANAGER
+        form = resp.forms["representative-form"]
+        form["email"] = existing_user.email
+        form["role"] = Representative.OPEN_DATA_MANAGER
         form.submit()
 
         existing_user.refresh_from_db()
@@ -4776,13 +4775,14 @@ class TestDatasetMemberCreate:
 
         url = reverse("dataset-representative-create", args=[dataset.pk])
         resp = app.get(url)
-        form = resp.forms['representative-form']
-        form['email'] = user.email
+        form = resp.forms["representative-form"]
+        form["email"] = user.email
         form.submit()
 
         user.refresh_from_db()
 
         assert user.organization == org
+
 
 class TestDatasetMemberUpdate:
     def test_dataset_member_update_does_not_assign_org(self, app: DjangoTestApp):

--- a/tests/likes/test_views.py
+++ b/tests/likes/test_views.py
@@ -114,6 +114,7 @@ def test_like_with_public_dataset_with_access(app: DjangoTestApp):
     assert response.status_code == 302
     assert response.url == dataset.get_absolute_url()
 
+
 @pytest.mark.django_db
 def test_like_with_non_public_dataset_without_access(app: DjangoTestApp):
     dataset = DatasetFactory(is_public=False)

--- a/tests/messages/test_newsletter_models.py
+++ b/tests/messages/test_newsletter_models.py
@@ -19,11 +19,13 @@ class TestNewsletterSubscriber:
         assert subscriber.unsubscribe_token is not None
         assert subscriber.created is not None
 
-
-    @pytest.mark.parametrize("email_variant", [
-        "test@example.com",
-        "tEST@example.com",
-    ])
+    @pytest.mark.parametrize(
+        "email_variant",
+        [
+            "test@example.com",
+            "tEST@example.com",
+        ],
+    )
     def test_unique_email_constraint(self, email_variant):
         NewsletterSubscriber.objects.create(email="test@example.com")
 
@@ -33,7 +35,9 @@ class TestNewsletterSubscriber:
     def test_auto_set_confirmation_expiry(self):
         before_creation = timezone.now()
         expected_expiry = before_creation + timedelta(hours=24)
-        subscriber = NewsletterSubscriber.objects.create(email="test@example.com", confirmation_expires_at=expected_expiry)
+        subscriber = NewsletterSubscriber.objects.create(
+            email="test@example.com", confirmation_expires_at=expected_expiry
+        )
         actual_expiry = subscriber.confirmation_expires_at
 
         tolerance = timedelta(minutes=1)
@@ -41,17 +45,13 @@ class TestNewsletterSubscriber:
 
     def test_is_confirmation_expired_false_when_not_expired(self):
         future_time = timezone.now() + timedelta(hours=1)
-        subscriber = NewsletterSubscriber.objects.create(
-            email="test@example.com", confirmation_expires_at=future_time
-        )
+        subscriber = NewsletterSubscriber.objects.create(email="test@example.com", confirmation_expires_at=future_time)
 
         assert subscriber.is_confirmation_expired() is False
 
     def test_is_confirmation_expired_true_when_expired(self):
         past_time = timezone.now() - timedelta(hours=1)
-        subscriber = NewsletterSubscriber.objects.create(
-            email="test@example.com", confirmation_expires_at=past_time
-        )
+        subscriber = NewsletterSubscriber.objects.create(email="test@example.com", confirmation_expires_at=past_time)
 
         assert subscriber.is_confirmation_expired() is True
 

--- a/tests/messages/test_signals.py
+++ b/tests/messages/test_signals.py
@@ -20,27 +20,27 @@ def last_month():
 @pytest.fixture
 def subscriber():
     return NewsletterSubscriber.objects.create(
-        email='test@example.com',
+        email="test@example.com",
         status=NewsletterSubscriber.SUBSCRIBED,
     )
 
 
 @pytest.mark.django_db
-@patch('vitrina.messages.signals.email')
-@patch('djangocms_blog.models.Post.get_absolute_url')
+@patch("vitrina.messages.signals.email")
+@patch("djangocms_blog.models.Post.get_absolute_url")
 def test_newsletter_with_blog_and_dataset(mock_get_absolute_url, mock_email, last_month, subscriber):
-    mock_get_absolute_url.return_value = '/blog/test-blog/'
+    mock_get_absolute_url.return_value = "/blog/test-blog/"
     Post.objects.create(
-        title='Test Blog',
-        slug='test-blog',
+        title="Test Blog",
+        slug="test-blog",
         publish=True,
         date_published=last_month,
         app_config=BlogConfig.objects.create(namespace="blog"),
     )
 
     Dataset.objects.create(
-        title='Test Dataset',
-        description='Description here',
+        title="Test Dataset",
+        description="Description here",
         is_public=True,
         published=last_month,
         status=Dataset.HAS_DATA,
@@ -53,7 +53,7 @@ def test_newsletter_with_blog_and_dataset(mock_get_absolute_url, mock_email, las
 @pytest.mark.django_db
 def test_no_content_yields_no_newsletter():
     NewsletterSubscriber.objects.create(
-        email='empty@test.com',
+        email="empty@test.com",
         status=NewsletterSubscriber.SUBSCRIBED,
     )
 
@@ -64,8 +64,8 @@ def test_no_content_yields_no_newsletter():
 @pytest.mark.django_db
 def test_deleted_on_dataset_not_sent(last_month, subscriber):
     Dataset.objects.create(
-        title='Hidden Dataset',
-        description='...',
+        title="Hidden Dataset",
+        description="...",
         created=last_month,
         deleted_on=timezone.now(),
         status=Dataset.HAS_DATA,
@@ -76,11 +76,11 @@ def test_deleted_on_dataset_not_sent(last_month, subscriber):
 
 
 @pytest.mark.django_db
-@patch('vitrina.messages.signals.email')
+@patch("vitrina.messages.signals.email")
 def test_unpublished_blog_post_not_included(mock_email, last_month, subscriber):
     Post.objects.create(
-        title='Hidden Post',
-        slug='hidden-post',
+        title="Hidden Post",
+        slug="hidden-post",
         publish=False,
         date_published=last_month,
     )
@@ -90,18 +90,20 @@ def test_unpublished_blog_post_not_included(mock_email, last_month, subscriber):
 
 
 @pytest.mark.django_db
-@patch('vitrina.messages.signals.email')
+@patch("vitrina.messages.signals.email")
 def test_multiple_subscribers_all_get_newsletter(mock_email, last_month):
-    NewsletterSubscriber.objects.bulk_create([
-        NewsletterSubscriber(email='a@test.com', status=NewsletterSubscriber.SUBSCRIBED),
-        NewsletterSubscriber(email='b@test.com', status=NewsletterSubscriber.SUBSCRIBED),
-        NewsletterSubscriber(email='c@test.com', status=NewsletterSubscriber.UNSUBSCRIBED),
-        NewsletterSubscriber(email='d@test.com', status=NewsletterSubscriber.PENDING),
-    ])
+    NewsletterSubscriber.objects.bulk_create(
+        [
+            NewsletterSubscriber(email="a@test.com", status=NewsletterSubscriber.SUBSCRIBED),
+            NewsletterSubscriber(email="b@test.com", status=NewsletterSubscriber.SUBSCRIBED),
+            NewsletterSubscriber(email="c@test.com", status=NewsletterSubscriber.UNSUBSCRIBED),
+            NewsletterSubscriber(email="d@test.com", status=NewsletterSubscriber.PENDING),
+        ]
+    )
 
     Dataset.objects.create(
-        title='Shared Dataset',
-        description='Used for both',
+        title="Shared Dataset",
+        description="Used for both",
         is_public=True,
         published=last_month,
         status=Dataset.HAS_DATA,
@@ -112,15 +114,15 @@ def test_multiple_subscribers_all_get_newsletter(mock_email, last_month):
 
 
 @pytest.mark.django_db
-@patch('vitrina.messages.signals.email')
-@patch('djangocms_blog.models.Post.get_absolute_url')
+@patch("vitrina.messages.signals.email")
+@patch("djangocms_blog.models.Post.get_absolute_url")
 def test_more_than_3_datasets_splits_correctly(mock_get_absolute_url, mock_email, last_month, subscriber):
-    mock_get_absolute_url.return_value = '/blog/test/'
+    mock_get_absolute_url.return_value = "/blog/test/"
 
     for i in range(5):
         Dataset.objects.create(
-            title=f'Dataset {i + 1}',
-            description=f'Description {i + 1}',
+            title=f"Dataset {i + 1}",
+            description=f"Description {i + 1}",
             is_public=True,
             published=last_month,
             status=Dataset.HAS_DATA,
@@ -131,21 +133,21 @@ def test_more_than_3_datasets_splits_correctly(mock_get_absolute_url, mock_email
 
     # Verify email was called with correct context structure
     call_args = mock_email.call_args
-    context = call_args[1]['context']
+    context = call_args[1]["context"]
 
     # Should have exactly 3 top datasets and 2 list datasets
-    assert len(context['top_datasets']) == 3
-    assert len(context['list_datasets']) == 2
-    assert 'list_datasets' in context
+    assert len(context["top_datasets"]) == 3
+    assert len(context["list_datasets"]) == 2
+    assert "list_datasets" in context
 
 
 @pytest.mark.django_db
-@patch('vitrina.messages.signals.email')
+@patch("vitrina.messages.signals.email")
 def test_exactly_3_datasets_no_list(mock_email, last_month, subscriber):
     for i in range(3):
         Dataset.objects.create(
-            title=f'Dataset {i + 1}',
-            description=f'Description {i + 1}',
+            title=f"Dataset {i + 1}",
+            description=f"Description {i + 1}",
             is_public=True,
             published=last_month,
             status=Dataset.HAS_DATA,
@@ -154,25 +156,25 @@ def test_exactly_3_datasets_no_list(mock_email, last_month, subscriber):
     count = send_monthly_newsletter.send(sender=None)[0][1]
     assert count == 1
 
-    context = mock_email.call_args[1]['context']
-    assert len(context['top_datasets']) == 3
-    assert context.get('list_datasets') is None
+    context = mock_email.call_args[1]["context"]
+    assert len(context["top_datasets"]) == 3
+    assert context.get("list_datasets") is None
 
 
 @pytest.mark.django_db
-@patch('vitrina.messages.signals.email')
+@patch("vitrina.messages.signals.email")
 def test_private_datasets_excluded(mock_email, last_month, subscriber):
     Dataset.objects.create(
-        title='Private Dataset',
-        description='Should not appear',
+        title="Private Dataset",
+        description="Should not appear",
         is_public=False,
         published=last_month,
         status=Dataset.HAS_DATA,
     )
 
     Dataset.objects.create(
-        title='Public Dataset',
-        description='Should appear',
+        title="Public Dataset",
+        description="Should appear",
         is_public=True,
         published=last_month,
         status=Dataset.HAS_DATA,
@@ -181,19 +183,19 @@ def test_private_datasets_excluded(mock_email, last_month, subscriber):
     count = send_monthly_newsletter.send(sender=None)[0][1]
     assert count == 1
 
-    context = mock_email.call_args[1]['context']
-    assert len(context['top_datasets']) == 1
-    assert context['top_datasets'][0]['title'] == 'Public Dataset'
+    context = mock_email.call_args[1]["context"]
+    assert len(context["top_datasets"]) == 1
+    assert context["top_datasets"][0]["title"] == "Public Dataset"
 
 
 @pytest.mark.django_db
-@patch('vitrina.messages.signals.email')
+@patch("vitrina.messages.signals.email")
 def test_current_month_content_excluded(mock_email, subscriber):
     now = timezone.now()
 
     Dataset.objects.create(
-        title='Current Month Dataset',
-        description='Should not appear',
+        title="Current Month Dataset",
+        description="Should not appear",
         is_public=True,
         published=now,
         status=Dataset.HAS_DATA,
@@ -204,19 +206,19 @@ def test_current_month_content_excluded(mock_email, subscriber):
 
 
 @pytest.mark.django_db
-@patch('vitrina.messages.signals.email')
+@patch("vitrina.messages.signals.email")
 def test_email_sending_failure_continues(mock_email, last_month):
     subscribers = []
     for i in range(3):
         subscriber = NewsletterSubscriber.objects.create(
-            email=f'test{i}@example.com',
+            email=f"test{i}@example.com",
             status=NewsletterSubscriber.SUBSCRIBED,
         )
         subscribers.append(subscriber)
 
     Dataset.objects.create(
-        title='Test Dataset',
-        description='Test',
+        title="Test Dataset",
+        description="Test",
         is_public=True,
         published=last_month,
         status=Dataset.HAS_DATA,
@@ -230,14 +232,14 @@ def test_email_sending_failure_continues(mock_email, last_month):
 
 
 @pytest.mark.django_db
-@patch('vitrina.messages.signals.email')
-@patch('djangocms_blog.models.Post.get_absolute_url')
+@patch("vitrina.messages.signals.email")
+@patch("djangocms_blog.models.Post.get_absolute_url")
 def test_context_structure_blog_posts(mock_get_absolute_url, mock_email, last_month, subscriber):
-    mock_get_absolute_url.return_value = '/blog/test-post/'
+    mock_get_absolute_url.return_value = "/blog/test-post/"
 
     Post.objects.create(
-        title='Test Blog Post',
-        slug='test-post',
+        title="Test Blog Post",
+        slug="test-post",
         publish=True,
         date_published=last_month,
         app_config=BlogConfig.objects.create(namespace="blog"),
@@ -246,23 +248,23 @@ def test_context_structure_blog_posts(mock_get_absolute_url, mock_email, last_mo
     count = send_monthly_newsletter.send(sender=None)[0][1]
     assert count == 1
 
-    context = mock_email.call_args[1]['context']
-    blog_post = context['blog_posts'][0]
+    context = mock_email.call_args[1]["context"]
+    blog_post = context["blog_posts"][0]
 
-    assert 'title' in blog_post
-    assert 'url' in blog_post
-    assert 'day' in blog_post
-    assert 'month' in blog_post
-    assert blog_post['title'] == 'Test Blog Post'
-    assert blog_post['url'] == '/blog/test-post/'
+    assert "title" in blog_post
+    assert "url" in blog_post
+    assert "day" in blog_post
+    assert "month" in blog_post
+    assert blog_post["title"] == "Test Blog Post"
+    assert blog_post["url"] == "/blog/test-post/"
 
 
 @pytest.mark.django_db
-@patch('vitrina.messages.signals.email')
+@patch("vitrina.messages.signals.email")
 def test_context_structure_datasets(mock_email, last_month, subscriber):
     Dataset.objects.create(
-        title='Test Dataset',
-        description='Test description',
+        title="Test Dataset",
+        description="Test description",
         is_public=True,
         published=last_month,
         status=Dataset.HAS_DATA,
@@ -271,21 +273,21 @@ def test_context_structure_datasets(mock_email, last_month, subscriber):
     count = send_monthly_newsletter.send(sender=None)[0][1]
     assert count == 1
 
-    context = mock_email.call_args[1]['context']
-    dataset = context['top_datasets'][0]
+    context = mock_email.call_args[1]["context"]
+    dataset = context["top_datasets"][0]
 
-    assert 'id' in dataset
-    assert 'title' in dataset
-    assert 'description' in dataset
-    assert dataset['title'] == 'Test Dataset'
+    assert "id" in dataset
+    assert "title" in dataset
+    assert "description" in dataset
+    assert dataset["title"] == "Test Dataset"
 
 
 @pytest.mark.django_db
-@patch('vitrina.messages.signals.email')
+@patch("vitrina.messages.signals.email")
 def test_month_year_formatting(mock_email, last_month, subscriber):
     Dataset.objects.create(
-        title='Test Dataset',
-        description='Test',
+        title="Test Dataset",
+        description="Test",
         is_public=True,
         published=last_month,
         status=Dataset.HAS_DATA,
@@ -294,23 +296,33 @@ def test_month_year_formatting(mock_email, last_month, subscriber):
     count = send_monthly_newsletter.send(sender=None)[0][1]
     assert count == 1
 
-    context = mock_email.call_args[1]['context']
-    month_year = context['month_year']
+    context = mock_email.call_args[1]["context"]
+    month_year = context["month_year"]
 
     assert str(timezone.now().year) in month_year
     lithuanian_months = [
-        "sausis", "vasaris", "kovas", "balandis", "gegužė", "birželis",
-        "liepa", "rugpjūtis", "rugsėjis", "spalis", "lapkritis", "gruodis"
+        "sausis",
+        "vasaris",
+        "kovas",
+        "balandis",
+        "gegužė",
+        "birželis",
+        "liepa",
+        "rugpjūtis",
+        "rugsėjis",
+        "spalis",
+        "lapkritis",
+        "gruodis",
     ]
     assert any(month in month_year for month in lithuanian_months)
 
 
 @pytest.mark.django_db
-@patch('vitrina.messages.signals.email')
+@patch("vitrina.messages.signals.email")
 def test_unsubscribe_url_in_context(mock_email, last_month, subscriber):
     Dataset.objects.create(
-        title='Test Dataset',
-        description='Test',
+        title="Test Dataset",
+        description="Test",
         is_public=True,
         published=last_month,
         status=Dataset.HAS_DATA,
@@ -319,20 +331,20 @@ def test_unsubscribe_url_in_context(mock_email, last_month, subscriber):
     count = send_monthly_newsletter.send(sender=None)[0][1]
     assert count == 1
 
-    context = mock_email.call_args[1]['context']
-    unsubscribe_url = context['unsubscribe_url']
+    context = mock_email.call_args[1]["context"]
+    unsubscribe_url = context["unsubscribe_url"]
 
-    assert 'unsubscribe' in unsubscribe_url
+    assert "unsubscribe" in unsubscribe_url
     assert str(subscriber.unsubscribe_token) in unsubscribe_url
-    assert unsubscribe_url.startswith('https://')
+    assert unsubscribe_url.startswith("https://")
 
 
 @pytest.mark.django_db
-@patch('vitrina.messages.signals.email')
+@patch("vitrina.messages.signals.email")
 def test_domain_in_context(mock_email, last_month, subscriber):
     Dataset.objects.create(
-        title='Test Dataset',
-        description='Test',
+        title="Test Dataset",
+        description="Test",
         is_public=True,
         published=last_month,
         status=Dataset.HAS_DATA,
@@ -341,8 +353,8 @@ def test_domain_in_context(mock_email, last_month, subscriber):
     count = send_monthly_newsletter.send(sender=None)[0][1]
     assert count == 1
 
-    context = mock_email.call_args[1]['context']
-    domain = context['domain']
+    context = mock_email.call_args[1]["context"]
+    domain = context["domain"]
 
     # Should be the current site's domain
     current_site = Site.objects.get_current()
@@ -350,13 +362,13 @@ def test_domain_in_context(mock_email, last_month, subscriber):
 
 
 @pytest.mark.django_db
-@patch('vitrina.messages.signals.email')
-@patch('djangocms_blog.models.Post.get_absolute_url')
+@patch("vitrina.messages.signals.email")
+@patch("djangocms_blog.models.Post.get_absolute_url")
 def test_only_blog_posts_no_datasets(mock_get_absolute_url, mock_email, last_month, subscriber):
-    mock_get_absolute_url.return_value = '/blog/only-blog/'
+    mock_get_absolute_url.return_value = "/blog/only-blog/"
     Post.objects.create(
-        title='Only Blog Post',
-        slug='only-blog',
+        title="Only Blog Post",
+        slug="only-blog",
         publish=True,
         date_published=last_month,
         app_config=BlogConfig.objects.create(namespace="blog"),
@@ -365,19 +377,19 @@ def test_only_blog_posts_no_datasets(mock_get_absolute_url, mock_email, last_mon
     count = send_monthly_newsletter.send(sender=None)[0][1]
     assert count == 1
 
-    context = mock_email.call_args[1]['context']
-    assert 'blog_posts' in context
-    assert len(context['blog_posts']) == 1
-    assert 'top_datasets' in context
-    assert len(context['top_datasets']) == 0
+    context = mock_email.call_args[1]["context"]
+    assert "blog_posts" in context
+    assert len(context["blog_posts"]) == 1
+    assert "top_datasets" in context
+    assert len(context["top_datasets"]) == 0
 
 
 @pytest.mark.django_db
-@patch('vitrina.messages.signals.email')
+@patch("vitrina.messages.signals.email")
 def test_only_datasets_no_blog_posts(mock_email, last_month, subscriber):
     Dataset.objects.create(
-        title='Only Dataset',
-        description='Test',
+        title="Only Dataset",
+        description="Test",
         is_public=True,
         published=last_month,
         status=Dataset.HAS_DATA,
@@ -386,11 +398,11 @@ def test_only_datasets_no_blog_posts(mock_email, last_month, subscriber):
     count = send_monthly_newsletter.send(sender=None)[0][1]
     assert count == 1
 
-    context = mock_email.call_args[1]['context']
-    assert 'top_datasets' in context
-    assert len(context['top_datasets']) == 1
-    assert 'blog_posts' in context
-    assert len(context['blog_posts']) == 0
+    context = mock_email.call_args[1]["context"]
+    assert "top_datasets" in context
+    assert len(context["top_datasets"]) == 1
+    assert "blog_posts" in context
+    assert len(context["blog_posts"]) == 0
 
 
 @pytest.mark.django_db
@@ -399,8 +411,8 @@ def test_no_subscribers_returns_early():
     last_month = last_month.replace(day=15)
 
     Dataset.objects.create(
-        title='Test Dataset',
-        description='Test',
+        title="Test Dataset",
+        description="Test",
         is_public=True,
         published=last_month,
         status=Dataset.HAS_DATA,

--- a/tests/messages/test_signals.py
+++ b/tests/messages/test_signals.py
@@ -129,32 +129,6 @@ def test_more_than_3_datasets_splits_correctly(mock_get_absolute_url, mock_email
     count = send_monthly_newsletter.send(sender=None)[0][1]
     assert count == 1
 
-    call_args = mock_email.call_args
-    context = call_args[1]['context']
-
-    assert len(context['top_datasets']) == 3
-    assert len(context['list_datasets']) == 2
-    assert 'list_datasets' in context
-
-
-@pytest.mark.django_db
-@patch('vitrina.messages.signals.email')
-@patch('djangocms_blog.models.Post.get_absolute_url')
-def test_more_than_3_datasets_splits_correctly(mock_get_absolute_url, mock_email, last_month, subscriber):
-    mock_get_absolute_url.return_value = '/blog/test/'
-
-    for i in range(5):
-        Dataset.objects.create(
-            title=f'Dataset {i + 1}',
-            description=f'Description {i + 1}',
-            is_public=True,
-            published=last_month,
-            status=Dataset.HAS_DATA,
-        )
-
-    count = send_monthly_newsletter.send(sender=None)[0][1]
-    assert count == 1
-
     # Verify email was called with correct context structure
     call_args = mock_email.call_args
     context = call_args[1]['context']

--- a/tests/messages/test_views.py
+++ b/tests/messages/test_views.py
@@ -22,7 +22,6 @@ from vitrina.projects.factories import ProjectFactory
 from vitrina.requests.factories import RequestFactory
 from vitrina.requests.models import Request
 from vitrina.users.factories import UserFactory
-from vitrina.users.models import User
 
 
 @pytest.fixture

--- a/tests/messages/test_views.py
+++ b/tests/messages/test_views.py
@@ -33,36 +33,38 @@ def subscription_data():
     dataset = DatasetFactory()
     project = ProjectFactory()
     user = UserFactory(organization=org1)
-    return {
-        'request': request,
-        'dataset': dataset,
-        'project': project,
-        'user': user
-    }
+    return {"request": request, "dataset": dataset, "project": project, "user": user}
 
 
 @pytest.mark.django_db
 def test_request_subscribe_without_user(app: DjangoTestApp, subscription_data):
-    resp = app.get(subscription_data['request'].get_absolute_url())
+    resp = app.get(subscription_data["request"].get_absolute_url())
     assert Subscription.objects.count() == 0
 
-    elem = resp.html.find(id='number-of-subscribers')
-    assert elem.get_text().strip() == '0'
+    elem = resp.html.find(id="number-of-subscribers")
+    assert elem.get_text().strip() == "0"
 
 
 @pytest.mark.django_db
 def test_request_subscribe_url_no_login(app: DjangoTestApp, subscription_data):
-    resp = app.get(subscription_data['request'].get_absolute_url())
-    elem = resp.html.find(id='request_subscription')
-    form_url = elem.find('a', {'id': 'subscribe-form'})
+    resp = app.get(subscription_data["request"].get_absolute_url())
+    elem = resp.html.find(id="request_subscription")
+    form_url = elem.find("a", {"id": "subscribe-form"})
     assert form_url is None
 
 
 @pytest.mark.django_db
 def test_request_subscribe_form_no_login(app: DjangoTestApp, subscription_data):
-    response = app.get(reverse('subscribe-form', kwargs={'content_type_id': get_content_type_for_model(Request).id,
-                                                         'obj_id': subscription_data['request'].id,
-                                                         'user_id': subscription_data['user'].id}))
+    response = app.get(
+        reverse(
+            "subscribe-form",
+            kwargs={
+                "content_type_id": get_content_type_for_model(Request).id,
+                "obj_id": subscription_data["request"].id,
+                "user_id": subscription_data["user"].id,
+            },
+        )
+    )
     assert settings.LOGIN_URL in response.location
 
 
@@ -71,25 +73,29 @@ def test_dataset_subscribe_for_other_user(app: DjangoTestApp, subscription_data)
     user = UserFactory()
     app.set_user(user)
 
-    kwargs = {'content_type_id': get_content_type_for_model(Dataset).id,
-              'obj_id': subscription_data['dataset'].id,
-              'user_id': subscription_data['user'].id}
-    resp = app.get(reverse('subscribe-form', kwargs=kwargs))
-    assert resp.url == reverse('dataset-detail', kwargs={'pk': subscription_data['dataset'].id})
+    kwargs = {
+        "content_type_id": get_content_type_for_model(Dataset).id,
+        "obj_id": subscription_data["dataset"].id,
+        "user_id": subscription_data["user"].id,
+    }
+    resp = app.get(reverse("subscribe-form", kwargs=kwargs))
+    assert resp.url == reverse("dataset-detail", kwargs={"pk": subscription_data["dataset"].id})
 
 
 @pytest.mark.django_db
 def test_dataset_unsubscribe_for_other_user(app: DjangoTestApp, subscription_data):
-    app.set_user(subscription_data['user'])
-    kwargs = {'content_type_id': get_content_type_for_model(Dataset).id,
-              'obj_id': subscription_data['dataset'].id,
-              'user_id': subscription_data['user'].id}
-    form = app.get(reverse('subscribe-form', kwargs=kwargs)).forms['subscribe-form']
-    form['email_subscribed'] = True
-    form['dataset_update_sub'] = True
+    app.set_user(subscription_data["user"])
+    kwargs = {
+        "content_type_id": get_content_type_for_model(Dataset).id,
+        "obj_id": subscription_data["dataset"].id,
+        "user_id": subscription_data["user"].id,
+    }
+    form = app.get(reverse("subscribe-form", kwargs=kwargs)).forms["subscribe-form"]
+    form["email_subscribed"] = True
+    form["dataset_update_sub"] = True
     resp = form.submit()
 
-    assert resp.url == reverse('dataset-detail', kwargs={'pk': subscription_data['dataset'].id})
+    assert resp.url == reverse("dataset-detail", kwargs={"pk": subscription_data["dataset"].id})
     assert Subscription.objects.count() == 1
 
     assert len(mail.outbox) == 1
@@ -97,72 +103,76 @@ def test_dataset_unsubscribe_for_other_user(app: DjangoTestApp, subscription_dat
     user = UserFactory()
     app.set_user(user)
 
-    csrf_token = app.cookies['csrftoken']
-    resp = app.post(reverse('unsubscribe', kwargs=kwargs), {'csrfmiddlewaretoken': csrf_token})
-    assert resp.url == reverse('dataset-detail', kwargs={'pk': subscription_data['dataset'].id})
+    csrf_token = app.cookies["csrftoken"]
+    resp = app.post(reverse("unsubscribe", kwargs=kwargs), {"csrfmiddlewaretoken": csrf_token})
+    assert resp.url == reverse("dataset-detail", kwargs={"pk": subscription_data["dataset"].id})
     assert Subscription.objects.count() == 1
 
 
 @pytest.mark.django_db
 def test_request_subscribe_form_with_user(app: DjangoTestApp, subscription_data):
-    app.set_user(subscription_data['user'])
-    kwargs = {'content_type_id': get_content_type_for_model(Request).id,
-              'obj_id': subscription_data['request'].id,
-              'user_id': subscription_data['user'].id}
-    form = app.get(reverse('subscribe-form', kwargs=kwargs)).forms['subscribe-form']
-    form['email_subscribed'] = True
-    form['request_update_sub'] = True
+    app.set_user(subscription_data["user"])
+    kwargs = {
+        "content_type_id": get_content_type_for_model(Request).id,
+        "obj_id": subscription_data["request"].id,
+        "user_id": subscription_data["user"].id,
+    }
+    form = app.get(reverse("subscribe-form", kwargs=kwargs)).forms["subscribe-form"]
+    form["email_subscribed"] = True
+    form["request_update_sub"] = True
     resp = form.submit()
 
-    assert resp.url == reverse('request-detail', kwargs={'pk': subscription_data['request'].id})
+    assert resp.url == reverse("request-detail", kwargs={"pk": subscription_data["request"].id})
     assert Subscription.objects.count() == 1
 
     assert len(mail.outbox) == 1
 
-    resp = app.get(subscription_data['request'].get_absolute_url())
+    resp = app.get(subscription_data["request"].get_absolute_url())
 
-    elem = resp.html.find(id='number-of-subscribers')
-    assert elem.get_text().strip() == '1'
+    elem = resp.html.find(id="number-of-subscribers")
+    assert elem.get_text().strip() == "1"
 
-    elem = resp.html.find(id='request_subscription')
-    attr = elem.find('input', {'type': 'submit'}).attrs['value']
+    elem = resp.html.find(id="request_subscription")
+    attr = elem.find("input", {"type": "submit"}).attrs["value"]
     assert attr == "Atsisakyti prenumeratos"
 
-    resp.forms['unsubscribe-form'].submit()
-    resp = app.get(subscription_data['request'].get_absolute_url())
+    resp.forms["unsubscribe-form"].submit()
+    resp = app.get(subscription_data["request"].get_absolute_url())
     assert Subscription.objects.count() == 0
 
     assert len(mail.outbox) == 2
 
-    elem = resp.html.find(id='number-of-subscribers')
-    assert elem.get_text().strip() == '0'
+    elem = resp.html.find(id="number-of-subscribers")
+    assert elem.get_text().strip() == "0"
 
 
 @pytest.mark.django_db
 def test_request_comment_subscription_email(app: DjangoTestApp, subscription_data):
-    app.set_user(subscription_data['user'])
-    kwargs = {'content_type_id': get_content_type_for_model(Request).id,
-              'obj_id': subscription_data['request'].id,
-              'user_id': subscription_data['user'].id}
-    form = app.get(reverse('subscribe-form', kwargs=kwargs)).forms['subscribe-form']
-    form['email_subscribed'] = True
-    form['request_update_sub'] = True
-    form['request_comments_sub'] = True
+    app.set_user(subscription_data["user"])
+    kwargs = {
+        "content_type_id": get_content_type_for_model(Request).id,
+        "obj_id": subscription_data["request"].id,
+        "user_id": subscription_data["user"].id,
+    }
+    form = app.get(reverse("subscribe-form", kwargs=kwargs)).forms["subscribe-form"]
+    form["email_subscribed"] = True
+    form["request_update_sub"] = True
+    form["request_comments_sub"] = True
     resp = form.submit()
 
-    assert resp.url == reverse('request-detail', kwargs={'pk': subscription_data['request'].id})
+    assert resp.url == reverse("request-detail", kwargs={"pk": subscription_data["request"].id})
     assert Subscription.objects.count() == 1
 
     assert len(mail.outbox) == 1
 
     comment_user = UserFactory()
     app.set_user(comment_user)
-    ct = ContentType.objects.get_for_model(subscription_data['request'])
-    form = app.get(subscription_data['request'].get_absolute_url()).forms['comment-form']
-    form['is_public'] = True
-    form['body'] = "Test comment"
+    ct = ContentType.objects.get_for_model(subscription_data["request"])
+    form = app.get(subscription_data["request"].get_absolute_url()).forms["comment-form"]
+    form["is_public"] = True
+    form["body"] = "Test comment"
     form.submit()
-    created_comment = Comment.objects.filter(content_type=ct, object_id=subscription_data['request'].pk)
+    created_comment = Comment.objects.filter(content_type=ct, object_id=subscription_data["request"].pk)
     assert created_comment.count() == 1
     assert Subscription.objects.count() == 2
     assert len(mail.outbox) == 2
@@ -170,26 +180,28 @@ def test_request_comment_subscription_email(app: DjangoTestApp, subscription_dat
 
 @pytest.mark.django_db
 def test_request_update_subscription_email(app: DjangoTestApp, subscription_data):
-    app.set_user(subscription_data['user'])
-    kwargs = {'content_type_id': get_content_type_for_model(Request).id,
-              'obj_id': subscription_data['request'].id,
-              'user_id': subscription_data['user'].id}
-    form = app.get(reverse('subscribe-form', kwargs=kwargs)).forms['subscribe-form']
-    form['email_subscribed'] = True
-    form['request_update_sub'] = True
+    app.set_user(subscription_data["user"])
+    kwargs = {
+        "content_type_id": get_content_type_for_model(Request).id,
+        "obj_id": subscription_data["request"].id,
+        "user_id": subscription_data["user"].id,
+    }
+    form = app.get(reverse("subscribe-form", kwargs=kwargs)).forms["subscribe-form"]
+    form["email_subscribed"] = True
+    form["request_update_sub"] = True
     resp = form.submit()
 
-    assert resp.url == reverse('request-detail', kwargs={'pk': subscription_data['request'].id})
+    assert resp.url == reverse("request-detail", kwargs={"pk": subscription_data["request"].id})
     assert Subscription.objects.count() == 1
 
     assert len(mail.outbox) == 1
 
     staff_user = UserFactory(is_staff=True)
     app.set_user(staff_user)
-    request = subscription_data['request']
-    form = app.get(reverse("request-update", args=[request.pk])).forms['request-form']
-    form['title'] = "Updated title"
-    form['description'] = "Updated description"
+    request = subscription_data["request"]
+    form = app.get(reverse("request-update", args=[request.pk])).forms["request-form"]
+    form["title"] = "Updated title"
+    form["description"] = "Updated description"
     resp = form.submit()
     request.refresh_from_db()
     assert resp.status_code == 302
@@ -199,89 +211,100 @@ def test_request_update_subscription_email(app: DjangoTestApp, subscription_data
 
 @pytest.mark.django_db
 def test_dataset_subscribe_without_user(app: DjangoTestApp, subscription_data):
-    resp = app.get(subscription_data['dataset'].get_absolute_url()).follow()
+    resp = app.get(subscription_data["dataset"].get_absolute_url()).follow()
     assert Subscription.objects.count() == 0
 
-    elem = resp.html.find(id='number-of-subscribers')
-    assert elem.get_text().strip() == '0'
+    elem = resp.html.find(id="number-of-subscribers")
+    assert elem.get_text().strip() == "0"
 
 
 @pytest.mark.django_db
 def test_dataset_subscribe_url_no_login(app: DjangoTestApp, subscription_data):
-    resp = app.get(subscription_data['dataset'].get_absolute_url()).follow()
-    elem = resp.html.find(id='dataset_subscription')
-    form_url = elem.find('a', {'id': 'subscribe-form'})
+    resp = app.get(subscription_data["dataset"].get_absolute_url()).follow()
+    elem = resp.html.find(id="dataset_subscription")
+    form_url = elem.find("a", {"id": "subscribe-form"})
     assert form_url is None
 
 
 @pytest.mark.django_db
 def test_dataset_subscribe_form_no_login(app: DjangoTestApp, subscription_data):
-    response = app.get(reverse('subscribe-form', kwargs={'content_type_id': get_content_type_for_model(Dataset).id,
-                                                         'obj_id': subscription_data['dataset'].id,
-                                                         'user_id': subscription_data['user'].id}))
+    response = app.get(
+        reverse(
+            "subscribe-form",
+            kwargs={
+                "content_type_id": get_content_type_for_model(Dataset).id,
+                "obj_id": subscription_data["dataset"].id,
+                "user_id": subscription_data["user"].id,
+            },
+        )
+    )
     assert settings.LOGIN_URL in response.location
 
 
 @pytest.mark.django_db
 def test_dataset_subscribe_form_with_user(app: DjangoTestApp, subscription_data):
-    app.set_user(subscription_data['user'])
-    kwargs = {'content_type_id': get_content_type_for_model(Dataset).id,
-              'obj_id': subscription_data['dataset'].id,
-              'user_id': subscription_data['user'].id}
-    form = app.get(reverse('subscribe-form', kwargs=kwargs)).forms['subscribe-form']
-    form['email_subscribed'] = True
-    form['dataset_update_sub'] = True
+    app.set_user(subscription_data["user"])
+    kwargs = {
+        "content_type_id": get_content_type_for_model(Dataset).id,
+        "obj_id": subscription_data["dataset"].id,
+        "user_id": subscription_data["user"].id,
+    }
+    form = app.get(reverse("subscribe-form", kwargs=kwargs)).forms["subscribe-form"]
+    form["email_subscribed"] = True
+    form["dataset_update_sub"] = True
     resp = form.submit()
 
-    assert resp.url == reverse('dataset-detail', kwargs={'pk': subscription_data['dataset'].id})
+    assert resp.url == reverse("dataset-detail", kwargs={"pk": subscription_data["dataset"].id})
     assert Subscription.objects.count() == 1
 
     assert len(mail.outbox) == 1
 
-    resp = app.get(subscription_data['dataset'].get_absolute_url()).follow()
+    resp = app.get(subscription_data["dataset"].get_absolute_url()).follow()
 
-    elem = resp.html.find(id='number-of-subscribers')
-    assert elem.get_text().strip() == '1'
+    elem = resp.html.find(id="number-of-subscribers")
+    assert elem.get_text().strip() == "1"
 
-    elem = resp.html.find(id='dataset_subscription')
-    attr = elem.find('input', {'type': 'submit'}).attrs['value']
+    elem = resp.html.find(id="dataset_subscription")
+    attr = elem.find("input", {"type": "submit"}).attrs["value"]
     assert attr == "Atsisakyti prenumeratos"
 
-    resp.forms['unsubscribe-form'].submit()
-    resp = app.get(subscription_data['dataset'].get_absolute_url()).follow()
+    resp.forms["unsubscribe-form"].submit()
+    resp = app.get(subscription_data["dataset"].get_absolute_url()).follow()
     assert Subscription.objects.count() == 0
 
     assert len(mail.outbox) == 2
 
-    elem = resp.html.find(id='number-of-subscribers')
-    assert elem.get_text().strip() == '0'
+    elem = resp.html.find(id="number-of-subscribers")
+    assert elem.get_text().strip() == "0"
 
 
 @pytest.mark.django_db
 def test_dataset_comment_subscription_email(app: DjangoTestApp, subscription_data):
-    app.set_user(subscription_data['user'])
-    kwargs = {'content_type_id': get_content_type_for_model(Dataset).id,
-              'obj_id': subscription_data['dataset'].id,
-              'user_id': subscription_data['user'].id}
-    form = app.get(reverse('subscribe-form', kwargs=kwargs)).forms['subscribe-form']
-    form['email_subscribed'] = True
-    form['dataset_update_sub'] = True
-    form['dataset_comments_sub'] = True
+    app.set_user(subscription_data["user"])
+    kwargs = {
+        "content_type_id": get_content_type_for_model(Dataset).id,
+        "obj_id": subscription_data["dataset"].id,
+        "user_id": subscription_data["user"].id,
+    }
+    form = app.get(reverse("subscribe-form", kwargs=kwargs)).forms["subscribe-form"]
+    form["email_subscribed"] = True
+    form["dataset_update_sub"] = True
+    form["dataset_comments_sub"] = True
     resp = form.submit()
 
-    assert resp.url == reverse('dataset-detail', kwargs={'pk': subscription_data['dataset'].id})
+    assert resp.url == reverse("dataset-detail", kwargs={"pk": subscription_data["dataset"].id})
     assert Subscription.objects.count() == 1
 
     assert len(mail.outbox) == 1
 
     comment_user = UserFactory()
     app.set_user(comment_user)
-    ct = ContentType.objects.get_for_model(subscription_data['dataset'])
-    form = app.get(subscription_data['dataset'].get_absolute_url()).follow().forms['comment-form']
-    form['is_public'] = True
-    form['body'] = "Test comment"
+    ct = ContentType.objects.get_for_model(subscription_data["dataset"])
+    form = app.get(subscription_data["dataset"].get_absolute_url()).follow().forms["comment-form"]
+    form["is_public"] = True
+    form["body"] = "Test comment"
     form.submit()
-    created_comment = Comment.objects.filter(content_type=ct, object_id=subscription_data['dataset'].pk)
+    created_comment = Comment.objects.filter(content_type=ct, object_id=subscription_data["dataset"].pk)
     assert created_comment.count() == 1
     assert Subscription.objects.count() == 2
     assert len(mail.outbox) == 2
@@ -289,27 +312,29 @@ def test_dataset_comment_subscription_email(app: DjangoTestApp, subscription_dat
 
 @pytest.mark.django_db
 def test_dataset_update_subscription_email(app: DjangoTestApp, subscription_data):
-    app.set_user(subscription_data['user'])
-    kwargs = {'content_type_id': get_content_type_for_model(Dataset).id,
-              'obj_id': subscription_data['dataset'].id,
-              'user_id': subscription_data['user'].id}
-    form = app.get(reverse('subscribe-form', kwargs=kwargs)).forms['subscribe-form']
-    form['email_subscribed'] = True
-    form['dataset_update_sub'] = True
+    app.set_user(subscription_data["user"])
+    kwargs = {
+        "content_type_id": get_content_type_for_model(Dataset).id,
+        "obj_id": subscription_data["dataset"].id,
+        "user_id": subscription_data["user"].id,
+    }
+    form = app.get(reverse("subscribe-form", kwargs=kwargs)).forms["subscribe-form"]
+    form["email_subscribed"] = True
+    form["dataset_update_sub"] = True
     resp = form.submit()
 
-    assert resp.url == reverse('dataset-detail', kwargs={'pk': subscription_data['dataset'].id})
+    assert resp.url == reverse("dataset-detail", kwargs={"pk": subscription_data["dataset"].id})
     assert Subscription.objects.count() == 1
 
     assert len(mail.outbox) == 1
 
-    dataset = subscription_data['dataset']
+    dataset = subscription_data["dataset"]
     representative = ViispRepresentativeFactory(content_object=dataset.organization)
     user = representative.user
     app.set_user(user)
-    form = app.get(reverse("dataset-change", args=[dataset.pk])).forms['dataset-form']
-    form['title'] = "Updated title"
-    form['description'] = "Updated description"
+    form = app.get(reverse("dataset-change", args=[dataset.pk])).forms["dataset-form"]
+    form["title"] = "Updated title"
+    form["description"] = "Updated description"
     resp = form.submit()
     dataset.refresh_from_db()
     assert resp.status_code == 302
@@ -319,24 +344,24 @@ def test_dataset_update_subscription_email(app: DjangoTestApp, subscription_data
 
 @pytest.mark.django_db
 def test_dataset_update_global_org_subscription_email(app: DjangoTestApp, subscription_data):
-    global_sub_user = subscription_data['user']
+    global_sub_user = subscription_data["user"]
     app.set_user(global_sub_user)
     Subscription.objects.create(
         user=global_sub_user,
         content_type=ContentType.objects.get_for_model(Organization),
         sub_type=Subscription.ORGANIZATION,
         dataset_update_sub=True,
-        email_subscribed=True
+        email_subscribed=True,
     )
     assert Subscription.objects.count() == 1
 
-    dataset = subscription_data['dataset']
+    dataset = subscription_data["dataset"]
     representative = ViispRepresentativeFactory(content_object=dataset.organization)
     user = representative.user
     app.set_user(user)
-    form = app.get(reverse("dataset-change", args=[dataset.pk])).forms['dataset-form']
-    form['title'] = "Updated title"
-    form['description'] = "Updated description"
+    form = app.get(reverse("dataset-change", args=[dataset.pk])).forms["dataset-form"]
+    form["title"] = "Updated title"
+    form["description"] = "Updated description"
     resp = form.submit()
     dataset.refresh_from_db()
     assert resp.status_code == 302
@@ -346,89 +371,100 @@ def test_dataset_update_global_org_subscription_email(app: DjangoTestApp, subscr
 
 @pytest.mark.django_db
 def test_project_subscribe_without_user(app: DjangoTestApp, subscription_data):
-    resp = app.get(subscription_data['project'].get_absolute_url())
+    resp = app.get(subscription_data["project"].get_absolute_url())
     assert Subscription.objects.count() == 0
 
-    elem = resp.html.find(id='number-of-subscribers')
-    assert elem.get_text().strip() == '0'
+    elem = resp.html.find(id="number-of-subscribers")
+    assert elem.get_text().strip() == "0"
 
 
 @pytest.mark.django_db
 def test_project_subscribe_url_no_login(app: DjangoTestApp, subscription_data):
-    resp = app.get(subscription_data['project'].get_absolute_url())
-    elem = resp.html.find(id='project_subscription')
-    form_url = elem.find('a', {'id': 'subscribe-form'})
+    resp = app.get(subscription_data["project"].get_absolute_url())
+    elem = resp.html.find(id="project_subscription")
+    form_url = elem.find("a", {"id": "subscribe-form"})
     assert form_url is None
 
 
 @pytest.mark.django_db
 def test_project_subscribe_form_no_login(app: DjangoTestApp, subscription_data):
-    response = app.get(reverse('subscribe-form', kwargs={'content_type_id': get_content_type_for_model(Project).id,
-                                                         'obj_id': subscription_data['project'].id,
-                                                         'user_id': subscription_data['user'].id}))
+    response = app.get(
+        reverse(
+            "subscribe-form",
+            kwargs={
+                "content_type_id": get_content_type_for_model(Project).id,
+                "obj_id": subscription_data["project"].id,
+                "user_id": subscription_data["user"].id,
+            },
+        )
+    )
     assert settings.LOGIN_URL in response.location
 
 
 @pytest.mark.django_db
 def test_project_subscribe_form_with_user(app: DjangoTestApp, subscription_data):
-    app.set_user(subscription_data['user'])
-    kwargs = {'content_type_id': get_content_type_for_model(Project).id,
-              'obj_id': subscription_data['project'].id,
-              'user_id': subscription_data['user'].id}
-    form = app.get(reverse('subscribe-form', kwargs=kwargs)).forms['subscribe-form']
-    form['email_subscribed'] = True
-    form['project_update_sub'] = True
+    app.set_user(subscription_data["user"])
+    kwargs = {
+        "content_type_id": get_content_type_for_model(Project).id,
+        "obj_id": subscription_data["project"].id,
+        "user_id": subscription_data["user"].id,
+    }
+    form = app.get(reverse("subscribe-form", kwargs=kwargs)).forms["subscribe-form"]
+    form["email_subscribed"] = True
+    form["project_update_sub"] = True
     resp = form.submit()
 
-    assert resp.url == reverse('project-detail', kwargs={'pk': subscription_data['project'].id})
+    assert resp.url == reverse("project-detail", kwargs={"pk": subscription_data["project"].id})
     assert Subscription.objects.count() == 1
 
     assert len(mail.outbox) == 1
 
-    resp = app.get(subscription_data['project'].get_absolute_url())
+    resp = app.get(subscription_data["project"].get_absolute_url())
 
-    elem = resp.html.find(id='number-of-subscribers')
-    assert elem.get_text().strip() == '1'
+    elem = resp.html.find(id="number-of-subscribers")
+    assert elem.get_text().strip() == "1"
 
-    elem = resp.html.find(id='project_subscription')
-    attr = elem.find('input', {'type': 'submit'}).attrs['value']
+    elem = resp.html.find(id="project_subscription")
+    attr = elem.find("input", {"type": "submit"}).attrs["value"]
     assert attr == "Atsisakyti prenumeratos"
 
-    resp.forms['unsubscribe-form'].submit()
-    resp = app.get(subscription_data['project'].get_absolute_url())
+    resp.forms["unsubscribe-form"].submit()
+    resp = app.get(subscription_data["project"].get_absolute_url())
     assert Subscription.objects.count() == 0
 
     assert len(mail.outbox) == 2
 
-    elem = resp.html.find(id='number-of-subscribers')
-    assert elem.get_text().strip() == '0'
+    elem = resp.html.find(id="number-of-subscribers")
+    assert elem.get_text().strip() == "0"
 
 
 @pytest.mark.django_db
 def test_project_comment_subscription_email(app: DjangoTestApp, subscription_data):
-    app.set_user(subscription_data['user'])
-    kwargs = {'content_type_id': get_content_type_for_model(Project).id,
-              'obj_id': subscription_data['project'].id,
-              'user_id': subscription_data['user'].id}
-    form = app.get(reverse('subscribe-form', kwargs=kwargs)).forms['subscribe-form']
-    form['email_subscribed'] = True
-    form['project_update_sub'] = True
-    form['project_comments_sub'] = True
+    app.set_user(subscription_data["user"])
+    kwargs = {
+        "content_type_id": get_content_type_for_model(Project).id,
+        "obj_id": subscription_data["project"].id,
+        "user_id": subscription_data["user"].id,
+    }
+    form = app.get(reverse("subscribe-form", kwargs=kwargs)).forms["subscribe-form"]
+    form["email_subscribed"] = True
+    form["project_update_sub"] = True
+    form["project_comments_sub"] = True
     resp = form.submit()
 
-    assert resp.url == reverse('project-detail', kwargs={'pk': subscription_data['project'].id})
+    assert resp.url == reverse("project-detail", kwargs={"pk": subscription_data["project"].id})
     assert Subscription.objects.count() == 1
 
     assert len(mail.outbox) == 1
 
     comment_user = UserFactory()
     app.set_user(comment_user)
-    ct = ContentType.objects.get_for_model(subscription_data['project'])
-    form = app.get(subscription_data['project'].get_absolute_url()).forms['comment-form']
-    form['is_public'] = True
-    form['body'] = "Test comment"
+    ct = ContentType.objects.get_for_model(subscription_data["project"])
+    form = app.get(subscription_data["project"].get_absolute_url()).forms["comment-form"]
+    form["is_public"] = True
+    form["body"] = "Test comment"
     form.submit()
-    created_comment = Comment.objects.filter(content_type=ct, object_id=subscription_data['project'].pk)
+    created_comment = Comment.objects.filter(content_type=ct, object_id=subscription_data["project"].pk)
     assert created_comment.count() == 1
     assert Subscription.objects.count() == 2
     assert len(mail.outbox) == 2
@@ -436,27 +472,29 @@ def test_project_comment_subscription_email(app: DjangoTestApp, subscription_dat
 
 @pytest.mark.django_db
 def test_project_update_subscription_email(app: DjangoTestApp, subscription_data):
-    app.set_user(subscription_data['user'])
-    kwargs = {'content_type_id': get_content_type_for_model(Project).id,
-              'obj_id': subscription_data['project'].id,
-              'user_id': subscription_data['user'].id}
-    form = app.get(reverse('subscribe-form', kwargs=kwargs)).forms['subscribe-form']
-    form['email_subscribed'] = True
-    form['project_update_sub'] = True
+    app.set_user(subscription_data["user"])
+    kwargs = {
+        "content_type_id": get_content_type_for_model(Project).id,
+        "obj_id": subscription_data["project"].id,
+        "user_id": subscription_data["user"].id,
+    }
+    form = app.get(reverse("subscribe-form", kwargs=kwargs)).forms["subscribe-form"]
+    form["email_subscribed"] = True
+    form["project_update_sub"] = True
     resp = form.submit()
 
-    assert resp.url == reverse('project-detail', kwargs={'pk': subscription_data['project'].id})
+    assert resp.url == reverse("project-detail", kwargs={"pk": subscription_data["project"].id})
     assert Subscription.objects.count() == 1
 
     assert len(mail.outbox) == 1
 
     staff_user = UserFactory(is_staff=True)
     app.set_user(staff_user)
-    project = subscription_data['project']
+    project = subscription_data["project"]
 
-    form = app.get(reverse("project-update", args=[project.pk])).forms['project-form']
-    form['title'] = "Updated title"
-    form['description'] = "Updated description"
+    form = app.get(reverse("project-update", args=[project.pk])).forms["project-form"]
+    form["title"] = "Updated title"
+    form["description"] = "Updated description"
     resp = form.submit()
 
     project.refresh_from_db()
@@ -467,13 +505,13 @@ def test_project_update_subscription_email(app: DjangoTestApp, subscription_data
 
 @pytest.mark.django_db
 def test_auto_subscribe_for_comment_and_reply_mail(app: DjangoTestApp, subscription_data):
-    app.set_user(subscription_data['user'])
-    ct = ContentType.objects.get_for_model(subscription_data['dataset'])
-    form = app.get(subscription_data['dataset'].get_absolute_url()).follow().forms['comment-form']
-    form['is_public'] = True
-    form['body'] = "Test comment"
+    app.set_user(subscription_data["user"])
+    ct = ContentType.objects.get_for_model(subscription_data["dataset"])
+    form = app.get(subscription_data["dataset"].get_absolute_url()).follow().forms["comment-form"]
+    form["is_public"] = True
+    form["body"] = "Test comment"
     form.submit()
-    created_comment = Comment.objects.filter(content_type=ct, object_id=subscription_data['dataset'].pk)
+    created_comment = Comment.objects.filter(content_type=ct, object_id=subscription_data["dataset"].pk)
     assert created_comment.count() == 1
     assert Subscription.objects.count() == 1
     assert len(mail.outbox) == 0
@@ -481,55 +519,59 @@ def test_auto_subscribe_for_comment_and_reply_mail(app: DjangoTestApp, subscript
     reply_user = UserFactory()
     comment = created_comment.first()
     app.set_user(reply_user)
-    form = app.get(comment.content_object.get_absolute_url()).follow().forms[f'reply-form-{comment.pk}']
-    form['is_public'] = True
-    form['body'] = "Test reply"
+    form = app.get(comment.content_object.get_absolute_url()).follow().forms[f"reply-form-{comment.pk}"]
+    form["is_public"] = True
+    form["body"] = "Test reply"
     resp = form.submit().follow().follow()
     comments = Comment.objects.filter(content_type=comment.content_type, object_id=comment.object_id)
     reply = Comment.objects.filter(content_type=comment.content_type, parent=comment).first()
     assert comments.count() == 2
-    assert comment in list(resp.context['comments'])[0]
-    assert reply in list(resp.context['comments'])[1]
+    assert comment in list(resp.context["comments"])[0]
+    assert reply in list(resp.context["comments"])[1]
     assert len(mail.outbox) == 1
 
 
 @pytest.mark.django_db
 def test_dataset_and_org_sub_mail(app: DjangoTestApp, subscription_data):
-    app.set_user(subscription_data['user'])
-    kwargs = {'content_type_id': get_content_type_for_model(Organization).id,
-              'obj_id': subscription_data['dataset'].organization.id,
-              'user_id': subscription_data['user'].id}
-    form = app.get(reverse('subscribe-form', kwargs=kwargs)).forms['subscribe-form']
-    form['email_subscribed'] = True
-    form['dataset_update_sub'] = True
-    form['dataset_comments_sub'] = True
+    app.set_user(subscription_data["user"])
+    kwargs = {
+        "content_type_id": get_content_type_for_model(Organization).id,
+        "obj_id": subscription_data["dataset"].organization.id,
+        "user_id": subscription_data["user"].id,
+    }
+    form = app.get(reverse("subscribe-form", kwargs=kwargs)).forms["subscribe-form"]
+    form["email_subscribed"] = True
+    form["dataset_update_sub"] = True
+    form["dataset_comments_sub"] = True
     resp = form.submit()
 
-    assert resp.url == reverse('organization-detail', kwargs={'pk': subscription_data['dataset'].organization.id})
+    assert resp.url == reverse("organization-detail", kwargs={"pk": subscription_data["dataset"].organization.id})
     assert Subscription.objects.count() == 1
     assert len(mail.outbox) == 1
 
-    kwargs = {'content_type_id': get_content_type_for_model(Dataset).id,
-              'obj_id': subscription_data['dataset'].id,
-              'user_id': subscription_data['user'].id}
-    form = app.get(reverse('subscribe-form', kwargs=kwargs)).forms['subscribe-form']
-    form['email_subscribed'] = True
-    form['dataset_update_sub'] = True
-    form['dataset_comments_sub'] = True
+    kwargs = {
+        "content_type_id": get_content_type_for_model(Dataset).id,
+        "obj_id": subscription_data["dataset"].id,
+        "user_id": subscription_data["user"].id,
+    }
+    form = app.get(reverse("subscribe-form", kwargs=kwargs)).forms["subscribe-form"]
+    form["email_subscribed"] = True
+    form["dataset_update_sub"] = True
+    form["dataset_comments_sub"] = True
     resp = form.submit()
 
-    assert resp.url == reverse('dataset-detail', kwargs={'pk': subscription_data['dataset'].id})
+    assert resp.url == reverse("dataset-detail", kwargs={"pk": subscription_data["dataset"].id})
     assert Subscription.objects.count() == 2
     assert len(mail.outbox) == 2
 
-    dataset = subscription_data['dataset']
+    dataset = subscription_data["dataset"]
     representative = ViispRepresentativeFactory(content_object=dataset.organization)
     user = representative.user
     app.set_user(user)
 
-    form = app.get(reverse("dataset-change", args=[dataset.pk])).forms['dataset-form']
-    form['title'] = "Updated title"
-    form['description'] = "Updated description"
+    form = app.get(reverse("dataset-change", args=[dataset.pk])).forms["dataset-form"]
+    form["title"] = "Updated title"
+    form["description"] = "Updated description"
     resp = form.submit()
 
     dataset.refresh_from_db()
@@ -544,18 +586,18 @@ def test_subscribe_with_non_public_dataset_without_access(app: DjangoTestApp):
     user = UserFactory()
     app.set_user(user)
     ct = ContentType.objects.get_for_model(dataset)
-    response = app.get(reverse('subscribe-form', args=[ct.pk, dataset.pk, user.pk]), expect_errors=True)
+    response = app.get(reverse("subscribe-form", args=[ct.pk, dataset.pk, user.pk]), expect_errors=True)
     assert response.status_code == 403
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-        "role",
-        [
-            Representative.OPEN_DATA_MANAGER,
-            Representative.RESOURCE_MANAGER,
-        ],
-    )
+    "role",
+    [
+        Representative.OPEN_DATA_MANAGER,
+        Representative.RESOURCE_MANAGER,
+    ],
+)
 def test_subscribe_with_non_public_dataset_with_access(app: DjangoTestApp, role: str):
     dataset = DatasetFactory(is_public=False)
     ct = ContentType.objects.get_for_model(dataset)
@@ -567,7 +609,7 @@ def test_subscribe_with_non_public_dataset_with_access(app: DjangoTestApp, role:
         role=role,
     )
     app.set_user(user)
-    response = app.get(reverse('subscribe-form', args=[ct.pk, dataset.pk, user.pk]))
+    response = app.get(reverse("subscribe-form", args=[ct.pk, dataset.pk, user.pk]))
     assert response.status_code == 200
 
 
@@ -577,30 +619,27 @@ def test_unsubscribe_with_non_public_dataset_without_access(app: DjangoTestApp):
     user = UserFactory()
     app.set_user(user)
     ct = ContentType.objects.get_for_model(dataset)
-    response = app.post(reverse('unsubscribe', args=[ct.pk, dataset.pk, user.pk]), expect_errors=True)
+    response = app.post(reverse("unsubscribe", args=[ct.pk, dataset.pk, user.pk]), expect_errors=True)
     assert response.status_code == 403
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-        "role",
-        [
-            Representative.OPEN_DATA_MANAGER,
-            Representative.RESOURCE_MANAGER,
-        ],
-    )
+    "role",
+    [
+        Representative.OPEN_DATA_MANAGER,
+        Representative.RESOURCE_MANAGER,
+    ],
+)
 def test_unsubscribe_with_non_public_dataset_with_access(app: DjangoTestApp, role: str):
     dataset = DatasetFactory(is_public=False)
     ct = ContentType.objects.get_for_model(dataset)
     user = UserFactory()
     RepresentativeFactory(
-        content_type=ContentType.objects.get_for_model(dataset),
-        object_id=dataset.pk,
-        user=user,
-        role=role
+        content_type=ContentType.objects.get_for_model(dataset), object_id=dataset.pk, user=user, role=role
     )
     app.set_user(user)
-    response = app.post(reverse('unsubscribe', args=[ct.pk, dataset.pk, user.pk]))
+    response = app.post(reverse("unsubscribe", args=[ct.pk, dataset.pk, user.pk]))
     assert response.status_code == 302
 
 
@@ -610,7 +649,7 @@ def test_subscribe_with_not_approved_project_without_access(app: DjangoTestApp):
     user = UserFactory()
     app.set_user(user)
     ct = ContentType.objects.get_for_model(project)
-    response = app.get(reverse('subscribe-form', args=[ct.pk, project.pk, user.pk]), expect_errors=True)
+    response = app.get(reverse("subscribe-form", args=[ct.pk, project.pk, user.pk]), expect_errors=True)
     assert response.status_code == 403
 
 
@@ -620,7 +659,7 @@ def test_subscribe_with_not_approved_project_with_access(app: DjangoTestApp):
     project = ProjectFactory(status=Project.CREATED, user=user)
     ct = ContentType.objects.get_for_model(project)
     app.set_user(user)
-    response = app.get(reverse('subscribe-form', args=[ct.pk, project.pk, user.pk]))
+    response = app.get(reverse("subscribe-form", args=[ct.pk, project.pk, user.pk]))
     assert response.status_code == 200
 
 
@@ -630,7 +669,7 @@ def test_unsubscribe_with_not_approved_project_without_access(app: DjangoTestApp
     user = UserFactory()
     app.set_user(user)
     ct = ContentType.objects.get_for_model(project)
-    response = app.post(reverse('unsubscribe', args=[ct.pk, project.pk, user.pk]), expect_errors=True)
+    response = app.post(reverse("unsubscribe", args=[ct.pk, project.pk, user.pk]), expect_errors=True)
     assert response.status_code == 403
 
 
@@ -640,7 +679,7 @@ def test_unsubscribe_with_not_approved_project_with_access(app: DjangoTestApp):
     project = ProjectFactory(status=Project.CREATED, user=user)
     ct = ContentType.objects.get_for_model(project)
     app.set_user(user)
-    response = app.post(reverse('unsubscribe', args=[ct.pk, project.pk, user.pk]))
+    response = app.post(reverse("unsubscribe", args=[ct.pk, project.pk, user.pk]))
     assert response.status_code == 302
 
 
@@ -652,44 +691,38 @@ def client():
 @pytest.mark.django_db
 class TestNewsletterSubscribeView:
     def test_subscribe_new_email_success(self, client):
-        response = client.post(reverse('newsletter-subscribe'), {
-            'email': 'newuser@example.com'
-        })
+        response = client.post(reverse("newsletter-subscribe"), {"email": "newuser@example.com"})
 
         assert response.status_code == 302
 
-        subscriber = NewsletterSubscriber.objects.get(email='newuser@example.com')
+        subscriber = NewsletterSubscriber.objects.get(email="newuser@example.com")
         assert subscriber.status == NewsletterSubscriber.PENDING
         assert subscriber.confirmation_token is not None
 
         # Should send confirmation email
         assert len(mail.outbox) == 1
-        assert mail.outbox[0].to == ['newuser@example.com']
-        assert 'naujienlaiškio prenumeratos patvirtinimas' in mail.outbox[0].subject.lower()
+        assert mail.outbox[0].to == ["newuser@example.com"]
+        assert "naujienlaiškio prenumeratos patvirtinimas" in mail.outbox[0].subject.lower()
 
     def test_subscribe_already_confirmed_email(self, client):
         NewsletterSubscriber.objects.create(
-            email='existing@example.com',
+            email="existing@example.com",
             status=NewsletterSubscriber.SUBSCRIBED,
         )
 
-        response = client.post(reverse('newsletter-subscribe'), {
-            'email': 'existing@example.com'
-        })
+        response = client.post(reverse("newsletter-subscribe"), {"email": "existing@example.com"})
 
         assert response.status_code == 302
 
         # Should not create new subscriber
-        subscribers = NewsletterSubscriber.objects.filter(email='existing@example.com')
+        subscribers = NewsletterSubscriber.objects.filter(email="existing@example.com")
         assert subscribers.count() == 1
 
         # Should not send email
         assert len(mail.outbox) == 0
 
     def test_subscribe_empty_email(self, client):
-        response = client.post(reverse('newsletter-subscribe'), {
-            'email': ''
-        })
+        response = client.post(reverse("newsletter-subscribe"), {"email": ""})
 
         assert response.status_code == 302
 
@@ -700,9 +733,7 @@ class TestNewsletterSubscribeView:
         assert len(mail.outbox) == 0
 
     def test_subscribe_invalid_email_format(self, client):
-        response = client.post(reverse('newsletter-subscribe'), {
-            'email': 'invalid-email'
-        })
+        response = client.post(reverse("newsletter-subscribe"), {"email": "invalid-email"})
 
         # HTML validation should prevent this.
         assert response.status_code == 302
@@ -713,16 +744,12 @@ class TestNewsletterConfirmView:
     def test_confirm_expired_token(self, client):
         past_time = timezone.now() - timedelta(hours=25)
         subscriber = NewsletterSubscriber.objects.create(
-            email='expired@example.com',
+            email="expired@example.com",
         )
         subscriber.initiate_subscription()
-        NewsletterSubscriber.objects.filter(pk=subscriber.pk).update(
-            confirmation_expires_at=past_time
-        )
+        NewsletterSubscriber.objects.filter(pk=subscriber.pk).update(confirmation_expires_at=past_time)
 
-        response = client.get(reverse('newsletter-confirm', kwargs={
-            'token': subscriber.confirmation_token
-        }))
+        response = client.get(reverse("newsletter-confirm", kwargs={"token": subscriber.confirmation_token}))
 
         assert response.status_code == 302
 
@@ -731,31 +758,25 @@ class TestNewsletterConfirmView:
         assert subscriber.status == NewsletterSubscriber.PENDING
 
     def test_resubmit_pending_does_not_duplicate(self, client):
-        email = 'pending@example.com'
-        client.post(reverse('newsletter-subscribe'), {'email': email})
-        client.post(reverse('newsletter-subscribe'), {'email': email})
+        email = "pending@example.com"
+        client.post(reverse("newsletter-subscribe"), {"email": email})
+        client.post(reverse("newsletter-subscribe"), {"email": email})
         assert NewsletterSubscriber.objects.filter(email=email).count() == 1
 
     def test_confirm_nonexistent_token(self, client):
         fake_token = uuid.uuid4()
 
-        response = client.get(reverse('newsletter-confirm', kwargs={
-            'token': fake_token
-        }))
+        response = client.get(reverse("newsletter-confirm", kwargs={"token": fake_token}))
 
         assert response.status_code == 302  # Redirect
 
     def test_confirm_already_confirmed_token(self, client):
         NewsletterSubscriber.objects.create(
-            email='already@example.com',
-            status=NewsletterSubscriber.SUBSCRIBED,
-            confirmation_token=None
+            email="already@example.com", status=NewsletterSubscriber.SUBSCRIBED, confirmation_token=None
         )
 
         fake_token = uuid.uuid4()
-        response = client.get(reverse('newsletter-confirm', kwargs={
-            'token': fake_token
-        }))
+        response = client.get(reverse("newsletter-confirm", kwargs={"token": fake_token}))
 
         assert response.status_code == 302  # Should redirect
 
@@ -764,30 +785,33 @@ class TestNewsletterConfirmView:
 class TestNewsletterUnsubscribeView:
     def test_unsubscribe_get_shows_confirmation_page(self, client):
         subscriber = NewsletterSubscriber.objects.create(
-            email='unsubscribe@example.com',
+            email="unsubscribe@example.com",
             status=NewsletterSubscriber.SUBSCRIBED,
         )
 
-        response = client.get(reverse('newsletter-unsubscribe', kwargs={
-            'token': subscriber.unsubscribe_token,
-        }))
+        response = client.get(
+            reverse(
+                "newsletter-unsubscribe",
+                kwargs={
+                    "token": subscriber.unsubscribe_token,
+                },
+            )
+        )
 
         assert response.status_code == 200
-        assert 'newsletter/unsubscribe_confirm.html' in [t.name for t in response.templates]
+        assert "newsletter/unsubscribe_confirm.html" in [t.name for t in response.templates]
         assert subscriber.email in response.content.decode()
 
     def test_unsubscribe_post_deactivates_subscription(self, client):
         subscriber = NewsletterSubscriber.objects.create(
-            email='unsubscribe@example.com',
+            email="unsubscribe@example.com",
             status=NewsletterSubscriber.SUBSCRIBED,
         )
 
-        response = client.post(reverse('newsletter-unsubscribe', kwargs={
-            'token': subscriber.unsubscribe_token
-        }))
+        response = client.post(reverse("newsletter-unsubscribe", kwargs={"token": subscriber.unsubscribe_token}))
 
         assert response.status_code == 200
-        assert 'newsletter/unsubscribed.html' in [t.name for t in response.templates]
+        assert "newsletter/unsubscribed.html" in [t.name for t in response.templates]
 
         subscriber.refresh_from_db()
         assert subscriber.status == NewsletterSubscriber.UNSUBSCRIBED
@@ -795,21 +819,17 @@ class TestNewsletterUnsubscribeView:
     def test_unsubscribe_invalid_token(self, client):
         fake_token = uuid.uuid4()
 
-        response = client.get(reverse('newsletter-unsubscribe', kwargs={
-            'token': fake_token
-        }))
+        response = client.get(reverse("newsletter-unsubscribe", kwargs={"token": fake_token}))
 
         assert response.status_code == 404
 
     def test_unsubscribe_inactive_subscription(self, client):
         subscriber = NewsletterSubscriber.objects.create(
-            email='inactive@example.com',
+            email="inactive@example.com",
             status=NewsletterSubscriber.UNSUBSCRIBED,
         )
 
-        response = client.get(reverse('newsletter-unsubscribe', kwargs={
-            'token': subscriber.unsubscribe_token
-        }))
+        response = client.get(reverse("newsletter-unsubscribe", kwargs={"token": subscriber.unsubscribe_token}))
 
         assert response.status_code == 404
 
@@ -818,42 +838,38 @@ class TestNewsletterUnsubscribeView:
 class TestNewsletterWorkflow:
     def test_complete_subscription_workflow(self, client):
         """Test complete workflow: subscribe -> confirm -> unsubscribe"""
-        email = 'workflow@example.com'
+        email = "workflow@example.com"
 
         # Step 1: Subscribe
-        response = client.post(reverse('newsletter-subscribe'), {'email': email})
+        response = client.post(reverse("newsletter-subscribe"), {"email": email})
         assert response.status_code == 302
 
         subscriber = NewsletterSubscriber.objects.get(email=email)
         assert subscriber.status == NewsletterSubscriber.PENDING
 
         # Step 2: Confirm
-        response = client.get(reverse('newsletter-confirm', kwargs={
-            'token': subscriber.confirmation_token
-        }))
+        response = client.get(reverse("newsletter-confirm", kwargs={"token": subscriber.confirmation_token}))
         assert response.status_code == 200
 
         subscriber.refresh_from_db()
         assert subscriber.status == NewsletterSubscriber.SUBSCRIBED
 
         # Step 3: Unsubscribe
-        response = client.post(reverse('newsletter-unsubscribe', kwargs={
-            'token': subscriber.unsubscribe_token
-        }))
+        response = client.post(reverse("newsletter-unsubscribe", kwargs={"token": subscriber.unsubscribe_token}))
         assert response.status_code == 200
 
         subscriber.refresh_from_db()
         assert subscriber.status == NewsletterSubscriber.UNSUBSCRIBED
 
     def test_resubscribe_after_unsubscribe(self, client):
-        email = 'resubscribe@example.com'
+        email = "resubscribe@example.com"
 
         NewsletterSubscriber.objects.create(
             email=email,
             status=NewsletterSubscriber.UNSUBSCRIBED,
         )
 
-        response = client.post(reverse('newsletter-subscribe'), {'email': email})
+        response = client.post(reverse("newsletter-subscribe"), {"email": email})
         assert response.status_code == 302
 
         subscribers = NewsletterSubscriber.objects.filter(email=email)

--- a/tests/oauth/test_oauth.py
+++ b/tests/oauth/test_oauth.py
@@ -16,7 +16,7 @@ from vitrina.api.oauth import (
     IsOAuthTokenValid,
     OAuthTokenHasScopes,
     OAuthTokenHasValidOrganizationClaim,
-    OAuthClientAuthenticator
+    OAuthClientAuthenticator,
 )
 from vitrina.orgs.factories import OrganizationFactory
 from vitrina.uapi.factories import AgentFactory
@@ -33,12 +33,12 @@ def request_factory():
     return APIRequestFactory()
 
 
-
 @pytest.fixture
 def rsa_keypair():
     private = JsonWebKey.generate_key("RSA", 2048, is_private=True)
     public = JsonWebKey.import_key(private.as_dict(is_private=False))
     return private.as_dict(), public.as_dict()
+
 
 @pytest.fixture
 def download_only_oauth_settings(settings):
@@ -68,12 +68,13 @@ def decoded_jwt() -> JWTClaims:
         "sub": "client",
         "scope": "test_scope",
         "iat": int(time.time()),
-        "exp": int(time.time()) + 300
+        "exp": int(time.time()) + 300,
     }
     encoded = jwt.encode({"alg": "HS256"}, claims, key).decode()
     decoded = jwt.decode(encoded, key)
 
     return decoded
+
 
 def test_authentication_with_local_jwk_authenticate_success(request_factory: APIRequestFactory, decoded_jwt: JWTClaims):
     request = request_factory.get("/", HTTP_AUTHORIZATION="Bearer <token>")
@@ -89,23 +90,17 @@ def test_authentication_with_local_jwk_authenticate_success(request_factory: API
     "raised_exception, exception_message",
     [
         [BadSignatureError("Very bad signature"), "bad_signature"],
-        [TokenExpiredError("Very expired token"), "token_expired"]
-    ]
+        [TokenExpiredError("Very expired token"), "token_expired"],
+    ],
 )
 def test_authentication_with_local_jwk_authenticate_exception_raised(
-    raised_exception: Exception,
-    exception_message: str,
-    request_factory: APIRequestFactory
+    raised_exception: Exception, exception_message: str, request_factory: APIRequestFactory
 ):
     request = request_factory.get("/", HTTP_AUTHORIZATION="Bearer <token>")
 
     with (
-        patch.object(
-            OAuthClientAuthenticator,
-            "retrieve_and_verify_token",
-            side_effect=raised_exception
-        ),
-        pytest.raises(AuthenticationFailed) as exc_info
+        patch.object(OAuthClientAuthenticator, "retrieve_and_verify_token", side_effect=raised_exception),
+        pytest.raises(AuthenticationFailed) as exc_info,
     ):
         OAuth2Authentication().authenticate(request)
 
@@ -118,7 +113,7 @@ def test_authentication_with_local_jwk_authenticate_exception_raised(
         None,  # No Authorization header
         "InvalidHeaderWithoutSpace",  # Header causes ValueError when splitting
         "Basic <token>",  # Header not starting with `Bearer`
-    ]
+    ],
 )
 def test_authentication_with_local_jwk_authenticate_no_access_token_in_request(
     auth_header: Optional[str],
@@ -143,7 +138,7 @@ def test_authentication_with_local_jwk_authenticate_token_not_verified(request_f
             "retrieve_and_verify_token",
             return_value=None,
         ),
-        pytest.raises(AuthenticationFailed) as exc_info
+        pytest.raises(AuthenticationFailed) as exc_info,
     ):
         OAuth2Authentication().authenticate(request)
 
@@ -225,9 +220,9 @@ def test_token_has_permissions_view_has_no_scopes(
 @pytest.mark.parametrize(
     "required_scopes, token_scopes, expected_result",
     [
-        ([], "read write", True),           # No required scopes
-        (["admin"], "read write", False),   # Required scope not in token scopes
-        (["read"], "read write", True),     # Required scope in token scopes
+        ([], "read write", True),  # No required scopes
+        (["admin"], "read write", False),  # Required scope not in token scopes
+        (["read"], "read write", True),  # Required scope in token scopes
     ],
 )
 def test_token_has_permissions_invalid_scopes(

--- a/tests/orgs/test_admin.py
+++ b/tests/orgs/test_admin.py
@@ -6,7 +6,6 @@ from django_webtest import DjangoTestApp
 
 from vitrina.datasets.factories import DatasetFactory
 from vitrina.datasets.models import Dataset
-from vitrina.orgs import forms
 from vitrina.orgs.factories import OrganizationFactory
 from vitrina.orgs.models import Organization, Representative
 
@@ -34,14 +33,6 @@ def test_admin_publisher_list_display(app: DjangoTestApp):
     resp = app.get(reverse('admin:vitrina_orgs_publisherorganization_changelist'))
     assert [org.title for org in resp.context['cl'].result_list] == ['title1', 'title2', 'title3']
     assert org.title not in [org.title for org in resp.context['cl'].result_list]
-
-@pytest.mark.django_db
-def test_admin_publisher_update(app: DjangoTestApp):
-    admin = User.objects.create_superuser(email="admin@gmail.com", password="test123")
-    publisher_org = OrganizationFactory(publisher=True)
-    app.set_user(admin)
-    form = app.get(reverse('admin:vitrina_orgs_publisherorganization_change', args=[publisher_org.pk])).forms['publisherorganization_form']
-    assert True
 
 
 @pytest.fixture

--- a/tests/orgs/test_admin.py
+++ b/tests/orgs/test_admin.py
@@ -17,8 +17,8 @@ def test_admin_add_publisher(app: DjangoTestApp):
     admin = User.objects.create_superuser(email="admin@gmail.com", password="test123")
     organization = OrganizationFactory()
     app.set_user(admin)
-    form = app.get(reverse('admin:vitrina_orgs_publisherorganization_add')).forms['publisherorganization_form']
-    form['organization'] = organization.pk
+    form = app.get(reverse("admin:vitrina_orgs_publisherorganization_add")).forms["publisherorganization_form"]
+    form["organization"] = organization.pk
     form.submit()
     assert Organization.objects.filter(publisher=True, pk=organization.pk).exists()
 
@@ -26,21 +26,19 @@ def test_admin_add_publisher(app: DjangoTestApp):
 @pytest.mark.django_db
 def test_admin_publisher_list_display(app: DjangoTestApp):
     admin = User.objects.create_superuser(email="admin@gmail.com", password="test123")
-    org = OrganizationFactory(title = 'title')
-    for title in ['title1', 'title2', 'title3']:
+    org = OrganizationFactory(title="title")
+    for title in ["title1", "title2", "title3"]:
         OrganizationFactory(title=title, publisher=True)
     app.set_user(admin)
-    resp = app.get(reverse('admin:vitrina_orgs_publisherorganization_changelist'))
-    assert [org.title for org in resp.context['cl'].result_list] == ['title1', 'title2', 'title3']
-    assert org.title not in [org.title for org in resp.context['cl'].result_list]
+    resp = app.get(reverse("admin:vitrina_orgs_publisherorganization_changelist"))
+    assert [org.title for org in resp.context["cl"].result_list] == ["title1", "title2", "title3"]
+    assert org.title not in [org.title for org in resp.context["cl"].result_list]
 
 
 @pytest.fixture
 def admin_user():
-    return User.objects.create_superuser(
-        email="admin@gmail.com",
-        password="test123"
-    )
+    return User.objects.create_superuser(email="admin@gmail.com", password="test123")
+
 
 @pytest.fixture
 def publisher_org():
@@ -57,20 +55,17 @@ def test_admin_dataset_assign(app: DjangoTestApp, admin_user: User, publisher_or
     datasets = [DatasetFactory() for _ in range(3)]
 
     app.set_user(admin_user)
-    form = app.get(
-        reverse('admin:vitrina_orgs_publisherorganization_change',
-                args=[publisher_org.pk])
-    ).forms['publisherorganization_form']
+    form = app.get(reverse("admin:vitrina_orgs_publisherorganization_change", args=[publisher_org.pk])).forms[
+        "publisherorganization_form"
+    ]
 
-    form['datasets'] = [str(dataset.id) for dataset in datasets]
+    form["datasets"] = [str(dataset.id) for dataset in datasets]
     response = form.submit()
 
     assert response.status_code == 302
     for dataset in datasets:
         assert Representative.objects.filter(
-            organization=publisher_org,
-            content_type=ContentType.objects.get_for_model(Dataset),
-            object_id=dataset.id
+            organization=publisher_org, content_type=ContentType.objects.get_for_model(Dataset), object_id=dataset.id
         ).exists()
 
 
@@ -80,29 +75,22 @@ def test_admin_dataset_remove(app: DjangoTestApp, admin_user: User, publisher_or
     app.set_user(admin_user)
     for dataset in datasets:
         Representative.objects.create(
-            organization=publisher_org,
-            content_type=ContentType.objects.get_for_model(Dataset),
-            object_id=dataset.id
+            organization=publisher_org, content_type=ContentType.objects.get_for_model(Dataset), object_id=dataset.id
         )
-    form = app.get(
-        reverse('admin:vitrina_orgs_publisherorganization_change',
-                args=[publisher_org.pk])
-    ).forms['publisherorganization_form']
-    form['datasets'] = [str(datasets[0].id), str(datasets[1].id)]
+    form = app.get(reverse("admin:vitrina_orgs_publisherorganization_change", args=[publisher_org.pk])).forms[
+        "publisherorganization_form"
+    ]
+    form["datasets"] = [str(datasets[0].id), str(datasets[1].id)]
     response = form.submit()
     assert response.status_code == 302
 
     assert not Representative.objects.filter(
-        organization=publisher_org,
-        content_type=ContentType.objects.get_for_model(Dataset),
-        object_id=datasets[2].id
+        organization=publisher_org, content_type=ContentType.objects.get_for_model(Dataset), object_id=datasets[2].id
     ).exists()
 
     for dataset in datasets[:2]:
         assert Representative.objects.filter(
-            organization=publisher_org,
-            content_type=ContentType.objects.get_for_model(Dataset),
-            object_id=dataset.id
+            organization=publisher_org, content_type=ContentType.objects.get_for_model(Dataset), object_id=dataset.id
         ).exists()
 
 
@@ -111,20 +99,17 @@ def test_admin_organization_assign(app: DjangoTestApp, admin_user: User, publish
     orgs = [OrganizationFactory() for _ in range(3)]
 
     app.set_user(admin_user)
-    form = app.get(
-        reverse('admin:vitrina_orgs_publisherorganization_change',
-                args=[publisher_org.pk])
-    ).forms['publisherorganization_form']
+    form = app.get(reverse("admin:vitrina_orgs_publisherorganization_change", args=[publisher_org.pk])).forms[
+        "publisherorganization_form"
+    ]
 
-    form['creator_assignment'] = [str(org.id) for org in orgs]
+    form["creator_assignment"] = [str(org.id) for org in orgs]
     response = form.submit()
 
     assert response.status_code == 302
     for org in orgs:
         assert Representative.objects.filter(
-            organization=publisher_org,
-            content_type=ContentType.objects.get_for_model(Organization),
-            object_id=org.id
+            organization=publisher_org, content_type=ContentType.objects.get_for_model(Organization), object_id=org.id
         ).exists()
 
 
@@ -134,21 +119,15 @@ def test_admin_organization_remove(app: DjangoTestApp, admin_user: User, publish
     app.set_user(admin_user)
     for org in orgs:
         Representative.objects.create(
-            organization=publisher_org,
-            content_type=ContentType.objects.get_for_model(Organization),
-            object_id=org.id
+            organization=publisher_org, content_type=ContentType.objects.get_for_model(Organization), object_id=org.id
         )
-    form = app.get(
-        reverse('admin:vitrina_orgs_publisherorganization_change',
-                args=[publisher_org.pk])
-    ).forms['publisherorganization_form']
-    form['creator_assignment'] = [str(orgs[0].id), str(orgs[1].id)]
+    form = app.get(reverse("admin:vitrina_orgs_publisherorganization_change", args=[publisher_org.pk])).forms[
+        "publisherorganization_form"
+    ]
+    form["creator_assignment"] = [str(orgs[0].id), str(orgs[1].id)]
     response = form.submit()
     assert response.status_code == 302
 
     assert not Representative.objects.filter(
-        organization=publisher_org,
-        content_type=ContentType.objects.get_for_model(Organization),
-        object_id=orgs[2].id
+        organization=publisher_org, content_type=ContentType.objects.get_for_model(Organization), object_id=orgs[2].id
     ).exists()
-

--- a/tests/orgs/test_services.py
+++ b/tests/orgs/test_services.py
@@ -1099,7 +1099,7 @@ def test_organization_representative_view_permission_publisher(role: str, expect
     organization = OrganizationFactory()
 
     ct = ContentType.objects.get_for_model(organization)
-    manager = RepresentativeFactory(
+    RepresentativeFactory(
         organization=user_organization,
         content_type=ct,
         object_id=organization.pk,

--- a/tests/orgs/test_services.py
+++ b/tests/orgs/test_services.py
@@ -38,7 +38,9 @@ def non_public_but_public_access_dataset():
 @pytest.fixture
 def representative_on_dataset(public_dataset):
     ct = ContentType.objects.get_for_model(public_dataset)
-    return RepresentativeFactory(content_type=ct, object_id=public_dataset.pk, role=Representative.OPEN_DATA_COORDINATOR)
+    return RepresentativeFactory(
+        content_type=ct, object_id=public_dataset.pk, role=Representative.OPEN_DATA_COORDINATOR
+    )
 
 
 @pytest.mark.django_db
@@ -68,17 +70,13 @@ def test_has_perm__is_staff():
     [
         (Representative.OPEN_DATA_MANAGER, False),
         (Representative.RESOURCE_MANAGER, False),
-    ]
+    ],
 )
 def test_organization_edit_permission_managers(role: str, expected: bool):
     organization = OrganizationFactory()
     ct = ContentType.objects.get_for_model(organization)
 
-    manager = RepresentativeFactory(
-        content_type=ct,
-        object_id=organization.pk,
-        role=role
-    )
+    manager = RepresentativeFactory(content_type=ct, object_id=organization.pk, role=role)
 
     res = has_perm(manager.user, Action.UPDATE, organization)
 
@@ -91,7 +89,7 @@ def test_organization_edit_permission_managers(role: str, expected: bool):
     [
         (Representative.RESOURCE_COORDINATOR, True),
         (Representative.OPEN_DATA_COORDINATOR, True),
-    ]
+    ],
 )
 def test_organization_edit_permission_coordinator(role: str, expected: bool):
     organization = OrganizationFactory()
@@ -107,7 +105,7 @@ def test_organization_edit_permission_coordinator(role: str, expected: bool):
     [
         (Representative.RESOURCE_MANAGER, True),
         (Representative.OPEN_DATA_MANAGER, True),
-    ]
+    ],
 )
 def test_dataset_create_permission_organization_manager(role: str, expected: bool):
     organization = OrganizationFactory()
@@ -123,7 +121,7 @@ def test_dataset_create_permission_organization_manager(role: str, expected: boo
     [
         (Representative.RESOURCE_COORDINATOR, True),
         (Representative.OPEN_DATA_COORDINATOR, True),
-    ]
+    ],
 )
 def test_dataset_create_permission_organization_coordinator(role: str, expected: bool):
     organization = OrganizationFactory()
@@ -183,7 +181,10 @@ def test_dataset_permissions(role, action, dataset_fixture, expected, request):
     dataset = request.getfixturevalue(dataset_fixture)
     user = UserFactory(is_staff=(role == "global_manager"))
     ct = ContentType.objects.get_for_model(dataset)
-    rep_roles = {"open_data_manager": Representative.OPEN_DATA_MANAGER, "resource_manager": Representative.RESOURCE_MANAGER}
+    rep_roles = {
+        "open_data_manager": Representative.OPEN_DATA_MANAGER,
+        "resource_manager": Representative.RESOURCE_MANAGER,
+    }
     if role in rep_roles:
         RepresentativeFactory(
             content_type=ct,
@@ -228,7 +229,7 @@ def test_representative_update_permissions_fixed(role, action, obj_fixture, expe
     [
         (Representative.RESOURCE_MANAGER, True),
         (Representative.OPEN_DATA_MANAGER, True),
-    ]
+    ],
 )
 def test_dataset_history_view_permission_manager(role: str, expected: bool):
     dataset = DatasetFactory()
@@ -244,7 +245,7 @@ def test_dataset_history_view_permission_manager(role: str, expected: bool):
     [
         (Representative.RESOURCE_COORDINATOR, True),
         (Representative.OPEN_DATA_COORDINATOR, True),
-    ]
+    ],
 )
 def test_dataset_history_view_permission_coordinator(role: str, expected: bool):
     dataset = DatasetFactory()
@@ -306,7 +307,7 @@ def test_project_edit_permission_author():
     [
         (Representative.RESOURCE_MANAGER, True),
         (Representative.OPEN_DATA_MANAGER, True),
-    ]
+    ],
 )
 def test_dataset_distribution_create_permission_organization_manager(role: str, expected: bool):
     dataset = DatasetFactory()
@@ -322,14 +323,12 @@ def test_dataset_distribution_create_permission_organization_manager(role: str, 
     [
         (Representative.RESOURCE_COORDINATOR, True),
         (Representative.OPEN_DATA_COORDINATOR, True),
-    ]
+    ],
 )
 def test_dataset_distribution_create_permission_organization_coordinator(role: str, expected: bool):
     dataset = DatasetFactory()
     ct = ContentType.objects.get_for_model(dataset.organization)
-    coordinator = RepresentativeFactory(
-        content_type=ct, object_id=dataset.organization.pk, role=role
-    )
+    coordinator = RepresentativeFactory(content_type=ct, object_id=dataset.organization.pk, role=role)
     res = has_perm(coordinator.user, Action.CREATE, DatasetDistribution, dataset)
     assert res is expected
 
@@ -340,7 +339,7 @@ def test_dataset_distribution_create_permission_organization_coordinator(role: s
     [
         (Representative.RESOURCE_MANAGER, True),
         (Representative.OPEN_DATA_MANAGER, True),
-    ]
+    ],
 )
 def test_dataset_distribution_create_permission_dataset_manager(role: str, expected: bool):
     dataset = DatasetFactory()
@@ -356,7 +355,7 @@ def test_dataset_distribution_create_permission_dataset_manager(role: str, expec
     [
         (Representative.RESOURCE_COORDINATOR, True),
         (Representative.OPEN_DATA_COORDINATOR, True),
-    ]
+    ],
 )
 def test_dataset_distribution_create_permission_dataset_coordinator(role: str, expected: bool):
     dataset = DatasetFactory()
@@ -372,14 +371,12 @@ def test_dataset_distribution_create_permission_dataset_coordinator(role: str, e
     [
         (Representative.RESOURCE_MANAGER, True),
         (Representative.OPEN_DATA_MANAGER, True),
-    ]
+    ],
 )
 def test_dataset_distribution_edit_permission_organization_manager(role: str, expected: bool):
     dataset_distribution = DatasetDistributionFactory()
     ct = ContentType.objects.get_for_model(dataset_distribution.dataset.organization)
-    manager = RepresentativeFactory(
-        content_type=ct, object_id=dataset_distribution.dataset.organization.pk, role=role
-    )
+    manager = RepresentativeFactory(content_type=ct, object_id=dataset_distribution.dataset.organization.pk, role=role)
     res = has_perm(manager.user, Action.UPDATE, dataset_distribution)
     assert res is expected
 
@@ -390,7 +387,7 @@ def test_dataset_distribution_edit_permission_organization_manager(role: str, ex
     [
         (Representative.RESOURCE_COORDINATOR, True),
         (Representative.OPEN_DATA_COORDINATOR, True),
-    ]
+    ],
 )
 def test_dataset_distribution_edit_permission_organization_coordinator(role: str, expected: bool):
     dataset_distribution = DatasetDistributionFactory()
@@ -408,14 +405,12 @@ def test_dataset_distribution_edit_permission_organization_coordinator(role: str
     [
         (Representative.RESOURCE_MANAGER, True),
         (Representative.OPEN_DATA_MANAGER, True),
-    ]
+    ],
 )
 def test_dataset_distribution_edit_permission_dataset_manager(role: str, expected: bool):
     dataset_distribution = DatasetDistributionFactory()
     ct = ContentType.objects.get_for_model(dataset_distribution.dataset)
-    manager = RepresentativeFactory(
-        content_type=ct, object_id=dataset_distribution.dataset.pk, role=role
-    )
+    manager = RepresentativeFactory(content_type=ct, object_id=dataset_distribution.dataset.pk, role=role)
     res = has_perm(manager.user, Action.UPDATE, dataset_distribution)
     assert res is expected
 
@@ -426,14 +421,12 @@ def test_dataset_distribution_edit_permission_dataset_manager(role: str, expecte
     [
         (Representative.RESOURCE_COORDINATOR, True),
         (Representative.OPEN_DATA_COORDINATOR, True),
-    ]
+    ],
 )
 def test_dataset_distribution_edit_permission_dataset_coordinator(role: str, expected: bool):
     dataset_distribution = DatasetDistributionFactory()
     ct = ContentType.objects.get_for_model(dataset_distribution.dataset)
-    coordinator = RepresentativeFactory(
-        content_type=ct, object_id=dataset_distribution.dataset.pk, role=role
-    )
+    coordinator = RepresentativeFactory(content_type=ct, object_id=dataset_distribution.dataset.pk, role=role)
     res = has_perm(coordinator.user, Action.UPDATE, dataset_distribution)
     assert res is expected
 
@@ -444,7 +437,7 @@ def test_dataset_distribution_edit_permission_dataset_coordinator(role: str, exp
     [
         (Representative.RESOURCE_MANAGER, False),
         (Representative.OPEN_DATA_MANAGER, False),
-    ]
+    ],
 )
 def test_organization_representative_create_permission_manager(role: str, expected: bool):
     organization = OrganizationFactory()
@@ -462,7 +455,7 @@ def test_organization_representative_create_permission_manager(role: str, expect
         (Representative.OPEN_DATA_COORDINATOR, True),
         (Representative.RESOURCE_MANAGER, False),
         (Representative.OPEN_DATA_MANAGER, False),
-    ]
+    ],
 )
 def test_organization_representative_create_permission_representative(role: str, expected: bool):
     organization = OrganizationFactory()
@@ -480,7 +473,7 @@ def test_organization_representative_create_permission_representative(role: str,
         (Representative.OPEN_DATA_COORDINATOR, True),
         (Representative.RESOURCE_MANAGER, False),
         (Representative.OPEN_DATA_MANAGER, False),
-    ]
+    ],
 )
 def test_organization_representative_edit_permission_representative(role: str, expected: bool):
     organization = OrganizationFactory()
@@ -496,7 +489,7 @@ def test_organization_representative_edit_permission_representative(role: str, e
     [
         (Representative.RESOURCE_MANAGER, False),
         (Representative.OPEN_DATA_MANAGER, False),
-    ]
+    ],
 )
 def test_organization_representative_view_permission_manager(role: str, expected: bool):
     organization = OrganizationFactory()
@@ -512,7 +505,7 @@ def test_organization_representative_view_permission_manager(role: str, expected
     [
         (Representative.RESOURCE_COORDINATOR, True),
         (Representative.OPEN_DATA_COORDINATOR, True),
-    ]
+    ],
 )
 def test_organization_representative_view_permission_coordinator(role: str, expected: bool):
     organization = OrganizationFactory()
@@ -528,7 +521,7 @@ def test_organization_representative_view_permission_coordinator(role: str, expe
     [
         (Representative.RESOURCE_MANAGER, False),
         (Representative.OPEN_DATA_MANAGER, False),
-    ]
+    ],
 )
 def test_dataset_representative_create_permission_organization_manager(role: str, expected: bool):
     dataset = DatasetFactory()
@@ -544,14 +537,12 @@ def test_dataset_representative_create_permission_organization_manager(role: str
     [
         (Representative.RESOURCE_COORDINATOR, True),
         (Representative.OPEN_DATA_COORDINATOR, True),
-    ]
+    ],
 )
 def test_dataset_representative_create_permission_organization_coordinator(role: str, expected: bool):
     dataset = DatasetFactory()
     ct = ContentType.objects.get_for_model(dataset.organization)
-    coordinator = RepresentativeFactory(
-        content_type=ct, object_id=dataset.organization.pk, role=role
-    )
+    coordinator = RepresentativeFactory(content_type=ct, object_id=dataset.organization.pk, role=role)
     res = has_perm(coordinator.user, Action.CREATE, Representative, dataset)
     assert res is expected
 
@@ -562,7 +553,7 @@ def test_dataset_representative_create_permission_organization_coordinator(role:
     [
         (Representative.RESOURCE_MANAGER, False),
         (Representative.OPEN_DATA_MANAGER, False),
-    ]
+    ],
 )
 def test_dataset_representative_create_permission_dataset_manager(role: str, expected: bool):
     dataset = DatasetFactory()
@@ -578,7 +569,7 @@ def test_dataset_representative_create_permission_dataset_manager(role: str, exp
     [
         (Representative.RESOURCE_COORDINATOR, True),
         (Representative.OPEN_DATA_COORDINATOR, True),
-    ]
+    ],
 )
 def test_dataset_representative_create_permission_dataset_coordinator(role: str, expected: bool):
     dataset = DatasetFactory()
@@ -594,15 +585,13 @@ def test_dataset_representative_create_permission_dataset_coordinator(role: str,
     [
         (Representative.RESOURCE_MANAGER, False),
         (Representative.OPEN_DATA_MANAGER, False),
-    ]
+    ],
 )
 def test_dataset_representative_edit_permission_organization_manager(role: str, expected: bool):
     dataset = DatasetFactory()
     organization_ct = ContentType.objects.get_for_model(dataset.organization)
     dataset_ct = ContentType.objects.get_for_model(dataset)
-    manager = RepresentativeFactory(
-        content_type=organization_ct, object_id=dataset.organization.pk, role=role
-    )
+    manager = RepresentativeFactory(content_type=organization_ct, object_id=dataset.organization.pk, role=role)
     representative = RepresentativeFactory(content_type=dataset_ct, object_id=dataset.pk)
     res = has_perm(manager.user, Action.UPDATE, representative)
     assert res is expected
@@ -614,15 +603,13 @@ def test_dataset_representative_edit_permission_organization_manager(role: str, 
     [
         (Representative.RESOURCE_COORDINATOR, True),
         (Representative.OPEN_DATA_COORDINATOR, True),
-    ]
+    ],
 )
 def test_dataset_representative_edit_permission_organization_coordinator(role: str, expected: bool):
     dataset = DatasetFactory()
     organization_ct = ContentType.objects.get_for_model(dataset.organization)
     dataset_ct = ContentType.objects.get_for_model(dataset)
-    coordinator = RepresentativeFactory(
-        content_type=organization_ct, object_id=dataset.organization.pk, role=role
-    )
+    coordinator = RepresentativeFactory(content_type=organization_ct, object_id=dataset.organization.pk, role=role)
     representative = RepresentativeFactory(content_type=dataset_ct, object_id=dataset.pk)
     res = has_perm(coordinator.user, Action.UPDATE, representative)
     assert res is expected
@@ -634,7 +621,7 @@ def test_dataset_representative_edit_permission_organization_coordinator(role: s
     [
         (Representative.RESOURCE_MANAGER, False),
         (Representative.OPEN_DATA_MANAGER, False),
-    ]
+    ],
 )
 def test_dataset_representative_edit_permission_dataset_manager(role: str, expected: bool):
     dataset = DatasetFactory()
@@ -651,7 +638,7 @@ def test_dataset_representative_edit_permission_dataset_manager(role: str, expec
     [
         (Representative.RESOURCE_COORDINATOR, True),
         (Representative.OPEN_DATA_COORDINATOR, True),
-    ]
+    ],
 )
 def test_dataset_representative_edit_permission_dataset_coordinator(role: str, expected: bool):
     dataset = DatasetFactory()
@@ -668,7 +655,7 @@ def test_dataset_representative_edit_permission_dataset_coordinator(role: str, e
     [
         (Representative.RESOURCE_MANAGER, True),
         (Representative.OPEN_DATA_MANAGER, True),
-    ]
+    ],
 )
 def test_dataset_representative_view_permission_organization_manager(role: str, expected: bool):
     dataset = DatasetFactory()
@@ -684,14 +671,12 @@ def test_dataset_representative_view_permission_organization_manager(role: str, 
     [
         (Representative.RESOURCE_COORDINATOR, True),
         (Representative.OPEN_DATA_COORDINATOR, True),
-    ]
+    ],
 )
 def test_dataset_representative_view_permission_organization_coordinator(role: str, expected: bool):
     dataset = DatasetFactory()
     ct = ContentType.objects.get_for_model(dataset.organization)
-    coordinator = RepresentativeFactory(
-        content_type=ct, object_id=dataset.organization.pk, role=role
-    )
+    coordinator = RepresentativeFactory(content_type=ct, object_id=dataset.organization.pk, role=role)
     res = has_perm(coordinator.user, Action.VIEW, Representative, dataset)
     assert res is expected
 
@@ -702,7 +687,7 @@ def test_dataset_representative_view_permission_organization_coordinator(role: s
     [
         (Representative.RESOURCE_MANAGER, True),
         (Representative.OPEN_DATA_MANAGER, True),
-    ]
+    ],
 )
 def test_dataset_representative_view_permission_dataset_manager(role: str, expected: bool):
     dataset = DatasetFactory()
@@ -718,7 +703,7 @@ def test_dataset_representative_view_permission_dataset_manager(role: str, expec
     [
         (Representative.RESOURCE_COORDINATOR, True),
         (Representative.OPEN_DATA_COORDINATOR, True),
-    ]
+    ],
 )
 def test_dataset_representative_view_permission_dataset_coordinator(role: str, expected: bool):
     dataset = DatasetFactory()
@@ -770,7 +755,7 @@ def test_user_view_permission_author():
         (Dataset.RESTRICTED, Representative.RESOURCE_MANAGER, True),
         (Dataset.NON_PUBLIC, Representative.RESOURCE_MANAGER, True),
         (Dataset.CONFIDENTIAL, Representative.RESOURCE_MANAGER, True),
-    ]
+    ],
 )
 def test_dataset_structure_create_permission_dataset_manager(access_rights: str, role: str, expected: bool):
     dataset = DatasetFactory(access_rights=access_rights)
@@ -792,7 +777,7 @@ def test_dataset_structure_create_permission_dataset_manager(access_rights: str,
         (Dataset.RESTRICTED, Representative.RESOURCE_COORDINATOR, True),
         (Dataset.NON_PUBLIC, Representative.RESOURCE_COORDINATOR, True),
         (Dataset.CONFIDENTIAL, Representative.RESOURCE_COORDINATOR, True),
-    ]
+    ],
 )
 def test_dataset_structure_create_permission_dataset_coordinator(access_rights: str, role: str, expected: bool):
     dataset = DatasetFactory(access_rights=access_rights)
@@ -814,7 +799,7 @@ def test_dataset_structure_create_permission_dataset_coordinator(access_rights: 
         (Dataset.RESTRICTED, Representative.RESOURCE_MANAGER, True),
         (Dataset.NON_PUBLIC, Representative.RESOURCE_MANAGER, True),
         (Dataset.CONFIDENTIAL, Representative.RESOURCE_MANAGER, True),
-    ]
+    ],
 )
 def test_dataset_structure_create_permission_organization_manager(access_rights: str, role: str, expected: bool):
     dataset = DatasetFactory(access_rights=access_rights)
@@ -836,7 +821,7 @@ def test_dataset_structure_create_permission_organization_manager(access_rights:
         (Dataset.RESTRICTED, Representative.RESOURCE_MANAGER, True),
         (Dataset.NON_PUBLIC, Representative.RESOURCE_MANAGER, True),
         (Dataset.CONFIDENTIAL, Representative.RESOURCE_MANAGER, True),
-    ]
+    ],
 )
 def test_dataset_structure_update_permission_manager(access_rights: str, role: str, expected: bool):
     org = DatasetFactory().organization
@@ -867,14 +852,12 @@ def test_dataset_structure_update_permission_manager(access_rights: str, role: s
         (Dataset.RESTRICTED, Representative.RESOURCE_COORDINATOR, True),
         (Dataset.NON_PUBLIC, Representative.RESOURCE_COORDINATOR, True),
         (Dataset.CONFIDENTIAL, Representative.RESOURCE_COORDINATOR, True),
-    ]
+    ],
 )
 def test_dataset_structure_create_permission_organization_coordinator(access_rights: str, role: str, expected: bool):
     dataset = DatasetFactory(access_rights=access_rights)
     ct = ContentType.objects.get_for_model(dataset.organization)
-    coordinator = RepresentativeFactory(
-        content_type=ct, object_id=dataset.organization.pk, role=role
-    )
+    coordinator = RepresentativeFactory(content_type=ct, object_id=dataset.organization.pk, role=role)
     res = has_perm(coordinator.user, Action.CREATE, DatasetStructure, dataset)
     assert res is expected
 
@@ -936,7 +919,7 @@ def test_pre_representative_delete__different_organization_dataset():
     [
         (Representative.RESOURCE_MANAGER, True),
         (Representative.OPEN_DATA_MANAGER, True),
-    ]
+    ],
 )
 def test_dataset_create_permission_dataset_publisher(role: str, expected: bool):
     dataset = DatasetFactory(is_public=False)
@@ -963,7 +946,7 @@ def test_dataset_create_permission_dataset_publisher(role: str, expected: bool):
     [
         (Representative.RESOURCE_MANAGER, True),
         (Representative.OPEN_DATA_MANAGER, True),
-    ]
+    ],
 )
 def test_dataset_create_permission_organization_publisher(role: str, expected: bool):
     dataset = DatasetFactory(is_public=False)
@@ -996,8 +979,7 @@ def test_dataset_create_permission_organization_publisher(role: str, expected: b
         (Dataset.RESTRICTED, Representative.RESOURCE_MANAGER, True),
         (Dataset.NON_PUBLIC, Representative.RESOURCE_MANAGER, True),
         (Dataset.CONFIDENTIAL, Representative.RESOURCE_MANAGER, True),
-
-    ]
+    ],
 )
 def test_dataset_edit_permission_dataset_publisher(access_rights: str, role: str, expected: bool):
     dataset = DatasetFactory(is_public=False, access_rights=access_rights)
@@ -1030,8 +1012,7 @@ def test_dataset_edit_permission_dataset_publisher(access_rights: str, role: str
         (Dataset.RESTRICTED, Representative.RESOURCE_MANAGER, True),
         (Dataset.NON_PUBLIC, Representative.RESOURCE_MANAGER, True),
         (Dataset.CONFIDENTIAL, Representative.RESOURCE_MANAGER, True),
-
-    ]
+    ],
 )
 def test_dataset_edit_permission_organization_publisher(access_rights: str, role: str, expected: bool):
     dataset = DatasetFactory(is_public=False, access_rights=access_rights)
@@ -1064,8 +1045,7 @@ def test_dataset_edit_permission_organization_publisher(access_rights: str, role
         (Dataset.RESTRICTED, Representative.RESOURCE_MANAGER, True),
         (Dataset.NON_PUBLIC, Representative.RESOURCE_MANAGER, True),
         (Dataset.CONFIDENTIAL, Representative.RESOURCE_MANAGER, True),
-
-    ]
+    ],
 )
 def test_dataset_history_view_permission_publisher(access_rights: str, role: str, expected: bool):
     organization = OrganizationFactory()
@@ -1075,9 +1055,7 @@ def test_dataset_history_view_permission_publisher(access_rights: str, role: str
 
     dataset = DatasetFactory(access_rights=access_rights)
     ct = ContentType.objects.get_for_model(dataset)
-    RepresentativeFactory(
-        organization=organization, content_type=ct, object_id=dataset.pk, role=role, user=user
-    )
+    RepresentativeFactory(organization=organization, content_type=ct, object_id=dataset.pk, role=role, user=user)
     res = has_perm(user, Action.HISTORY_VIEW, dataset)
     assert res is expected
 
@@ -1088,7 +1066,7 @@ def test_dataset_history_view_permission_publisher(access_rights: str, role: str
     [
         (Representative.OPEN_DATA_MANAGER, False),
         (Representative.RESOURCE_MANAGER, False),
-    ]
+    ],
 )
 def test_organization_representative_view_permission_publisher(role: str, expected: bool):
     user_organization = OrganizationFactory()
@@ -1116,7 +1094,7 @@ def test_organization_representative_view_permission_publisher(role: str, expect
     [
         (Representative.OPEN_DATA_MANAGER, False),
         (Representative.RESOURCE_MANAGER, False),
-    ]
+    ],
 )
 def test_organization_create_publisher(role: str, expected: bool):
     organization = OrganizationFactory()
@@ -1142,7 +1120,7 @@ def test_organization_create_publisher(role: str, expected: bool):
     [
         (Representative.OPEN_DATA_MANAGER, False),
         (Representative.RESOURCE_MANAGER, False),
-    ]
+    ],
 )
 def test_organization_edit_publisher(role: str, expected: bool):
     organization = OrganizationFactory()
@@ -1174,8 +1152,7 @@ def test_organization_edit_publisher(role: str, expected: bool):
         (Dataset.RESTRICTED, Representative.RESOURCE_MANAGER, True),
         (Dataset.NON_PUBLIC, Representative.RESOURCE_MANAGER, True),
         (Dataset.CONFIDENTIAL, Representative.RESOURCE_MANAGER, True),
-
-    ]
+    ],
 )
 def test_dataset_distribution_create_permission_organization_publisher(access_rights: str, role: str, expected: bool):
     dataset = DatasetFactory(access_rights=access_rights)
@@ -1201,7 +1178,7 @@ def test_dataset_distribution_create_permission_organization_publisher(access_ri
     [
         (Representative.OPEN_DATA_MANAGER, True),
         (Representative.RESOURCE_MANAGER, True),
-    ]
+    ],
 )
 def test_dataset_distribution_edit_permission_organization_publisher(role: str, expected: bool):
     organization = OrganizationFactory()
@@ -1229,18 +1206,20 @@ class TestHasDatasetPerm:
         representative = RepresentativeFactory(
             content_type=ContentType.objects.get_for_model(dataset),
             object_id=dataset.pk,
-            role=Representative.OPEN_DATA_MANAGER
+            role=Representative.OPEN_DATA_MANAGER,
         )
 
         assert _has_dataset_perm(representative.user, Action.UPDATE, dataset, dataset) is True
 
-    @pytest.mark.parametrize("access_rights", [Dataset.PUBLIC, Dataset.RESTRICTED, Dataset.NON_PUBLIC, Dataset.CONFIDENTIAL])
+    @pytest.mark.parametrize(
+        "access_rights", [Dataset.PUBLIC, Dataset.RESTRICTED, Dataset.NON_PUBLIC, Dataset.CONFIDENTIAL]
+    )
     def test_permissions_with_dataset_resource_representative(self, access_rights: str):
         dataset = DatasetFactory(access_rights=access_rights)
         representative = RepresentativeFactory(
             content_type=ContentType.objects.get_for_model(dataset),
             object_id=dataset.pk,
-            role=Representative.RESOURCE_MANAGER
+            role=Representative.RESOURCE_MANAGER,
         )
 
         assert _has_dataset_perm(representative.user, Action.UPDATE, dataset, dataset) is True
@@ -1252,23 +1231,24 @@ class TestHasDatasetPerm:
         representative = RepresentativeFactory(
             content_type=ContentType.objects.get_for_model(organization),
             object_id=organization.pk,
-            role=Representative.OPEN_DATA_MANAGER
+            role=Representative.OPEN_DATA_MANAGER,
         )
 
         assert _has_dataset_perm(representative.user, Action.UPDATE, dataset, dataset) is True
 
-    @pytest.mark.parametrize("access_rights", [Dataset.PUBLIC, Dataset.RESTRICTED, Dataset.NON_PUBLIC, Dataset.CONFIDENTIAL])
+    @pytest.mark.parametrize(
+        "access_rights", [Dataset.PUBLIC, Dataset.RESTRICTED, Dataset.NON_PUBLIC, Dataset.CONFIDENTIAL]
+    )
     def test_permissions_with_organization_resource_representative(self, access_rights: str):
         organization = OrganizationFactory()
         dataset = DatasetFactory(access_rights=access_rights, organization=organization)
         representative = RepresentativeFactory(
             content_type=ContentType.objects.get_for_model(organization),
             object_id=organization.pk,
-            role=Representative.RESOURCE_MANAGER
+            role=Representative.RESOURCE_MANAGER,
         )
 
         assert _has_dataset_perm(representative.user, Action.UPDATE, dataset, dataset) is True
-
 
     def test_permission_with_organization_representative_for_all_related_datasets(self):
         parent_organization = OrganizationFactory()
@@ -1292,11 +1272,7 @@ class TestViispOrganizationPermissions:
     def test_superuser_bypasses_viisp_check_organization_update(self):
         organization = OrganizationFactory()
         other_org = OrganizationFactory()
-        superuser = UserFactory(
-            is_superuser=True,
-            is_viisp_login=True,
-            viisp_company_code=other_org.company_code
-        )
+        superuser = UserFactory(is_superuser=True, is_viisp_login=True, viisp_company_code=other_org.company_code)
 
         res = has_perm(superuser, Action.UPDATE, organization)
         assert res is True
@@ -1304,22 +1280,14 @@ class TestViispOrganizationPermissions:
     def test_staff_bypasses_viisp_check_organization_update(self):
         organization = OrganizationFactory()
         other_org = OrganizationFactory()
-        staff_user = UserFactory(
-            is_staff=True,
-            is_viisp_login=True,
-            viisp_company_code=other_org.company_code
-        )
+        staff_user = UserFactory(is_staff=True, is_viisp_login=True, viisp_company_code=other_org.company_code)
 
         res = has_perm(staff_user, Action.UPDATE, organization)
         assert res is True
 
     def test_coordinator_with_matching_viisp_org_can_update(self):
         organization = OrganizationFactory()
-        user = UserFactory(
-            organization=organization,
-            is_viisp_login=True,
-            viisp_company_code=organization.company_code
-        )
+        user = UserFactory(organization=organization, is_viisp_login=True, viisp_company_code=organization.company_code)
         ct = ContentType.objects.get_for_model(organization)
         RepresentativeFactory(
             organization=organization,
@@ -1334,11 +1302,7 @@ class TestViispOrganizationPermissions:
     def test_coordinator_with_mismatched_viisp_org_cannot_update(self):
         organization = OrganizationFactory()
         other_org = OrganizationFactory()
-        user = UserFactory(
-            organization=organization,
-            is_viisp_login=True,
-            viisp_company_code=other_org.company_code
-        )
+        user = UserFactory(organization=organization, is_viisp_login=True, viisp_company_code=other_org.company_code)
         ct = ContentType.objects.get_for_model(organization)
         RepresentativeFactory(
             organization=organization,
@@ -1354,7 +1318,7 @@ class TestViispOrganizationPermissions:
         organization = OrganizationFactory()
         user = UserFactory(
             organization=organization,
-            is_viisp_login=False  # This makes viisp_organization None
+            is_viisp_login=False,  # This makes viisp_organization None
         )
         ct = ContentType.objects.get_for_model(organization)
         RepresentativeFactory(
@@ -1384,11 +1348,7 @@ class TestViispOrganizationPermissions:
 
     def test_viisp_check_for_representative_update_with_org_parent(self):
         organization = OrganizationFactory()
-        user = UserFactory(
-            organization=organization,
-            is_viisp_login=True,
-            viisp_company_code=organization.company_code
-        )
+        user = UserFactory(organization=organization, is_viisp_login=True, viisp_company_code=organization.company_code)
         ct = ContentType.objects.get_for_model(organization)
         RepresentativeFactory(
             organization=organization,
@@ -1403,11 +1363,7 @@ class TestViispOrganizationPermissions:
     def test_viisp_check_fails_for_representative_update_mismatched_org(self):
         organization = OrganizationFactory()
         other_org = OrganizationFactory()
-        user = UserFactory(
-            organization=organization,
-            is_viisp_login=True,
-            viisp_company_code=other_org.company_code
-        )
+        user = UserFactory(organization=organization, is_viisp_login=True, viisp_company_code=other_org.company_code)
         ct = ContentType.objects.get_for_model(organization)
         RepresentativeFactory(
             organization=organization,
@@ -1422,18 +1378,14 @@ class TestViispOrganizationPermissions:
     def test_viisp_check_not_applied_to_dataset_create(self):
         organization = OrganizationFactory()
         other_org = OrganizationFactory()
-        user = UserFactory(
-            organization=organization,
-            is_viisp_login=True,
-            viisp_company_code=other_org.company_code
-        )
+        user = UserFactory(organization=organization, is_viisp_login=True, viisp_company_code=other_org.company_code)
         ct = ContentType.objects.get_for_model(organization)
         RepresentativeFactory(
             organization=organization,
             content_type=ct,
             object_id=organization.pk,
             user=None,
-            role=Representative.OPEN_DATA_MANAGER
+            role=Representative.OPEN_DATA_MANAGER,
         )
 
         res = has_perm(user, Action.CREATE, Dataset, organization)

--- a/tests/orgs/test_views.py
+++ b/tests/orgs/test_views.py
@@ -20,7 +20,6 @@ from itsdangerous import URLSafeSerializer
 from pdfminer.high_level import extract_text
 from webtest import Upload
 
-from vitrina import settings
 from vitrina.api.factories import APIKeyFactory
 from vitrina.api.models import ApiKey
 from vitrina.classifiers.factories import AreaOfManagementFactory
@@ -36,7 +35,7 @@ from vitrina.projects.factories import ProjectFactory
 from vitrina.requests.factories import RequestFactory
 from vitrina.smart_contracts import AgreementStatuses
 from vitrina.smart_contracts.factories import AgreementFactory, AgreementPDFFileFactory, AgreementJSONFileFactory
-from vitrina.smart_contracts.models import SmartContractTemplate, Agreement, AgreementFile
+from vitrina.smart_contracts.models import SmartContractTemplate
 from vitrina.users.factories import UserFactory
 from vitrina.users.models import User
 
@@ -79,7 +78,7 @@ def test_organization_dataset_tab(app: DjangoTestApp):
     organization1 = OrganizationFactory()
     organization2 = OrganizationFactory()
     dataset1 = DatasetFactory(organization=organization1)
-    dataset2 = DatasetFactory(organization=organization2)
+    DatasetFactory(organization=organization2)
     resp = app.get(reverse('organization-datasets', args=[organization1.pk]))
     assert [int(obj.pk) for obj in resp.context['object_list']] == [dataset1.pk]
     assert list(resp.html.find("li", class_="is-active").a.stripped_strings) == ["Duomenų ištekliai"]
@@ -1044,8 +1043,8 @@ def test_contact_create_for_non_registered_contact(app, representative_data):
     assert resp.status_code == 302
 
     contact = Contact.objects.first()
-    assert contact.content_type == None
-    assert contact.object_id == None
+    assert contact.content_type is None
+    assert contact.object_id is None
     assert contact.organization == org
     assert contact.contact_name == "Test Testeron"
     assert contact.position == "Tester"

--- a/tests/orgs/test_views.py
+++ b/tests/orgs/test_views.py
@@ -48,7 +48,7 @@ def test_organization_detail_tab(app: DjangoTestApp):
     parent_organization = OrganizationFactory()
     organization = parent_organization.add_child(instance=OrganizationFactory.build())
     resp = app.get(organization.get_absolute_url())
-    assert list(resp.context['ancestors']) == [parent_organization]
+    assert list(resp.context["ancestors"]) == [parent_organization]
     assert list(resp.html.find("li", class_="is-active").a.stripped_strings) == ["Informacija"]
 
 
@@ -66,8 +66,8 @@ def test_organization_members_tab(app: DjangoTestApp):
     )
     admin = User.objects.create_superuser(email="admin@gmail.com", password="test123")
     app.set_user(admin)
-    resp = app.get(reverse('organization-members', args=[organization1.pk]))
-    assert list(resp.context['members']) == [representative1]
+    resp = app.get(reverse("organization-members", args=[organization1.pk]))
+    assert list(resp.context["members"]) == [representative1]
     assert list(resp.html.find("li", class_="is-active").a.stripped_strings) == [
         "Tvarkytojai",
     ]
@@ -79,8 +79,8 @@ def test_organization_dataset_tab(app: DjangoTestApp):
     organization2 = OrganizationFactory()
     dataset1 = DatasetFactory(organization=organization1)
     DatasetFactory(organization=organization2)
-    resp = app.get(reverse('organization-datasets', args=[organization1.pk]))
-    assert [int(obj.pk) for obj in resp.context['object_list']] == [dataset1.pk]
+    resp = app.get(reverse("organization-datasets", args=[organization1.pk]))
+    assert [int(obj.pk) for obj in resp.context["object_list"]] == [dataset1.pk]
     assert list(resp.html.find("li", class_="is-active").a.stripped_strings) == ["Duomenų ištekliai"]
 
 
@@ -94,11 +94,7 @@ def organizations():
         )
     with freeze_time(timezone.localize(datetime(2022, 10, 22, 10, 30))):
         jurisdiction2 = AreaOfManagementFactory(id=30)
-        organization2 = OrganizationFactory(
-            slug="org2",
-            title="Organization 2",
-            jurisdiction=jurisdiction2
-        )
+        organization2 = OrganizationFactory(slug="org2", title="Organization 2", jurisdiction=jurisdiction2)
     with freeze_time(datetime(2022, 9, 22, 10, 30)):
         organization3 = OrganizationFactory(
             slug="org3",
@@ -110,101 +106,83 @@ def organizations():
 
 @pytest.mark.haystack
 def test_search_without_query(app: DjangoTestApp, organizations):
-    resp = app.get(reverse('organization-list'))
-    assert [int(obj.pk) for obj in resp.context['object_list']] == [organizations[0].pk, organizations[1].pk, organizations[2].pk]
+    resp = app.get(reverse("organization-list"))
+    assert [int(obj.pk) for obj in resp.context["object_list"]] == [
+        organizations[0].pk,
+        organizations[1].pk,
+        organizations[2].pk,
+    ]
 
 
 def test_search_with_query_that_doesnt_match(app: DjangoTestApp, organizations):
-    resp = app.get("%s?q=%s" % (reverse('organization-list'), "doesnt-match"))
-    assert [int(obj.pk) for obj in resp.context['object_list']] == []
+    resp = app.get("%s?q=%s" % (reverse("organization-list"), "doesnt-match"))
+    assert [int(obj.pk) for obj in resp.context["object_list"]] == []
 
 
 @pytest.mark.haystack
 def test_search_with_query_that_matches_one(app: DjangoTestApp, organizations):
-    resp = app.get("%s?q=%s" % (reverse('organization-list'), "1"))
-    assert [int(obj.pk) for obj in resp.context['object_list']] == [organizations[0].pk]
+    resp = app.get("%s?q=%s" % (reverse("organization-list"), "1"))
+    assert [int(obj.pk) for obj in resp.context["object_list"]] == [organizations[0].pk]
 
 
 @pytest.mark.haystack
 def test_search_with_query_that_matches_all(app: DjangoTestApp, organizations):
-    resp = app.get("%s?q=%s" % (reverse('organization-list'), "organization"))
-    assert [int(obj.pk) for obj in resp.context['object_list']] == [organizations[0].pk, organizations[1].pk,
-                                                                    organizations[2].pk]
+    resp = app.get("%s?q=%s" % (reverse("organization-list"), "organization"))
+    assert [int(obj.pk) for obj in resp.context["object_list"]] == [
+        organizations[0].pk,
+        organizations[1].pk,
+        organizations[2].pk,
+    ]
 
 
 @pytest.mark.haystack
 def test_filter_without_query(app: DjangoTestApp, organizations):
-    resp = app.get(reverse('organization-list'))
-    assert [int(obj.pk) for obj in resp.context['object_list']] == [organizations[0].pk, organizations[1].pk,
-                                                                    organizations[2].pk]
-    assert resp.context['selected_jurisdiction'] is None
-    assert resp.context['jurisdictions'] == [
-        {
-            'id': 30,
-            'title': 'Jurisdiction30',
-            'query': "?jurisdiction=30",
-            'count': 2
-        },
-        {
-            'id': 1,
-            'title': 'Nepriskirta',
-            'query': "?jurisdiction=1",
-            'count': 1
-        },
+    resp = app.get(reverse("organization-list"))
+    assert [int(obj.pk) for obj in resp.context["object_list"]] == [
+        organizations[0].pk,
+        organizations[1].pk,
+        organizations[2].pk,
+    ]
+    assert resp.context["selected_jurisdiction"] is None
+    assert resp.context["jurisdictions"] == [
+        {"id": 30, "title": "Jurisdiction30", "query": "?jurisdiction=30", "count": 2},
+        {"id": 1, "title": "Nepriskirta", "query": "?jurisdiction=1", "count": 1},
     ]
 
 
 @pytest.mark.haystack
 def test_filter_with_jurisdiction(app: DjangoTestApp, organizations):
-    resp = app.get("%s?jurisdiction=1" % reverse('organization-list'))
-    assert [int(obj.pk) for obj in resp.context['object_list']] == [organizations[0].pk]
-    assert resp.context['selected_jurisdiction'] == "Nepriskirta"
-    assert resp.context['jurisdictions'] == [
-        {
-            'id': 1,
-            'title': 'Nepriskirta',
-            'query': "?jurisdiction=1",
-            'count': 1
-        }
-    ]
+    resp = app.get("%s?jurisdiction=1" % reverse("organization-list"))
+    assert [int(obj.pk) for obj in resp.context["object_list"]] == [organizations[0].pk]
+    assert resp.context["selected_jurisdiction"] == "Nepriskirta"
+    assert resp.context["jurisdictions"] == [{"id": 1, "title": "Nepriskirta", "query": "?jurisdiction=1", "count": 1}]
 
 
 @pytest.mark.haystack
 def test_filter_with_other_jurisdiction(app: DjangoTestApp, organizations):
-    resp = app.get("%s?jurisdiction=30" % reverse('organization-list'))
-    assert [int(obj.pk) for obj in resp.context['object_list']] == [organizations[1].pk,
-                                                                    organizations[2].pk]
-    assert resp.context['selected_jurisdiction'] == "Jurisdiction30"
-    assert resp.context['jurisdictions'] == [
-        {
-            'id': 30,
-            'title': 'Jurisdiction30',
-            'query': "?jurisdiction=30",
-            'count': 2
-        }
+    resp = app.get("%s?jurisdiction=30" % reverse("organization-list"))
+    assert [int(obj.pk) for obj in resp.context["object_list"]] == [organizations[1].pk, organizations[2].pk]
+    assert resp.context["selected_jurisdiction"] == "Jurisdiction30"
+    assert resp.context["jurisdictions"] == [
+        {"id": 30, "title": "Jurisdiction30", "query": "?jurisdiction=30", "count": 2}
     ]
 
 
 @pytest.mark.haystack
 def test_filter_with_non_existent_jurisdiction(app: DjangoTestApp, organizations):
-    resp = app.get("%s?jurisdiction=0" % reverse('organization-list'))
-    assert [int(obj.pk) for obj in resp.context['object_list']] == []
-    assert resp.context['selected_jurisdiction'] is None
-    assert resp.context['jurisdictions'] == []
+    resp = app.get("%s?jurisdiction=0" % reverse("organization-list"))
+    assert [int(obj.pk) for obj in resp.context["object_list"]] == []
+    assert resp.context["selected_jurisdiction"] is None
+    assert resp.context["jurisdictions"] == []
 
 
 @pytest.mark.haystack
 def test_filter_with_jurisdiction_and_title(app: DjangoTestApp, organizations):
-    resp = app.get("%s?q=2&jurisdiction=30" % reverse('organization-list'))
-    assert [int(obj.pk) for obj in resp.context['object_list']] == [organizations[1].pk]
-    assert resp.context['selected_jurisdiction'] == "Jurisdiction30"
-    assert resp.context['jurisdictions'] == [
-        {
-            'id': 30,
-            'title': 'Jurisdiction30',
-            'query': "?q=2&jurisdiction=30",
-            'count': 1
-        },
+    resp = app.get("%s?q=2&jurisdiction=30" % reverse("organization-list"))
+    assert [int(obj.pk) for obj in resp.context["object_list"]] == [organizations[1].pk]
+    assert resp.context["selected_jurisdiction"] == "Jurisdiction30"
+    assert resp.context["jurisdictions"] == [
+        {"id": 30, "title": "Jurisdiction30", "query": "?q=2&jurisdiction=30", "count": 1},
     ]
 
 
@@ -212,48 +190,39 @@ def test_filter_with_jurisdiction_and_title(app: DjangoTestApp, organizations):
 def test_filter_with_query_containing_special_characters(app: DjangoTestApp):
     jurisdiction = AreaOfManagementFactory(id=30, name_lt="Jurisdiction\"<'>\\", name_en="Jurisdiction\"<'>\\")
     organization = OrganizationFactory(title="Organization \"<'>\\", jurisdiction=jurisdiction)
-    resp = app.get("%s?q=\"<'>\\&jurisdiction=30" % reverse('organization-list'))
-    assert [int(obj.pk) for obj in resp.context['object_list']] == [organization.pk]
-    assert resp.context['selected_jurisdiction'] == "Jurisdiction\"<'>\\"
-    assert resp.context['jurisdictions'] == [
-        {
-            'id' : 30,
-            'title': "Jurisdiction\"<'>\\",
-            'query': "?q=\"<'>\\&jurisdiction=30",
-            'count': 1
-        },
+    resp = app.get("%s?q=\"<'>\\&jurisdiction=30" % reverse("organization-list"))
+    assert [int(obj.pk) for obj in resp.context["object_list"]] == [organization.pk]
+    assert resp.context["selected_jurisdiction"] == "Jurisdiction\"<'>\\"
+    assert resp.context["jurisdictions"] == [
+        {"id": 30, "title": "Jurisdiction\"<'>\\", "query": "?q=\"<'>\\&jurisdiction=30", "count": 1},
     ]
 
 
 @pytest.fixture
 def representative_data():
     open_data_manager = User.objects.create_user(
-        email="manager@gmail.com",
-        password="manager123",
-        first_name="Manager",
-        last_name="User",
-        phone="861234567"
+        email="manager@gmail.com", password="manager123", first_name="Manager", last_name="User", phone="861234567"
     )
     resource_manager = User.objects.create_user(
         email="resource_manager@gmail.com",
         password="manager123",
         first_name="Manager",
         last_name="User",
-        phone="861234567"
+        phone="861234567",
     )
     open_data_coordinator = User.objects.create_user(
         email="coordinator@gmail.com",
         password="coordinator123",
         first_name="Coordinator",
         last_name="User",
-        phone="869876543"
+        phone="869876543",
     )
     resource_coordinator = User.objects.create_user(
         email="resource_coordinator@gmail.com",
         password="coordinator123",
         first_name="Coordinator",
         last_name="User",
-        phone="869876543"
+        phone="869876543",
     )
     organization = OrganizationFactory()
     viisp_coordinator = User.objects.create_user(
@@ -263,133 +232,128 @@ def representative_data():
         last_name="User",
         phone="869876543",
         is_viisp_login=True,
-        viisp_company_code=organization.company_code
+        viisp_company_code=organization.company_code,
     )
     content_type = ContentType.objects.get_for_model(Organization)
     open_data_representative_manager = RepresentativeFactory(
-        role="open_data_manager",
-        content_type=content_type,
-        object_id=organization.pk
+        role="open_data_manager", content_type=content_type, object_id=organization.pk
     )
     resource_representative_manager = RepresentativeFactory(
-        role="resource_manager",
-        content_type=content_type,
-        object_id=organization.pk
+        role="resource_manager", content_type=content_type, object_id=organization.pk
     )
     open_data_representative_coordinator = RepresentativeFactory(
-        role="open_data_coordinator",
-        content_type=content_type,
-        object_id=organization.pk,
-        user=open_data_coordinator
+        role="open_data_coordinator", content_type=content_type, object_id=organization.pk, user=open_data_coordinator
     )
     resource_representative_coordinator = RepresentativeFactory(
-        role="resource_coordinator",
-        content_type=content_type,
-        object_id=organization.pk,
-        user=resource_coordinator
+        role="resource_coordinator", content_type=content_type, object_id=organization.pk, user=resource_coordinator
     )
     representative_viisp_coordinator = RepresentativeFactory(
-        role="resource_coordinator",
-        content_type=content_type,
-        object_id=organization.pk,
-        user=viisp_coordinator
+        role="resource_coordinator", content_type=content_type, object_id=organization.pk, user=viisp_coordinator
     )
     return {
-        'open_data_manager': open_data_manager,
-        'resource_manager': resource_manager,
-        'open_data_coordinator': open_data_coordinator,
-        'resource_coordinator': resource_coordinator,
-        'viisp_coordinator': viisp_coordinator,
-        'organization': organization,
-        'open_data_representative_manager': open_data_representative_manager,
-        'resource_representative_manager': resource_representative_manager,
-        'open_data_representative_coordinator': open_data_representative_coordinator,
-        'resource_representative_coordinator': resource_representative_coordinator,
-        'representative_viisp_coordinator': representative_viisp_coordinator
+        "open_data_manager": open_data_manager,
+        "resource_manager": resource_manager,
+        "open_data_coordinator": open_data_coordinator,
+        "resource_coordinator": resource_coordinator,
+        "viisp_coordinator": viisp_coordinator,
+        "organization": organization,
+        "open_data_representative_manager": open_data_representative_manager,
+        "resource_representative_manager": resource_representative_manager,
+        "open_data_representative_coordinator": open_data_representative_coordinator,
+        "resource_representative_coordinator": resource_representative_coordinator,
+        "representative_viisp_coordinator": representative_viisp_coordinator,
     }
 
 
 def test_representative_create_without_permission(app: DjangoTestApp, representative_data):
-    app.set_user(representative_data['open_data_manager'])
-    resp = app.get(reverse('representative-create', kwargs={
-        'pk': representative_data['organization'].pk
-    }), expect_errors=True)
+    app.set_user(representative_data["open_data_manager"])
+    resp = app.get(
+        reverse("representative-create", kwargs={"pk": representative_data["organization"].pk}), expect_errors=True
+    )
     assert resp.status_code == 403
 
 
 def test_representative_create_with_existing_user(app: DjangoTestApp, representative_data):
-    app.set_user(representative_data['open_data_coordinator'])
-    form = app.get(reverse('representative-create', kwargs={
-        'pk': representative_data['organization'].pk
-    })).forms['representative-form']
-    form['email'] = "manager@gmail.com"
-    form['role'] = "open_data_coordinator"
+    app.set_user(representative_data["open_data_coordinator"])
+    form = app.get(reverse("representative-create", kwargs={"pk": representative_data["organization"].pk})).forms[
+        "representative-form"
+    ]
+    form["email"] = "manager@gmail.com"
+    form["role"] = "open_data_coordinator"
     resp = form.submit()
     assert resp.status_code == 302
-    assert resp.url == reverse('organization-members', kwargs={'pk': representative_data['organization'].pk})
+    assert resp.url == reverse("organization-members", kwargs={"pk": representative_data["organization"].pk})
     assert Representative.objects.filter(email="manager@gmail.com").count() == 1
-    assert Representative.objects.filter(email="manager@gmail.com").first().content_object == \
-           representative_data['organization']
-    assert Representative.objects.filter(email="manager@gmail.com").first().user == representative_data['open_data_manager']
-    assert Representative.objects.filter(
-        email="manager@gmail.com"
-    ).first().user.organization == representative_data['organization']
+    assert (
+        Representative.objects.filter(email="manager@gmail.com").first().content_object
+        == representative_data["organization"]
+    )
+    assert (
+        Representative.objects.filter(email="manager@gmail.com").first().user
+        == representative_data["open_data_manager"]
+    )
+    assert (
+        Representative.objects.filter(email="manager@gmail.com").first().user.organization
+        == representative_data["organization"]
+    )
 
 
 def test_representative_create_can_make_agreements_disabled(app: DjangoTestApp, representative_data):
-    app.set_user(representative_data['open_data_coordinator'])
-    form = app.get(reverse('representative-create', kwargs={
-        'pk': representative_data['organization'].pk
-    })).forms['representative-form']
-    assert 'disabled' in form["can_make_agreements"].attrs
-    form['email'] = "manager@gmail.com"
-    form['role'] = "open_data_coordinator"
-    form['can_make_agreements'] = True
+    app.set_user(representative_data["open_data_coordinator"])
+    form = app.get(reverse("representative-create", kwargs={"pk": representative_data["organization"].pk})).forms[
+        "representative-form"
+    ]
+    assert "disabled" in form["can_make_agreements"].attrs
+    form["email"] = "manager@gmail.com"
+    form["role"] = "open_data_coordinator"
+    form["can_make_agreements"] = True
     resp = form.submit()
     assert resp.status_code == 302
-    assert resp.url == reverse('organization-members', kwargs={'pk': representative_data['organization'].pk})
+    assert resp.url == reverse("organization-members", kwargs={"pk": representative_data["organization"].pk})
     representative_qs = Representative.objects.filter(email="manager@gmail.com")
     assert representative_qs.count() == 1
     representative = representative_qs.first()
-    assert representative.content_object == representative_data['organization']
-    assert representative.user == representative_data['open_data_manager']
-    assert representative.user.organization == representative_data['organization']
+    assert representative.content_object == representative_data["organization"]
+    assert representative.user == representative_data["open_data_manager"]
+    assert representative.user.organization == representative_data["organization"]
     assert not representative.can_make_agreements
 
 
 def test_representative_create_with_can_make_agreements_rights(app: DjangoTestApp, representative_data):
-    app.set_user(representative_data['viisp_coordinator'])
-    form = app.get(reverse('representative-create', kwargs={
-        'pk': representative_data['organization'].pk
-    })).forms['representative-form']
-    form['email'] = "manager@gmail.com"
-    form['role'] = "open_data_coordinator"
-    form['can_make_agreements'] = True
+    app.set_user(representative_data["viisp_coordinator"])
+    form = app.get(reverse("representative-create", kwargs={"pk": representative_data["organization"].pk})).forms[
+        "representative-form"
+    ]
+    form["email"] = "manager@gmail.com"
+    form["role"] = "open_data_coordinator"
+    form["can_make_agreements"] = True
     resp = form.submit()
     assert resp.status_code == 302
-    assert resp.url == reverse('organization-members', kwargs={'pk': representative_data['organization'].pk})
+    assert resp.url == reverse("organization-members", kwargs={"pk": representative_data["organization"].pk})
     representative_qs = Representative.objects.filter(email="manager@gmail.com")
     assert representative_qs.count() == 1
     representative = representative_qs.first()
-    assert representative.content_object == representative_data['organization']
-    assert representative.user == representative_data['open_data_manager']
-    assert representative.user.organization == representative_data['organization']
+    assert representative.content_object == representative_data["organization"]
+    assert representative.user == representative_data["open_data_manager"]
+    assert representative.user.organization == representative_data["organization"]
     assert representative.can_make_agreements
 
 
 def test_representative_create_without_user(app: DjangoTestApp, representative_data):
-    app.set_user(representative_data['open_data_coordinator'])
-    form = app.get(reverse('representative-create', kwargs={
-        'pk': representative_data['organization'].pk
-    })).forms['representative-form']
-    form['email'] = "new@gmail.com"
-    form['role'] = "open_data_manager"
+    app.set_user(representative_data["open_data_coordinator"])
+    form = app.get(reverse("representative-create", kwargs={"pk": representative_data["organization"].pk})).forms[
+        "representative-form"
+    ]
+    form["email"] = "new@gmail.com"
+    form["role"] = "open_data_manager"
     resp = form.submit()
     assert resp.status_code == 302
-    assert resp.url == reverse('organization-members', kwargs={'pk': representative_data['organization'].pk})
+    assert resp.url == reverse("organization-members", kwargs={"pk": representative_data["organization"].pk})
     assert Representative.objects.filter(email="new@gmail.com").count() == 1
-    assert Representative.objects.filter(email="new@gmail.com").first().content_object == \
-           representative_data['organization']
+    assert (
+        Representative.objects.filter(email="new@gmail.com").first().content_object
+        == representative_data["organization"]
+    )
     assert Representative.objects.filter(email="new@gmail.com").first().user is None
     assert len(mail.outbox) == 1
     assert mail.outbox[0].to == ["new@gmail.com"]
@@ -401,18 +365,14 @@ def test_representative_create_without_user_for_two_organizations(app: DjangoTes
     organization2 = OrganizationFactory()
     app.set_user(user)
 
-    form = app.get(reverse('representative-create', kwargs={
-        'pk': organization1.pk
-    })).forms['representative-form']
-    form['email'] = "new@gmail.com"
-    form['role'] = "open_data_manager"
+    form = app.get(reverse("representative-create", kwargs={"pk": organization1.pk})).forms["representative-form"]
+    form["email"] = "new@gmail.com"
+    form["role"] = "open_data_manager"
     form.submit()
 
-    form = app.get(reverse('representative-create', kwargs={
-        'pk': organization2.pk
-    })).forms['representative-form']
-    form['email'] = "new@gmail.com"
-    form['role'] = "open_data_manager"
+    form = app.get(reverse("representative-create", kwargs={"pk": organization2.pk})).forms["representative-form"]
+    form["email"] = "new@gmail.com"
+    form["role"] = "open_data_manager"
     form.submit()
 
     assert Representative.objects.filter(email="new@gmail.com").count() == 2
@@ -421,40 +381,40 @@ def test_representative_create_without_user_for_two_organizations(app: DjangoTes
 
 
 def test_representative_create_invalid_phone(app: DjangoTestApp, representative_data):
-    app.set_user(representative_data['open_data_coordinator'])
-    form = app.get(reverse('representative-create', kwargs={
-        'pk': representative_data['organization'].pk
-    })).forms['representative-form']
-    form['email'] = "new@gmail.com"
-    form['role'] = "open_data_manager"
-    form['phone'] = "123456"
+    app.set_user(representative_data["open_data_coordinator"])
+    form = app.get(reverse("representative-create", kwargs={"pk": representative_data["organization"].pk})).forms[
+        "representative-form"
+    ]
+    form["email"] = "new@gmail.com"
+    form["role"] = "open_data_manager"
+    form["phone"] = "123456"
     resp = form.submit()
     assert resp.status_code == 200
-    assert "Primtini formatai: +3706XXXXXXX, 0XXXXXXXX)" in resp.context['form'].errors['phone'][0]
+    assert "Primtini formatai: +3706XXXXXXX, 0XXXXXXXX)" in resp.context["form"].errors["phone"][0]
     assert Representative.objects.filter(email="new@gmail.com").count() == 0
 
 
 def test_representative_create_valid_phone(app: DjangoTestApp, representative_data):
-    app.set_user(representative_data['open_data_coordinator'])
+    app.set_user(representative_data["open_data_coordinator"])
 
-    form = app.get(reverse('representative-create', kwargs={
-        'pk': representative_data['organization'].pk
-    })).forms['representative-form']
-    form['email'] = "new1@gmail.com"
-    form['role'] = "open_data_manager"
-    form['phone'] = "+37061234567"
+    form = app.get(reverse("representative-create", kwargs={"pk": representative_data["organization"].pk})).forms[
+        "representative-form"
+    ]
+    form["email"] = "new1@gmail.com"
+    form["role"] = "open_data_manager"
+    form["phone"] = "+37061234567"
     resp = form.submit()
     assert resp.status_code == 302
     rep_queryset = Representative.objects.filter(email="new1@gmail.com")
     assert rep_queryset.count() == 1
     assert rep_queryset.first().phone == "+37061234567"
 
-    form = app.get(reverse('representative-create', kwargs={
-        'pk': representative_data['organization'].pk
-    })).forms['representative-form']
-    form['email'] = "new2@gmail.com"
-    form['role'] = "open_data_manager"
-    form['phone'] = "061234567"
+    form = app.get(reverse("representative-create", kwargs={"pk": representative_data["organization"].pk})).forms[
+        "representative-form"
+    ]
+    form["email"] = "new2@gmail.com"
+    form["role"] = "open_data_manager"
+    form["phone"] = "061234567"
     resp = form.submit()
     assert resp.status_code == 302
     rep_queryset = Representative.objects.filter(email="new2@gmail.com")
@@ -463,18 +423,23 @@ def test_representative_create_valid_phone(app: DjangoTestApp, representative_da
 
 
 def test_representative_update_phone(app: DjangoTestApp, representative_data):
-    representative_data['open_data_representative_manager'].user = representative_data['open_data_manager']
-    representative_data['open_data_representative_manager'].save()
-    app.set_user(representative_data['open_data_coordinator'])
-    form = app.get(reverse('representative-update', kwargs={
-        'pk': representative_data['organization'].pk,
-        'representative_id': representative_data['open_data_representative_manager'].pk
-    })).forms['representative-form']
-    form['phone'] = "061234567"
+    representative_data["open_data_representative_manager"].user = representative_data["open_data_manager"]
+    representative_data["open_data_representative_manager"].save()
+    app.set_user(representative_data["open_data_coordinator"])
+    form = app.get(
+        reverse(
+            "representative-update",
+            kwargs={
+                "pk": representative_data["organization"].pk,
+                "representative_id": representative_data["open_data_representative_manager"].pk,
+            },
+        )
+    ).forms["representative-form"]
+    form["phone"] = "061234567"
     resp = form.submit()
     assert resp.status_code == 302
-    representative_data['open_data_representative_manager'].refresh_from_db()
-    assert representative_data['open_data_representative_manager'].phone == "061234567"
+    representative_data["open_data_representative_manager"].refresh_from_db()
+    assert representative_data["open_data_representative_manager"].phone == "061234567"
 
 
 def test_representative_subscription(app: DjangoTestApp, representative_data):
@@ -484,23 +449,25 @@ def test_representative_subscription(app: DjangoTestApp, representative_data):
     user = UserFactory(is_staff=True)
     app.set_user(user)
 
-    form = app.get(reverse('representative-create', kwargs={
-        'pk': representative_data['organization'].pk
-    })).forms['representative-form']
-    form['email'] = "manager@gmail.com"
-    form['role'] = "open_data_manager"
-    form['subscribe'] = True
+    form = app.get(reverse("representative-create", kwargs={"pk": representative_data["organization"].pk})).forms[
+        "representative-form"
+    ]
+    form["email"] = "manager@gmail.com"
+    form["role"] = "open_data_manager"
+    form["subscribe"] = True
     resp = form.submit()
 
     assert resp.status_code == 302
-    assert resp.url == reverse('organization-members', kwargs={'pk': representative_data['organization'].pk})
+    assert resp.url == reverse("organization-members", kwargs={"pk": representative_data["organization"].pk})
     assert Representative.objects.filter(email="manager@gmail.com").count() == 1
-    assert Representative.objects.filter(email="manager@gmail.com").first().content_object == \
-           representative_data['organization']
+    assert (
+        Representative.objects.filter(email="manager@gmail.com").first().content_object
+        == representative_data["organization"]
+    )
     assert len(mail.outbox) == 1
     assert mail.outbox[0].to == ["manager@gmail.com"]
 
-    subscription = Subscription.objects.get(user=representative_data['open_data_manager'])
+    subscription = Subscription.objects.get(user=representative_data["open_data_manager"])
     assert subscription.sub_type == Subscription.ORGANIZATION
 
 
@@ -508,168 +475,172 @@ def test_register_after_adding_representative(app: DjangoTestApp, representative
     new_representative = RepresentativeFactory(
         email="new@gmail.com",
         content_type=ContentType.objects.get_for_model(Organization),
-        object_id=representative_data['organization'].pk,
-        user=None
+        object_id=representative_data["organization"].pk,
+        user=None,
     )
     serializer = URLSafeSerializer(settings.SECRET_KEY)
     token = serializer.dumps({"representative_id": new_representative.pk})
 
-    with patch('django_recaptcha.fields.client.submit') as mocked_submit:
+    with patch("django_recaptcha.fields.client.submit") as mocked_submit:
         mocked_submit.return_value = RecaptchaResponse(is_valid=True)
-        resp = app.post(reverse('representative-register', kwargs={'token': token}), {
-            'first_name': "New",
-            'last_name': "User",
-            'email': "new@gmail.com",
-            'password1': "v)Yxu*DF8}rj~(Sz!-X:Ws",
-            'password2': "v)Yxu*DF8}rj~(Sz!-X:Ws",
-            'agree_to_terms': True,
-            "g-recaptcha-response": "PASSED",
-        })
+        resp = app.post(
+            reverse("representative-register", kwargs={"token": token}),
+            {
+                "first_name": "New",
+                "last_name": "User",
+                "email": "new@gmail.com",
+                "password1": "v)Yxu*DF8}rj~(Sz!-X:Ws",
+                "password2": "v)Yxu*DF8}rj~(Sz!-X:Ws",
+                "agree_to_terms": True,
+                "g-recaptcha-response": "PASSED",
+            },
+        )
         new_representative.refresh_from_db()
         assert resp.status_code == 302
-        assert resp.url == reverse('home')
-        assert User.objects.filter(email='new@gmail.com').count() == 1
-        assert new_representative.user == User.objects.filter(email='new@gmail.com').first()
-        assert new_representative.user.organization == representative_data['organization']
+        assert resp.url == reverse("home")
+        assert User.objects.filter(email="new@gmail.com").count() == 1
+        assert new_representative.user == User.objects.filter(email="new@gmail.com").first()
+        assert new_representative.user.organization == representative_data["organization"]
 
 
 def test_representative_update_without_permission(app: DjangoTestApp, representative_data):
-    app.set_user(representative_data['open_data_manager'])
-    resp = app.get(reverse('representative-create', kwargs={
-        'pk': representative_data['organization'].pk
-    }), expect_errors=True)
+    app.set_user(representative_data["open_data_manager"])
+    resp = app.get(
+        reverse("representative-create", kwargs={"pk": representative_data["organization"].pk}), expect_errors=True
+    )
     assert resp.status_code == 403
 
 
 def test_representative_update_no_coordinators(app: DjangoTestApp, representative_data):
-    app.set_user(representative_data['open_data_coordinator'])
-    representative_data['representative_viisp_coordinator'].role = 'resource_manager'
-    representative_data['representative_viisp_coordinator'].save()
-    representative_data['resource_representative_coordinator'].role = 'resource_manager'
-    representative_data['resource_representative_coordinator'].save()
-    form = app.get(reverse('representative-update', kwargs={
-        'pk': representative_data['organization'].pk,
-        'representative_id': representative_data['open_data_representative_coordinator'].pk
-    })).forms['representative-form']
-    form['role'] = "open_data_manager"
+    app.set_user(representative_data["open_data_coordinator"])
+    representative_data["representative_viisp_coordinator"].role = "resource_manager"
+    representative_data["representative_viisp_coordinator"].save()
+    representative_data["resource_representative_coordinator"].role = "resource_manager"
+    representative_data["resource_representative_coordinator"].save()
+    form = app.get(
+        reverse(
+            "representative-update",
+            kwargs={
+                "pk": representative_data["organization"].pk,
+                "representative_id": representative_data["open_data_representative_coordinator"].pk,
+            },
+        )
+    ).forms["representative-form"]
+    form["role"] = "open_data_manager"
     resp = form.submit()
-    assert len(resp.context['form'].errors) == 1
+    assert len(resp.context["form"].errors) == 1
 
 
 def test_representative_update_with_correct_data(app: DjangoTestApp, representative_data):
-    representative_data['open_data_representative_manager'].user = representative_data['open_data_manager']
-    representative_data['open_data_representative_manager'].save()
-    app.set_user(representative_data['open_data_coordinator'])
-    form = app.get(reverse('representative-update', kwargs={
-        'pk': representative_data['organization'].pk,
-        'representative_id': representative_data['open_data_representative_manager'].pk
-    })).forms['representative-form']
-    form['role'] = "open_data_coordinator"
+    representative_data["open_data_representative_manager"].user = representative_data["open_data_manager"]
+    representative_data["open_data_representative_manager"].save()
+    app.set_user(representative_data["open_data_coordinator"])
+    form = app.get(
+        reverse(
+            "representative-update",
+            kwargs={
+                "pk": representative_data["organization"].pk,
+                "representative_id": representative_data["open_data_representative_manager"].pk,
+            },
+        )
+    ).forms["representative-form"]
+    form["role"] = "open_data_coordinator"
     resp = form.submit()
-    representative_data['open_data_representative_manager'].refresh_from_db()
+    representative_data["open_data_representative_manager"].refresh_from_db()
     assert resp.status_code == 302
-    assert resp.url == reverse('organization-members', kwargs={'pk': representative_data['organization'].pk})
-    assert representative_data['open_data_representative_manager'].role == "open_data_coordinator"
-    assert representative_data['open_data_representative_manager'].user.organization == representative_data['organization']
+    assert resp.url == reverse("organization-members", kwargs={"pk": representative_data["organization"].pk})
+    assert representative_data["open_data_representative_manager"].role == "open_data_coordinator"
+    assert (
+        representative_data["open_data_representative_manager"].user.organization == representative_data["organization"]
+    )
 
 
 def test_representative_update_can_make_agreements(app: DjangoTestApp, representative_data):
-    app.set_user(representative_data['viisp_coordinator'])
-    form = app.get(reverse('representative-update', kwargs={
-        'pk': representative_data['organization'].pk,
-        'representative_id': representative_data['open_data_representative_manager'].pk
-    })).forms['representative-form']
-    form['can_make_agreements'] = True
+    app.set_user(representative_data["viisp_coordinator"])
+    form = app.get(
+        reverse(
+            "representative-update",
+            kwargs={
+                "pk": representative_data["organization"].pk,
+                "representative_id": representative_data["open_data_representative_manager"].pk,
+            },
+        )
+    ).forms["representative-form"]
+    form["can_make_agreements"] = True
     resp = form.submit()
-    representative_data['open_data_representative_manager'].refresh_from_db()
+    representative_data["open_data_representative_manager"].refresh_from_db()
     assert resp.status_code == 302
-    assert resp.url == reverse('organization-members', kwargs={'pk': representative_data['organization'].pk})
-    assert representative_data['open_data_representative_manager'].can_make_agreements
+    assert resp.url == reverse("organization-members", kwargs={"pk": representative_data["organization"].pk})
+    assert representative_data["open_data_representative_manager"].can_make_agreements
 
 
 def test_organization_plan_create_with_no_publisher(app: DjangoTestApp):
     organization = OrganizationFactory()
     ct = ContentType.objects.get_for_model(organization)
-    rep = RepresentativeFactory(
-        content_type=ct,
-        object_id=organization.pk,
-        role=Representative.OPEN_DATA_MANAGER
-    )
+    rep = RepresentativeFactory(content_type=ct, object_id=organization.pk, role=Representative.OPEN_DATA_MANAGER)
     app.set_user(rep.user)
 
-    form = app.get(reverse('organization-plans-create', args=[organization.pk])).forms['plan-form']
-    form['title'] = "Test plan"
-    form['description'] = "Plan for testing"
-    form['publisher'] = ''
+    form = app.get(reverse("organization-plans-create", args=[organization.pk])).forms["plan-form"]
+    form["title"] = "Test plan"
+    form["description"] = "Plan for testing"
+    form["publisher"] = ""
     resp = form.submit()
 
-    assert list(resp.context['form'].errors.values()) == [[
-        "Turi būti nurodytas paslaugų teikėjas arba paslaugų teikėjo pavadinimas."
-    ]]
+    assert list(resp.context["form"].errors.values()) == [
+        ["Turi būti nurodytas paslaugų teikėjas arba paslaugų teikėjo pavadinimas."]
+    ]
 
 
 def test_organization_plan_create_with_multiple_publishers(app: DjangoTestApp):
     organization = OrganizationFactory()
     ct = ContentType.objects.get_for_model(organization)
-    rep = RepresentativeFactory(
-        content_type=ct,
-        object_id=organization.pk,
-        role=Representative.OPEN_DATA_MANAGER
-    )
+    rep = RepresentativeFactory(content_type=ct, object_id=organization.pk, role=Representative.OPEN_DATA_MANAGER)
     app.set_user(rep.user)
 
-    form = app.get(reverse('organization-plans-create', args=[organization.pk])).forms['plan-form']
-    form['title'] = "Test plan"
-    form['description'] = "Plan for testing"
-    form['publisher'].force_value(organization.pk)
-    form['provider_title'] = "Publisher"
+    form = app.get(reverse("organization-plans-create", args=[organization.pk])).forms["plan-form"]
+    form["title"] = "Test plan"
+    form["description"] = "Plan for testing"
+    form["publisher"].force_value(organization.pk)
+    form["provider_title"] = "Publisher"
     resp = form.submit()
 
-    assert list(resp.context['form'].errors.values()) == [[
-        "Turi būti nurodytas arba paslaugų teikėjas, arba paslaugų teikėjo pavadinimas, bet ne abu."
-    ]]
+    assert list(resp.context["form"].errors.values()) == [
+        ["Turi būti nurodytas arba paslaugų teikėjas, arba paslaugų teikėjo pavadinimas, bet ne abu."]
+    ]
 
 
 def test_organization_plan_create(app: DjangoTestApp):
     organization = OrganizationFactory()
     ct = ContentType.objects.get_for_model(organization)
-    rep = RepresentativeFactory(
-        content_type=ct,
-        object_id=organization.pk,
-        role=Representative.OPEN_DATA_MANAGER
-    )
+    rep = RepresentativeFactory(content_type=ct, object_id=organization.pk, role=Representative.OPEN_DATA_MANAGER)
     rep.user.organization = organization
     rep.user.save()
     app.set_user(rep.user)
 
-    form = app.get(reverse('organization-plans-create', args=[organization.pk])).forms['plan-form']
-    form['title'] = "Test plan"
-    form['description'] = "Plan for testing"
+    form = app.get(reverse("organization-plans-create", args=[organization.pk])).forms["plan-form"]
+    form["title"] = "Test plan"
+    form["description"] = "Plan for testing"
     resp = form.submit()
 
-    assert resp.url == reverse('organization-plans', args=[organization.pk])
+    assert resp.url == reverse("organization-plans", args=[organization.pk])
     assert Plan.objects.count() == 1
-    assert Plan.objects.first().title == 'Test plan'
-    assert Plan.objects.first().description == 'Plan for testing'
+    assert Plan.objects.first().title == "Test plan"
+    assert Plan.objects.first().description == "Plan for testing"
     assert Plan.objects.first().receiver == organization
 
 
 def test_organization_plan_update(app: DjangoTestApp):
     plan = PlanFactory()
     ct = ContentType.objects.get_for_model(plan.receiver)
-    rep = RepresentativeFactory(
-        content_type=ct,
-        object_id=plan.receiver.pk,
-        role=Representative.OPEN_DATA_MANAGER
-    )
+    rep = RepresentativeFactory(content_type=ct, object_id=plan.receiver.pk, role=Representative.OPEN_DATA_MANAGER)
     app.set_user(rep.user)
 
-    form = app.get(reverse('plan-change', args=[plan.receiver.pk, plan.pk])).forms['plan-form']
-    form['title'] = "Test plan (updated)"
-    form['publisher'].force_value(plan.receiver.pk)
+    form = app.get(reverse("plan-change", args=[plan.receiver.pk, plan.pk])).forms["plan-form"]
+    form["title"] = "Test plan (updated)"
+    form["publisher"].force_value(plan.receiver.pk)
     resp = form.submit()
 
-    assert resp.url == reverse('plan-detail', args=[plan.receiver.pk, plan.pk])
+    assert resp.url == reverse("plan-detail", args=[plan.receiver.pk, plan.pk])
     assert Plan.objects.count() == 1
     assert Plan.objects.first().title == "Test plan (updated)"
     assert Plan.objects.first().publisher == plan.receiver
@@ -680,7 +651,7 @@ def test_organization_merge_without_permission(app: DjangoTestApp):
     app.set_user(user)
 
     organization = OrganizationFactory()
-    resp = app.get(reverse('merge-organizations', args=[organization.pk]), expect_errors=True)
+    resp = app.get(reverse("merge-organizations", args=[organization.pk]), expect_errors=True)
 
     assert resp.status_code == 403
 
@@ -697,24 +668,23 @@ def test_organization_merge(app: DjangoTestApp):
     request = RequestFactory()
     request.organizations.add(organization)
     representative = RepresentativeFactory(
-        content_type=ContentType.objects.get_for_model(organization),
-        object_id=organization.pk
+        content_type=ContentType.objects.get_for_model(organization), object_id=organization.pk
     )
 
-    form = app.get(reverse('confirm-organization-merge', args=[
-        organization.pk,
-        merge_organization.pk
-    ])).forms['confirm-merge-form']
+    form = app.get(reverse("confirm-organization-merge", args=[organization.pk, merge_organization.pk])).forms[
+        "confirm-merge-form"
+    ]
     resp = form.submit()
 
-    assert resp.url == reverse('organization-detail', args=[merge_organization.pk])
+    assert resp.url == reverse("organization-detail", args=[merge_organization.pk])
     assert Organization.objects.filter(pk=organization_id).count() == 0
     assert list(merge_organization.dataset_set.all()) == [dataset]
     assert list(merge_organization.request_set.all()) == [request]
-    assert list(Representative.objects.filter(
-        content_type=ContentType.objects.get_for_model(merge_organization),
-        object_id=merge_organization.pk
-    )) == [representative]
+    assert list(
+        Representative.objects.filter(
+            content_type=ContentType.objects.get_for_model(merge_organization), object_id=merge_organization.pk
+        )
+    ) == [representative]
 
 
 def test_organization_open_plans(app: DjangoTestApp):
@@ -723,8 +693,8 @@ def test_organization_open_plans(app: DjangoTestApp):
     PlanFactory(is_closed=False, receiver=organization)
     PlanFactory(is_closed=False, receiver=organization)
 
-    resp = app.get(reverse('organization-plans', args=[organization.pk]))
-    assert len(resp.context['plans']) == 2
+    resp = app.get(reverse("organization-plans", args=[organization.pk]))
+    assert len(resp.context["plans"]) == 2
 
 
 def test_organization_closed_plans(app: DjangoTestApp):
@@ -733,13 +703,13 @@ def test_organization_closed_plans(app: DjangoTestApp):
     PlanFactory(is_closed=False, receiver=organization)
     PlanFactory(is_closed=False, receiver=organization)
 
-    resp = app.get("%s?status=closed" % reverse('organization-plans', args=[organization.pk]))
-    assert len(resp.context['plans']) == 1
+    resp = app.get("%s?status=closed" % reverse("organization-plans", args=[organization.pk]))
+    assert len(resp.context["plans"]) == 1
 
 
 def test_change_form_no_login(app: DjangoTestApp):
     org = OrganizationFactory()
-    response = app.get(reverse('organization-change', kwargs={'pk': org.id}))
+    response = app.get(reverse("organization-change", kwargs={"pk": org.id}))
     assert response.status_code == 302
     assert settings.LOGIN_URL in response.location
 
@@ -748,16 +718,16 @@ def test_change_form_wrong_login(app: DjangoTestApp):
     org = OrganizationFactory()
     user = User.objects.create_user(email="test@test.com", password="test123")
     app.set_user(user)
-    response = app.get(reverse('organization-change', kwargs={'pk': org.id}))
+    response = app.get(reverse("organization-change", kwargs={"pk": org.id}))
     assert response.status_code == 302
     assert str(org.id) in response.location
 
 
 def generate_photo_file(height, length) -> bytes:
     file = io.BytesIO()
-    image = Image.new('RGBA', size=(height, length), color=(155, 0, 0))
-    image.save(file, 'png')
-    file.name = 'img.png'
+    image = Image.new("RGBA", size=(height, length), color=(155, 0, 0))
+    image.save(file, "png")
+    file.name = "img.png"
     return file.getvalue()
 
 
@@ -769,20 +739,20 @@ def test_change_form_correct_login(app: DjangoTestApp):
     user = representative.user
     app.set_user(user)
 
-    form = app.get(reverse('organization-change', kwargs={'pk': org.id})).forms['organization-form']
+    form = app.get(reverse("organization-change", kwargs={"pk": org.id})).forms["organization-form"]
 
-    form['title'] = 'Edited title'
-    form['description'] = 'edited org description'
-    form['jurisdiction'] = jurisdiction.id
-    form['image'] = Upload('img.png', generate_photo_file(300, 300), 'image')
+    form["title"] = "Edited title"
+    form["description"] = "edited org description"
+    form["jurisdiction"] = jurisdiction.id
+    form["image"] = Upload("img.png", generate_photo_file(300, 300), "image")
 
     resp = form.submit()
     org.refresh_from_db()
 
     assert resp.status_code == 302
-    assert resp.url == reverse('organization-detail', kwargs={'pk': org.id})
-    assert org.title == 'Edited title'
-    assert org.description == 'edited org description'
+    assert resp.url == reverse("organization-detail", kwargs={"pk": org.id})
+    assert org.title == "Edited title"
+    assert org.description == "edited org description"
 
 
 def test_click_edit_button(app: DjangoTestApp):
@@ -790,82 +760,76 @@ def test_click_edit_button(app: DjangoTestApp):
     org = representative.content_object
     user = representative.user
     app.set_user(user)
-    response = app.get(reverse('organization-detail', kwargs={'pk': org.id}))
-    response.click(linkid='change_organization')
+    response = app.get(reverse("organization-detail", kwargs={"pk": org.id}))
+    response.click(linkid="change_organization")
     assert response.status_code == 200
 
 
 def test_contact_tab_access_coordinator(app, representative_data):
-    app.set_user(representative_data['open_data_coordinator'])
+    app.set_user(representative_data["open_data_coordinator"])
 
-    resp = app.get(reverse('organization-contacts', kwargs={
-        'pk': representative_data['organization'].pk
-    }))
+    resp = app.get(reverse("organization-contacts", kwargs={"pk": representative_data["organization"].pk}))
 
     assert resp.status_code == 200
-    assert 'Kontaktai' in resp.text
-    assert 'contacts/add' in resp.text
+    assert "Kontaktai" in resp.text
+    assert "contacts/add" in resp.text
 
 
 def test_contact_tab_access_denied_for_manager(app, representative_data):
-    app.set_user(representative_data['open_data_manager'])
+    app.set_user(representative_data["open_data_manager"])
 
-    resp = app.get(reverse('organization-contacts', kwargs={
-        'pk': representative_data['organization'].pk
-    }), expect_errors=True)
+    resp = app.get(
+        reverse("organization-contacts", kwargs={"pk": representative_data["organization"].pk}), expect_errors=True
+    )
 
     assert resp.status_code == 403
 
 
 def test_contact_tab_display_org_contacts(app, representative_data):
-    app.set_user(representative_data['open_data_coordinator'])
-    organization = representative_data['organization']
+    app.set_user(representative_data["open_data_coordinator"])
+    organization = representative_data["organization"]
 
     Contact.objects.create(
         organization=organization,
         content_type=ContentType.objects.get_for_model(organization),
         object_id=organization.pk,
         email="org@test.com",
-        phone="+37061234567"
+        phone="+37061234567",
     )
 
-    resp = app.get(reverse('organization-contacts', kwargs={
-        'pk': organization.pk
-    }))
+    resp = app.get(reverse("organization-contacts", kwargs={"pk": organization.pk}))
 
     assert resp.status_code == 200
-    assert 'org@test.com' in resp.text
-    assert '+37061234567' in resp.text
+    assert "org@test.com" in resp.text
+    assert "+37061234567" in resp.text
     assert organization.title in resp.text
 
 
 def test_contact_tab_display_user_contacts(app, representative_data):
-    app.set_user(representative_data['open_data_coordinator'])
-    organization = representative_data['organization']
-    user = representative_data['open_data_manager']
+    app.set_user(representative_data["open_data_coordinator"])
+    organization = representative_data["organization"]
+    user = representative_data["open_data_manager"]
 
     Contact.objects.create(
         organization=organization,
         content_type=ContentType.objects.get_for_model(user),
         object_id=user.pk,
         email="user@test.com",
-        phone="+37061234567"
+        phone="+37061234567",
     )
 
-    resp = app.get(reverse('organization-contacts', kwargs={
-        'pk': organization.pk
-    }))
+    resp = app.get(reverse("organization-contacts", kwargs={"pk": organization.pk}))
 
     assert resp.status_code == 200
-    assert 'user@test.com' in resp.text
-    assert '+37061234567' in resp.text
+    assert "user@test.com" in resp.text
+    assert "+37061234567" in resp.text
     assert user.get_full_name() in resp.text
 
 
 def test_contact_tab_display_multiple_contacts(app, representative_data):
-    app.set_user(representative_data['open_data_coordinator'])
-    organization = representative_data['organization']
-    user1 =  UserFactory(organization=organization)
+    app.set_user(representative_data["open_data_coordinator"])
+    organization = representative_data["organization"]
+    user1 = UserFactory(organization=organization)
     user2 = UserFactory(organization=organization)
 
     contacts = [
@@ -874,27 +838,25 @@ def test_contact_tab_display_multiple_contacts(app, representative_data):
             content_type=ContentType.objects.get_for_model(organization),
             object_id=organization.pk,
             email="org@test.com",
-            phone="+37061234567"
+            phone="+37061234567",
         ),
         Contact.objects.create(
             organization=organization,
             content_type=ContentType.objects.get_for_model(user1),
             object_id=user1.pk,
             email="user1@test.com",
-            phone="+37067654321"
+            phone="+37067654321",
         ),
         Contact.objects.create(
             organization=organization,
             content_type=ContentType.objects.get_for_model(user2),
             object_id=user2.pk,
             email="user2@test.com",
-            phone="+37061111111"
-        )
+            phone="+37061111111",
+        ),
     ]
 
-    resp = app.get(reverse('organization-contacts', kwargs={
-        'pk': organization.pk
-    }))
+    resp = app.get(reverse("organization-contacts", kwargs={"pk": organization.pk}))
 
     assert resp.status_code == 200
 
@@ -908,8 +870,8 @@ def test_contact_tab_display_multiple_contacts(app, representative_data):
 
 
 def test_contact_tab_pagination(app, representative_data):
-    app.set_user(representative_data['open_data_coordinator'])
-    organization = representative_data['organization']
+    app.set_user(representative_data["open_data_coordinator"])
+    organization = representative_data["organization"]
 
     for i in range(15):
         user = UserFactory(organization=organization)
@@ -917,68 +879,60 @@ def test_contact_tab_pagination(app, representative_data):
             organization=organization,
             content_type=ContentType.objects.get_for_model(user),
             object_id=user.pk,
-            email=f"user{i}@test.com"
+            email=f"user{i}@test.com",
         )
 
-    resp = app.get(reverse('organization-contacts', kwargs={
-        'pk': organization.pk
-    }))
+    resp = app.get(reverse("organization-contacts", kwargs={"pk": organization.pk}))
 
     assert resp.status_code == 200
-    assert 'page=2' in resp.text
+    assert "page=2" in resp.text
 
-    soup = BeautifulSoup(resp.content, 'html.parser')
-    rows = soup.find('table').find('tbody').find_all('tr')
+    soup = BeautifulSoup(resp.content, "html.parser")
+    rows = soup.find("table").find("tbody").find_all("tr")
     assert len(rows) == 10
 
 
 def test_contact_tab_empty_state(app, representative_data):
-    app.set_user(representative_data['open_data_coordinator'])
+    app.set_user(representative_data["open_data_coordinator"])
 
-    resp = app.get(reverse('organization-contacts', kwargs={
-        'pk': representative_data['organization'].pk
-    }))
+    resp = app.get(reverse("organization-contacts", kwargs={"pk": representative_data["organization"].pk}))
 
     assert resp.status_code == 200
-    soup = BeautifulSoup(resp.content, 'html.parser')
-    rows = soup.find('table')
+    soup = BeautifulSoup(resp.content, "html.parser")
+    rows = soup.find("table")
     assert rows is None
 
 
 def test_contact_tab_actions_coordinator(app, representative_data):
-    app.set_user(representative_data['open_data_coordinator'])
-    organization = representative_data['organization']
+    app.set_user(representative_data["open_data_coordinator"])
+    organization = representative_data["organization"]
 
     contact = Contact.objects.create(
         organization=organization,
         content_type=ContentType.objects.get_for_model(organization),
         object_id=organization.pk,
-        email="test@test.com"
+        email="test@test.com",
     )
 
-    resp = app.get(reverse('organization-contacts', kwargs={
-        'pk': organization.pk
-    }))
+    resp = app.get(reverse("organization-contacts", kwargs={"pk": organization.pk}))
 
     assert resp.status_code == 200
-    assert f'contacts/{contact.pk}/change' in resp.text
-    assert f'contacts/{contact.pk}/delete' in resp.text
+    assert f"contacts/{contact.pk}/change" in resp.text
+    assert f"contacts/{contact.pk}/delete" in resp.text
 
 
 def test_contact_create_for_org(app, representative_data):
-    org = representative_data['organization']
-    app.set_user(representative_data['open_data_coordinator'])
-    form = app.get(reverse('contact-create', kwargs={
-        'pk': org.pk
-    })).forms['contact-form']
+    org = representative_data["organization"]
+    app.set_user(representative_data["open_data_coordinator"])
+    form = app.get(reverse("contact-create", kwargs={"pk": org.pk})).forms["contact-form"]
 
-    form['contact'] = f"org-{org.pk}"
-    form['email'] = "org@test.com"
-    form['phone'] = "+37061234567"
+    form["contact"] = f"org-{org.pk}"
+    form["email"] = "org@test.com"
+    form["phone"] = "+37061234567"
 
     resp = form.submit()
     assert resp.status_code == 302
-    assert resp.url == reverse('organization-contacts', kwargs={'pk': org.pk})
+    assert resp.url == reverse("organization-contacts", kwargs={"pk": org.pk})
 
     contact = Contact.objects.first()
     assert contact.content_type == ContentType.objects.get_for_model(org)
@@ -987,9 +941,7 @@ def test_contact_create_for_org(app, representative_data):
     assert contact.phone == "+37061234567"
     assert contact.organization == org
 
-    resp = app.get(reverse('organization-contacts', kwargs={
-        'pk': org.pk
-    }))
+    resp = app.get(reverse("organization-contacts", kwargs={"pk": org.pk}))
     assert resp.status_code == 200
     assert contact.email in resp.text
     assert contact.phone in resp.text
@@ -997,16 +949,14 @@ def test_contact_create_for_org(app, representative_data):
 
 
 def test_contact_create_for_user_valid_data(app, representative_data):
-    org = representative_data['organization']
-    app.set_user(representative_data['open_data_coordinator'])
-    coordinator = representative_data['open_data_coordinator']
-    form = app.get(reverse('contact-create', kwargs={
-        'pk': org.pk
-    })).forms['contact-form']
-    form['contact'] = f"user-{coordinator.pk}"
-    form['email'] = "user@test.com"
-    form['phone'] = "+37061234567"
-    form['position'] = "Tester"
+    org = representative_data["organization"]
+    app.set_user(representative_data["open_data_coordinator"])
+    coordinator = representative_data["open_data_coordinator"]
+    form = app.get(reverse("contact-create", kwargs={"pk": org.pk})).forms["contact-form"]
+    form["contact"] = f"user-{coordinator.pk}"
+    form["email"] = "user@test.com"
+    form["phone"] = "+37061234567"
+    form["position"] = "Tester"
 
     resp = form.submit()
     assert resp.status_code == 302
@@ -1017,27 +967,23 @@ def test_contact_create_for_user_valid_data(app, representative_data):
     assert contact.email == "user@test.com"
     assert contact.phone == "+37061234567"
 
-    resp = app.get(reverse('organization-contacts', kwargs={
-        'pk': org.pk
-    }))
+    resp = app.get(reverse("organization-contacts", kwargs={"pk": org.pk}))
     assert resp.status_code == 200
     assert contact.email in resp.text
     assert contact.phone in resp.text
     assert coordinator.get_full_name() in resp.text
-    
+
 
 def test_contact_create_for_non_registered_contact(app, representative_data):
-    org = representative_data['organization']
-    app.set_user(representative_data['open_data_coordinator'])
+    org = representative_data["organization"]
+    app.set_user(representative_data["open_data_coordinator"])
 
-    form = app.get(reverse('contact-create', kwargs={
-        'pk': org.pk
-    })).forms['contact-form']
+    form = app.get(reverse("contact-create", kwargs={"pk": org.pk})).forms["contact-form"]
 
     form["contact_name"] = "Test Testeron"
-    form['email'] = "user@test.com"
-    form['phone'] = "+37061234567"
-    form['position'] = "Tester"
+    form["email"] = "user@test.com"
+    form["phone"] = "+37061234567"
+    form["position"] = "Tester"
 
     resp = form.submit()
     assert resp.status_code == 302
@@ -1051,9 +997,7 @@ def test_contact_create_for_non_registered_contact(app, representative_data):
     assert contact.email == "user@test.com"
     assert contact.phone == "+37061234567"
 
-    resp = app.get(reverse('organization-contacts', kwargs={
-        'pk': org.pk
-    }))
+    resp = app.get(reverse("organization-contacts", kwargs={"pk": org.pk}))
     assert resp.status_code == 200
     assert contact.contact_name in resp.text
     assert contact.position in resp.text
@@ -1062,31 +1006,26 @@ def test_contact_create_for_non_registered_contact(app, representative_data):
 
 
 def test_contact_create_no_permission(app, representative_data):
-    app.set_user(representative_data['open_data_manager'])
-    resp = app.get(reverse('contact-create', kwargs={
-        'pk': representative_data['organization'].pk
-    }), expect_errors=True)
+    app.set_user(representative_data["open_data_manager"])
+    resp = app.get(reverse("contact-create", kwargs={"pk": representative_data["organization"].pk}), expect_errors=True)
     assert resp.status_code == 403
 
 
 def test_contact_update_org(app, representative_data):
-    app.set_user(representative_data['open_data_coordinator'])
-    org = representative_data['organization']
+    app.set_user(representative_data["open_data_coordinator"])
+    org = representative_data["organization"]
     contact = Contact.objects.create(
         organization=org,
         content_type=ContentType.objects.get_for_model(org),
         object_id=org.pk,
         email="old@test.com",
-        phone="+37061234567"
+        phone="+37061234567",
     )
 
-    form = app.get(reverse('contact-update', kwargs={
-        'pk': org.pk,
-        'contact_id': contact.pk
-    })).forms['contact-form']
+    form = app.get(reverse("contact-update", kwargs={"pk": org.pk, "contact_id": contact.pk})).forms["contact-form"]
 
-    form['email'] = "updated@test.com"
-    form['phone'] = "+37067654321"
+    form["email"] = "updated@test.com"
+    form["phone"] = "+37067654321"
 
     resp = form.submit()
     assert resp.status_code == 302
@@ -1097,9 +1036,9 @@ def test_contact_update_org(app, representative_data):
 
 
 def test_contact_update_user(app, representative_data):
-    coordinator = representative_data['open_data_coordinator']
+    coordinator = representative_data["open_data_coordinator"]
     app.set_user(coordinator)
-    org = representative_data['organization']
+    org = representative_data["organization"]
     contact = Contact.objects.create(
         organization=org,
         content_type=ContentType.objects.get_for_model(coordinator),
@@ -1108,12 +1047,9 @@ def test_contact_update_user(app, representative_data):
         phone="+37061234567",
         position="Tester",
     )
-    form = app.get(reverse('contact-update', kwargs={
-        'pk': org.pk,
-        'contact_id': contact.pk
-    })).forms['contact-form']
+    form = app.get(reverse("contact-update", kwargs={"pk": org.pk, "contact_id": contact.pk})).forms["contact-form"]
 
-    form['email'] = "updated@test.com"
+    form["email"] = "updated@test.com"
 
     resp = form.submit()
     assert resp.status_code == 302
@@ -1123,40 +1059,35 @@ def test_contact_update_user(app, representative_data):
 
 
 def test_contact_delete(app, representative_data):
-    app.set_user(representative_data['open_data_coordinator'])
-    org = representative_data['organization']
+    app.set_user(representative_data["open_data_coordinator"])
+    org = representative_data["organization"]
     contact = Contact.objects.create(
         organization=org,
         content_type=ContentType.objects.get_for_model(org),
         object_id=org.pk,
     )
-    url = reverse('organization-contacts', kwargs={
-        'pk': org.pk
-    })
+    url = reverse("organization-contacts", kwargs={"pk": org.pk})
     resp = app.get(url)
     resp = resp.click(linkid=f"delete-contact-{contact.pk}-btn")
-    form = resp.forms['delete-form']
+    form = resp.forms["delete-form"]
     resp = form.submit()
 
-    assert resp.headers['location'] == url
+    assert resp.headers["location"] == url
     assert resp.status_code == 302
     c = Contact.objects.filter(pk=contact.pk)
     assert not c.exists()
 
 
 def test_contact_delete_no_permission(app, representative_data):
-    app.set_user(representative_data['open_data_manager'])  # Manager shouldn't have permission
-    org = representative_data['organization']
+    app.set_user(representative_data["open_data_manager"])  # Manager shouldn't have permission
+    org = representative_data["organization"]
     contact = Contact.objects.create(
         organization=org,
         content_type=ContentType.objects.get_for_model(org),
         object_id=org.pk,
     )
 
-    resp = app.get(reverse('contact-delete', kwargs={
-        'pk': org.pk,
-        'contact_id': contact.pk
-    }), expect_errors=True)
+    resp = app.get(reverse("contact-delete", kwargs={"pk": org.pk, "contact_id": contact.pk}), expect_errors=True)
 
     assert resp.status_code == 403
     assert Contact.objects.count() == 1
@@ -1199,10 +1130,10 @@ def test_non_gov_organizaton_no_gov_kind(app: DjangoTestApp):
     user = representative.user
     app.set_user(user)
 
-    form = app.get(reverse('organization-change', kwargs={'pk': org.id})).forms['organization-form']
+    form = app.get(reverse("organization-change", kwargs={"pk": org.id})).forms["organization-form"]
 
-    kind_values = [value for value, _, _ in form['kind'].options]
-    
+    kind_values = [value for value, _, _ in form["kind"].options]
+
     assert len(kind_values) == 2
     assert Organization.GOV not in kind_values
 
@@ -1216,10 +1147,10 @@ def test_gov_organizaton_cannot_select_different_kind(app: DjangoTestApp):
     user = representative.user
     app.set_user(user)
 
-    form = app.get(reverse('organization-change', kwargs={'pk': org.id})).forms['organization-form']
+    form = app.get(reverse("organization-change", kwargs={"pk": org.id})).forms["organization-form"]
 
-    kind_values = [value for value, _, _ in form['kind'].options]
-    
+    kind_values = [value for value, _, _ in form["kind"].options]
+
     assert len(kind_values) == 1
     assert kind_values[0] == Organization.GOV
 
@@ -1228,7 +1159,7 @@ def test_create_organization(app: DjangoTestApp):
     user = UserFactory(is_superuser=True)
     app.set_user(user)
 
-    form = app.get(reverse('organization-create')).forms['organization-form']
+    form = app.get(reverse("organization-create")).forms["organization-form"]
 
     form["company_code"] = "123456789"
     form["title"] = "Imone"
@@ -1260,7 +1191,7 @@ def test_partner_register_no_permission(app: DjangoTestApp):
     user = UserFactory()
     app.set_user(user)
 
-    response = app.get(reverse('partner-register'))
+    response = app.get(reverse("partner-register"))
 
     assert response.status_code == 302
     assert response.url == reverse("viisp-login")
@@ -1270,7 +1201,7 @@ def test_partner_register_access_with_permission(app: DjangoTestApp):
     user = UserFactory(is_viisp_login=True)
     app.set_user(user)
 
-    response = app.get(reverse('partner-register'))
+    response = app.get(reverse("partner-register"))
 
     assert response.status_code == 200
 
@@ -1286,16 +1217,11 @@ class TestRepresentativeDeleteView:
             object_id=organization.pk,
         )
 
-        app.post(
-            reverse("representative-delete", args=[organization.pk, representative.pk])
-        )
+        app.post(reverse("representative-delete", args=[organization.pk, representative.pk]))
 
         assert not Representative.objects.filter(pk=representative.pk).exists()
 
-    
-    def test_remove_publisher_from_all_representative_organization_datasets(
-        self, app: DjangoTestApp
-    ) -> None:
+    def test_remove_publisher_from_all_representative_organization_datasets(self, app: DjangoTestApp) -> None:
         user = UserFactory(is_staff=True)
         app.set_user(user)
 
@@ -1307,18 +1233,14 @@ class TestRepresentativeDeleteView:
         )
         dataset = DatasetFactory(organization=organization, publisher=organization)
 
-        app.post(
-            reverse("representative-delete", args=[organization.pk, representative.pk])
-        )
+        app.post(reverse("representative-delete", args=[organization.pk, representative.pk]))
 
         dataset.refresh_from_db()
         assert dataset.publisher is None
 
 
 class TestOrganizationApiKeysDeleteView:
-    def test_delete_api_client_if_spinta_request_successful(
-        self, app: DjangoTestApp
-    ) -> None:
+    def test_delete_api_client_if_spinta_request_successful(self, app: DjangoTestApp) -> None:
         user = UserFactory(is_staff=True)
         app.set_user(user)
         organization = OrganizationFactory()
@@ -1335,9 +1257,7 @@ class TestOrganizationApiKeysDeleteView:
             assert not ApiKey.objects.exists()
             api_delete_request_mock.assert_called_once()
 
-    def test_do_not_delete_api_client_if_spinta_request_unsuccessful(
-        self, app: DjangoTestApp
-    ) -> None:
+    def test_do_not_delete_api_client_if_spinta_request_unsuccessful(self, app: DjangoTestApp) -> None:
         user = UserFactory(is_staff=True)
         app.set_user(user)
         organization = OrganizationFactory()
@@ -1353,7 +1273,6 @@ class TestOrganizationApiKeysDeleteView:
 
             assert ApiKey.objects.exists()
             api_delete_request_mock.assert_called_once()
-
 
 
 class TestOrganizationBasedAgreementList:
@@ -1377,8 +1296,7 @@ class TestOrganizationBasedAgreementList:
         now = datetime.now(tz=timezone)
 
         agreements = [
-            AgreementFactory(assigner=organization, status=status, created_at=now)
-            for status in AgreementStatuses
+            AgreementFactory(assigner=organization, status=status, created_at=now) for status in AgreementStatuses
         ]
         older_agreement = AgreementFactory(
             assigner=organization,
@@ -1393,7 +1311,8 @@ class TestOrganizationBasedAgreementList:
         agreements.extend([older_agreement, newer_agreement])
 
         expected_agreement_order = sorted(
-            agreements, key=lambda agreement: (status_priority.get(agreement.status, 8), agreement.created_at),
+            agreements,
+            key=lambda agreement: (status_priority.get(agreement.status, 8), agreement.created_at),
         )
         ordered_expected_agreement_ids = [agreement.uuid for agreement in expected_agreement_order]
 
@@ -1433,9 +1352,7 @@ class TestOrganizationBasedAgreementList:
         assert response.status_code == 403
 
     def test_cannot_list_if_representative_of_another_organization(
-        self,
-        app: DjangoTestApp,
-        organization: Organization
+        self, app: DjangoTestApp, organization: Organization
     ):
         other_organization = OrganizationFactory()
 
@@ -1531,21 +1448,23 @@ class TestOrganizationBasedAgreementNegotiateApprove:
         RepresentativeFactory(user=assigner_user, content_object=assigner_organization, can_make_agreements=True)
         RepresentativeFactory(user=assignee_user, content_object=assignee_organization, can_make_agreements=True)
 
-        project = ProjectFactory(organization=assignee_organization, datasets=[dataset], other_assignee_legislations="Test")
+        project = ProjectFactory(
+            organization=assignee_organization, datasets=[dataset], other_assignee_legislations="Test"
+        )
 
         assignee_contact = ContactFactory(
             organization=assignee_organization,
             object_id=assignee_user.pk,
             content_type=ContentType.objects.get_for_model(assignee_user),
             email=assignee_user.email,
-            phone=assignee_user.phone
+            phone=assignee_user.phone,
         )
         assigner_contact = ContactFactory(
             organization=assigner_organization,
             object_id=assigner_user.pk,
             content_type=ContentType.objects.get_for_model(assigner_user),
             email=assigner_user.email,
-            phone=assigner_user.phone
+            phone=assigner_user.phone,
         )
 
         agreement = AgreementFactory(
@@ -1564,8 +1483,8 @@ class TestOrganizationBasedAgreementNegotiateApprove:
             {
                 "template": template.pk,
                 "assigner_representative": assigner_contact.pk,
-                "other_assigner_legislations": "Legislation A; Legislation B"
-            }
+                "other_assigner_legislations": "Legislation A; Legislation B",
+            },
         )
 
         # Assert
@@ -1605,7 +1524,7 @@ class TestOrganizationBasedAgreementNegotiateApprove:
                 "assigner_representative": None,
                 "other_assigner_legislations": "",
             },
-            expect_errors=True
+            expect_errors=True,
         )
 
         # Assert
@@ -1646,7 +1565,7 @@ class TestOrganizationBasedAgreementNegotiateApprove:
                 "assigner_representative": None,
                 "other_assigner_legislations": "",
             },
-            expect_errors=True
+            expect_errors=True,
         )
 
         # Assert
@@ -1654,15 +1573,18 @@ class TestOrganizationBasedAgreementNegotiateApprove:
         agreement.refresh_from_db()
         assert agreement.status == AgreementStatuses.SUBMITTED
 
-    @pytest.mark.parametrize("status", [
-        AgreementStatuses.CREATED,
-        AgreementStatuses.APPROVED,
-        AgreementStatuses.FORMED,
-        AgreementStatuses.INITIATED,
-        AgreementStatuses.SIGNED,
-        AgreementStatuses.ACTIVE,
-        AgreementStatuses.TERMINATED,
-    ])
+    @pytest.mark.parametrize(
+        "status",
+        [
+            AgreementStatuses.CREATED,
+            AgreementStatuses.APPROVED,
+            AgreementStatuses.FORMED,
+            AgreementStatuses.INITIATED,
+            AgreementStatuses.SIGNED,
+            AgreementStatuses.ACTIVE,
+            AgreementStatuses.TERMINATED,
+        ],
+    )
     def test_incorrect_agreement_status(self, app: DjangoTestApp, dataset, status):
         # Arrange
         template = SmartContractTemplate.objects.create(
@@ -1689,22 +1611,23 @@ class TestOrganizationBasedAgreementNegotiateApprove:
         RepresentativeFactory(user=assigner_user, content_object=assigner_organization, can_make_agreements=True)
         RepresentativeFactory(user=assignee_user, content_object=assignee_organization, can_make_agreements=True)
 
-        project = ProjectFactory(organization=assignee_organization, datasets=[dataset],
-                                 other_assignee_legislations="Test")
+        project = ProjectFactory(
+            organization=assignee_organization, datasets=[dataset], other_assignee_legislations="Test"
+        )
 
         assignee_contact = ContactFactory(
             organization=assignee_organization,
             object_id=assignee_user.pk,
             content_type=ContentType.objects.get_for_model(assignee_user),
             email=assignee_user.email,
-            phone=assignee_user.phone
+            phone=assignee_user.phone,
         )
         assigner_contact = ContactFactory(
             organization=assigner_organization,
             object_id=assigner_user.pk,
             content_type=ContentType.objects.get_for_model(assigner_user),
             email=assigner_user.email,
-            phone=assigner_user.phone
+            phone=assigner_user.phone,
         )
 
         agreement = AgreementFactory(
@@ -1720,7 +1643,11 @@ class TestOrganizationBasedAgreementNegotiateApprove:
         # Act
         response = app.post(
             reverse("organization-agreement-approve", args=[assigner_organization.pk, agreement.pk]),
-            {"template": template.pk, "assigner_representative": assigner_contact.pk, "other_assigner_legislations": ""}
+            {
+                "template": template.pk,
+                "assigner_representative": assigner_contact.pk,
+                "other_assigner_legislations": "",
+            },
         )
 
         # Assert
@@ -1797,10 +1724,7 @@ class TestOrganizationBasedAgreementNegotiateForm:
         )
 
         # Act
-        response = app.post(
-            reverse("organization-agreement-form", args=[assigner_organization.pk, agreement.pk]),
-            {}
-        )
+        response = app.post(reverse("organization-agreement-form", args=[assigner_organization.pk, agreement.pk]), {})
 
         # Assert
         assert response.status_code == 302
@@ -2042,15 +1966,18 @@ class TestOrganizationBasedAgreementNegotiateForm:
         assert agreement.status == AgreementStatuses.APPROVED
         assert not agreement.files.exists()
 
-    @pytest.mark.parametrize("initial_status", [
-        AgreementStatuses.CREATED,
-        AgreementStatuses.SUBMITTED,
-        AgreementStatuses.FORMED,
-        AgreementStatuses.INITIATED,
-        AgreementStatuses.SIGNED,
-        AgreementStatuses.ACTIVE,
-        AgreementStatuses.TERMINATED,
-    ])
+    @pytest.mark.parametrize(
+        "initial_status",
+        [
+            AgreementStatuses.CREATED,
+            AgreementStatuses.SUBMITTED,
+            AgreementStatuses.FORMED,
+            AgreementStatuses.INITIATED,
+            AgreementStatuses.SIGNED,
+            AgreementStatuses.ACTIVE,
+            AgreementStatuses.TERMINATED,
+        ],
+    )
     def test_incorrect_agreement_status(self, initial_status, app, dataset: Dataset):
         """Cannot form an agreement if status is not APPROVED."""
         template = SmartContractTemplate.objects.create(
@@ -2171,7 +2098,7 @@ class TestOrganizationBasedAgreementNegotiateSign:
         # Act
         response = app.post(
             reverse("organization-agreement-sign", args=[assigner_organization.pk, agreement.pk]),
-            upload_files=[("file", "agreement.adoc", agreement_two_signers.read_bytes(), "text/plain")]
+            upload_files=[("file", "agreement.adoc", agreement_two_signers.read_bytes(), "text/plain")],
         )
 
         # Assert
@@ -2180,16 +2107,19 @@ class TestOrganizationBasedAgreementNegotiateSign:
         assert agreement.status == AgreementStatuses.SIGNED
         assert agreement.is_agent_sync_enabled
 
-    @pytest.mark.parametrize("initial_status", [
-        AgreementStatuses.CREATED,
-        AgreementStatuses.SUBMITTED,
-        AgreementStatuses.APPROVED,
-        AgreementStatuses.SIGNED,
-        AgreementStatuses.ACTIVE,
-        AgreementStatuses.TERMINATED,
-    ])
+    @pytest.mark.parametrize(
+        "initial_status",
+        [
+            AgreementStatuses.CREATED,
+            AgreementStatuses.SUBMITTED,
+            AgreementStatuses.APPROVED,
+            AgreementStatuses.SIGNED,
+            AgreementStatuses.ACTIVE,
+            AgreementStatuses.TERMINATED,
+        ],
+    )
     def test_incorrect_status(
-            self, initial_status, app: DjangoTestApp, agreement_pdf: Path, agreement_two_signers: str, odrl_json: Path
+        self, initial_status, app: DjangoTestApp, agreement_pdf: Path, agreement_two_signers: str, odrl_json: Path
     ):
         # Arrange
         template = SmartContractTemplate.objects.create(
@@ -2197,10 +2127,16 @@ class TestOrganizationBasedAgreementNegotiateSign:
         )
 
         assigner_organization, assignee_organization = OrganizationFactory.create_batch(2)
-        assigner_user = UserFactory(organization=assigner_organization, is_viisp_login=True,
-                                    viisp_company_code=assigner_organization.company_code)
-        assignee_user = UserFactory(organization=assignee_organization, is_viisp_login=True,
-                                    viisp_company_code=assignee_organization.company_code)
+        assigner_user = UserFactory(
+            organization=assigner_organization,
+            is_viisp_login=True,
+            viisp_company_code=assigner_organization.company_code,
+        )
+        assignee_user = UserFactory(
+            organization=assignee_organization,
+            is_viisp_login=True,
+            viisp_company_code=assignee_organization.company_code,
+        )
 
         RepresentativeFactory(user=assigner_user, content_object=assigner_organization, can_make_agreements=True)
         assigner_contact = ContactFactory(
@@ -2237,7 +2173,7 @@ class TestOrganizationBasedAgreementNegotiateSign:
         response = app.post(
             reverse("organization-agreement-sign", args=[assigner_organization.pk, agreement.pk]),
             upload_files=[("file", "agreement.adoc", agreement_two_signers.read_bytes(), "text/plain")],
-            expect_errors=True
+            expect_errors=True,
         )
 
         # Assert
@@ -2333,7 +2269,7 @@ class TestOrganizationBasedAgreementNegotiateSign:
         # Act
         response = app.post(
             reverse("organization-agreement-sign", args=[assigner_organization.pk, agreement.pk]),
-            upload_files=[("file", "agreement.adoc", agreement_two_signers.read_bytes(), "text/plain")]
+            upload_files=[("file", "agreement.adoc", agreement_two_signers.read_bytes(), "text/plain")],
         )
 
         # Assert

--- a/tests/projects/test_views.py
+++ b/tests/projects/test_views.py
@@ -30,40 +30,31 @@ pytestmark = pytest.mark.django_db
 
 def generate_photo_file() -> bytes:
     file = io.BytesIO()
-    image = Image.new('RGBA', size=(100, 100), color=(155, 0, 0))
-    image.save(file, 'png')
-    file.name = 'example.png'
+    image = Image.new("RGBA", size=(100, 100), color=(155, 0, 0))
+    image.save(file, "png")
+    file.name = "example.png"
     return file.getvalue()
 
-@pytest.mark.parametrize(
-        'is_public',
-        [
-            True,False
-        ]
-)
+
+@pytest.mark.parametrize("is_public", [True, False])
 def test_project_create_personal(app: DjangoTestApp, is_public: bool):
     user = UserFactory()
     app.set_user(user)
 
     url = reverse("project-create")
     revision_comment = RevisionComment(
-        source=RevisionSource.VIEW,
-        action="project-create",
-        http_method="POST",
-        path=url,
-        args=(),
-        kwargs={}
+        source=RevisionSource.VIEW, action="project-create", http_method="POST", path=url, args=(), kwargs={}
     )
-    form = app.get(url).forms['project-form']
-    form['title'] = "Project"
-    form['description'] = "Description"
-    form['url'] = "example.com"
-    form['image'] = Upload('example.png', generate_photo_file(), 'image')
-    form['is_public'] = is_public
+    form = app.get(url).forms["project-form"]
+    form["title"] = "Project"
+    form["description"] = "Description"
+    form["url"] = "example.com"
+    form["image"] = Upload("example.png", generate_photo_file(), "image")
+    form["is_public"] = is_public
     resp = form.submit()
 
-    project_qs = Project.objects.filter(title='Project')
-    assert  project_qs.exists()
+    project_qs = Project.objects.filter(title="Project")
+    assert project_qs.exists()
     added_project = project_qs.first()
     assert resp.status_code == 302
     assert resp.url == added_project.get_absolute_url()
@@ -74,6 +65,7 @@ def test_project_create_personal(app: DjangoTestApp, is_public: bool):
     assert not added_project.organization
     assert added_project.is_public == is_public
 
+
 def test_project_create_for_organization(app: DjangoTestApp):
     representative = ViispRepresentativeFactory(can_make_agreements=True)
     user = representative.user
@@ -82,22 +74,17 @@ def test_project_create_for_organization(app: DjangoTestApp):
 
     url = reverse("project-create")
     revision_comment = RevisionComment(
-        source=RevisionSource.VIEW,
-        action="project-create",
-        http_method="POST",
-        path=url,
-        args=(),
-        kwargs={}
+        source=RevisionSource.VIEW, action="project-create", http_method="POST", path=url, args=(), kwargs={}
     )
-    form = app.get(url).forms['project-form']
-    form['title'] = "Project"
-    form['description'] = "Description"
-    form['organization'] = organization.id
-    form['url'] = "example.com"
-    form['image'] = Upload('example.png', generate_photo_file(), 'image')
+    form = app.get(url).forms["project-form"]
+    form["title"] = "Project"
+    form["description"] = "Description"
+    form["organization"] = organization.id
+    form["url"] = "example.com"
+    form["image"] = Upload("example.png", generate_photo_file(), "image")
     resp = form.submit()
 
-    added_project = Project.objects.filter(title='Project').first()
+    added_project = Project.objects.filter(title="Project").first()
     assert added_project
     assert resp.status_code == 302
     assert resp.url == added_project.get_absolute_url()
@@ -108,35 +95,37 @@ def test_project_create_for_organization(app: DjangoTestApp):
     assert added_project.organization == organization
     assert not added_project.is_public
 
+
 def test_organization_project_create_viisp_no_representative(app: DjangoTestApp):
     organization = OrganizationFactory()
     user = UserFactory(is_viisp_login=True, viisp_company_code=organization.company_code)
     app.set_user(user)
 
-    form = app.get(reverse("project-create")).forms['project-form']
-    form['title'] = "Project"
-    form['description'] = "Description"
-    form['url'] = "example.com"
-    form['image'] = Upload('example.png', generate_photo_file(), 'image')
-    assert 'organization' not in form.fields
+    form = app.get(reverse("project-create")).forms["project-form"]
+    form["title"] = "Project"
+    form["description"] = "Description"
+    form["url"] = "example.com"
+    form["image"] = Upload("example.png", generate_photo_file(), "image")
+    assert "organization" not in form.fields
 
     resp = form.submit()
 
     assert resp.status_code == 302
-    project = Project.objects.filter(title='Project').first()
+    project = Project.objects.filter(title="Project").first()
     assert not project.organization
+
 
 def test_organization_project_create_viisp_representative_no_agreements_flag(app: DjangoTestApp):
     representative = ViispRepresentativeFactory(can_make_agreements=False)
     user = representative.user
     app.set_user(user)
 
-    form = app.get(reverse("project-create")).forms['project-form']
-    form['title'] = "Project"
-    form['description'] = "Description"
-    form['url'] = "example.com"
-    form['image'] = Upload('example.png', generate_photo_file(), 'image')
-    assert 'organization' not in form.fields
+    form = app.get(reverse("project-create")).forms["project-form"]
+    form["title"] = "Project"
+    form["description"] = "Description"
+    form["url"] = "example.com"
+    form["image"] = Upload("example.png", generate_photo_file(), "image")
+    assert "organization" not in form.fields
 
 
 def test_personal_project_update(app: DjangoTestApp):
@@ -152,11 +141,11 @@ def test_personal_project_update(app: DjangoTestApp):
         http_method="POST",
         path=url,
         args=(),
-        kwargs={"pk": project.pk}
+        kwargs={"pk": project.pk},
     )
-    form = app.get(url).forms['project-form']
-    form['title'] = "Updated title"
-    form['description'] = "Updated description"
+    form = app.get(url).forms["project-form"]
+    form["title"] = "Updated title"
+    form["description"] = "Updated description"
     resp = form.submit()
 
     project.refresh_from_db()
@@ -166,6 +155,7 @@ def test_personal_project_update(app: DjangoTestApp):
     assert project.description == "Updated description"
     assert Version.objects.get_for_object(project).count() == 1
     assert Version.objects.get_for_object(project).first().revision.comment == revision_comment.to_json()
+
 
 def test_organization_project_update_no_permission(app: DjangoTestApp):
     representative = ViispRepresentativeFactory(can_make_agreements=False)
@@ -177,6 +167,7 @@ def test_organization_project_update_no_permission(app: DjangoTestApp):
     resp = app.get(reverse("project-update", args=[project.pk]), expect_errors=True)
     assert resp.status_code == 403
 
+
 def test_personal_project_update_no_permission(app: DjangoTestApp):
     user = UserFactory()
     project = ProjectFactory()
@@ -186,6 +177,7 @@ def test_personal_project_update_no_permission(app: DjangoTestApp):
     resp = app.get(reverse("project-update", args=[project.pk]), expect_errors=True)
     assert resp.status_code == 403
 
+
 def test_project_cannot_update_organization(app: DjangoTestApp):
     representative = ViispRepresentativeFactory(can_make_agreements=True)
     user = representative.user
@@ -193,7 +185,7 @@ def test_project_cannot_update_organization(app: DjangoTestApp):
 
     app.set_user(user)
 
-    form = app.get(reverse("project-update", args=[project.pk])).forms['project-form']
+    form = app.get(reverse("project-update", args=[project.pk])).forms["project-form"]
     assert "organization" not in form.fields
 
 
@@ -208,6 +200,7 @@ def test_project_update_with_agreements(app: DjangoTestApp, organization: Organi
     resp = app.get(reverse("project-update", args=[project.pk]))
 
     assert resp.status_code == 302
+
 
 def test_project_update_with_organization(app: DjangoTestApp):
     representative = ViispRepresentativeFactory(can_make_agreements=True)
@@ -224,11 +217,11 @@ def test_project_update_with_organization(app: DjangoTestApp):
         http_method="POST",
         path=url,
         args=(),
-        kwargs={"pk": project.pk}
+        kwargs={"pk": project.pk},
     )
-    form = app.get(url).forms['project-form']
-    form['title'] = "Updated title"
-    form['description'] = "Updated description"
+    form = app.get(url).forms["project-form"]
+    form["title"] = "Updated title"
+    form["description"] = "Updated description"
     resp = form.submit()
 
     project.refresh_from_db()
@@ -239,6 +232,7 @@ def test_project_update_with_organization(app: DjangoTestApp):
     assert Version.objects.get_for_object(project).count() == 1
     assert Version.objects.get_for_object(project).first().revision.comment == revision_comment.to_json()
 
+
 def test_project_update_with_organization_no_representative(app: DjangoTestApp):
     user = UserFactory()
     organization = OrganizationFactory()
@@ -246,7 +240,7 @@ def test_project_update_with_organization_no_representative(app: DjangoTestApp):
 
     app.set_user(user)
 
-    resp = app.get(reverse("project-update", args=[project.pk]),  expect_errors=True)
+    resp = app.get(reverse("project-update", args=[project.pk]), expect_errors=True)
     assert resp.status_code == 403
 
 
@@ -254,7 +248,7 @@ def test_project_history_view_without_permission(app: DjangoTestApp):
     user = UserFactory()
     project = ProjectFactory()
     app.set_user(user)
-    resp = app.get(reverse('project-history', args=[project.pk]), expect_errors=True)
+    resp = app.get(reverse("project-history", args=[project.pk]), expect_errors=True)
     assert resp.status_code == 403
 
 
@@ -270,40 +264,40 @@ def test_project_history_view_with_permission(app: DjangoTestApp):
         http_method="POST",
         path=url,
         args=(),
-        kwargs={"pk": project.pk}
+        kwargs={"pk": project.pk},
     )
-    form = app.get(url).forms['project-form']
-    form['title'] = "Updated title"
-    form['description'] = "Updated description"
+    form = app.get(url).forms["project-form"]
+    form["title"] = "Updated title"
+    form["description"] = "Updated description"
     resp = form.submit().follow()
     with reversion.create_revision():
         agreement_file = AgreementPDFFileFactory(agreement__project=project)
         scope = UseCaseClientScopeFactory(use_case_client__use_case=project)
-    
+
     action_objects = [
         (str(agreement_file.agreement), None),
         (str(agreement_file), None),
         (str(scope.use_case_client), None),
-        (str(scope), None)
+        (str(scope), None),
     ]
 
     resp = resp.click(linkid="history-tab")
     project.refresh_from_db()
-    assert resp.context['detail_url_name'] == 'project-detail'
-    assert resp.context['history_url_name'] == 'project-history'
-    assert len(resp.context['history']) == 2
+    assert resp.context["detail_url_name"] == "project-detail"
+    assert resp.context["history_url_name"] == "project-history"
+    assert len(resp.context["history"]) == 2
 
-    entry1 = resp.context['history'][0]
+    entry1 = resp.context["history"][0]
     assert entry1["action"]["comment"] == ""
     assert len(entry1["action"]["objects"]) == 4
     assert set(entry1["action"]["objects"]) == set(action_objects)
-    assert entry1['user'] is None
+    assert entry1["user"] is None
 
-    entry2 = resp.context['history'][1]
+    entry2 = resp.context["history"][1]
     assert entry2["action"]["comment"] == f"{revision_comment.action}({revision_comment.kwargs})"
     assert len(entry2["action"]["objects"]) == 1
     assert entry2["action"]["objects"][0] == (str(project), project.get_absolute_url())
-    assert entry2['user'] == user
+    assert entry2["user"] == user
 
 
 def test_request_comment_with_status(app: DjangoTestApp):
@@ -311,23 +305,18 @@ def test_request_comment_with_status(app: DjangoTestApp):
     project = ProjectFactory(status=Project.CREATED)
     app.set_user(user)
 
-    form = app.get(project.get_absolute_url()).forms['comment-form']
+    form = app.get(project.get_absolute_url()).forms["comment-form"]
     match = resolve(form.action)
     revision_comment = RevisionComment(
-        source=RevisionSource.VIEW,
-        action="comment",
-        http_method="POST",
-        path=form.action,
-        args=(),
-        kwargs=match.kwargs
+        source=RevisionSource.VIEW, action="comment", http_method="POST", path=form.action, args=(), kwargs=match.kwargs
     )
-    form['is_public'] = True
-    form['status'] = Comment.APPROVED
-    form['body'] = "Approving this project"
+    form["is_public"] = True
+    form["status"] = Comment.APPROVED
+    form["body"] = "Approving this project"
     resp = form.submit().follow()
 
     comment = project.comments.get()
-    assert comment in list(resp.context['comments'])[0]
+    assert comment in list(resp.context["comments"])[0]
     assert comment.type == Comment.STATUS
     assert comment.status == Comment.APPROVED
 
@@ -340,23 +329,18 @@ def test_request_comment_with_status_rejected(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
 
-    form = app.get(project.get_absolute_url()).forms['comment-form']
+    form = app.get(project.get_absolute_url()).forms["comment-form"]
     match = resolve(form.action)
     revision_comment = RevisionComment(
-        source=RevisionSource.VIEW,
-        action="comment",
-        http_method="POST",
-        path=form.action,
-        args=(),
-        kwargs=match.kwargs
+        source=RevisionSource.VIEW, action="comment", http_method="POST", path=form.action, args=(), kwargs=match.kwargs
     )
-    form['is_public'] = True
-    form['status'] = Comment.REJECTED
-    form['body'] = ""
+    form["is_public"] = True
+    form["status"] = Comment.REJECTED
+    form["body"] = ""
     resp = form.submit().follow()
 
     comment = project.comments.get()
-    assert comment in list(resp.context['comments'])[0]
+    assert comment in list(resp.context["comments"])[0]
     assert comment.type == Comment.STATUS
     assert comment.status == Comment.REJECTED
 
@@ -369,8 +353,8 @@ def test_request_comment_with_same_status(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
 
-    form = app.get(project.get_absolute_url()).forms['comment-form']
-    form['status'] = Comment.APPROVED
+    form = app.get(project.get_absolute_url()).forms["comment-form"]
+    form["status"] = Comment.APPROVED
     form.submit().follow()
 
     assert project.comments.count() == 0
@@ -386,9 +370,9 @@ def test_remove_dataset_no_permission(app: DjangoTestApp):
 
     app.set_user(user)
 
-    resp = app.get(reverse('project-dataset-remove', kwargs={'pk': project.pk,
-                                                             'dataset_id': dataset.pk}),
-                   expect_errors=True)
+    resp = app.get(
+        reverse("project-dataset-remove", kwargs={"pk": project.pk, "dataset_id": dataset.pk}), expect_errors=True
+    )
 
     assert resp.status_code == 403
 
@@ -399,12 +383,7 @@ def test_remove_dataset(app: DjangoTestApp) -> None:
     dataset = DatasetFactory()
     project = ProjectFactory(datasets=[dataset])
 
-    app.post(
-        reverse(
-            "project-dataset-remove",
-            kwargs={"pk": project.pk, "dataset_id": dataset.pk}
-        )
-    )
+    app.post(reverse("project-dataset-remove", kwargs={"pk": project.pk, "dataset_id": dataset.pk}))
 
     project.refresh_from_db()
     assert not project.datasets.exists()
@@ -417,16 +396,16 @@ def test_remove_dataset_with_permission(app: DjangoTestApp):
     project.datasets.add(dataset)
     assert project.datasets.all().count() == 1
 
-    url = reverse('project-datasets', kwargs={'pk': project.pk})
+    url = reverse("project-datasets", kwargs={"pk": project.pk})
     app.set_user(user)
 
     resp = app.get(url)
-    resp = resp.click(linkid=f"remove-dataset-{ dataset.pk }-btn")
+    resp = resp.click(linkid=f"remove-dataset-{dataset.pk}-btn")
 
-    form = resp.forms['delete-form']
+    form = resp.forms["delete-form"]
     resp = form.submit()
 
-    assert resp.headers['location'] == url
+    assert resp.headers["location"] == url
     assert project.datasets.all().count() == 0
 
 
@@ -434,14 +413,15 @@ def test_not_approved_project_view_without_permission(app: DjangoTestApp):
     user = UserFactory()
     project = ProjectFactory(status=Project.CREATED)
     app.set_user(user)
-    resp = app.get(reverse('project-detail', args=[project.pk]), expect_errors=True)
+    resp = app.get(reverse("project-detail", args=[project.pk]), expect_errors=True)
     assert resp.status_code == 403
+
 
 def test_approved_non_public_project_view_without_permission(app: DjangoTestApp):
     user = UserFactory()
     project = ProjectFactory(status=Project.APPROVED, is_public=False)
     app.set_user(user)
-    resp = app.get(reverse('project-detail', args=[project.pk]), expect_errors=True)
+    resp = app.get(reverse("project-detail", args=[project.pk]), expect_errors=True)
     assert resp.status_code == 403
 
 
@@ -450,19 +430,20 @@ def test_not_approved_project_view_with_permission(app: DjangoTestApp):
     project = ProjectFactory(user=user, status=Project.CREATED)
     app.set_user(user)
 
-    resp = app.get(reverse('project-detail', args=[project.pk]))
-    assert resp.context['object'] == project
+    resp = app.get(reverse("project-detail", args=[project.pk]))
+    assert resp.context["object"] == project
+
 
 @pytest.mark.parametrize(
-        'project_status, is_public',
-        [
-            (Project.APPROVED, True),
-            (Project.APPROVED, False),
-            (Project.CREATED, True),
-            (Project.CREATED, False),
-            (Project.REJECTED, True),
-            (Project.REJECTED, False),
-        ]
+    "project_status, is_public",
+    [
+        (Project.APPROVED, True),
+        (Project.APPROVED, False),
+        (Project.CREATED, True),
+        (Project.CREATED, False),
+        (Project.REJECTED, True),
+        (Project.REJECTED, False),
+    ],
 )
 def test_representative_can_view_any_organization_projects(app: DjangoTestApp, project_status, is_public: bool):
     organization = OrganizationFactory()
@@ -471,58 +452,62 @@ def test_representative_can_view_any_organization_projects(app: DjangoTestApp, p
     project = ProjectFactory(organization=organization, is_public=is_public, status=project_status)
     app.set_user(user)
 
-    resp = app.get(reverse('project-detail', args=[project.pk]))
-    assert resp.context['object'] == project
+    resp = app.get(reverse("project-detail", args=[project.pk]))
+    assert resp.context["object"] == project
+
 
 @pytest.mark.parametrize(
-        'project_status, is_public',
-        [
-            (Project.APPROVED, False),
-            (Project.CREATED, True),
-            (Project.CREATED, False),
-            (Project.REJECTED, True),
-            (Project.REJECTED, False),
-        ]
+    "project_status, is_public",
+    [
+        (Project.APPROVED, False),
+        (Project.CREATED, True),
+        (Project.CREATED, False),
+        (Project.REJECTED, True),
+        (Project.REJECTED, False),
+    ],
 )
-def test_non_representative_cannot_view_non_public_non_approved_organization_projects(app: DjangoTestApp, project_status, is_public: bool):
+def test_non_representative_cannot_view_non_public_non_approved_organization_projects(
+    app: DjangoTestApp, project_status, is_public: bool
+):
     organization = OrganizationFactory()
     user = UserFactory()
     project = ProjectFactory(organization=organization, is_public=is_public, status=project_status)
     app.set_user(user)
 
-    resp = app.get(reverse('project-detail', args=[project.pk]), expect_errors=True)
+    resp = app.get(reverse("project-detail", args=[project.pk]), expect_errors=True)
     assert resp.status_code == 403
 
+
 @pytest.mark.parametrize(
-        'project_status, is_public',
-        [
-            (Project.APPROVED, True),
-            (Project.APPROVED, False),
-            (Project.CREATED, True),
-            (Project.CREATED, False),
-            (Project.REJECTED, True),
-            (Project.REJECTED, False),
-        ]
+    "project_status, is_public",
+    [
+        (Project.APPROVED, True),
+        (Project.APPROVED, False),
+        (Project.CREATED, True),
+        (Project.CREATED, False),
+        (Project.REJECTED, True),
+        (Project.REJECTED, False),
+    ],
 )
 def test_user_can_view_any_personal_projects(app: DjangoTestApp, project_status, is_public: bool):
     user = UserFactory()
     project = ProjectFactory(user=user, is_public=is_public, status=project_status)
     app.set_user(user)
 
-    resp = app.get(reverse('project-detail', args=[project.pk]))
-    assert resp.context['object'] == project
+    resp = app.get(reverse("project-detail", args=[project.pk]))
+    assert resp.context["object"] == project
 
 
 @pytest.mark.parametrize(
-        'project_status, is_public',
-        [
-            (Project.APPROVED, True),
-            (Project.APPROVED, False),
-            (Project.CREATED, True),
-            (Project.CREATED, False),
-            (Project.REJECTED, True),
-            (Project.REJECTED, False),
-        ]
+    "project_status, is_public",
+    [
+        (Project.APPROVED, True),
+        (Project.APPROVED, False),
+        (Project.CREATED, True),
+        (Project.CREATED, False),
+        (Project.REJECTED, True),
+        (Project.REJECTED, False),
+    ],
 )
 def test_assigner_can_view_any_projects_it_is_part_of(app: DjangoTestApp, project_status, is_public: bool):
     organization = OrganizationFactory()
@@ -533,15 +518,17 @@ def test_assigner_can_view_any_projects_it_is_part_of(app: DjangoTestApp, projec
     project.datasets.add(dataset)
     app.set_user(user)
 
-    resp = app.get(reverse('project-detail', args=[project.pk]))
-    assert resp.context['object'] == project
+    resp = app.get(reverse("project-detail", args=[project.pk]))
+    assert resp.context["object"] == project
+
 
 def test_clients_view_without_permission(app: DjangoTestApp):
     user = UserFactory()
     project = ProjectFactory(user=user)
     app.set_user(user)
-    resp = app.get(reverse('project-clients', args=[project.pk]), expect_errors=True)
+    resp = app.get(reverse("project-clients", args=[project.pk]), expect_errors=True)
     assert resp.status_code == 403
+
 
 def test_clients_view(app: DjangoTestApp):
     organization = OrganizationFactory()
@@ -550,7 +537,7 @@ def test_clients_view(app: DjangoTestApp):
     project = ProjectFactory(user=user, organization=organization)
     UseCaseClientFactory.create_batch(2, use_case=project)
     app.set_user(user)
-    resp = app.get(reverse('project-clients', args=[project.pk]))
+    resp = app.get(reverse("project-clients", args=[project.pk]))
     assert resp.status_code == 200
     assert project.client_set.count() == 2
     assert resp.context["clients"].count() == 2
@@ -563,12 +550,8 @@ def test_client_create_without_permission(app: DjangoTestApp):
     app.set_user(user)
     project = ProjectFactory(user=user, organization=organization)
 
-    resp = app.get(
-        reverse("project-clients-create", args=[project.pk]),
-        expect_errors=True
-    )
+    resp = app.get(reverse("project-clients-create", args=[project.pk]), expect_errors=True)
     assert resp.status_code == 403
-
 
 
 def test_client_create(app: DjangoTestApp, oauth_settings):
@@ -606,14 +589,22 @@ def test_client_create(app: DjangoTestApp, oauth_settings):
 
         # --- Assertions for correct OAuth requests ---
         # Access token POST
-        token_requests = [req for req in m.request_history if req.method == "POST" and req.url == oauth_settings.OAUTH_SERVER_TOKEN_URL]
+        token_requests = [
+            req
+            for req in m.request_history
+            if req.method == "POST" and req.url == oauth_settings.OAUTH_SERVER_TOKEN_URL
+        ]
         assert token_requests, "No access token request made"
         token_data = parse_qs(token_requests[0].text)
         assert token_data.get("grant_type") == ["client_credentials"]
         assert token_data.get("scope") == [oauth_settings.OAUTH_CLIENTS_MANAGEMENT_SCOPE]
 
         # Client creation POST
-        client_requests = [req for req in m.request_history if req.method == "POST" and req.url == oauth_settings.OAUTH_SERVER_CLIENTS_URL]
+        client_requests = [
+            req
+            for req in m.request_history
+            if req.method == "POST" and req.url == oauth_settings.OAUTH_SERVER_CLIENTS_URL
+        ]
         assert client_requests, "No client creation request made"
         client_json = client_requests[0].json()
         assert "secret" in client_json
@@ -628,12 +619,8 @@ def test_client_update_without_permission(app: DjangoTestApp):
     app.set_user(user)
     project = ProjectFactory(user=user, organization=organization)
     client = UseCaseClientFactory(use_case=project)
-    resp = app.get(
-        reverse("project-clients-update", args=[project.pk, client.uuid]),
-        expect_errors=True
-    )
+    resp = app.get(reverse("project-clients-update", args=[project.pk, client.uuid]), expect_errors=True)
     assert resp.status_code == 403
-
 
 
 def test_client_update(app: DjangoTestApp, oauth_settings):
@@ -646,9 +633,7 @@ def test_client_update(app: DjangoTestApp, oauth_settings):
         project = ProjectFactory(organization=representative.content_object)
         client = UseCaseClientFactory()
 
-        form = app.get(
-            reverse("project-clients-update", args=[project.pk, client.uuid])
-        ).forms["client-form"]
+        form = app.get(reverse("project-clients-update", args=[project.pk, client.uuid])).forms["client-form"]
         form["name"] = "Client"
         resp = form.submit()
 
@@ -669,12 +654,8 @@ def test_client_scope_create(app: DjangoTestApp, oauth_settings, organization):
         app.set_user(user)
         project = ProjectFactory(organization=representative.content_object)
         client: UseCaseClient = UseCaseClientFactory(use_case=project)
-        agreement = AgreementFactory(
-            project=project, assigner=organization, status=AgreementStatuses.ACTIVE
-        )
-        available_scope: AgreementScope = agreement.scopes.create(
-            scope="Test", action="WRITE", resource="dataset"
-        )
+        agreement = AgreementFactory(project=project, assigner=organization, status=AgreementStatuses.ACTIVE)
+        available_scope: AgreementScope = agreement.scopes.create(scope="Test", action="WRITE", resource="dataset")
 
         url = reverse("project-clients-scopes-create", args=[project.pk, client.pk])
         resp = app.get(url)
@@ -684,9 +665,7 @@ def test_client_scope_create(app: DjangoTestApp, oauth_settings, organization):
         form["scope"] = available_scope.pk
         response = form.submit()
 
-        created_scope = UseCaseClientScope.objects.filter(
-            use_case_client=client
-        ).first()
+        created_scope = UseCaseClientScope.objects.filter(use_case_client=client).first()
 
         assert created_scope
         assert created_scope.is_active is False
@@ -705,16 +684,12 @@ def test_client_scope_toggle(app: DjangoTestApp, oauth_settings):
         client: UseCaseClient = UseCaseClientFactory(use_case=project)
         scope = client.scopes.create(scope="Test", action="WRITE", resource="dataset")
 
-        url = reverse(
-            "project-clients-scopes-detail-toggle", args=[project.pk, client.pk, scope.pk]
-        )
+        url = reverse("project-clients-scopes-detail-toggle", args=[project.pk, client.pk, scope.pk])
         resp = app.post(url)
 
         assert resp.status_code == 302
 
-        updated_scope = UseCaseClientScope.objects.filter(
-            use_case_client=client
-        ).first()
+        updated_scope = UseCaseClientScope.objects.filter(use_case_client=client).first()
         assert updated_scope
         assert updated_scope.is_active is True
 
@@ -736,6 +711,7 @@ def test_client_scope_toggle(app: DjangoTestApp, oauth_settings):
         assert data.get("grant_type") == ["client_credentials"]
         assert data.get("scope") == [oauth_settings.OAUTH_CLIENTS_MANAGEMENT_SCOPE]
 
+
 @pytest.fixture
 def oauth_settings(settings):
     settings.OAUTH_SERVER_TOKEN_URL = "https://oauth.test/token"
@@ -743,6 +719,7 @@ def oauth_settings(settings):
     settings.OAUTH_CLIENT_SECRET_BASE64 = "ZmFrZV9iYXNlNjRfY2xpZW50X3NlY3JldA=="
     settings.OAUTH_CLIENTS_MANAGEMENT_SCOPE = "auth_clients"
     return settings
+
 
 def mock_oauth_endpoints(m, settings):
     m.post(

--- a/tests/requests/test_escalation_tasks.py
+++ b/tests/requests/test_escalation_tasks.py
@@ -122,11 +122,17 @@ class TestGetDatasetEditorsEmails:
         dataset_ct = ContentType.objects.get_for_model(dataset)
 
         RepresentativeFactory(
-            content_type=dataset_ct, object_id=dataset.pk, email="editor1@example.com", role=Representative.OPEN_DATA_MANAGER
+            content_type=dataset_ct,
+            object_id=dataset.pk,
+            email="editor1@example.com",
+            role=Representative.OPEN_DATA_MANAGER,
         )
 
         RepresentativeFactory(
-            content_type=dataset_ct, object_id=dataset.pk, email="editor2@example.com", role=Representative.RESOURCE_MANAGER
+            content_type=dataset_ct,
+            object_id=dataset.pk,
+            email="editor2@example.com",
+            role=Representative.RESOURCE_MANAGER,
         )
 
         emails = get_dataset_managers(request_obj)
@@ -139,11 +145,17 @@ class TestGetDatasetEditorsEmails:
         dataset_ct = ContentType.objects.get_for_model(dataset)
 
         RepresentativeFactory(
-            content_type=dataset_ct, object_id=dataset.pk, email="editor@example.com", role=Representative.OPEN_DATA_MANAGER
+            content_type=dataset_ct,
+            object_id=dataset.pk,
+            email="editor@example.com",
+            role=Representative.OPEN_DATA_MANAGER,
         )
 
         RepresentativeFactory(
-            content_type=dataset_ct, object_id=dataset.pk, email="coord@example.com", role=Representative.OPEN_DATA_COORDINATOR
+            content_type=dataset_ct,
+            object_id=dataset.pk,
+            email="coord@example.com",
+            role=Representative.OPEN_DATA_COORDINATOR,
         )
 
         emails = get_dataset_managers(request_obj)
@@ -174,11 +186,17 @@ class TestGetOrganizationCoordinatorsEmails:
         org_ct = ContentType.objects.get_for_model(organization)
 
         RepresentativeFactory(
-            content_type=org_ct, object_id=organization.pk, email="coord1@example.com", role=Representative.OPEN_DATA_COORDINATOR
+            content_type=org_ct,
+            object_id=organization.pk,
+            email="coord1@example.com",
+            role=Representative.OPEN_DATA_COORDINATOR,
         )
 
         RepresentativeFactory(
-            content_type=org_ct, object_id=organization.pk, email="coord2@example.com", role=Representative.RESOURCE_COORDINATOR
+            content_type=org_ct,
+            object_id=organization.pk,
+            email="coord2@example.com",
+            role=Representative.RESOURCE_COORDINATOR,
         )
 
         emails = get_organization_coordinators_emails(request_obj)
@@ -191,11 +209,17 @@ class TestGetOrganizationCoordinatorsEmails:
         org_ct = ContentType.objects.get_for_model(organization)
 
         RepresentativeFactory(
-            content_type=org_ct, object_id=organization.pk, email="coord@example.com", role=Representative.RESOURCE_COORDINATOR
+            content_type=org_ct,
+            object_id=organization.pk,
+            email="coord@example.com",
+            role=Representative.RESOURCE_COORDINATOR,
         )
 
         RepresentativeFactory(
-            content_type=org_ct, object_id=organization.pk, email="manager@example.com", role=Representative.RESOURCE_MANAGER
+            content_type=org_ct,
+            object_id=organization.pk,
+            email="manager@example.com",
+            role=Representative.RESOURCE_MANAGER,
         )
 
         emails = get_organization_coordinators_emails(request_obj)
@@ -228,7 +252,10 @@ class TestGetRecipientsForLevel:
         dataset_ct = ContentType.objects.get_for_model(dataset)
 
         RepresentativeFactory(
-            content_type=dataset_ct, object_id=dataset.pk, email="editor@example.com", role=Representative.OPEN_DATA_MANAGER
+            content_type=dataset_ct,
+            object_id=dataset.pk,
+            email="editor@example.com",
+            role=Representative.OPEN_DATA_MANAGER,
         )
 
         escalation.escalation_level = RequestEscalation.LEVEL_MANAGER
@@ -241,7 +268,10 @@ class TestGetRecipientsForLevel:
         org_ct = ContentType.objects.get_for_model(organization)
 
         RepresentativeFactory(
-            content_type=org_ct, object_id=organization.pk, email="coord@example.com", role=Representative.OPEN_DATA_COORDINATOR
+            content_type=org_ct,
+            object_id=organization.pk,
+            email="coord@example.com",
+            role=Representative.OPEN_DATA_COORDINATOR,
         )
 
         escalation.escalation_level = RequestEscalation.LEVEL_COORDINATOR
@@ -266,7 +296,10 @@ class TestEscalateToNextLevel:
         org_ct = ContentType.objects.get_for_model(organization)
 
         RepresentativeFactory(
-            content_type=org_ct, object_id=organization.pk, email="coord@example.com", role=Representative.OPEN_DATA_COORDINATOR
+            content_type=org_ct,
+            object_id=organization.pk,
+            email="coord@example.com",
+            role=Representative.OPEN_DATA_COORDINATOR,
         )
 
         escalation.escalation_level = RequestEscalation.LEVEL_MANAGER
@@ -355,7 +388,10 @@ class TestEscalationPipelineFunctional:
     ):
         dataset_ct = ContentType.objects.get_for_model(dataset)
         RepresentativeFactory(
-            content_type=dataset_ct, object_id=dataset.pk, email="editor@example.com", role=Representative.OPEN_DATA_MANAGER
+            content_type=dataset_ct,
+            object_id=dataset.pk,
+            email="editor@example.com",
+            role=Representative.OPEN_DATA_MANAGER,
         )
 
         request_obj = RequestFactory(dataset=dataset)
@@ -402,7 +438,10 @@ class TestEscalationPipelineFunctional:
 
         # Level 0: Editors
         RepresentativeFactory(
-            content_type=dataset_ct, object_id=dataset.pk, email="editor@example.com", role=Representative.OPEN_DATA_MANAGER
+            content_type=dataset_ct,
+            object_id=dataset.pk,
+            email="editor@example.com",
+            role=Representative.OPEN_DATA_MANAGER,
         )
 
         # Level 1: Coordinators
@@ -519,7 +558,10 @@ class TestEscalationPipelineFunctional:
         org_ct = ContentType.objects.get_for_model(organization)
 
         RepresentativeFactory(
-            content_type=dataset_ct, object_id=dataset.pk, email="editor@example.com", role=Representative.OPEN_DATA_MANAGER
+            content_type=dataset_ct,
+            object_id=dataset.pk,
+            email="editor@example.com",
+            role=Representative.OPEN_DATA_MANAGER,
         )
 
         coordinator_user = UserFactory(email="coordinator@example.com")
@@ -583,7 +625,10 @@ class TestEscalationPipelineFunctional:
         org_ct = ContentType.objects.get_for_model(organization)
 
         RepresentativeFactory(
-            content_type=dataset_ct, object_id=dataset.pk, email="editor@example.com", role=Representative.OPEN_DATA_MANAGER
+            content_type=dataset_ct,
+            object_id=dataset.pk,
+            email="editor@example.com",
+            role=Representative.OPEN_DATA_MANAGER,
         )
 
         RepresentativeFactory(
@@ -633,7 +678,10 @@ class TestEscalationPipelineFunctional:
         """
         dataset_ct = ContentType.objects.get_for_model(dataset)
         RepresentativeFactory(
-            content_type=dataset_ct, object_id=dataset.pk, email="editor@example.com", role=Representative.OPEN_DATA_MANAGER
+            content_type=dataset_ct,
+            object_id=dataset.pk,
+            email="editor@example.com",
+            role=Representative.OPEN_DATA_MANAGER,
         )
 
         # Day 0: Create request

--- a/tests/requests/test_views.py
+++ b/tests/requests/test_views.py
@@ -34,21 +34,16 @@ def test_request_create(app: DjangoTestApp):
     app.set_user(user)
     url = reverse("request-create")
     revision_comment = RevisionComment(
-        source=RevisionSource.VIEW,
-        action="request-create",
-        http_method="POST",
-        path=url,
-        args=(),
-        kwargs={}
+        source=RevisionSource.VIEW, action="request-create", http_method="POST", path=url, args=(), kwargs={}
     )
-    form = app.get(url).forms['request-form']
-    form['title'] = "Request"
-    form['description'] = "Description"
+    form = app.get(url).forms["request-form"]
+    form["title"] = "Request"
+    form["description"] = "Description"
     resp = form.submit()
     added_request = Request.objects.filter(translations__title="Request")
     assert added_request.count() == 1
     assert resp.status_code == 302
-    assert resp.url == Request.objects.filter(translations__title='Request').first().get_absolute_url()
+    assert resp.url == Request.objects.filter(translations__title="Request").first().get_absolute_url()
     assert Version.objects.get_for_object(added_request.first()).count() == 1
     assert Version.objects.get_for_object(added_request.first()).first().revision.comment == revision_comment.to_json()
 
@@ -76,11 +71,11 @@ def test_request_update_with_permitted_user(app: DjangoTestApp):
         http_method="POST",
         path=url,
         args=(),
-        kwargs={"pk": request.pk}
+        kwargs={"pk": request.pk},
     )
-    form = app.get(url).forms['request-form']
-    form['title'] = "Updated title"
-    form['description'] = "Updated description"
+    form = app.get(url).forms["request-form"]
+    form["title"] = "Updated title"
+    form["description"] = "Updated description"
     resp = form.submit()
     assert resp.status_code == 302
     assert resp.url == request.get_absolute_url()
@@ -103,13 +98,13 @@ def test_request_detail_view(app: DjangoTestApp):
     structure1 = RequestStructureFactory(request_id=request.pk)
     structure2 = RequestStructureFactory(request_id=request.pk)
 
-    resp = app.get(reverse('request-detail', args=[request.pk]))
+    resp = app.get(reverse("request-detail", args=[request.pk]))
 
-    assert resp.context['status'] == "Atmestas"
-    assert resp.context['purposes'] == ['science', 'product']
-    assert resp.context['changes'] == ['format']
-    assert resp.context['formats'] == ['csv', 'json', 'rdf']
-    assert list(resp.context['structure']) == [structure1, structure2]
+    assert resp.context["status"] == "Atmestas"
+    assert resp.context["purposes"] == ["science", "product"]
+    assert resp.context["changes"] == ["format"]
+    assert resp.context["formats"] == ["csv", "json", "rdf"]
+    assert list(resp.context["structure"]) == [structure1, structure2]
 
 
 @pytest.mark.django_db
@@ -117,7 +112,7 @@ def test_request_history_view_without_permission(app: DjangoTestApp):
     user = UserFactory()
     request = RequestFactory()
     app.set_user(user)
-    resp = app.get(reverse('request-history', args=[request.pk]), expect_errors=True)
+    resp = app.get(reverse("request-history", args=[request.pk]), expect_errors=True)
     assert resp.status_code == 403
 
 
@@ -135,19 +130,19 @@ def test_request_history_view_with_permission(app: DjangoTestApp):
         http_method="POST",
         path=url,
         args=(),
-        kwargs={"pk": request.pk}
+        kwargs={"pk": request.pk},
     )
-    form = app.get(url).forms['request-form']
-    form['title'] = "Updated title"
-    form['description'] = "Updated description"
+    form = app.get(url).forms["request-form"]
+    form["title"] = "Updated title"
+    form["description"] = "Updated description"
     resp = form.submit().follow()
     resp = resp.click(linkid="history-tab")
-    assert resp.context['detail_url_name'] == 'request-detail'
-    assert resp.context['history_url_name'] == 'request-history'
-    assert len(resp.context['history']) == 1
-    history_action = resp.context['history'][0]['action']
+    assert resp.context["detail_url_name"] == "request-detail"
+    assert resp.context["history_url_name"] == "request-history"
+    assert len(resp.context["history"]) == 1
+    history_action = resp.context["history"][0]["action"]
     assert history_action["comment"] == f"{revision_comment.action}({revision_comment.kwargs})"
-    assert resp.context['history'][0]['user'] == user
+    assert resp.context["history"][0]["user"] == user
 
 
 @pytest.mark.django_db
@@ -156,7 +151,7 @@ def test_add_request_to_plan_with_non_representative(app: DjangoTestApp):
     app.set_user(user)
     request = RequestFactory(user=user)
 
-    resp = app.get(reverse('request-plans-create', args=[request.pk]), expect_errors=True)
+    resp = app.get(reverse("request-plans-create", args=[request.pk]), expect_errors=True)
     assert resp.status_code == 403
 
 
@@ -170,20 +165,15 @@ def test_add_request_to_plan_with_representative(app: DjangoTestApp):
     )
     app.set_user(representative.user)
     request = RequestFactory(user=representative.user, status=Request.APPROVED)
-    RequestAssignmentFactory(
-        request=request,
-        organization=organization
-    )
-    plan = PlanFactory(
-        deadline=(date.today() + timedelta(days=1))
-    )
+    RequestAssignmentFactory(request=request, organization=organization)
+    plan = PlanFactory(deadline=(date.today() + timedelta(days=1)))
 
-    resp = app.get(reverse('request-plans-create', args=[request.pk]))
-    form = resp.forms['request-plan-form']
-    form['plan'] = plan.pk
+    resp = app.get(reverse("request-plans-create", args=[request.pk]))
+    form = resp.forms["request-plan-form"]
+    form["plan"] = plan.pk
     resp = form.submit()
 
-    assert resp.url == reverse('request-plans', args=[request.pk])
+    assert resp.url == reverse("request-plans", args=[request.pk])
     assert request.planrequest_set.count() == 1
     assert request.planrequest_set.first().plan == plan
 
@@ -194,7 +184,7 @@ def test_add_request_to_plan_with_closed_request(app: DjangoTestApp):
     app.set_user(user)
     request = RequestFactory(status=Request.REJECTED)
 
-    resp = app.get(reverse('request-plans-create', args=[request.pk]), expect_errors=True)
+    resp = app.get(reverse("request-plans-create", args=[request.pk]), expect_errors=True)
     assert resp.status_code == 403
 
 
@@ -206,7 +196,7 @@ def test_add_request_to_plan_title(app: DjangoTestApp):
     request = RequestFactory(status=Request.APPROVED)
     request.organizations.add(organization)
 
-    form = app.get(reverse('request-plans-create', args=[request.pk])).forms['plan-form']
+    form = app.get(reverse("request-plans-create", args=[request.pk])).forms["plan-form"]
     form.submit()
 
     plan = Plan.objects.filter(planrequest__request=request)
@@ -219,15 +209,12 @@ def test_add_request_to_plan_title_error(app: DjangoTestApp):
     organization = OrganizationFactory()
     user = UserFactory(is_staff=True, organization=organization)
     app.set_user(user)
-    request_object = RequestObjectFactory(
-        external_object_id="123",
-        external_content_type="datasets/Model"
-    )
+    request_object = RequestObjectFactory(external_object_id="123", external_content_type="datasets/Model")
     request_object.request.organizations.add(organization)
     request_object.request.status = Request.APPROVED
     request_object.request.save()
 
-    form = app.get(reverse('request-plans-create', args=[request_object.request.pk])).forms['plan-form']
+    form = app.get(reverse("request-plans-create", args=[request_object.request.pk])).forms["plan-form"]
     form.submit()
 
     plan = Plan.objects.filter(planrequest__request=request_object.request)
@@ -239,42 +226,26 @@ def test_add_request_to_plan_title_error(app: DjangoTestApp):
 def test_request_orgs_view(app: DjangoTestApp):
     organization = OrganizationFactory()
     request = RequestFactory()
-    RequestAssignmentFactory(
-        organization=organization,
-        request=request,
-        status=request.status
-    )
-    resp = app.get(reverse('request-organizations', args=[request.pk]))
-    assert resp.html.find(id='display_date')
+    RequestAssignmentFactory(organization=organization, request=request, status=request.status)
+    resp = app.get(reverse("request-organizations", args=[request.pk]))
+    assert resp.html.find(id="display_date")
 
 
 @pytest.mark.django_db
 def test_request_orgs_view_delete_button_no_user(app: DjangoTestApp):
     request = RequestFactory()
-    resp = app.get(reverse('request-organizations', args=[request.pk]))
-    delete_button = resp.html.find(id='request-orgs-delete')
+    resp = app.get(reverse("request-organizations", args=[request.pk]))
+    delete_button = resp.html.find(id="request-orgs-delete")
     assert delete_button is None
-
-
-@pytest.mark.django_db
-def test_request_orgs_view_click_delete_button_no_user(app: DjangoTestApp):
-    request = RequestFactory()
-    resp = app.get(reverse('request-organizations', args=[request.pk]))
-    resp = resp.click(linkid='org-dataset-url')
-    assert resp.url == reverse('request-organizations', args=[request.pk])
 
 
 @pytest.mark.django_db
 def test_request_orgs_view_click_delete_button_redirects_if_no_user(app: DjangoTestApp):
     request = RequestFactory()
     organization = OrganizationFactory()
-    ra = RequestAssignmentFactory(
-        organization=organization,
-        request=request,
-        status=request.status
-    )
-    resp = app.get(reverse('request-orgs-delete', args=[ra.pk]))
-    assert resp.url == reverse('request-organizations', args=[request.pk])
+    ra = RequestAssignmentFactory(organization=organization, request=request, status=request.status)
+    resp = app.get(reverse("request-orgs-delete", args=[ra.pk]))
+    assert resp.url == reverse("request-organizations", args=[request.pk])
 
 
 @pytest.mark.django_db
@@ -283,14 +254,10 @@ def test_request_orgs_view_click_delete_button_staff_user(app: DjangoTestApp):
     app.set_user(user)
     request = RequestFactory()
     organization = OrganizationFactory()
-    ra = RequestAssignmentFactory(
-        organization=organization,
-        request=request,
-        status=request.status
-    )
-    form = app.get(reverse('request-orgs-delete', args=[ra.pk])).forms['delete-form']
+    ra = RequestAssignmentFactory(organization=organization, request=request, status=request.status)
+    form = app.get(reverse("request-orgs-delete", args=[ra.pk])).forms["delete-form"]
     resp = form.submit()
-    assert resp.url == reverse('request-organizations', args=[request.pk])
+    assert resp.url == reverse("request-organizations", args=[request.pk])
 
 
 @pytest.mark.django_db
@@ -299,18 +266,15 @@ def test_add_new_dataset_to_request_without_permission(app: DjangoTestApp):
     app.set_user(user)
     request = RequestFactory()
     organization = OrganizationFactory()
-    RequestAssignmentFactory(
-        organization=organization,
-        request=request,
-        status=request.status
-    )
+    RequestAssignmentFactory(organization=organization, request=request, status=request.status)
     subclass = DCATResourceSubclassFactory()
 
-    resp = app.get(reverse('request-datasets', args=[request.pk]))
+    resp = app.get(reverse("request-datasets", args=[request.pk]))
     assert "add-new-dataset" not in resp.text
     resp = app.get(
-        reverse('dataset-add', args=[organization.pk, subclass.pk]) + f"?next={reverse('request-datasets', args=[request.pk])}",
-        expect_errors=True
+        reverse("dataset-add", args=[organization.pk, subclass.pk])
+        + f"?next={reverse('request-datasets', args=[request.pk])}",
+        expect_errors=True,
     )
     assert resp.status_code == 403
 
@@ -321,21 +285,18 @@ def test_add_new_dataset_to_request_with_representative_permission(app: DjangoTe
     user = UserFactory(organization=organization)
     app.set_user(user)
     request = RequestFactory()
-    RequestAssignmentFactory(
-        organization=organization,
-        request=request,
-        status=request.status
-    )
+    RequestAssignmentFactory(organization=organization, request=request, status=request.status)
     RepresentativeFactory(
-        user=user,
-        content_type=ContentType.objects.get_for_model(organization),
-        object_id=organization.pk
+        user=user, content_type=ContentType.objects.get_for_model(organization), object_id=organization.pk
     )
-    resp = app.get(reverse('request-datasets', args=[request.pk]))
+    resp = app.get(reverse("request-datasets", args=[request.pk]))
     assert "add-new-dataset" in resp.text
     resp = resp.click(linkid="add-new-dataset")
-    assert resp.request.path_qs == \
-           reverse('resource-subclass-add', args=[organization.pk]) + f"?next={reverse('request-datasets', args=[request.pk])}"
+    assert (
+        resp.request.path_qs
+        == reverse("resource-subclass-add", args=[organization.pk])
+        + f"?next={reverse('request-datasets', args=[request.pk])}"
+    )
 
 
 @pytest.mark.django_db
@@ -345,26 +306,23 @@ def test_add_new_dataset_to_request_with_organization_permission(app: DjangoTest
     user = UserFactory(organization=organization2)
     app.set_user(user)
     request = RequestFactory()
-    RequestAssignmentFactory(
-        organization=organization,
-        request=request,
-        status=request.status
-    )
+    RequestAssignmentFactory(organization=organization, request=request, status=request.status)
     RepresentativeFactory(
         organization=organization2,
         content_type=ContentType.objects.get_for_model(organization),
-        object_id=organization.pk
+        object_id=organization.pk,
     )
     RepresentativeFactory(
-        user=user,
-        content_type=ContentType.objects.get_for_model(organization2),
-        object_id=organization2.pk
+        user=user, content_type=ContentType.objects.get_for_model(organization2), object_id=organization2.pk
     )
-    resp = app.get(reverse('request-datasets', args=[request.pk]))
+    resp = app.get(reverse("request-datasets", args=[request.pk]))
     assert "add-new-dataset" in resp.text
     resp = resp.click(linkid="add-new-dataset")
-    assert resp.request.path_qs == \
-           reverse('resource-subclass-add', args=[organization2.pk]) + f"?next={reverse('request-datasets', args=[request.pk])}"
+    assert (
+        resp.request.path_qs
+        == reverse("resource-subclass-add", args=[organization2.pk])
+        + f"?next={reverse('request-datasets', args=[request.pk])}"
+    )
 
 
 @pytest.mark.django_db
@@ -373,14 +331,10 @@ def test_add_existing_dataset_to_request_without_permission(app: DjangoTestApp):
     app.set_user(user)
     request = RequestFactory()
     organization = OrganizationFactory()
-    RequestAssignmentFactory(
-        organization=organization,
-        request=request,
-        status=request.status
-    )
-    resp = app.get(reverse('request-datasets', args=[request.pk]))
+    RequestAssignmentFactory(organization=organization, request=request, status=request.status)
+    resp = app.get(reverse("request-datasets", args=[request.pk]))
     assert "add-dataset" not in resp.text
-    resp = app.get(reverse('request-datasets-edit', args=[request.pk]), expect_errors=True)
+    resp = app.get(reverse("request-datasets-edit", args=[request.pk]), expect_errors=True)
     assert resp.status_code == 403
 
 
@@ -391,20 +345,14 @@ def test_add_existing_dataset_to_request_with_representative_permission(app: Dja
     app.set_user(user)
     request = RequestFactory()
     organization = OrganizationFactory()
-    RequestAssignmentFactory(
-        organization=organization,
-        request=request,
-        status=request.status
-    )
+    RequestAssignmentFactory(organization=organization, request=request, status=request.status)
     RepresentativeFactory(
-        user=user,
-        content_type=ContentType.objects.get_for_model(organization),
-        object_id=organization.pk
+        user=user, content_type=ContentType.objects.get_for_model(organization), object_id=organization.pk
     )
-    resp = app.get(reverse('request-datasets', args=[request.pk]))
+    resp = app.get(reverse("request-datasets", args=[request.pk]))
     assert "add-dataset" in resp.text
-    resp = app.get(reverse('request-datasets-edit', args=[request.pk]))
-    assert resp.request.path_qs == reverse('request-datasets-edit', args=[request.pk])
+    resp = app.get(reverse("request-datasets-edit", args=[request.pk]))
+    assert resp.request.path_qs == reverse("request-datasets-edit", args=[request.pk])
 
 
 @pytest.mark.django_db
@@ -414,25 +362,19 @@ def test_add_existing_dataset_to_request_with_organization_permission(app: Djang
     user = UserFactory(organization=organization2)
     app.set_user(user)
     request = RequestFactory()
-    RequestAssignmentFactory(
-        organization=organization,
-        request=request,
-        status=request.status
-    )
+    RequestAssignmentFactory(organization=organization, request=request, status=request.status)
     RepresentativeFactory(
         organization=organization2,
         content_type=ContentType.objects.get_for_model(organization),
-        object_id=organization.pk
+        object_id=organization.pk,
     )
     RepresentativeFactory(
-        user=user,
-        content_type=ContentType.objects.get_for_model(organization2),
-        object_id=organization2.pk
+        user=user, content_type=ContentType.objects.get_for_model(organization2), object_id=organization2.pk
     )
-    resp = app.get(reverse('request-datasets', args=[request.pk]))
+    resp = app.get(reverse("request-datasets", args=[request.pk]))
     assert "add-dataset" in resp.text
-    resp = app.get(reverse('request-datasets-edit', args=[request.pk]))
-    assert resp.request.path_qs == reverse('request-datasets-edit', args=[request.pk])
+    resp = app.get(reverse("request-datasets-edit", args=[request.pk]))
+    assert resp.request.path_qs == reverse("request-datasets-edit", args=[request.pk])
 
 
 @pytest.mark.django_db
@@ -446,7 +388,7 @@ def test_open_data_coordinator_cannot_see_non_public_datasets(app: "DjangoTestAp
         organization=org,
         content_type=ContentType.objects.get_for_model(org),
         role=Representative.OPEN_DATA_COORDINATOR,
-        object_id=org.pk
+        object_id=org.pk,
     )
 
     request = RequestFactory()
@@ -458,9 +400,7 @@ def test_open_data_coordinator_cannot_see_non_public_datasets(app: "DjangoTestAp
     non_public_ds = DatasetFactory(organization=org, access_rights=Dataset.NON_PUBLIC)
 
     for ds in [public_ds, restricted_ds, non_public_ds]:
-        RequestObjectFactory(
-            request=request, content_type=ContentType.objects.get_for_model(Dataset), object_id=ds.pk
-        )
+        RequestObjectFactory(request=request, content_type=ContentType.objects.get_for_model(Dataset), object_id=ds.pk)
 
     url = reverse("request-datasets-edit", args=[request.pk])
     resp = app.get(url)
@@ -476,20 +416,12 @@ def test_remove_dataset_from_request_without_permission(app: DjangoTestApp):
     app.set_user(user)
     request = RequestFactory()
     organization = OrganizationFactory()
-    RequestAssignmentFactory(
-        organization=organization,
-        request=request,
-        status=request.status
-    )
+    RequestAssignmentFactory(organization=organization, request=request, status=request.status)
     dataset = DatasetFactory()
-    RequestObjectFactory(
-        request=request,
-        content_type=ContentType.objects.get_for_model(dataset),
-        object_id=dataset.pk
-    )
-    resp = app.get(reverse('request-datasets', args=[request.pk]))
+    RequestObjectFactory(request=request, content_type=ContentType.objects.get_for_model(dataset), object_id=dataset.pk)
+    resp = app.get(reverse("request-datasets", args=[request.pk]))
     assert f"remove-dataset-{dataset.pk}-btn" not in resp.text
-    resp = app.get(reverse('request-dataset-remove', args=[request.pk, dataset.pk]), expect_errors=True)
+    resp = app.get(reverse("request-dataset-remove", args=[request.pk, dataset.pk]), expect_errors=True)
     assert resp.status_code == 403
 
 
@@ -500,24 +432,14 @@ def test_remove_dataset_from_request_with_representative_permission(app: DjangoT
     app.set_user(user)
     request = RequestFactory()
     organization = OrganizationFactory()
-    RequestAssignmentFactory(
-        organization=organization,
-        request=request,
-        status=request.status
-    )
+    RequestAssignmentFactory(organization=organization, request=request, status=request.status)
     RepresentativeFactory(
-        user=user,
-        content_type=ContentType.objects.get_for_model(organization),
-        object_id=organization.pk
+        user=user, content_type=ContentType.objects.get_for_model(organization), object_id=organization.pk
     )
     dataset = DatasetFactory()
-    RequestObjectFactory(
-        request=request,
-        content_type=ContentType.objects.get_for_model(dataset),
-        object_id=dataset.pk
-    )
+    RequestObjectFactory(request=request, content_type=ContentType.objects.get_for_model(dataset), object_id=dataset.pk)
 
-    app.post(reverse('request-dataset-remove', args=[request.pk, dataset.pk]))
+    app.post(reverse("request-dataset-remove", args=[request.pk, dataset.pk]))
 
     request.refresh_from_db()
     assert request.pk
@@ -534,29 +456,19 @@ def test_remove_dataset_from_request_with_organization_permission(app: DjangoTes
     user = UserFactory(organization=organization2)
     app.set_user(user)
     request = RequestFactory()
-    RequestAssignmentFactory(
-        organization=organization,
-        request=request,
-        status=request.status
-    )
+    RequestAssignmentFactory(organization=organization, request=request, status=request.status)
     RepresentativeFactory(
         organization=organization2,
         content_type=ContentType.objects.get_for_model(organization),
-        object_id=organization.pk
+        object_id=organization.pk,
     )
     RepresentativeFactory(
-        user=user,
-        content_type=ContentType.objects.get_for_model(organization2),
-        object_id=organization2.pk
+        user=user, content_type=ContentType.objects.get_for_model(organization2), object_id=organization2.pk
     )
     dataset = DatasetFactory()
-    RequestObjectFactory(
-        request=request,
-        content_type=ContentType.objects.get_for_model(dataset),
-        object_id=dataset.pk
-    )
+    RequestObjectFactory(request=request, content_type=ContentType.objects.get_for_model(dataset), object_id=dataset.pk)
 
-    app.post(reverse('request-dataset-remove', args=[request.pk, dataset.pk]))
+    app.post(reverse("request-dataset-remove", args=[request.pk, dataset.pk]))
 
     request.refresh_from_db()
     assert request.pk
@@ -567,36 +479,36 @@ def test_remove_dataset_from_request_with_organization_permission(app: DjangoTes
 
 
 @pytest.mark.django_db
-@patch('vitrina.requests.views.email')
+@patch("vitrina.requests.views.email")
 def test_request_create_email_only_to_users_with_flag(mock_email, app: DjangoTestApp):
     creator = UserFactory(is_staff=True)
-    UserFactory(email='with_flag@test.com', receive_request_email=True)
-    UserFactory(email='without_flag@test.com', receive_request_email=False)
+    UserFactory(email="with_flag@test.com", receive_request_email=True)
+    UserFactory(email="without_flag@test.com", receive_request_email=False)
 
     app.set_user(creator)
-    form = app.get(reverse("request-create")).forms['request-form']
-    form['title'] = "Test Request"
-    form['description'] = "Test Description"
+    form = app.get(reverse("request-create")).forms["request-form"]
+    form["title"] = "Test Request"
+    form["description"] = "Test Description"
     form.submit()
 
     mock_email.assert_called_once()
     email_list = list(mock_email.call_args[0][0])
 
-    assert 'with_flag@test.com' in email_list
-    assert 'without_flag@test.com' not in email_list
+    assert "with_flag@test.com" in email_list
+    assert "without_flag@test.com" not in email_list
 
 
 @pytest.mark.django_db
-@patch('vitrina.requests.views.email')
+@patch("vitrina.requests.views.email")
 def test_request_create_no_email_when_no_users_have_flag(mock_email, app: DjangoTestApp):
     creator = UserFactory(is_staff=True)
-    UserFactory(email='user1@test.com', receive_request_email=False)
-    UserFactory(email='user2@test.com', receive_request_email=False)
+    UserFactory(email="user1@test.com", receive_request_email=False)
+    UserFactory(email="user2@test.com", receive_request_email=False)
 
     app.set_user(creator)
-    form = app.get(reverse("request-create")).forms['request-form']
-    form['title'] = "Test Request"
-    form['description'] = "Test Description"
+    form = app.get(reverse("request-create")).forms["request-form"]
+    form["title"] = "Test Request"
+    form["description"] = "Test Description"
     form.submit()
 
     if mock_email.called:

--- a/tests/requests/test_views.py
+++ b/tests/requests/test_views.py
@@ -22,7 +22,6 @@ from vitrina.requests.factories import (
 )
 from vitrina.requests.models import Request, RequestObject
 from vitrina.users.factories import UserFactory, ManagerFactory
-from vitrina.users.factories import UserFactory
 from vitrina.orgs.factories import OrganizationFactory, RepresentativeFactory
 from vitrina.utils import RevisionComment, RevisionSource
 
@@ -32,7 +31,6 @@ timezone = pytz.timezone(settings.TIME_ZONE)
 @pytest.mark.django_db
 def test_request_create(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
-    orgs = [OrganizationFactory(), OrganizationFactory()]
     app.set_user(user)
     url = reverse("request-create")
     revision_comment = RevisionComment(
@@ -126,7 +124,6 @@ def test_request_history_view_without_permission(app: DjangoTestApp):
 @pytest.mark.django_db
 def test_request_history_view_with_permission(app: DjangoTestApp):
     user = ManagerFactory(is_staff=True)
-    orgs = [OrganizationFactory().pk, OrganizationFactory().pk]
     request = RequestFactory(user=user)
     request.organizations.add(user.organization)
     app.set_user(user)
@@ -242,7 +239,7 @@ def test_add_request_to_plan_title_error(app: DjangoTestApp):
 def test_request_orgs_view(app: DjangoTestApp):
     organization = OrganizationFactory()
     request = RequestFactory()
-    ra = RequestAssignmentFactory(
+    RequestAssignmentFactory(
         organization=organization,
         request=request,
         status=request.status
@@ -268,7 +265,7 @@ def test_request_orgs_view_click_delete_button_no_user(app: DjangoTestApp):
 
 
 @pytest.mark.django_db
-def test_request_orgs_view_click_delete_button_no_user(app: DjangoTestApp):
+def test_request_orgs_view_click_delete_button_redirects_if_no_user(app: DjangoTestApp):
     request = RequestFactory()
     organization = OrganizationFactory()
     ra = RequestAssignmentFactory(
@@ -308,6 +305,7 @@ def test_add_new_dataset_to_request_without_permission(app: DjangoTestApp):
         status=request.status
     )
     subclass = DCATResourceSubclassFactory()
+
     resp = app.get(reverse('request-datasets', args=[request.pk]))
     assert "add-new-dataset" not in resp.text
     resp = app.get(
@@ -333,7 +331,6 @@ def test_add_new_dataset_to_request_with_representative_permission(app: DjangoTe
         content_type=ContentType.objects.get_for_model(organization),
         object_id=organization.pk
     )
-    subclass = DCATResourceSubclassFactory()
     resp = app.get(reverse('request-datasets', args=[request.pk]))
     assert "add-new-dataset" in resp.text
     resp = resp.click(linkid="add-new-dataset")
@@ -364,7 +361,6 @@ def test_add_new_dataset_to_request_with_organization_permission(app: DjangoTest
         object_id=organization2.pk
     )
     resp = app.get(reverse('request-datasets', args=[request.pk]))
-    subclass = DCATResourceSubclassFactory()
     assert "add-new-dataset" in resp.text
     resp = resp.click(linkid="add-new-dataset")
     assert resp.request.path_qs == \

--- a/tests/resources/test_views.py
+++ b/tests/resources/test_views.py
@@ -29,15 +29,18 @@ def test_change_form_wrong_login(app: DjangoTestApp, is_versioned: bool):
     resource = DatasetDistributionFactory()
     if is_versioned:
         ModelFactory(dataset=resource.dataset, distribution=resource)
-        resource_change_url = reverse('resource-change', kwargs={'pk': resource.id, 'version_id': resource.metadata_version.pk})
+        resource_change_url = reverse(
+            "resource-change", kwargs={"pk": resource.id, "version_id": resource.metadata_version.pk}
+        )
     else:
-        resource_change_url = reverse('resource-change-no-version', kwargs={'pk': resource.id})
+        resource_change_url = reverse("resource-change-no-version", kwargs={"pk": resource.id})
 
     user = User.objects.create_user(email="test@test.com", password="test123")
     app.set_user(user)
     response = app.get(resource_change_url)
     assert response.status_code == 302
     assert str(resource.dataset_id) in response.location
+
 
 @pytest.mark.parametrize("status", [s for s in VersionStatus.values if s != VersionStatus.DRAFT])
 @pytest.mark.django_db
@@ -48,38 +51,44 @@ def test_change_form_in_not_draft_version_not_allowed(app: DjangoTestApp, status
     resource.metadata_version.save()
     user = UserFactory(is_staff=True)
     app.set_user(user)
-    response = app.get(reverse('resource-change', kwargs={'pk': resource.id, 'version_id': resource.metadata_version.pk}), expect_errors=True)
+    response = app.get(
+        reverse("resource-change", kwargs={"pk": resource.id, "version_id": resource.metadata_version.pk}),
+        expect_errors=True,
+    )
     assert response.status_code == 302
     assert response.location == resource.get_absolute_url()
+
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("is_versioned", [True, False])
 def test_change_form_correct_login(app: DjangoTestApp, is_versioned: bool):
-    resource = DatasetDistributionFactory(title='base title', description='base description')
+    resource = DatasetDistributionFactory(title="base title", description="base description")
     if is_versioned:
         ModelFactory(dataset=resource.dataset, distribution=resource)
-        resource_change_url = reverse('resource-change', kwargs={'pk': resource.id, 'version_id': resource.metadata_version.pk})
-        expected_url = reverse('resource-detail', args=[resource.dataset.pk, resource.metadata_version.pk, resource.pk])
+        resource_change_url = reverse(
+            "resource-change", kwargs={"pk": resource.id, "version_id": resource.metadata_version.pk}
+        )
+        expected_url = reverse("resource-detail", args=[resource.dataset.pk, resource.metadata_version.pk, resource.pk])
         expected_metadata_rows = 1
     else:
-        resource_change_url = reverse('resource-change-no-version', kwargs={'pk': resource.id})
-        expected_url = reverse('resource-detail-no-version', args=[resource.dataset.pk, resource.pk])
+        resource_change_url = reverse("resource-change-no-version", kwargs={"pk": resource.id})
+        expected_url = reverse("resource-detail-no-version", args=[resource.dataset.pk, resource.pk])
         expected_metadata_rows = 0
 
     user = UserFactory(is_staff=True, organization=resource.dataset.organization)
     app.set_user(user)
-    form = app.get(resource_change_url).forms['resource-form']
-    form['title'] = "Edited title"
-    form['description'] = "edited resource description"
-    form['level'] = 2
+    form = app.get(resource_change_url).forms["resource-form"]
+    form["title"] = "Edited title"
+    form["description"] = "edited resource description"
+    form["level"] = 2
     resp = form.submit()
     resource.refresh_from_db()
     assert resp.status_code == 302
     assert resp.url == expected_url
-    assert resource.title == 'Edited title'
-    assert resource.description == 'edited resource description'
+    assert resource.title == "Edited title"
+    assert resource.description == "edited resource description"
     assert resource.metadata.count() == expected_metadata_rows
-    assert resource.name.startswith('resource')
+    assert resource.name.startswith("resource")
     assert resource.title == "Edited title"
     assert resource.description == "edited resource description"
     assert resource.level == 2
@@ -87,18 +96,18 @@ def test_change_form_correct_login(app: DjangoTestApp, is_versioned: bool):
 
 @pytest.mark.django_db
 def test_click_edit_button(app: DjangoTestApp):
-    resource = DatasetDistributionFactory(title='base title', description='base description')
+    resource = DatasetDistributionFactory(title="base title", description="base description")
     user = UserFactory(is_staff=True, organization=resource.dataset.organization)
     app.set_user(user)
-    response = app.get(reverse('dataset-detail', kwargs={'pk': resource.dataset_id})).follow()
-    response.click(linkid='change_resource')
+    response = app.get(reverse("dataset-detail", kwargs={"pk": resource.dataset_id})).follow()
+    response.click(linkid="change_resource")
     assert response.status_code == 200
 
 
 @pytest.mark.django_db
 def test_add_form_no_login(app: DjangoTestApp):
     resource = DatasetDistributionFactory()
-    response = app.get(reverse('resource-add', kwargs={'pk': resource.dataset_id}))
+    response = app.get(reverse("resource-add", kwargs={"pk": resource.dataset_id}))
     assert response.status_code == 302
     assert settings.LOGIN_URL in response.location
 
@@ -108,7 +117,7 @@ def test_add_form_wrong_login(app: DjangoTestApp):
     user = UserFactory()
     app.set_user(user)
     resource = DatasetDistributionFactory()
-    response = app.get(reverse('resource-add', kwargs={'pk': resource.dataset_id}))
+    response = app.get(reverse("resource-add", kwargs={"pk": resource.dataset_id}))
     assert response.status_code == 302
     assert str(resource.dataset_id) in response.location
 
@@ -116,67 +125,71 @@ def test_add_form_wrong_login(app: DjangoTestApp):
 @pytest.mark.django_db
 def test_add_form_correct_login(app: DjangoTestApp):
     dataset = DatasetFactory()
-    file_format = FileFormat(extension='URL')
+    file_format = FileFormat(extension="URL")
     user = UserFactory(is_staff=True, organization=dataset.organization)
     app.set_user(user)
-    form = app.get(reverse('resource-add', kwargs={'pk': dataset.pk})).forms['resource-form']
-    form['title'] = 'Added title'
-    form['description'] = 'Added new resource description'
-    form['format'] = file_format.id
-    form['download_url'] = "www.google.lt"
-    form['level'] = 1
+    form = app.get(reverse("resource-add", kwargs={"pk": dataset.pk})).forms["resource-form"]
+    form["title"] = "Added title"
+    form["description"] = "Added new resource description"
+    form["format"] = file_format.id
+    form["download_url"] = "www.google.lt"
+    form["level"] = 1
     resp = form.submit()
     assert resp.status_code == 302
     assert DatasetDistribution.objects.filter().count() == 1
     assert DatasetDistribution.objects.first().metadata.count() == 0
-    assert DatasetDistribution.objects.first().name == 'resource1'
-    assert DatasetDistribution.objects.first().title == 'Added title'
-    assert DatasetDistribution.objects.first().description == 'Added new resource description'
+    assert DatasetDistribution.objects.first().name == "resource1"
+    assert DatasetDistribution.objects.first().title == "Added title"
+    assert DatasetDistribution.objects.first().description == "Added new resource description"
     assert DatasetDistribution.objects.first().level == 1
 
 
 @pytest.mark.django_db
 def test_create_dataset_distribution_with_applicable_legislation(app: DjangoTestApp):
     dataset = DatasetFactory()
-    file_format = FileFormat(extension='URL')
+    file_format = FileFormat(extension="URL")
     user = UserFactory(is_staff=True, organization=dataset.organization)
     applicable_legislation_urls = ["http://www.google.com", "http://www.example.com"]
-    app.set_user(user) 
-    form = app.get(reverse('resource-add', kwargs={'pk': dataset.pk})).forms['resource-form']
-    form['format'] = file_format.id
-    form['download_url'] = "www.google.lt"
+    app.set_user(user)
+    form = app.get(reverse("resource-add", kwargs={"pk": dataset.pk})).forms["resource-form"]
+    form["format"] = file_format.id
+    form["download_url"] = "www.google.lt"
     form["applicable_legislation"] = applicable_legislation_urls
     with patch("vitrina.datasets.tasks.update_applicable_legislation_description.delay") as mocked_task:
-            resp = form.submit()
+        resp = form.submit()
 
     assert resp.status_code == 302
     assert mocked_task.call_count == 1
     dataset_distribution = DatasetDistribution.objects.get()
-    assert set(dataset_distribution.applicable_legislation.values_list("url", flat=True)) == set(applicable_legislation_urls)
+    assert set(dataset_distribution.applicable_legislation.values_list("url", flat=True)) == set(
+        applicable_legislation_urls
+    )
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("is_versioned", [True, False])
 def test_update_dataset_distribution_with_applicable_legislation(app: DjangoTestApp, is_versioned: bool):
-    resource = DatasetDistributionFactory(title='base title', description='base description')
+    resource = DatasetDistributionFactory(title="base title", description="base description")
 
     if is_versioned:
         ModelFactory(dataset=resource.dataset, distribution=resource)
-        resource_change_url = reverse('resource-change', kwargs={'pk': resource.id, 'version_id': resource.metadata_version.pk})
+        resource_change_url = reverse(
+            "resource-change", kwargs={"pk": resource.id, "version_id": resource.metadata_version.pk}
+        )
     else:
-        resource_change_url = reverse('resource-change-no-version', kwargs={'pk': resource.id})
+        resource_change_url = reverse("resource-change-no-version", kwargs={"pk": resource.id})
 
     resource.applicable_legislation.set(ApplicableLegislationFactory.create_batch(4))
     user = UserFactory(is_staff=True, organization=resource.dataset.organization)
     app.set_user(user)
-    form = app.get(resource_change_url).forms['resource-form']
+    form = app.get(resource_change_url).forms["resource-form"]
     new_urls = ("http://www.google.", "http://www.example.com")
     for i, field in enumerate(form.fields["applicable_legislation"]):
         field.value = new_urls[i] if i < len(new_urls) else ""
 
     with patch("vitrina.datasets.tasks.update_applicable_legislation_description.delay") as mocked_task:
         resp = form.submit()
-        
+
     resource.refresh_from_db()
     assert resp.status_code == 302
     assert mocked_task.call_count == 1
@@ -187,19 +200,22 @@ def test_update_dataset_distribution_with_applicable_legislation(app: DjangoTest
 @pytest.mark.django_db
 @pytest.mark.parametrize("is_versioned", [True, False])
 def test_change_form_data_gov_url_upload_checked(app: DjangoTestApp, is_versioned: bool):
-    file_format = FileFormat(title='URL', extension='URL')
-    resource = DatasetDistributionFactory(title='base title', description='base description',
-                                          format=file_format, file=None)
+    file_format = FileFormat(title="URL", extension="URL")
+    resource = DatasetDistributionFactory(
+        title="base title", description="base description", format=file_format, file=None
+    )
     if is_versioned:
         ModelFactory(dataset=resource.dataset, distribution=resource)
-        resource_change_url = reverse('resource-change', kwargs={'pk': resource.id, 'version_id': resource.metadata_version.pk})
+        resource_change_url = reverse(
+            "resource-change", kwargs={"pk": resource.id, "version_id": resource.metadata_version.pk}
+        )
     else:
-        resource_change_url = reverse('resource-change-no-version', kwargs={'pk': resource.id})
+        resource_change_url = reverse("resource-change-no-version", kwargs={"pk": resource.id})
 
     user = UserFactory(is_staff=True)
     app.set_user(user)
-    form = app.get(resource_change_url).forms['resource-form']
-    form['download_url'] = 'get.data.gov.lt'
+    form = app.get(resource_change_url).forms["resource-form"]
+    form["download_url"] = "get.data.gov.lt"
     resp = form.submit()
     resource.refresh_from_db()
     assert resp.status_code == 302
@@ -210,18 +226,20 @@ def test_change_form_data_gov_url_upload_checked(app: DjangoTestApp, is_versione
 @pytest.mark.django_db
 @pytest.mark.parametrize("is_versioned", [True, False])
 def test_change_form_upload_checked(app: DjangoTestApp, is_versioned: bool):
-    resource = DatasetDistributionFactory(title='base title', description='base description')
+    resource = DatasetDistributionFactory(title="base title", description="base description")
 
     if is_versioned:
         ModelFactory(dataset=resource.dataset, distribution=resource)
-        resource_change_url = reverse('resource-change', kwargs={'pk': resource.id, 'version_id': resource.metadata_version.pk})
+        resource_change_url = reverse(
+            "resource-change", kwargs={"pk": resource.id, "version_id": resource.metadata_version.pk}
+        )
     else:
-        resource_change_url = reverse('resource-change-no-version', kwargs={'pk': resource.id})
+        resource_change_url = reverse("resource-change-no-version", kwargs={"pk": resource.id})
 
     user = UserFactory(is_staff=True)
     app.set_user(user)
-    form = app.get(resource_change_url).forms['resource-form']
-    form['upload_to_storage'] = True
+    form = app.get(resource_change_url).forms["resource-form"]
+    form["upload_to_storage"] = True
     resp = form.submit()
     resource.refresh_from_db()
     assert resp.status_code == 302
@@ -231,11 +249,11 @@ def test_change_form_upload_checked(app: DjangoTestApp, is_versioned: bool):
 
 @pytest.mark.django_db
 def test_click_add_button(app: DjangoTestApp):
-    resource = DatasetDistributionFactory(title='base title', description='base description')
+    resource = DatasetDistributionFactory(title="base title", description="base description")
     user = UserFactory(is_staff=True, organization=resource.dataset.organization)
     app.set_user(user)
-    response = app.get(reverse('dataset-detail', kwargs={'pk': resource.dataset_id})).follow()
-    response.click(linkid='add_resource')
+    response = app.get(reverse("dataset-detail", kwargs={"pk": resource.dataset_id})).follow()
+    response.click(linkid="add_resource")
     assert response.status_code == 200
 
 
@@ -246,9 +264,11 @@ def test_delete_no_login(app: DjangoTestApp, is_versioned: bool):
 
     if is_versioned:
         ModelFactory(dataset=resource.dataset, distribution=resource)
-        resource_delete_url = reverse('resource-delete', kwargs={'pk': resource.id, 'version_id': resource.metadata_version.pk})
+        resource_delete_url = reverse(
+            "resource-delete", kwargs={"pk": resource.id, "version_id": resource.metadata_version.pk}
+        )
     else:
-        resource_delete_url = reverse('resource-delete-no-version', kwargs={'pk': resource.id})
+        resource_delete_url = reverse("resource-delete-no-version", kwargs={"pk": resource.id})
 
     response = app.get(resource_delete_url)
     assert response.status_code == 302
@@ -264,13 +284,16 @@ def test_delete_wrong_login(app: DjangoTestApp, is_versioned: bool):
 
     if is_versioned:
         ModelFactory(dataset=resource.dataset, distribution=resource)
-        resource_delete_url = reverse('resource-delete', kwargs={'pk': resource.id, 'version_id': resource.metadata_version.pk})
+        resource_delete_url = reverse(
+            "resource-delete", kwargs={"pk": resource.id, "version_id": resource.metadata_version.pk}
+        )
     else:
-        resource_delete_url = reverse('resource-delete-no-version', kwargs={'pk': resource.id})
+        resource_delete_url = reverse("resource-delete-no-version", kwargs={"pk": resource.id})
 
     response = app.get(resource_delete_url)
     assert response.status_code == 302
     assert str(resource.dataset_id) in response.location
+
 
 @pytest.mark.parametrize("status", [s for s in VersionStatus.values if s != VersionStatus.DRAFT])
 @pytest.mark.django_db
@@ -282,8 +305,9 @@ def test_delete_resource_version_not_draft(app: DjangoTestApp, status: str):
     user = UserFactory(is_staff=True)
     app.set_user(user)
     response = app.get(
-        reverse('resource-delete', kwargs={'pk': resource.id, 'version_id': resource.metadata_version.pk}),
-        expect_errors=True)
+        reverse("resource-delete", kwargs={"pk": resource.id, "version_id": resource.metadata_version.pk}),
+        expect_errors=True,
+    )
     assert response.status_code == 302
     assert response.location == resource.get_absolute_url()
 
@@ -291,13 +315,15 @@ def test_delete_resource_version_not_draft(app: DjangoTestApp, status: str):
 @pytest.mark.django_db
 @pytest.mark.parametrize("is_versioned", [True, False])
 def test_delete_correct_login(app: DjangoTestApp, is_versioned: bool):
-    resource = DatasetDistributionFactory(title='base title', description='base description')
+    resource = DatasetDistributionFactory(title="base title", description="base description")
 
     if is_versioned:
         ModelFactory(dataset=resource.dataset, distribution=resource)
-        resource_delete_url = reverse('resource-delete', kwargs={'pk': resource.id, 'version_id': resource.metadata_version.pk})
+        resource_delete_url = reverse(
+            "resource-delete", kwargs={"pk": resource.id, "version_id": resource.metadata_version.pk}
+        )
     else:
-        resource_delete_url = reverse('resource-delete-no-version', kwargs={'pk': resource.id})
+        resource_delete_url = reverse("resource-delete-no-version", kwargs={"pk": resource.id})
 
     user = UserFactory(is_staff=True, organization=resource.dataset.organization)
     app.set_user(user)
@@ -314,12 +340,17 @@ def test_detail_tab_from_resource_detail_view(app: DjangoTestApp, is_versioned: 
     if is_versioned:
         metadata_version = VersionFactory(dataset=resource.dataset)
         ModelFactory(dataset=resource.dataset, distribution=resource, metadata_version=metadata_version)
-        resource_detail_url = reverse('resource-detail', kwargs={'pk': resource.dataset.id, 'version_id': resource.metadata_version.pk, 'resource_id': resource.pk})
+        resource_detail_url = reverse(
+            "resource-detail",
+            kwargs={"pk": resource.dataset.id, "version_id": resource.metadata_version.pk, "resource_id": resource.pk},
+        )
     else:
-        resource_detail_url = reverse('resource-detail-no-version', kwargs={'pk': resource.dataset.id, 'resource_id': resource.pk})
+        resource_detail_url = reverse(
+            "resource-detail-no-version", kwargs={"pk": resource.dataset.id, "resource_id": resource.pk}
+        )
 
     resp = app.get(resource_detail_url)
-    resp = resp.click(linkid='detail_tab')
+    resp = resp.click(linkid="detail_tab")
     assert resp.request.path == resource.dataset.get_absolute_url()
 
 
@@ -343,12 +374,14 @@ def test_create_resource_model(app: DjangoTestApp):
     resource = DatasetDistributionFactory()
     metadata_version = VersionFactory(dataset=resource.dataset)
     ModelFactory(dataset=resource.dataset, distribution=resource, metadata_version=metadata_version)
-    form = app.get(reverse('resource-model-create', args=[resource.dataset.pk, resource.metadata_version.pk, resource.pk])).forms['model-form']
-    form['name'] = "TestModel"
+    form = app.get(
+        reverse("resource-model-create", args=[resource.dataset.pk, resource.metadata_version.pk, resource.pk])
+    ).forms["model-form"]
+    form["name"] = "TestModel"
     resp = form.submit()
     assert resp.url == resource.get_absolute_url()
     assert resource.model_set.count() == 2
-    assert resource.model_set.last().name == 'TestModel'
+    assert resource.model_set.last().name == "TestModel"
 
 
 @pytest.mark.django_db
@@ -358,17 +391,17 @@ def test_create_resource_without_name(app: DjangoTestApp):
     resource = DatasetDistributionFactory()
     resource_name_number = resource.name.split("resource")[-1]
     dataset = resource.dataset
-    format = FileFormat(extension='URL')
-    form = app.get(reverse('resource-add', kwargs={'pk': dataset.pk})).forms['resource-form']
-    form['title'] = 'New resource'
-    form['format'] = format.pk
-    form['download_url'] = "www.test.com"
+    format = FileFormat(extension="URL")
+    form = app.get(reverse("resource-add", kwargs={"pk": dataset.pk})).forms["resource-form"]
+    form["title"] = "New resource"
+    form["format"] = format.pk
+    form["download_url"] = "www.test.com"
     resp = form.submit()
     new_resource = DatasetDistribution.objects.exclude(pk=resource.pk)
     assert resp.url == new_resource.first().get_absolute_url()
     assert new_resource.count() == 1
     assert new_resource.first().metadata.count() == 0
-    assert new_resource.first().name == f'resource{int(resource_name_number) + 1}'
+    assert new_resource.first().name == f"resource{int(resource_name_number) + 1}"
 
 
 @pytest.mark.django_db
@@ -376,20 +409,16 @@ def test_create_resource_with_existing_download_url(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
     dataset = DatasetFactory()
-    format = FileFormat(extension='URL')
-    DatasetDistributionFactory(
-        dataset=dataset,
-        format=format,
-        download_url="http://www.test.com"
-    )
-    form = app.get(reverse('resource-add', kwargs={'pk': dataset.pk})).forms['resource-form']
-    form['title'] = 'New resource'
-    form['format'] = format.pk
-    form['download_url'] = "http://www.test.com"
+    format = FileFormat(extension="URL")
+    DatasetDistributionFactory(dataset=dataset, format=format, download_url="http://www.test.com")
+    form = app.get(reverse("resource-add", kwargs={"pk": dataset.pk})).forms["resource-form"]
+    form["title"] = "New resource"
+    form["format"] = format.pk
+    form["download_url"] = "http://www.test.com"
     resp = form.submit()
-    assert list(resp.context['form'].errors.values()) == [[
-        'Duomenų šaltinis su šia atsisiuntimo nuoroda jau egzistuoja.'
-    ]]
+    assert list(resp.context["form"].errors.values()) == [
+        ["Duomenų šaltinis su šia atsisiuntimo nuoroda jau egzistuoja."]
+    ]
 
 
 @pytest.mark.django_db
@@ -401,9 +430,14 @@ def test_distribution_detail_with_non_public_dataset_without_access(app: DjangoT
     if is_versioned:
         metadata_version = VersionFactory(dataset=resource.dataset)
         ModelFactory(dataset=resource.dataset, distribution=resource, metadata_version=metadata_version)
-        resource_detail_url = reverse('resource-detail', kwargs={'pk': resource.dataset.id, 'version_id': resource.metadata_version.pk, 'resource_id': resource.pk})
+        resource_detail_url = reverse(
+            "resource-detail",
+            kwargs={"pk": resource.dataset.id, "version_id": resource.metadata_version.pk, "resource_id": resource.pk},
+        )
     else:
-        resource_detail_url = reverse('resource-detail-no-version', kwargs={'pk': resource.dataset.id, 'resource_id': resource.pk})
+        resource_detail_url = reverse(
+            "resource-detail-no-version", kwargs={"pk": resource.dataset.id, "resource_id": resource.pk}
+        )
 
     user = UserFactory()
     app.set_user(user)
@@ -423,18 +457,21 @@ def test_distribution_detail_with_non_public_dataset_without_access(app: DjangoT
         Representative.RESOURCE_MANAGER,
     ],
 )
-def test_distribution_detail_with_non_public_dataset_with_access(
-    app: DjangoTestApp, is_versioned: bool, role: str
-):
+def test_distribution_detail_with_non_public_dataset_with_access(app: DjangoTestApp, is_versioned: bool, role: str):
     dataset = DatasetFactory(is_public=False)
     resource = DatasetDistributionFactory(dataset=dataset)
 
     if is_versioned:
         metadata_version = VersionFactory(dataset=resource.dataset)
         ModelFactory(dataset=resource.dataset, distribution=resource, metadata_version=metadata_version)
-        resource_detail_url = reverse('resource-detail', kwargs={'pk': resource.dataset.id, 'version_id': resource.metadata_version.pk, 'resource_id': resource.pk})
+        resource_detail_url = reverse(
+            "resource-detail",
+            kwargs={"pk": resource.dataset.id, "version_id": resource.metadata_version.pk, "resource_id": resource.pk},
+        )
     else:
-        resource_detail_url = reverse('resource-detail-no-version', kwargs={'pk': resource.dataset.id, 'resource_id': resource.pk})
+        resource_detail_url = reverse(
+            "resource-detail-no-version", kwargs={"pk": resource.dataset.id, "resource_id": resource.pk}
+        )
 
     user = UserFactory()
     RepresentativeFactory(
@@ -442,11 +479,10 @@ def test_distribution_detail_with_non_public_dataset_with_access(
         object_id=dataset.pk,
         user=user,
         role=role,
-
     )
     app.set_user(user)
     response = app.get(resource_detail_url)
-    assert response.context['object'] == resource
+    assert response.context["object"] == resource
 
 
 @pytest.mark.django_db
@@ -460,19 +496,21 @@ def test_distribution_detail_dynamic_resource_json(app: DjangoTestApp):
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         name="TestModel",
-        metadata_version=metadata_version
-        )
+        metadata_version=metadata_version,
+    )
 
     user = UserFactory(is_staff=True)
     app.set_user(user)
 
-    response = app.get(reverse('dynamic-resource-detail', args=[dataset.pk, metadata_version.pk, resource.pk, "TestModel", "json"]))
+    response = app.get(
+        reverse("dynamic-resource-detail", args=[dataset.pk, metadata_version.pk, resource.pk, "TestModel", "json"])
+    )
     assert response.status_code == 200
-    assert response.context['resource']['title'] == "TestModel"
-    assert response.context['resource']['get_download_url'] == f'{SPINTA_SERVER_URL}/TestModel/:all/:format/json'
-    assert list(response.context['resource']['models']) == list(dataset.model_set.all())
-    assert response.context['format'] == 'JSON'
-    assert response.context['resource']['dataset'] == dataset
+    assert response.context["resource"]["title"] == "TestModel"
+    assert response.context["resource"]["get_download_url"] == f"{SPINTA_SERVER_URL}/TestModel/:all/:format/json"
+    assert list(response.context["resource"]["models"]) == list(dataset.model_set.all())
+    assert response.context["format"] == "JSON"
+    assert response.context["resource"]["dataset"] == dataset
 
 
 @pytest.mark.django_db
@@ -486,19 +524,21 @@ def test_distribution_detail_dynamic_resource_jsonl(app: DjangoTestApp):
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         name="TestModel",
-        metadata_version=metadata_version
-        )
+        metadata_version=metadata_version,
+    )
 
     user = UserFactory(is_staff=True)
     app.set_user(user)
 
-    response = app.get(reverse('dynamic-resource-detail', args=[dataset.pk, metadata_version.pk, resource.pk, "TestModel", "jsonl"]))
+    response = app.get(
+        reverse("dynamic-resource-detail", args=[dataset.pk, metadata_version.pk, resource.pk, "TestModel", "jsonl"])
+    )
     assert response.status_code == 200
-    assert response.context['resource']['title'] == "TestModel"
-    assert response.context['resource']['get_download_url'] == f'{SPINTA_SERVER_URL}/TestModel/:all/:format/jsonl'
-    assert list(response.context['resource']['models']) == list(dataset.model_set.all())
-    assert response.context['format'] == 'JSONL'
-    assert response.context['resource']['dataset'] == dataset
+    assert response.context["resource"]["title"] == "TestModel"
+    assert response.context["resource"]["get_download_url"] == f"{SPINTA_SERVER_URL}/TestModel/:all/:format/jsonl"
+    assert list(response.context["resource"]["models"]) == list(dataset.model_set.all())
+    assert response.context["format"] == "JSONL"
+    assert response.context["resource"]["dataset"] == dataset
 
 
 @pytest.mark.django_db
@@ -512,19 +552,21 @@ def test_distribution_detail_dynamic_resource_csv(app: DjangoTestApp):
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         name="TestModel",
-        metadata_version=metadata_version
-        )
+        metadata_version=metadata_version,
+    )
 
     user = UserFactory(is_staff=True)
     app.set_user(user)
 
-    response = app.get(reverse('dynamic-resource-detail', args=[dataset.pk, metadata_version.pk, resource.pk, "TestModel", "csv"]))
+    response = app.get(
+        reverse("dynamic-resource-detail", args=[dataset.pk, metadata_version.pk, resource.pk, "TestModel", "csv"])
+    )
     assert response.status_code == 200
-    assert response.context['resource']['title'] == "TestModel"
-    assert response.context['resource']['get_download_url'] == f'{SPINTA_SERVER_URL}/TestModel/:format/csv'
-    assert list(response.context['resource']['models']) == list(dataset.model_set.all())
-    assert response.context['format'] == 'CSV'
-    assert response.context['resource']['dataset'] == dataset
+    assert response.context["resource"]["title"] == "TestModel"
+    assert response.context["resource"]["get_download_url"] == f"{SPINTA_SERVER_URL}/TestModel/:format/csv"
+    assert list(response.context["resource"]["models"]) == list(dataset.model_set.all())
+    assert response.context["format"] == "CSV"
+    assert response.context["resource"]["dataset"] == dataset
 
 
 @pytest.mark.django_db
@@ -538,7 +580,7 @@ def test_distribution_detail_dynamic_resource_json_multiple_models(app: DjangoTe
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         name="TestModel",
-        metadata_version=metadata_version
+        metadata_version=metadata_version,
     )
     model2 = ModelFactory(dataset=dataset, metadata_version=metadata_version)
     MetadataFactory(
@@ -546,7 +588,7 @@ def test_distribution_detail_dynamic_resource_json_multiple_models(app: DjangoTe
         content_type=ContentType.objects.get_for_model(model2),
         object_id=model2.pk,
         name="TestModel2",
-        metadata_version=metadata_version
+        metadata_version=metadata_version,
     )
     model3 = ModelFactory(dataset=dataset, metadata_version=metadata_version)
     MetadataFactory(
@@ -554,19 +596,21 @@ def test_distribution_detail_dynamic_resource_json_multiple_models(app: DjangoTe
         content_type=ContentType.objects.get_for_model(model3),
         object_id=model3.pk,
         name="TestModel3",
-        metadata_version=metadata_version
+        metadata_version=metadata_version,
     )
 
     user = UserFactory(is_staff=True)
     app.set_user(user)
 
-    response = app.get(reverse('dynamic-resource-detail', args=[dataset.pk, metadata_version.pk, resource.pk, "TestModel", "json"]))
+    response = app.get(
+        reverse("dynamic-resource-detail", args=[dataset.pk, metadata_version.pk, resource.pk, "TestModel", "json"])
+    )
     assert response.status_code == 200
-    assert response.context['resource']['title'] == "TestModel"
-    assert response.context['resource']['get_download_url'] == f'{SPINTA_SERVER_URL}/TestModel/:all/:format/json'
-    assert list(response.context['resource']['models']) == list(dataset.model_set.all())
-    assert response.context['format'] == 'JSON'
-    assert response.context['resource']['dataset'] == resource.dataset
+    assert response.context["resource"]["title"] == "TestModel"
+    assert response.context["resource"]["get_download_url"] == f"{SPINTA_SERVER_URL}/TestModel/:all/:format/json"
+    assert list(response.context["resource"]["models"]) == list(dataset.model_set.all())
+    assert response.context["format"] == "JSON"
+    assert response.context["resource"]["dataset"] == resource.dataset
 
 
 @pytest.mark.django_db
@@ -580,7 +624,7 @@ def test_distribution_detail_dynamic_resource_jsonl_multiple_models(app: DjangoT
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         name="TestModel",
-        metadata_version=metadata_version
+        metadata_version=metadata_version,
     )
     model2 = ModelFactory(dataset=dataset, metadata_version=metadata_version)
     MetadataFactory(
@@ -588,7 +632,7 @@ def test_distribution_detail_dynamic_resource_jsonl_multiple_models(app: DjangoT
         content_type=ContentType.objects.get_for_model(model2),
         object_id=model2.pk,
         name="TestModel2",
-        metadata_version=metadata_version
+        metadata_version=metadata_version,
     )
     model3 = ModelFactory(dataset=dataset, metadata_version=metadata_version)
     MetadataFactory(
@@ -596,19 +640,21 @@ def test_distribution_detail_dynamic_resource_jsonl_multiple_models(app: DjangoT
         content_type=ContentType.objects.get_for_model(model3),
         object_id=model3.pk,
         name="TestModel3",
-        metadata_version=metadata_version
+        metadata_version=metadata_version,
     )
 
     user = UserFactory(is_staff=True)
     app.set_user(user)
 
-    response = app.get(reverse('dynamic-resource-detail', args=[dataset.pk, metadata_version.pk, resource.pk, "TestModel", "jsonl"]))
+    response = app.get(
+        reverse("dynamic-resource-detail", args=[dataset.pk, metadata_version.pk, resource.pk, "TestModel", "jsonl"])
+    )
     assert response.status_code == 200
-    assert response.context['resource']['title'] == "TestModel"
-    assert response.context['resource']['get_download_url'] == f'{SPINTA_SERVER_URL}/TestModel/:all/:format/jsonl'
-    assert list(response.context['resource']['models']) == list(dataset.model_set.all())
-    assert response.context['format'] == 'JSONL'
-    assert response.context['resource']['dataset'] == resource.dataset
+    assert response.context["resource"]["title"] == "TestModel"
+    assert response.context["resource"]["get_download_url"] == f"{SPINTA_SERVER_URL}/TestModel/:all/:format/jsonl"
+    assert list(response.context["resource"]["models"]) == list(dataset.model_set.all())
+    assert response.context["format"] == "JSONL"
+    assert response.context["resource"]["dataset"] == resource.dataset
 
 
 @pytest.mark.django_db
@@ -622,7 +668,7 @@ def test_distribution_detail_dynamic_resource_csv_multiple_models(app: DjangoTes
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         name="TestModel",
-        metadata_version=metadata_version
+        metadata_version=metadata_version,
     )
     model2 = ModelFactory(dataset=dataset, metadata_version=metadata_version)
     MetadataFactory(
@@ -630,7 +676,7 @@ def test_distribution_detail_dynamic_resource_csv_multiple_models(app: DjangoTes
         content_type=ContentType.objects.get_for_model(model2),
         object_id=model2.pk,
         name="TestModel2",
-        metadata_version=metadata_version
+        metadata_version=metadata_version,
     )
     model3 = ModelFactory(dataset=dataset, metadata_version=metadata_version)
     MetadataFactory(
@@ -638,55 +684,61 @@ def test_distribution_detail_dynamic_resource_csv_multiple_models(app: DjangoTes
         content_type=ContentType.objects.get_for_model(model3),
         object_id=model3.pk,
         name="TestModel3",
-        metadata_version=metadata_version
+        metadata_version=metadata_version,
     )
 
     user = UserFactory(is_staff=True)
     app.set_user(user)
 
-    response = app.get(reverse('dynamic-resource-detail', args=[dataset.pk, metadata_version.pk, resource.pk, "TestModel", "csv"]))
+    response = app.get(
+        reverse("dynamic-resource-detail", args=[dataset.pk, metadata_version.pk, resource.pk, "TestModel", "csv"])
+    )
     assert response.status_code == 200
-    assert response.context['resource']['title'] == "TestModel"
-    assert response.context['resource']['get_download_url'] == f'{SPINTA_SERVER_URL}/TestModel/:format/csv'
-    assert str(response.context['resource']['models'][0]) == "TestModel"
-    assert response.context['format'] == 'CSV'
-    assert response.context['resource']['dataset'] == resource.dataset
+    assert response.context["resource"]["title"] == "TestModel"
+    assert response.context["resource"]["get_download_url"] == f"{SPINTA_SERVER_URL}/TestModel/:format/csv"
+    assert str(response.context["resource"]["models"][0]) == "TestModel"
+    assert response.context["format"] == "CSV"
+    assert response.context["resource"]["dataset"] == resource.dataset
 
-    response = app.get(reverse('dynamic-resource-detail', args=[dataset.pk, metadata_version.pk, resource.pk, "TestModel2", "csv"]))
+    response = app.get(
+        reverse("dynamic-resource-detail", args=[dataset.pk, metadata_version.pk, resource.pk, "TestModel2", "csv"])
+    )
     assert response.status_code == 200
-    assert str(response.context['resource']['models'][0]) == "TestModel2"
+    assert str(response.context["resource"]["models"][0]) == "TestModel2"
 
-    response = app.get(reverse('dynamic-resource-detail', args=[dataset.pk, metadata_version.pk, resource.pk, "TestModel3", "csv"]))
+    response = app.get(
+        reverse("dynamic-resource-detail", args=[dataset.pk, metadata_version.pk, resource.pk, "TestModel3", "csv"])
+    )
     assert response.status_code == 200
-    assert str(response.context['resource']['models'][0]) == "TestModel3"
+    assert str(response.context["resource"]["models"][0]) == "TestModel3"
 
 
 @pytest.mark.django_db
 def test_create_distribution_with_invalid_url(app: DjangoTestApp):
     dataset = DatasetFactory()
-    file_format = FileFormat(extension='URL')
+    file_format = FileFormat(extension="URL")
     user = UserFactory(is_staff=True, organization=dataset.organization)
     app.set_user(user)
-    form = app.get(reverse('resource-add', kwargs={'pk': dataset.pk})).forms['resource-form']
-    form['title'] = 'Added title'
-    form['description'] = 'Added new resource description'
-    form['format'] = file_format.id
-    form['download_url'] = "invalid"
+    form = app.get(reverse("resource-add", kwargs={"pk": dataset.pk})).forms["resource-form"]
+    form["title"] = "Added title"
+    form["description"] = "Added new resource description"
+    form["format"] = file_format.id
+    form["download_url"] = "invalid"
     resp = form.submit()
-    assert 'Įveskite tinkamą URL adresą.' in list(resp.context['form'].errors['download_url'])
+    assert "Įveskite tinkamą URL adresą." in list(resp.context["form"].errors["download_url"])
 
 
 @pytest.mark.django_db
 def test_create_distribution__translation(app: DjangoTestApp):
     dataset = DatasetFactory()
-    file_format = FileFormat(extension='URL')
+    file_format = FileFormat(extension="URL")
     user = UserFactory(is_staff=True, organization=dataset.organization)
     app.set_user(user)
-    form = app.get(reverse('resource-add', kwargs={'pk': dataset.pk}) + "?language=lt").forms['resource-form']
-    form['title'] = 'Pavadinimas'
-    form['description'] = 'Aprašymas'
-    form['format'] = file_format.id
-    form['download_url'] = "www.google.lt"
+    form = app.get(reverse("resource-add", kwargs={"pk": dataset.pk}) + "?language=lt").forms["resource-form"]
+    form["title"] = "Pavadinimas"
+    form["description"] = "Aprašymas"
+    form["format"] = file_format.id
+    form["download_url"] = "www.google.lt"
     resp = form.submit()
     assert resp.status_code == 302
     assert DatasetDistribution.objects.count() == 1
@@ -706,15 +758,17 @@ def test_update_distribution__translation(app: DjangoTestApp, is_versioned: bool
 
     if is_versioned:
         ModelFactory(dataset=distribution.dataset, distribution=distribution)
-        resource_change_url = reverse('resource-change', kwargs={'pk': distribution.id, 'version_id': distribution.metadata_version.pk})
+        resource_change_url = reverse(
+            "resource-change", kwargs={"pk": distribution.id, "version_id": distribution.metadata_version.pk}
+        )
     else:
-        resource_change_url = reverse('resource-change-no-version', kwargs={'pk': distribution.id})
+        resource_change_url = reverse("resource-change-no-version", kwargs={"pk": distribution.id})
 
     user = UserFactory(is_staff=True, organization=distribution.dataset.organization)
     app.set_user(user)
-    form = app.get(resource_change_url + "?language=lt").forms['resource-form']
-    form['title'] = 'Pavadinimas'
-    form['description'] = 'Aprašymas'
+    form = app.get(resource_change_url + "?language=lt").forms["resource-form"]
+    form["title"] = "Pavadinimas"
+    form["description"] = "Aprašymas"
     resp = form.submit()
     distribution.refresh_from_db()
     assert resp.status_code == 302
@@ -732,21 +786,23 @@ def test_update_distribution__existing_translation(app: DjangoTestApp, is_versio
     distribution = DatasetDistributionFactory()
     if is_versioned:
         ModelFactory(dataset=distribution.dataset, distribution=distribution)
-        resource_change_url = reverse('resource-change', kwargs={'pk': distribution.id, 'version_id': distribution.metadata_version.pk})
+        resource_change_url = reverse(
+            "resource-change", kwargs={"pk": distribution.id, "version_id": distribution.metadata_version.pk}
+        )
     else:
-        resource_change_url = reverse('resource-change-no-version', kwargs={'pk': distribution.id})
+        resource_change_url = reverse("resource-change-no-version", kwargs={"pk": distribution.id})
 
     user = UserFactory(is_staff=True, organization=distribution.dataset.organization)
     app.set_user(user)
-    form = app.get(resource_change_url + "?language=lt").forms['resource-form']
-    form['title'] = 'Pavadinimas'
-    form['description'] = 'Aprašymas'
+    form = app.get(resource_change_url + "?language=lt").forms["resource-form"]
+    form["title"] = "Pavadinimas"
+    form["description"] = "Aprašymas"
     resp = form.submit()
     assert resp.status_code == 302
 
-    form = app.get(resource_change_url + "?language=en").forms['resource-form']
-    form['title'] = 'Title'
-    form['description'] = 'Description'
+    form = app.get(resource_change_url + "?language=en").forms["resource-form"]
+    form["title"] = "Title"
+    form["description"] = "Description"
     resp = form.submit()
 
     distribution.refresh_from_db()
@@ -768,12 +824,12 @@ def test_distribution_with_compression_and_packaging_formats(app: DjangoTestApp)
     compression_format = CompressionFormatFactory()
     packaging_format = PackagingFormatFactory()
 
-    form = app.get(reverse('resource-add', kwargs={'pk': dataset.pk})).forms['resource-form']
-    form['title'] = 'New resource'
-    form['format'] = file_format.pk
-    form['download_url'] = "http://www.test.com"
-    form['compression_format'] = compression_format.pk
-    form['packaging_format'] = packaging_format.pk
+    form = app.get(reverse("resource-add", kwargs={"pk": dataset.pk})).forms["resource-form"]
+    form["title"] = "New resource"
+    form["format"] = file_format.pk
+    form["download_url"] = "http://www.test.com"
+    form["compression_format"] = compression_format.pk
+    form["packaging_format"] = packaging_format.pk
     form.submit()
 
     assert DatasetDistribution.objects.count() == 1
@@ -789,15 +845,15 @@ def test_create_distribution_without_access_download_urls_and_file(app: DjangoTe
     dataset = DatasetFactory()
     file_format = FileFormat()
 
-    form = app.get(reverse('resource-add', kwargs={'pk': dataset.pk})).forms['resource-form']
-    form['title'] = 'New resource'
-    form['format'] = file_format.pk
+    form = app.get(reverse("resource-add", kwargs={"pk": dataset.pk})).forms["resource-form"]
+    form["title"] = "New resource"
+    form["format"] = file_format.pk
     resp = form.submit()
 
-    assert len(resp.context['form'].errors) == 3
-    assert resp.context['form'].errors['access_url'] == ['Pateikite duomenų prieigos nuorodą.']
-    assert resp.context['form'].errors['download_url'] == ['Arba pateikite duomenų atsisiuntimo nuorodą.']
-    assert resp.context['form'].errors['file'] == ['Arba įkelkite duomenų failą.']
+    assert len(resp.context["form"].errors) == 3
+    assert resp.context["form"].errors["access_url"] == ["Pateikite duomenų prieigos nuorodą."]
+    assert resp.context["form"].errors["download_url"] == ["Arba pateikite duomenų atsisiuntimo nuorodą."]
+    assert resp.context["form"].errors["file"] == ["Arba įkelkite duomenų failą."]
 
 
 @pytest.mark.django_db
@@ -811,17 +867,19 @@ def test_distribution_detail_dynamic_resource_rdf(app: DjangoTestApp):
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         name="TestModel",
-        metadata_version=metadata_version
+        metadata_version=metadata_version,
     )
     user = UserFactory(is_staff=True)
     app.set_user(user)
-    response = app.get(reverse('dynamic-resource-detail', args=[dataset.pk, metadata_version.pk, resource.pk, "TestModel", "rdf"]))
+    response = app.get(
+        reverse("dynamic-resource-detail", args=[dataset.pk, metadata_version.pk, resource.pk, "TestModel", "rdf"])
+    )
     assert response.status_code == 200
-    assert response.context['resource']['title'] == "TestModel"
-    assert response.context['resource']['get_download_url'] == f'{SPINTA_SERVER_URL}/TestModel/:all/:format/rdf'
-    assert list(response.context['resource']['models']) == list(dataset.model_set.all())
-    assert response.context['format'] == 'RDF'
-    assert response.context['resource']['dataset'] == dataset
+    assert response.context["resource"]["title"] == "TestModel"
+    assert response.context["resource"]["get_download_url"] == f"{SPINTA_SERVER_URL}/TestModel/:all/:format/rdf"
+    assert list(response.context["resource"]["models"]) == list(dataset.model_set.all())
+    assert response.context["format"] == "RDF"
+    assert response.context["resource"]["dataset"] == dataset
 
 
 @pytest.mark.django_db
@@ -835,6 +893,12 @@ def test_distribution_form_status_options(app: DjangoTestApp):
 
     assert response.status_code == 200
 
-    status_select = form.fields['status'][0]
+    status_select = form.fields["status"][0]
     values = [value for _, _, value in status_select.options]
-    assert values == ["Įgyvendintas – veikiantis", "Kuriamas", "Kūrimas suplanuotas", "Pasenęs", "Atsisakytas",]
+    assert values == [
+        "Įgyvendintas – veikiantis",
+        "Kuriamas",
+        "Kūrimas suplanuotas",
+        "Pasenęs",
+        "Atsisakytas",
+    ]

--- a/tests/resources/test_views.py
+++ b/tests/resources/test_views.py
@@ -5,7 +5,6 @@ from django_webtest import DjangoTestApp
 from unittest.mock import patch
 
 from vitrina import settings
-from vitrina.classifiers.models import Concept
 from vitrina.classifiers.factories import ApplicableLegislationFactory
 from vitrina.datasets.factories import DatasetFactory
 from vitrina.orgs.factories import RepresentativeFactory
@@ -20,7 +19,6 @@ from vitrina.resources.models import DatasetDistribution
 from vitrina.settings import SPINTA_SERVER_URL
 from vitrina.structure.factories import MetadataFactory, ModelFactory, VersionFactory
 from vitrina.structure import VersionStatus
-from vitrina.structure.factories import MetadataFactory
 from vitrina.users.factories import UserFactory
 from vitrina.users.models import User
 
@@ -457,7 +455,7 @@ def test_distribution_detail_dynamic_resource_json(app: DjangoTestApp):
     metadata_version = dataset.metadata.first().metadata_version
     resource = DatasetDistributionFactory(dataset=dataset, uapi_format=True)
     model = ModelFactory(dataset=dataset, metadata_version=metadata_version)
-    model_metadata = MetadataFactory(
+    MetadataFactory(
         dataset=dataset,
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
@@ -483,7 +481,7 @@ def test_distribution_detail_dynamic_resource_jsonl(app: DjangoTestApp):
     metadata_version = dataset.metadata.first().metadata_version
     resource = DatasetDistributionFactory(dataset=dataset, uapi_format=True)
     model = ModelFactory(dataset=dataset, metadata_version=metadata_version)
-    model_metadata = MetadataFactory(
+    MetadataFactory(
         dataset=dataset,
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
@@ -509,7 +507,7 @@ def test_distribution_detail_dynamic_resource_csv(app: DjangoTestApp):
     metadata_version = dataset.metadata.first().metadata_version
     resource = DatasetDistributionFactory(uapi_format=True)
     model = ModelFactory(dataset=dataset, metadata_version=metadata_version)
-    model_metadata = MetadataFactory(
+    MetadataFactory(
         dataset=dataset,
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,

--- a/tests/scripts/test_downloadstats.py
+++ b/tests/scripts/test_downloadstats.py
@@ -122,7 +122,7 @@ def test_downloadstats(patcher: MagicMock, tmp_path: Path):
     assert res.exit_code == 0
 
     log_file = tmp_path / 'accesslog.json'
-    logbytes = log_file.read_bytes()
+    log_file.read_bytes()
 
     session = patcher.return_value
 

--- a/tests/scripts/test_downloadstats.py
+++ b/tests/scripts/test_downloadstats.py
@@ -17,34 +17,34 @@ from scripts.downloadstats import find_transactions
 
 @pytest.fixture()
 def patcher():
-    with patch('requests.Session') as mock:
+    with patch("requests.Session") as mock:
         yield mock
 
 
 def flatten(entries: list[list[str]]):
-    return [
-        line
-        for lines in entries
-        for line in lines
-    ]
+    return [line for lines in entries for line in lines]
 
 
 def run(path: Path, entries: list[list[str]]):
-    log_file = path / 'accesslog.json'
-    log_file.write_text('\n'.join(flatten(entries)))
+    log_file = path / "accesslog.json"
+    log_file.write_text("\n".join(flatten(entries)))
 
-    config_file = path / 'config.json'
-    config_file.write_text(json.dumps({
-        "auth": {
-            "secret": "SECRETKEY",
-        },
-        "bots": [
-            "SemrushBot",
-        ],
-    }))
+    config_file = path / "config.json"
+    config_file.write_text(
+        json.dumps(
+            {
+                "auth": {
+                    "secret": "SECRETKEY",
+                },
+                "bots": [
+                    "SemrushBot",
+                ],
+            }
+        )
+    )
 
-    state_file = path / 'state.json'
-    bot_stats_file = path / 'downloadstats.json'
+    state_file = path / "state.json"
+    bot_stats_file = path / "downloadstats.json"
 
     app = Typer()
     app.command()(main)
@@ -52,14 +52,17 @@ def run(path: Path, entries: list[list[str]]):
     res = runner.invoke(
         app,
         [
-            'get.data.gov.lt',
+            "get.data.gov.lt",
             str(log_file),
-            '--config-file', str(config_file),
-            '--state-file', str(state_file),
-            '--bot-status-file', str(bot_stats_file),
+            "--config-file",
+            str(config_file),
+            "--state-file",
+            str(state_file),
+            "--bot-status-file",
+            str(bot_stats_file),
         ],
         env={
-            'HOME': str(path),
+            "HOME": str(path),
         },
         catch_exceptions=False,
     )
@@ -67,12 +70,12 @@ def run(path: Path, entries: list[list[str]]):
 
 
 def log(
-    day='1',
+    day="1",
     txn=None,
     objects=1,
-    action='getall',
-    format='html',
-    agent='HTTPie/2.6.0',
+    action="getall",
+    format="html",
+    agent="HTTPie/2.6.0",
     request=True,
     response=True,
 ):
@@ -81,7 +84,7 @@ def log(
         txn = str(uuid.uuid4())
     if request:
         messages.append(
-            '{'
+            "{"
             f'"time": "2000-01-0{day}T00:00:00.000000+00:00", '
             '"pid": 1, '
             '"type": "request", '
@@ -93,187 +96,173 @@ def log(
             '"url": "http://example.com/datasets/example/City", '
             '"client": "default", '
             f'"agent": "{agent}"'
-            '}'
-
+            "}"
         )
     if response:
         messages.append(
-            '{'
+            "{"
             f'"time": "2000-01-0{day}T00:00:00.000000+00:00", '
             '"type": "response", '
             '"delta": 0.019, '
             '"memory": 0, '
             f'"objects": {objects}, '
             f'"txn": "{txn}"'
-            '}'
+            "}"
         )
     return messages
 
 
 def test_downloadstats(patcher: MagicMock, tmp_path: Path):
-    res = run(tmp_path, [
-        log(day='1'),
-        log(day='2'),
-        log(day='2', objects=5),
-        log(day='2'),
-        log(day='2', agent='Mozilla/5.0 (compatible; SemrushBot)'),
-    ])
+    res = run(
+        tmp_path,
+        [
+            log(day="1"),
+            log(day="2"),
+            log(day="2", objects=5),
+            log(day="2"),
+            log(day="2", agent="Mozilla/5.0 (compatible; SemrushBot)"),
+        ],
+    )
 
     assert res.exit_code == 0
 
-    log_file = tmp_path / 'accesslog.json'
+    log_file = tmp_path / "accesslog.json"
     log_file.read_bytes()
 
     session = patcher.return_value
 
     # Only one request per day must be made
     assert session.post.call_count == 2
-    assert session.post.call_args.kwargs['data'] == {
-        'format': 'html',
-        'model': 'datasets/example/City',
-        'objects': 7,
-        'requests': 3,
-        'source': 'get.data.gov.lt',
-        'time': datetime(2000, 1, 2, tzinfo=timezone.utc),
+    assert session.post.call_args.kwargs["data"] == {
+        "format": "html",
+        "model": "datasets/example/City",
+        "objects": 7,
+        "requests": 3,
+        "source": "get.data.gov.lt",
+        "time": datetime(2000, 1, 2, tzinfo=timezone.utc),
     }
 
     # Authorization must be used
     # assert session.post.call_args.kwargs['headers'] == {
     #     'Authorization': 'ApiKey SECRETKEY',
     # }
-    state_file = tmp_path / 'state.json'
-    assert json.loads(state_file.read_text()) == {
-        'line_offset': 10,
-        'start_from': None,
-        'read_files': []}
+    state_file = tmp_path / "state.json"
+    assert json.loads(state_file.read_text()) == {"line_offset": 10, "start_from": None, "read_files": []}
 
-    bot_stats_file = tmp_path / 'downloadstats.json'
+    bot_stats_file = tmp_path / "downloadstats.json"
     assert json.loads(bot_stats_file.read_text()) == {
-        'agents': {
-            'HTTPie/2.6.0': 4,
-            'SemrushBot': 1,
+        "agents": {
+            "HTTPie/2.6.0": 4,
+            "SemrushBot": 1,
         },
     }
 
 
 def test_find_transactions(tmp_path: Path):
-    bots_found = {'agents': {}}
+    bots_found = {"agents": {}}
     transactions = {}
     temp = {}
-    name = 'get.data.gov.lt'
-    lines = flatten([
-        log(day='1'),
-        log(day='2'),
-        log(day='3', txn='1', response=False),
-    ])
-    endpoint_url = 'endpoint_url'
+    name = "get.data.gov.lt"
+    lines = flatten(
+        [
+            log(day="1"),
+            log(day="2"),
+            log(day="3", txn="1", response=False),
+        ]
+    )
+    endpoint_url = "endpoint_url"
     session = MagicMock()
     final_stats = {}
-    bot_status_file = tmp_path / 'state.json'
-    find_transactions(
-        name,
-        lines,
-        final_stats,
-        bot_status_file,
-        bots_found,
-        temp,
-        transactions
-    )
+    bot_status_file = tmp_path / "state.json"
+    find_transactions(name, lines, final_stats, bot_status_file, bots_found, temp, transactions)
     post_data(temp, name, session, endpoint_url)
 
     # Only one request per day must be made
     assert session.post.call_count == 2
-    assert session.post.call_args.kwargs['data'] == {
-        'format': 'html',
-        'model': 'datasets/example/City',
-        'objects': 1,
-        'requests': 1,
-        'source': 'get.data.gov.lt',
-        'time': datetime(2000, 1, 2, tzinfo=timezone.utc)
+    assert session.post.call_args.kwargs["data"] == {
+        "format": "html",
+        "model": "datasets/example/City",
+        "objects": 1,
+        "requests": 1,
+        "source": "get.data.gov.lt",
+        "time": datetime(2000, 1, 2, tzinfo=timezone.utc),
     }
 
     assert json.loads(bot_status_file.read_text()) == {
-        'agents': {
-            'HTTPie/2.6.0': 2,
+        "agents": {
+            "HTTPie/2.6.0": 2,
         },
     }
 
     # Test what would happen if request and response was split between batches
-    lines = flatten([
-        log(day='3', txn='1', request=False),
-    ])
-    find_transactions(
-        name,
-        lines,
-        final_stats,
-        bot_status_file,
-        bots_found,
-        temp,
-        transactions
+    lines = flatten(
+        [
+            log(day="3", txn="1", request=False),
+        ]
     )
+    find_transactions(name, lines, final_stats, bot_status_file, bots_found, temp, transactions)
     post_data(temp, name, session, endpoint_url)
 
     assert session.post.call_count == 3
-    assert session.post.call_args.kwargs['data'] == {
-        'format': 'html',
-        'model': 'datasets/example/City',
-        'objects': 1,
-        'requests': 1,
-        'source': 'get.data.gov.lt',
-        'time': datetime(2000, 1, 3, tzinfo=timezone.utc)
+    assert session.post.call_args.kwargs["data"] == {
+        "format": "html",
+        "model": "datasets/example/City",
+        "objects": 1,
+        "requests": 1,
+        "source": "get.data.gov.lt",
+        "time": datetime(2000, 1, 3, tzinfo=timezone.utc),
     }
 
     assert json.loads(bot_status_file.read_text()) == {
-        'agents': {
-            'HTTPie/2.6.0': 3,
+        "agents": {
+            "HTTPie/2.6.0": 3,
         },
     }
 
 
 def create_gz_file(path: Path, filename: str, content: str):
     gz_path = path / filename
-    with gzip.open(gz_path, 'wt') as f:
+    with gzip.open(gz_path, "wt") as f:
         f.write(content)
     return gz_path
 
 
 def test_reading_archived_logs(patcher: MagicMock, tmp_path: Path):
-    res = run(tmp_path, [
-        log(day='1'),
-        log(day='2', agent='Mozilla/5.0 (compatible; SemrushBot)'),
-    ])
+    res = run(
+        tmp_path,
+        [
+            log(day="1"),
+            log(day="2", agent="Mozilla/5.0 (compatible; SemrushBot)"),
+        ],
+    )
 
     for day in range(1, 3):
-        create_gz_file(tmp_path, f'accesslog.json-2000-01-0{day}.gz', '\n'.join(log(day=str(day))))
+        create_gz_file(tmp_path, f"accesslog.json-2000-01-0{day}.gz", "\n".join(log(day=str(day))))
     assert res.exit_code == 0
 
     session = patcher.return_value
 
-    res = run(tmp_path, [log(day='3')])
+    res = run(tmp_path, [log(day="3")])
     assert res.exit_code == 0
 
     assert session.post.call_count == 2
-    assert session.post.call_args.kwargs['data'] == {
-        'format': 'html',
-        'model': 'datasets/example/City',
-        'objects': 1,
-        'requests': 1,
-        'source': 'get.data.gov.lt',
-        'time': datetime(2000, 1, 2, tzinfo=timezone.utc),
+    assert session.post.call_args.kwargs["data"] == {
+        "format": "html",
+        "model": "datasets/example/City",
+        "objects": 1,
+        "requests": 1,
+        "source": "get.data.gov.lt",
+        "time": datetime(2000, 1, 2, tzinfo=timezone.utc),
     }
 
-    state_file = tmp_path / 'state.json'
+    state_file = tmp_path / "state.json"
     assert json.loads(state_file.read_text()) == {
-        'line_offset': 2,
-        'read_files': ['accesslog.json-2000-01-01.gz',
-                       'accesslog.json-2000-01-02.gz'],
-        'start_from': None,
+        "line_offset": 2,
+        "read_files": ["accesslog.json-2000-01-01.gz", "accesslog.json-2000-01-02.gz"],
+        "start_from": None,
     }
 
-    bot_stats_file = tmp_path / 'downloadstats.json'
+    bot_stats_file = tmp_path / "downloadstats.json"
     assert json.loads(bot_stats_file.read_text()) == {
-        'agents': {
-            'HTTPie/2.6.0': 2,
-            'SemrushBot': 1
-        },
+        "agents": {"HTTPie/2.6.0": 2, "SemrushBot": 1},
     }

--- a/tests/scripts/test_upload_data_to_storage.py
+++ b/tests/scripts/test_upload_data_to_storage.py
@@ -9,7 +9,7 @@ class TestHandleError(unittest.TestCase):
     def test_handle_error(self):
         try:
             raise ValueError("Oh no")
-        except ValueError as e:
+        except ValueError:
             tb = traceback.format_exc()
 
         result = handle_error(tb)

--- a/tests/scripts/test_upload_data_to_storage.py
+++ b/tests/scripts/test_upload_data_to_storage.py
@@ -5,7 +5,6 @@ from scripts.upload_data_to_storage import handle_error
 
 
 class TestHandleError(unittest.TestCase):
-
     def test_handle_error(self):
         try:
             raise ValueError("Oh no")

--- a/tests/security/__init__.py
+++ b/tests/security/__init__.py
@@ -1,6 +1,3 @@
 # Security tests
 
 
-
-
-

--- a/tests/security/test_comments_xss.py
+++ b/tests/security/test_comments_xss.py
@@ -234,6 +234,7 @@ def test_sanitize_html_preserves_aria():
     assert "aria-label" in result
     assert "aria-current" in result
 
+
 @pytest.mark.parametrize(
     "role",
     [

--- a/tests/security/test_debug_setting.py
+++ b/tests/security/test_debug_setting.py
@@ -3,6 +3,7 @@ Tests for DEBUG setting security configuration.
 
 WEB-11: Verify DEBUG=False in production
 """
+
 import os
 from unittest import mock
 from django.conf import settings
@@ -15,7 +16,7 @@ class TestDebugSetting:
     def test_debug_default_is_false(self):
         """
         Test that DEBUG defaults to False when no environment variable is set.
-        
+
         This is critical - if DEBUG=True in production, it exposes:
         - Stack traces with sensitive code paths
         - Settings and environment variables
@@ -25,15 +26,15 @@ class TestDebugSetting:
         # In our current runtime, we can't change settings.DEBUG,
         # but we can verify the environment parsing logic
         import environ
-        
+
         # Test that when DEBUG env var is not set, it defaults to False
         env = environ.Env()
-        
+
         # Mock environment without DEBUG
         with mock.patch.dict(os.environ, {}, clear=False):
             # Remove DEBUG if it exists
-            os.environ.pop('DEBUG', None)
-            
+            os.environ.pop("DEBUG", None)
+
             # This should default to False
             debug_value = env.bool("DEBUG", default=False)
             assert debug_value is False, "DEBUG should default to False for security"
@@ -41,30 +42,32 @@ class TestDebugSetting:
     def test_debug_respects_env_true(self):
         """Test that DEBUG=true in environment is properly parsed."""
         import environ
+
         env = environ.Env()
-        
-        with mock.patch.dict(os.environ, {'DEBUG': 'true'}):
+
+        with mock.patch.dict(os.environ, {"DEBUG": "true"}):
             debug_value = env.bool("DEBUG", default=False)
             assert debug_value is True
 
     def test_debug_respects_env_false(self):
         """Test that DEBUG=false in environment is properly parsed."""
         import environ
+
         env = environ.Env()
-        
-        with mock.patch.dict(os.environ, {'DEBUG': 'false'}):
+
+        with mock.patch.dict(os.environ, {"DEBUG": "false"}):
             debug_value = env.bool("DEBUG", default=False)
             assert debug_value is False
 
     def test_debug_setting_exists(self):
         """Test that DEBUG setting is configured in Django settings."""
-        assert hasattr(settings, 'DEBUG'), "DEBUG setting must be defined"
+        assert hasattr(settings, "DEBUG"), "DEBUG setting must be defined"
         assert isinstance(settings.DEBUG, bool), "DEBUG must be a boolean"
 
     def test_production_checklist(self):
         """
         Document production deployment checklist for DEBUG setting.
-        
+
         Production environment MUST have:
         1. DEBUG=false explicitly set in environment variables
         2. Docker compose files should use DEBUG=false
@@ -73,14 +76,14 @@ class TestDebugSetting:
         """
         # This is a documentation test - always passes
         # Real check: audit deployment configs
-        
+
         production_checklist = {
-            'env_debug_false': 'Set DEBUG=false in production .env',
-            'docker_compose': 'Update docker-compose.yml DEBUG=false',
-            'error_pages': 'Configure ALLOWED_HOSTS and custom error pages',
-            'nginx': 'Nginx should serve custom error pages'
+            "env_debug_false": "Set DEBUG=false in production .env",
+            "docker_compose": "Update docker-compose.yml DEBUG=false",
+            "error_pages": "Configure ALLOWED_HOSTS and custom error pages",
+            "nginx": "Nginx should serve custom error pages",
         }
-        
+
         # In actual deployment, verify these manually or via deployment tests
         assert production_checklist is not None
 
@@ -95,14 +98,14 @@ class TestDebugModeSecurityImplications:
         """
         # This is a documentation test
         sensitive_exposure = [
-            'SECRET_KEY',
-            'DATABASE_PASSWORD',
-            'AWS_SECRET_ACCESS_KEY',
-            'VIISP_CERTIFICATE',
-            'Internal file paths',
-            'Installed packages and versions'
+            "SECRET_KEY",
+            "DATABASE_PASSWORD",
+            "AWS_SECRET_ACCESS_KEY",
+            "VIISP_CERTIFICATE",
+            "Internal file paths",
+            "Installed packages and versions",
         ]
-        
+
         assert len(sensitive_exposure) > 0, "DEBUG=True exposes sensitive data"
 
     def test_debug_mode_exposes_sql_queries(self):
@@ -113,8 +116,9 @@ class TestDebugModeSecurityImplications:
         # This is a documentation test
         if settings.DEBUG:
             from django.db import connection
+
             # In debug mode, queries are stored
-            assert hasattr(connection, 'queries'), "DEBUG mode enables query logging"
+            assert hasattr(connection, "queries"), "DEBUG mode enables query logging"
 
     @pytest.mark.skipif(not settings.DEBUG, reason="Only runs in DEBUG mode")
     def test_debug_toolbar_should_not_be_in_production(self):
@@ -123,11 +127,10 @@ class TestDebugModeSecurityImplications:
         """
         # Check if debug toolbar is in INSTALLED_APPS
         debug_tools = [
-            'debug_toolbar',
-            'django_extensions',
+            "debug_toolbar",
+            "django_extensions",
         ]
-        
+
         for tool in debug_tools:
             if tool in settings.INSTALLED_APPS:
                 pytest.fail(f"{tool} should not be enabled in production (DEBUG=False)")
-

--- a/tests/security/test_sri_hashes.py
+++ b/tests/security/test_sri_hashes.py
@@ -3,6 +3,7 @@ Tests for Subresource Integrity (SRI) hashes in templates.
 
 Tests WEB-2 (External Scripts Without SRI).
 """
+
 import re
 from pathlib import Path
 
@@ -14,12 +15,12 @@ class TestSRIHashes:
         """Test that Chart.js in base.html has SRI integrity hash (WEB-2)."""
         base_template = Path("vitrina/templates/base.html")
         content = base_template.read_text()
-        
+
         # Check for Chart.js 4.3.0 with integrity hash
         assert "chart.js@4.3.0" in content, "Chart.js 4.3.0 should be loaded"
         assert 'integrity="sha384-' in content, "Chart.js should have SRI integrity hash"
         assert 'crossorigin="anonymous"' in content, "Chart.js should have crossorigin attribute"
-        
+
         # Verify the specific integrity hash for Chart.js 4.3.0
         expected_hash = "sha384-YAshAm4KKjf8V01c4sdNbPYiwU0D0Q82fjMHhKw8VvP0ecY4fxXsZAHxC4r4Ei+T"
         assert expected_hash in content, f"Chart.js should have the correct SRI hash: {expected_hash}"
@@ -28,12 +29,12 @@ class TestSRIHashes:
         """Test that Chart.js in users_count_stats_chart.html has SRI integrity hash (WEB-2)."""
         template = Path("vitrina/users/templates/users_count_stats_chart.html")
         content = template.read_text()
-        
+
         # Check for Chart.js 4.3.0 with integrity hash
         assert "chart.js@4.3.0" in content, "Chart.js 4.3.0 should be loaded"
         assert 'integrity="sha384-' in content, "Chart.js should have SRI integrity hash"
         assert 'crossorigin="anonymous"' in content, "Chart.js should have crossorigin attribute"
-        
+
         # Verify the specific integrity hash for Chart.js 4.3.0
         expected_hash = "sha384-YAshAm4KKjf8V01c4sdNbPYiwU0D0Q82fjMHhKw8VvP0ecY4fxXsZAHxC4r4Ei+T"
         assert expected_hash in content, f"Chart.js should have the correct SRI hash: {expected_hash}"
@@ -42,7 +43,7 @@ class TestSRIHashes:
         """Test that old HTTP jQuery is removed from users_count_stats_chart.html (WEB-5)."""
         template = Path("vitrina/users/templates/users_count_stats_chart.html")
         content = template.read_text()
-        
+
         # Check that old jQuery is NOT present
         assert "http://code.jquery.com" not in content, "Old HTTP jQuery should be removed"
         assert "jquery-1.10.0" not in content, "jQuery 1.10.0 should not be loaded"
@@ -51,7 +52,7 @@ class TestSRIHashes:
         """Test that old Chart.js 2.9.3 is removed from users_count_stats_chart.html (WEB-2)."""
         template = Path("vitrina/users/templates/users_count_stats_chart.html")
         content = template.read_text()
-        
+
         # Check that old Chart.js 2.9.3 is NOT present
         assert "chart.js@2.9.3" not in content, "Old Chart.js 2.9.3 should be removed"
 
@@ -61,26 +62,25 @@ class TestSRIHashes:
             Path("vitrina/templates/base.html"),
             Path("vitrina/users/templates/users_count_stats_chart.html"),
         ]
-        
+
         for template in templates:
             content = template.read_text()
-            
+
             # Look for HTTP (not HTTPS) CDN URLs
             # Exclude commented lines
-            lines = [line for line in content.split('\n') if not line.strip().startswith('{#')]
-            content_no_comments = '\n'.join(lines)
-            
+            lines = [line for line in content.split("\n") if not line.strip().startswith("{#")]
+            content_no_comments = "\n".join(lines)
+
             # Check for insecure CDN patterns
             insecure_patterns = [
                 r'src="http://[^"]*(?:cdn|code\.jquery|unpkg|jsdelivr)',
                 r'href="http://[^"]*(?:cdn|code\.jquery|unpkg|jsdelivr)',
             ]
-            
+
             for pattern in insecure_patterns:
                 matches = re.findall(pattern, content_no_comments, re.IGNORECASE)
                 assert not matches, (
-                    f"Found insecure HTTP CDN resource in {template}: {matches}. "
-                    f"All CDN resources must use HTTPS."
+                    f"Found insecure HTTP CDN resource in {template}: {matches}. All CDN resources must use HTTPS."
                 )
 
 
@@ -93,21 +93,21 @@ class TestSRIHashIntegrity:
             Path("vitrina/templates/base.html"),
             Path("vitrina/users/templates/users_count_stats_chart.html"),
         ]
-        
+
         for template in templates:
             content = template.read_text()
-            
+
             # Find all integrity attributes
             integrity_hashes = re.findall(r'integrity="([^"]+)"', content)
-            
+
             for hash_value in integrity_hashes:
                 # SRI hashes should use sha384 or sha512, not sha256
-                assert hash_value.startswith(('sha384-', 'sha512-')), (
+                assert hash_value.startswith(("sha384-", "sha512-")), (
                     f"SRI hash in {template} should use SHA-384 or SHA-512 for security: {hash_value}"
                 )
-                
+
                 # Hash should have reasonable length (base64 encoded)
-                hash_part = hash_value.split('-', 1)[1]
+                hash_part = hash_value.split("-", 1)[1]
                 assert len(hash_part) > 40, f"SRI hash seems too short in {template}: {hash_value}"
 
     def test_sri_has_crossorigin(self):
@@ -116,19 +116,14 @@ class TestSRIHashIntegrity:
             Path("vitrina/templates/base.html"),
             Path("vitrina/users/templates/users_count_stats_chart.html"),
         ]
-        
+
         for template in templates:
             content = template.read_text()
-            
+
             # Find script tags with integrity
-            script_blocks = re.findall(
-                r'<script[^>]*integrity="[^"]*"[^>]*>',
-                content,
-                re.MULTILINE | re.DOTALL
-            )
-            
+            script_blocks = re.findall(r'<script[^>]*integrity="[^"]*"[^>]*>', content, re.MULTILINE | re.DOTALL)
+
             for script in script_blocks:
-                assert 'crossorigin=' in script, (
+                assert "crossorigin=" in script, (
                     f"Script with integrity must have crossorigin attribute in {template}: {script}"
                 )
-

--- a/tests/smart_contracts/conftest.py
+++ b/tests/smart_contracts/conftest.py
@@ -3,13 +3,11 @@ from pathlib import Path
 from lxml import etree
 from cryptography import x509
 from base64 import b64decode
-from django.contrib.contenttypes.models import ContentType
 
 from vitrina.datasets.factories import DatasetFactory
 from vitrina.datasets.models import Dataset
 from vitrina.orgs.factories import OrganizationFactory
 from vitrina.orgs.models import Organization
-from vitrina.structure.factories import MetadataFactory
 from vitrina.smart_contracts.services import SAFE_PARSER, SIGNATURE_NAMESPACES
 
 

--- a/tests/smart_contracts/test_forms.py
+++ b/tests/smart_contracts/test_forms.py
@@ -7,11 +7,10 @@ from django.core.files.base import ContentFile
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django_webtest import DjangoTestApp
 
-from tests.conftest import organization
-from tests.smart_contracts.conftest import agreement_pdf, ODRL_JSON
+from tests.smart_contracts.conftest import ODRL_JSON
 from vitrina.datasets.factories import DatasetFactory, ContactFactory
 from vitrina.datasets.models import Dataset
-from vitrina.orgs.factories import OrganizationFactory, RepresentativeFactory
+from vitrina.orgs.factories import OrganizationFactory
 from vitrina.orgs.models import Organization
 from vitrina.projects.factories import ProjectFactory
 from vitrina.smart_contracts import AgreementStatuses
@@ -23,7 +22,6 @@ from vitrina.smart_contracts.forms import (
     AgreementFormForm, AgreementInitiateForm, AgreementSignForm,
 )
 from vitrina.smart_contracts.models import SmartContractTemplate
-from vitrina.structure.factories import MetadataFactory
 from vitrina.users.factories import UserFactory
 from vitrina.users.models import User
 

--- a/tests/smart_contracts/test_forms.py
+++ b/tests/smart_contracts/test_forms.py
@@ -19,7 +19,9 @@ from vitrina.smart_contracts.forms import (
     SmartContractForm,
     AgreementSubmitForm,
     AgreementApproveForm,
-    AgreementFormForm, AgreementInitiateForm, AgreementSignForm,
+    AgreementFormForm,
+    AgreementInitiateForm,
+    AgreementSignForm,
 )
 from vitrina.smart_contracts.models import SmartContractTemplate
 from vitrina.users.factories import UserFactory
@@ -36,9 +38,7 @@ class TestSmartContractForm:
 
         assert form.fields["scopes"].choices == []
 
-    def test_generates_no_scope_choices_if_organization_has_no_datasets(
-        self, organization: Organization
-    ) -> None:
+    def test_generates_no_scope_choices_if_organization_has_no_datasets(self, organization: Organization) -> None:
         form = SmartContractForm(
             instance=organization,
             dataset_metadata_by_organization={organization.id: []},
@@ -46,15 +46,11 @@ class TestSmartContractForm:
 
         assert form.fields["scopes"].choices == []
 
-    def test_generates_no_scope_choices_if_dataset_metadata_has_empty_name(
-        self, organization: Organization
-    ) -> None:
+    def test_generates_no_scope_choices_if_dataset_metadata_has_empty_name(self, organization: Organization) -> None:
         dataset = DatasetFactory(organization=organization, metadata="")
         form = SmartContractForm(
             instance=organization,
-            dataset_metadata_by_organization={
-                organization.id: [dataset.metadata.first()]
-            },
+            dataset_metadata_by_organization={organization.id: [dataset.metadata.first()]},
         )
         assert form.fields["scopes"].choices == []
 
@@ -63,9 +59,7 @@ class TestSmartContractForm:
     ) -> None:
         form = SmartContractForm(
             instance=organization,
-            dataset_metadata_by_organization={
-                organization.id: [dataset.metadata.first()]
-            },
+            dataset_metadata_by_organization={organization.id: [dataset.metadata.first()]},
         )
 
         assert set(form.fields["scopes"].choices) == {
@@ -88,14 +82,11 @@ class TestAgreementSubmitForm:
             object_id=None,
             content_type=None,
             email="example@example.com",
-            phone="+37060000000"
+            phone="+37060000000",
         )
 
         # Act
-        form = AgreementSubmitForm(
-            data={"assignee_representative": contact.pk},
-            agreement=agreement
-        )
+        form = AgreementSubmitForm(data={"assignee_representative": contact.pk}, agreement=agreement)
 
         # Assert
         assert form.is_valid(), form.errors
@@ -104,10 +95,7 @@ class TestAgreementSubmitForm:
         # Arrange
         unrelated_organization = OrganizationFactory()
 
-        agreement = AgreementFactory(
-            assignee=organization,
-            project=ProjectFactory(organization=organization)
-        )
+        agreement = AgreementFactory(assignee=organization, project=ProjectFactory(organization=organization))
         user = UserFactory(organization=organization)
 
         contact_no_user = ContactFactory(
@@ -116,7 +104,7 @@ class TestAgreementSubmitForm:
             content_type=None,
             object_id=None,
             email="example3@example.com",
-            phone="+37060000000"
+            phone="+37060000000",
         )
         contact_with_user = ContactFactory(
             contact_name="Vardenis Pavardenis",
@@ -124,7 +112,7 @@ class TestAgreementSubmitForm:
             object_id=user.id,
             content_type=ContentType.objects.get_for_model(User),
             email="example@example.com",
-            phone="+37060000000"
+            phone="+37060000000",
         )
         contact_unrelated_organization = ContactFactory(
             contact_name="Jonas Jonauskas",
@@ -132,7 +120,7 @@ class TestAgreementSubmitForm:
             content_type=None,
             object_id=None,
             email="example4@example.com",
-            phone="+37060000000"
+            phone="+37060000000",
         )
 
         # Act
@@ -146,10 +134,7 @@ class TestAgreementSubmitForm:
         assert contact_unrelated_organization not in selectable_contacts
 
     def test_failure_required_fields_unfilled(self, organization: Organization):
-        agreement = AgreementFactory(
-            assignee=organization,
-            project=ProjectFactory(organization=organization)
-        )
+        agreement = AgreementFactory(assignee=organization, project=ProjectFactory(organization=organization))
         form = AgreementSubmitForm(data={}, agreement=agreement)
 
         assert not form.is_valid()
@@ -177,7 +162,7 @@ class TestAgreementApproveForm:
             object_id=None,
             content_type=None,
             email="example@example.com",
-            phone="+37060000000"
+            phone="+37060000000",
         )
 
         # Act
@@ -185,9 +170,9 @@ class TestAgreementApproveForm:
             data={
                 "template": template.pk,
                 "assigner_representative": contact.pk,
-                "other_assigner_legislations": "Legislation A; Legislation B; Legislation C."
+                "other_assigner_legislations": "Legislation A; Legislation B; Legislation C.",
             },
-            agreement=agreement
+            agreement=agreement,
         )
 
         # Assert
@@ -214,7 +199,7 @@ class TestAgreementApproveForm:
             object_id=user.id,
             content_type=ContentType.objects.get_for_model(User),
             email="example@example.com",
-            phone="+37060000000"
+            phone="+37060000000",
         )
         contact_no_user = ContactFactory(
             contact_name="Petras Petrauskas",
@@ -222,7 +207,7 @@ class TestAgreementApproveForm:
             content_type=None,
             object_id=None,
             email="example3@example.com",
-            phone="+37060000000"
+            phone="+37060000000",
         )
         contact_unrelated_organization = ContactFactory(
             contact_name="Jonas Jonauskas",
@@ -230,7 +215,7 @@ class TestAgreementApproveForm:
             content_type=None,
             object_id=None,
             email="example4@example.com",
-            phone="+37060000000"
+            phone="+37060000000",
         )
 
         # Act
@@ -278,7 +263,8 @@ class TestAgreementApproveForm:
         agreements_selectable_in_form = list(form.fields["template"].queryset)
         assert template_unrelated_organization not in agreements_selectable_in_form
         assert all(
-            template in agreements_selectable_in_form for template in (
+            template in agreements_selectable_in_form
+            for template in (
                 template_no_organization,
                 template_current_organization,
             )
@@ -286,10 +272,7 @@ class TestAgreementApproveForm:
 
     def test_failure_required_fields_unfilled(self, organization: Organization):
         # Arrange
-        agreement = AgreementFactory(
-            assignee=organization,
-            project=ProjectFactory(organization=organization)
-        )
+        agreement = AgreementFactory(assignee=organization, project=ProjectFactory(organization=organization))
 
         # Act
         form = AgreementApproveForm(data={}, agreement=agreement)
@@ -305,10 +288,7 @@ class TestAgreementApproveForm:
 class TestAgreementFormForm:
     def test_success(self, organization: Organization):
         # Arrange
-        agreement = AgreementFactory(
-            assignee=organization,
-            project=ProjectFactory(organization=organization)
-        )
+        agreement = AgreementFactory(assignee=organization, project=ProjectFactory(organization=organization))
 
         # Act
         form = AgreementFormForm(data={}, agreement=agreement)
@@ -319,11 +299,12 @@ class TestAgreementFormForm:
 
 class TestAgreementInitiateAndSignForms:
     """Tests for both AgreementInitiateForm and AgreementSignForm have the same logic in their respective forms."""
+
     @pytest.mark.parametrize(
         "form_class,agreement_status,file_name",
         [
             (AgreementInitiateForm, AgreementStatuses.FORMED, "agreement_one_signer.adoc"),
-            (AgreementSignForm, AgreementStatuses.INITIATED, "agreement_two_signers.adoc")
+            (AgreementSignForm, AgreementStatuses.INITIATED, "agreement_two_signers.adoc"),
         ],
     )
     def test_success(
@@ -331,7 +312,7 @@ class TestAgreementInitiateAndSignForms:
         form_class: Type[AgreementInitiateForm | AgreementSignForm],
         agreement_status: AgreementStatuses,
         file_name: str,
-        agreement_pdf: str
+        agreement_pdf: str,
     ):
         # Arrange
         base_path = Path(__file__).parent / "files" / "test_contracts"
@@ -361,7 +342,9 @@ class TestAgreementInitiateAndSignForms:
         agreement_pdf_file = AgreementPDFFileFactory()
 
         # Act
-        form = AgreementInitiateForm(files={"file": uploaded_file}, agreement_pdf=agreement_pdf_file, agreement=agreement_pdf_file.agreement)
+        form = AgreementInitiateForm(
+            files={"file": uploaded_file}, agreement_pdf=agreement_pdf_file, agreement=agreement_pdf_file.agreement
+        )
 
         # Assert
         assert not form.is_valid()
@@ -374,9 +357,7 @@ class TestAgreementInitiateAndSignForms:
 
         # Act
         form = AgreementInitiateForm(
-            files={"file": uploaded_file},
-            agreement_pdf=agreement_pdf_file,
-            agreement=agreement_pdf_file.agreement
+            files={"file": uploaded_file}, agreement_pdf=agreement_pdf_file, agreement=agreement_pdf_file.agreement
         )
 
         # Assert
@@ -395,7 +376,7 @@ class TestAgreementInitiateAndSignForms:
             ("agreement_non_zip.adoc", "Prisegtas failas nėra ZIP archyvas."),
             ("agreement_not_signed.adoc", "Įkelta sutartis nepasirašyta."),
             ("agreement.pdf", "Dokumentas turi būti adoc formato."),
-        ]
+        ],
     )
     def test_initiate_and_sign_form_errors(
         self,

--- a/tests/smart_contracts/test_models.py
+++ b/tests/smart_contracts/test_models.py
@@ -14,9 +14,7 @@ def test_valid_markdown_file_is_accepted():
     content = b"# Sample Markdown"
     md_file = SimpleUploadedFile("template.md", content)
 
-    template = SmartContractTemplate.objects.create(
-        file=md_file, organization=organization
-    )
+    template = SmartContractTemplate.objects.create(file=md_file, organization=organization)
 
     assert template.file.name.endswith(".md")
     with open(template.file.path, "rb") as f:

--- a/tests/smart_contracts/test_services.py
+++ b/tests/smart_contracts/test_services.py
@@ -29,7 +29,11 @@ def test_is_checksum_valid_success(agreement_one_signer: Path):
 
 
 def test_is_checksum_valid_added_extra_scope():
-    assert not get_pdf_checksum_from_adoc(str(test_contracts_dir / "sutartis_signed_extra_scope.adoc")) == CONTRACT_CHECKSUM
+    assert (
+        not get_pdf_checksum_from_adoc(str(test_contracts_dir / "sutartis_signed_extra_scope.adoc"))
+        == CONTRACT_CHECKSUM
+    )
+
 
 def test_is_checksum_valid_missing_pdf_in_adoc(agreement_no_pdf: Path):
     with pytest.raises(InvalidAdocError, match="Blogas ADOC failas: Nerastas PDF failas."):
@@ -41,24 +45,17 @@ def test_extract_elements_from_adoc(agreement_one_signer: Path):
         "uapi:/datasets/gov/rc/ar/ws/Country/@resident/:getall",
         "uapi:/datasets/gov/rc/ar/ws/Country/@resident/:getone",
     ]
-    assert (
-        extract_elements_from_adoc(
-            str(agreement_one_signer), SCOPES_REGEX
-        )
-        == expected_scopes
-    )
+    assert extract_elements_from_adoc(str(agreement_one_signer), SCOPES_REGEX) == expected_scopes
 
 
 def test_extract_scopes_from_adoc_not_supported_file(agreement_pdf: Path):
-    with pytest.raises(
-        InvalidAdocError, match="Invalid ADOC file: File is not a zip file"
-    ):
-        extract_elements_from_adoc(
-            str(agreement_pdf), SCOPES_REGEX
-        )
+    with pytest.raises(InvalidAdocError, match="Invalid ADOC file: File is not a zip file"):
+        extract_elements_from_adoc(str(agreement_pdf), SCOPES_REGEX)
 
 
-def test_extract_sigatures_from_adoc(agreement_two_signers: Path, signature1: etree._Element, signature2: etree._Element):
+def test_extract_sigatures_from_adoc(
+    agreement_two_signers: Path, signature1: etree._Element, signature2: etree._Element
+):
     with zipfile.ZipFile(agreement_two_signers) as zip_file:
         signatures = extract_signatures_from_adoc(zip_file)
     assert len(signatures) == 2
@@ -90,7 +87,7 @@ def test_get_signer_from_certificate_no_first_name(certificate_no_first_name: x5
 def test_get_signers_from_adoc(agreement_two_signers: Path):
     with zipfile.ZipFile(agreement_two_signers) as zip_file:
         signers = get_signers_from_adoc(zip_file)
-    
+
     assert len(signers) == 2
     assert signers[0] == SIGNER1_FULL_NAME
     assert signers[1] == SIGNER2_FULL_NAME

--- a/tests/smart_contracts/test_views.py
+++ b/tests/smart_contracts/test_views.py
@@ -38,9 +38,7 @@ class TestProjectBasedAgreementListView:
         project = ProjectFactory(user=user)
         app.set_user(user)
 
-        response = app.get(
-            reverse("project-agreement-list", args=[project.pk]), expect_errors=True
-        )
+        response = app.get(reverse("project-agreement-list", args=[project.pk]), expect_errors=True)
         assert response.status_code == 403
 
     def test_cannot_list_no_permission(self, app: DjangoTestApp, organization: Organization) -> None:
@@ -48,14 +46,11 @@ class TestProjectBasedAgreementListView:
         project = ProjectFactory(user=user, organization=organization)
         app.set_user(user)
 
-        response = app.get(
-            reverse("project-agreement-list", args=[project.pk]), expect_errors=True
-        )
+        response = app.get(reverse("project-agreement-list", args=[project.pk]), expect_errors=True)
         assert response.status_code == 403
 
-    def test_list_agreements_as_assignee(
-        self, app: DjangoTestApp, organization: Organization) -> None:
-        user =  UserFactory()
+    def test_list_agreements_as_assignee(self, app: DjangoTestApp, organization: Organization) -> None:
+        user = UserFactory()
         RepresentativeFactory(user=user, content_object=organization)
         project = ProjectFactory(organization=organization)
         app.set_user(user)
@@ -67,11 +62,9 @@ class TestProjectBasedAgreementListView:
         assert project.agreements.count() == 2
         assert response.context["agreements"].count() == 2
 
-    def test_list_no_agreements(
-        self, app: DjangoTestApp, organization: Organization, dataset: Dataset
-    ) -> None:
+    def test_list_no_agreements(self, app: DjangoTestApp, organization: Organization, dataset: Dataset) -> None:
         representative = RepresentativeFactory(content_object=organization)
-        user =  representative.user
+        user = representative.user
         project = ProjectFactory(organization=organization, datasets=[dataset])
         app.set_user(user)
 
@@ -81,7 +74,7 @@ class TestProjectBasedAgreementListView:
         assert response.context["agreements"].count() == 0
 
     def test_list_agreements_as_assigner(self, app: DjangoTestApp, organization: Organization) -> None:
-        user =  UserFactory()
+        user = UserFactory()
         RepresentativeFactory(user=user, content_object=organization)
         project = ProjectFactory(organization=OrganizationFactory())
         app.set_user(user)
@@ -96,9 +89,7 @@ class TestProjectBasedAgreementListView:
 
 
 class TestProjectBasedAgreementDetailView:
-    def test_cannot_show_details_without_permission(
-        self, app: DjangoTestApp, organization: Organization
-    ) -> None:
+    def test_cannot_show_details_without_permission(self, app: DjangoTestApp, organization: Organization) -> None:
         user = UserFactory()
         app.set_user(user)
         project = ProjectFactory()
@@ -115,9 +106,7 @@ class TestProjectBasedAgreementDetailView:
         app.set_user(user)
         project = ProjectFactory()
 
-        response = app.get(
-            reverse("project-agreement-detail", args=[project.pk, uuid4()]), expect_errors=True
-        )
+        response = app.get(reverse("project-agreement-detail", args=[project.pk, uuid4()]), expect_errors=True)
         assert response.status_code == 404
 
     def test_http_404_when_agreement_does_not_exist_in_project(
@@ -135,9 +124,7 @@ class TestProjectBasedAgreementDetailView:
         )
         assert response.status_code == 404
 
-    def test_agreement_details(
-        self, app: DjangoTestApp, organization: Organization, dataset: Dataset
-    ) -> None:
+    def test_agreement_details(self, app: DjangoTestApp, organization: Organization, dataset: Dataset) -> None:
         user = UserFactory(organization=organization)
         RepresentativeFactory(user=user, content_object=organization)
         app.set_user(user)
@@ -150,30 +137,22 @@ class TestProjectBasedAgreementDetailView:
 
 
 class TestAgreementCreateView:
-    def test_cannot_create_agreement_without_permission(
-        self, app: DjangoTestApp
-    ) -> None:
+    def test_cannot_create_agreement_without_permission(self, app: DjangoTestApp) -> None:
         representative = ViispRepresentativeFactory(can_make_agreements=False)
         user = representative.user
         project = ProjectFactory(user=user, organization=representative.content_object)
         app.set_user(user)
 
-        response = app.get(
-            reverse("project-agreement-create", args=[project.pk]), expect_errors=True
-        )
+        response = app.get(reverse("project-agreement-create", args=[project.pk]), expect_errors=True)
         assert response.status_code == 403
 
-    def test_cannot_create_agreement_for_deleted_project(
-        self, app: DjangoTestApp
-    ) -> None:
+    def test_cannot_create_agreement_for_deleted_project(self, app: DjangoTestApp) -> None:
         representative = ViispRepresentativeFactory(can_make_agreements=True)
         user = representative.user
         project = ProjectFactory(user=user, organization=representative.content_object, deleted=True)
         app.set_user(user)
 
-        response = app.get(
-            reverse("project-agreement-create", args=[project.pk]), expect_errors=True
-        )
+        response = app.get(reverse("project-agreement-create", args=[project.pk]), expect_errors=True)
         assert response.status_code == 404
 
     def test_cannot_create_agreements_if_all_organizations_already_has_agreement(
@@ -215,9 +194,7 @@ class TestAgreementCreateView:
         assert agreement_scope.action == "getall"
         assert agreement_scope.scope == "uapi:/test/dataset/:getall"
 
-    def test_creates_multiple_agreements_and_scopes(
-        self, app: DjangoTestApp, organization: Organization
-    ) -> None:
+    def test_creates_multiple_agreements_and_scopes(self, app: DjangoTestApp, organization: Organization) -> None:
         dataset1 = DatasetFactory(organization=organization, metadata="test/dataset1")
         dataset2 = DatasetFactory(organization=organization, metadata="test/dataset2")
         diff_organization = OrganizationFactory()
@@ -241,15 +218,13 @@ class TestAgreementCreateView:
         assert response.url == reverse("project-agreement-list", args=[project.pk])
 
         assert Agreement.objects.filter(project=project).count() == 2
+        assert set(AgreementScope.objects.filter(agreement__assigner=organization).values_list("scope", flat=True)) == {
+            "uapi:/test/dataset1/:getall",
+            "uapi:/test/dataset2/:search",
+            "uapi:/test/dataset2/:select",
+        }
         assert set(
-            AgreementScope.objects.filter(agreement__assigner=organization).values_list(
-                "scope", flat=True
-            )
-        ) == {"uapi:/test/dataset1/:getall", "uapi:/test/dataset2/:search", "uapi:/test/dataset2/:select"}
-        assert set(
-            AgreementScope.objects.filter(
-                agreement__assigner=diff_organization
-            ).values_list("scope", flat=True)
+            AgreementScope.objects.filter(agreement__assigner=diff_organization).values_list("scope", flat=True)
         ) == {"uapi:/datasets/gov/org/dataset/:getall"}
 
     def test_can_create_agreements_for_organizations_that_currently_do_not_have_one(
@@ -296,9 +271,7 @@ class TestAgreementCreateView:
         assert response.status_code == 200
         assert Agreement.objects.filter(project=project).count() == 0
 
-    def test_create_agreement_for_personal_project(
-        self, app: DjangoTestApp, dataset: Dataset
-    ) -> None:
+    def test_create_agreement_for_personal_project(self, app: DjangoTestApp, dataset: Dataset) -> None:
         user = UserFactory()
         project = ProjectFactory(user=user, datasets=[dataset])
         app.set_user(user)
@@ -324,7 +297,7 @@ class TestAgreementSubmit:
             object_id=user.pk,
             content_type=ContentType.objects.get_for_model(User),
             email=user.email,
-            phone=user.phone
+            phone=user.phone,
         )
 
         project = ProjectFactory(
@@ -338,15 +311,13 @@ class TestAgreementSubmit:
             assignee_representative=None,
             assigner=assigner_organization,
             created_by=user,
-            status=AgreementStatuses.CREATED
+            status=AgreementStatuses.CREATED,
         )
 
         # Act
         response = app.post(
             reverse("project-agreement-submit", args=[project.pk, agreement.pk]),
-            {
-                "assignee_representative": contact.pk
-            }
+            {"assignee_representative": contact.pk},
         )
 
         # Assert
@@ -369,7 +340,7 @@ class TestAgreementSubmit:
             object_id=user.pk,
             content_type=ContentType.objects.get_for_model(User),
             email=user.email,
-            phone=user.phone
+            phone=user.phone,
         )
 
         project = ProjectFactory(
@@ -383,7 +354,7 @@ class TestAgreementSubmit:
             assignee_representative=None,
             assigner=assigner_organization,
             created_by=user,
-            status=AgreementStatuses.CREATED
+            status=AgreementStatuses.CREATED,
         )
 
         # Act
@@ -416,7 +387,7 @@ class TestAgreementSubmit:
             object_id=user.pk,
             content_type=ContentType.objects.get_for_model(User),
             email=user.email,
-            phone=user.phone
+            phone=user.phone,
         )
 
         project = ProjectFactory(
@@ -430,15 +401,13 @@ class TestAgreementSubmit:
             assignee_representative=None,
             assigner=assigner_organization,
             created_by=user,
-            status=AgreementStatuses.CREATED
+            status=AgreementStatuses.CREATED,
         )
 
         # Act
         response = app.post(
             reverse("project-agreement-submit", args=[project.pk, agreement.pk]),
-            {
-                "assignee_representative": contact.pk
-            },
+            {"assignee_representative": contact.pk},
             expect_errors=True,
         )
 
@@ -463,7 +432,7 @@ class TestAgreementSubmit:
             object_id=user.pk,
             content_type=ContentType.objects.get_for_model(User),
             email=user.email,
-            phone=user.phone
+            phone=user.phone,
         )
 
         project = ProjectFactory(
@@ -477,15 +446,13 @@ class TestAgreementSubmit:
             assignee_representative=None,
             assigner=assigner_organization,
             created_by=user,
-            status=AgreementStatuses.CREATED
+            status=AgreementStatuses.CREATED,
         )
 
         # Act
         response = app.post(
             reverse("project-agreement-submit", args=[project.pk, agreement.pk]),
-            {
-                "assignee_representative": contact.pk
-            },
+            {"assignee_representative": contact.pk},
             expect_errors=True,
         )
 
@@ -495,15 +462,18 @@ class TestAgreementSubmit:
         assert agreement.status == AgreementStatuses.CREATED
         assert not agreement.assignee_representative
 
-    @pytest.mark.parametrize("initial_agreement_status", [
-        AgreementStatuses.SUBMITTED,
-        AgreementStatuses.APPROVED,
-        AgreementStatuses.FORMED,
-        AgreementStatuses.INITIATED,
-        AgreementStatuses.SIGNED,
-        AgreementStatuses.ACTIVE,
-        AgreementStatuses.TERMINATED,
-    ])
+    @pytest.mark.parametrize(
+        "initial_agreement_status",
+        [
+            AgreementStatuses.SUBMITTED,
+            AgreementStatuses.APPROVED,
+            AgreementStatuses.FORMED,
+            AgreementStatuses.INITIATED,
+            AgreementStatuses.SIGNED,
+            AgreementStatuses.ACTIVE,
+            AgreementStatuses.TERMINATED,
+        ],
+    )
     def test_incorrect_agreement_status(
         self,
         initial_agreement_status: AgreementStatuses,
@@ -524,7 +494,7 @@ class TestAgreementSubmit:
             object_id=user.pk,
             content_type=ContentType.objects.get_for_model(User),
             email=user.email,
-            phone=user.phone
+            phone=user.phone,
         )
 
         project = ProjectFactory(
@@ -538,15 +508,13 @@ class TestAgreementSubmit:
             assignee_representative=None,
             assigner=assigner_organization,
             created_by=user,
-            status=initial_agreement_status
+            status=initial_agreement_status,
         )
 
         # Act
         response = app.post(
             reverse("project-agreement-submit", args=[project.pk, agreement.pk]),
-            {
-                "assignee_representative": contact.pk
-            }
+            {"assignee_representative": contact.pk},
         )
 
         # Assert
@@ -587,14 +555,14 @@ class TestAgreementApprove:
             object_id=assignee_user.pk,
             content_type=ContentType.objects.get_for_model(User),
             email=assignee_user.email,
-            phone=assignee_user.phone
+            phone=assignee_user.phone,
         )
         assigner_contact = ContactFactory(
             organization=assigner_organization,
             object_id=assigner_user.pk,
             content_type=ContentType.objects.get_for_model(User),
             email=assigner_user.email,
-            phone=assigner_user.phone
+            phone=assigner_user.phone,
         )
 
         project = ProjectFactory(
@@ -610,7 +578,7 @@ class TestAgreementApprove:
             assigner_representative=None,
             assigner=assigner_organization,
             created_by=assignee_user,
-            status=AgreementStatuses.SUBMITTED
+            status=AgreementStatuses.SUBMITTED,
         )
         other_assigner_legislations = "Legislation A; Legislation B; Legislation C."
 
@@ -620,8 +588,8 @@ class TestAgreementApprove:
             {
                 "template": template.pk,
                 "assigner_representative": assigner_contact.pk,
-                "other_assigner_legislations": other_assigner_legislations
-            }
+                "other_assigner_legislations": other_assigner_legislations,
+            },
         )
 
         # Assert
@@ -631,7 +599,6 @@ class TestAgreementApprove:
         assert agreement.template == template
         assert agreement.assigner_representative == assigner_contact
         assert agreement.other_assigner_legislations == other_assigner_legislations
-
 
     def test_unauthorized_not_representative(self, app: DjangoTestApp, dataset: Dataset):
         # Arrange
@@ -662,14 +629,14 @@ class TestAgreementApprove:
             object_id=assignee_user.pk,
             content_type=ContentType.objects.get_for_model(User),
             email=assignee_user.email,
-            phone=assignee_user.phone
+            phone=assignee_user.phone,
         )
         assigner_contact = ContactFactory(
             organization=assigner_organization,
             object_id=assigner_user.pk,
             content_type=ContentType.objects.get_for_model(User),
             email=assigner_user.email,
-            phone=assigner_user.phone
+            phone=assigner_user.phone,
         )
 
         project = ProjectFactory(
@@ -685,7 +652,7 @@ class TestAgreementApprove:
             assigner_representative=None,
             assigner=assigner_organization,
             created_by=assignee_user,
-            status=AgreementStatuses.SUBMITTED
+            status=AgreementStatuses.SUBMITTED,
         )
         other_assigner_legislations = "Legislation A; Legislation B; Legislation C."
 
@@ -695,7 +662,7 @@ class TestAgreementApprove:
             {
                 "template": template.pk,
                 "assigner_representative": assigner_contact.pk,
-                "other_assigner_legislations": other_assigner_legislations
+                "other_assigner_legislations": other_assigner_legislations,
             },
             expect_errors=True,
         )
@@ -738,14 +705,14 @@ class TestAgreementApprove:
             object_id=assignee_user.pk,
             content_type=ContentType.objects.get_for_model(User),
             email=assignee_user.email,
-            phone=assignee_user.phone
+            phone=assignee_user.phone,
         )
         assigner_contact = ContactFactory(
             organization=assigner_organization,
             object_id=assigner_user.pk,
             content_type=ContentType.objects.get_for_model(User),
             email=assigner_user.email,
-            phone=assigner_user.phone
+            phone=assigner_user.phone,
         )
 
         project = ProjectFactory(
@@ -761,7 +728,7 @@ class TestAgreementApprove:
             assigner_representative=None,
             assigner=assigner_organization,
             created_by=assignee_user,
-            status=AgreementStatuses.SUBMITTED
+            status=AgreementStatuses.SUBMITTED,
         )
         other_assigner_legislations = "Legislation A; Legislation B; Legislation C."
 
@@ -771,7 +738,7 @@ class TestAgreementApprove:
             {
                 "template": template.pk,
                 "assigner_representative": assigner_contact.pk,
-                "other_assigner_legislations": other_assigner_legislations
+                "other_assigner_legislations": other_assigner_legislations,
             },
             expect_errors=True,
         )
@@ -814,14 +781,14 @@ class TestAgreementApprove:
             object_id=assignee_user.pk,
             content_type=ContentType.objects.get_for_model(User),
             email=assignee_user.email,
-            phone=assignee_user.phone
+            phone=assignee_user.phone,
         )
         assigner_contact = ContactFactory(
             organization=assigner_organization,
             object_id=assigner_user.pk,
             content_type=ContentType.objects.get_for_model(User),
             email=assigner_user.email,
-            phone=assigner_user.phone
+            phone=assigner_user.phone,
         )
 
         project = ProjectFactory(
@@ -837,7 +804,7 @@ class TestAgreementApprove:
             assigner_representative=None,
             assigner=assigner_organization,
             created_by=assignee_user,
-            status=AgreementStatuses.SUBMITTED
+            status=AgreementStatuses.SUBMITTED,
         )
         other_assigner_legislations = "Legislation A; Legislation B; Legislation C."
 
@@ -847,7 +814,7 @@ class TestAgreementApprove:
             {
                 "template": template.pk,
                 "assigner_representative": assigner_contact.pk,
-                "other_assigner_legislations": other_assigner_legislations
+                "other_assigner_legislations": other_assigner_legislations,
             },
             expect_errors=True,
         )
@@ -860,20 +827,20 @@ class TestAgreementApprove:
         assert not agreement.assigner_representative
         assert not agreement.other_assigner_legislations
 
-    @pytest.mark.parametrize("initial_agreement_status", [
-        AgreementStatuses.CREATED,
-        AgreementStatuses.APPROVED,
-        AgreementStatuses.FORMED,
-        AgreementStatuses.INITIATED,
-        AgreementStatuses.SIGNED,
-        AgreementStatuses.ACTIVE,
-        AgreementStatuses.TERMINATED,
-    ])
+    @pytest.mark.parametrize(
+        "initial_agreement_status",
+        [
+            AgreementStatuses.CREATED,
+            AgreementStatuses.APPROVED,
+            AgreementStatuses.FORMED,
+            AgreementStatuses.INITIATED,
+            AgreementStatuses.SIGNED,
+            AgreementStatuses.ACTIVE,
+            AgreementStatuses.TERMINATED,
+        ],
+    )
     def test_incorrect_agreement_status(
-        self,
-        initial_agreement_status: AgreementStatuses,
-        app: DjangoTestApp,
-        dataset: Dataset
+        self, initial_agreement_status: AgreementStatuses, app: DjangoTestApp, dataset: Dataset
     ):
         # Arrange
         template = SmartContractTemplate.objects.create(
@@ -904,14 +871,14 @@ class TestAgreementApprove:
             object_id=assignee_user.pk,
             content_type=ContentType.objects.get_for_model(User),
             email=assignee_user.email,
-            phone=assignee_user.phone
+            phone=assignee_user.phone,
         )
         assigner_contact = ContactFactory(
             organization=assigner_organization,
             object_id=assigner_user.pk,
             content_type=ContentType.objects.get_for_model(User),
             email=assigner_user.email,
-            phone=assigner_user.phone
+            phone=assigner_user.phone,
         )
 
         project = ProjectFactory(
@@ -927,7 +894,7 @@ class TestAgreementApprove:
             assigner_representative=None,
             assigner=assigner_organization,
             created_by=assignee_user,
-            status=initial_agreement_status
+            status=initial_agreement_status,
         )
         other_assigner_legislations = "Legislation A; Legislation B; Legislation C."
 
@@ -937,8 +904,8 @@ class TestAgreementApprove:
             {
                 "template": template.pk,
                 "assigner_representative": assigner_contact.pk,
-                "other_assigner_legislations": other_assigner_legislations
-            }
+                "other_assigner_legislations": other_assigner_legislations,
+            },
         )
 
         # Assert
@@ -984,7 +951,7 @@ class TestAgreementForm:
             object_id=assignee_user.pk,
             content_type=ContentType.objects.get_for_model(User),
             email=assignee_user.email,
-            phone=assignee_user.phone
+            phone=assignee_user.phone,
         )
         assigner_contact = ContactFactory(
             organization=assigner_organization,
@@ -1014,10 +981,7 @@ class TestAgreementForm:
         )
 
         # Act
-        response = app.post(
-            reverse("project-agreement-form", args=[project.pk, agreement.pk]),
-            {}
-        )
+        response = app.post(reverse("project-agreement-form", args=[project.pk, agreement.pk]), {})
 
         # Assert
         assert response.status_code == 302
@@ -1141,7 +1105,7 @@ class TestAgreementForm:
             object_id=assignee_user.pk,
             content_type=ContentType.objects.get_for_model(User),
             email=assignee_user.email,
-            phone=assignee_user.phone
+            phone=assignee_user.phone,
         )
         assigner_contact = ContactFactory(
             organization=assigner_organization,
@@ -1184,7 +1148,9 @@ class TestAgreementForm:
         assert not agreement.files.exists()
 
     @pytest.mark.parametrize("is_acting_user_assignee", [True, False])
-    def test_unauthorized_not_viisp_authorized(self, is_acting_user_assignee: bool, app: DjangoTestApp, dataset: Dataset):
+    def test_unauthorized_not_viisp_authorized(
+        self, is_acting_user_assignee: bool, app: DjangoTestApp, dataset: Dataset
+    ):
         # Arrange
         template = SmartContractTemplate.objects.create(
             file=ContentFile(
@@ -1216,7 +1182,7 @@ class TestAgreementForm:
             object_id=assignee_user.pk,
             content_type=ContentType.objects.get_for_model(User),
             email=assignee_user.email,
-            phone=assignee_user.phone
+            phone=assignee_user.phone,
         )
         assigner_contact = ContactFactory(
             organization=assigner_organization,
@@ -1259,7 +1225,9 @@ class TestAgreementForm:
         assert not agreement.files.exists()
 
     @pytest.mark.parametrize("is_acting_user_assignee", [True, False])
-    def test_unauthorized_not_granted_agreement_signing_rights(self, is_acting_user_assignee: bool, app: DjangoTestApp, dataset: Dataset):
+    def test_unauthorized_not_granted_agreement_signing_rights(
+        self, is_acting_user_assignee: bool, app: DjangoTestApp, dataset: Dataset
+    ):
         # Arrange
         template = SmartContractTemplate.objects.create(
             file=ContentFile(
@@ -1291,7 +1259,7 @@ class TestAgreementForm:
             object_id=assignee_user.pk,
             content_type=ContentType.objects.get_for_model(User),
             email=assignee_user.email,
-            phone=assignee_user.phone
+            phone=assignee_user.phone,
         )
         assigner_contact = ContactFactory(
             organization=assigner_organization,
@@ -1333,16 +1301,21 @@ class TestAgreementForm:
         assert agreement.status == AgreementStatuses.APPROVED  # Unchanged.
         assert not agreement.files.exists()
 
-    @pytest.mark.parametrize("initial_agreement_status", [
-        AgreementStatuses.CREATED,
-        AgreementStatuses.SUBMITTED,
-        AgreementStatuses.FORMED,
-        AgreementStatuses.INITIATED,
-        AgreementStatuses.SIGNED,
-        AgreementStatuses.ACTIVE,
-        AgreementStatuses.TERMINATED,
-    ])
-    def test_incorrect_agreement_status(self, initial_agreement_status: AgreementStatuses, app: DjangoTestApp, dataset: Dataset):
+    @pytest.mark.parametrize(
+        "initial_agreement_status",
+        [
+            AgreementStatuses.CREATED,
+            AgreementStatuses.SUBMITTED,
+            AgreementStatuses.FORMED,
+            AgreementStatuses.INITIATED,
+            AgreementStatuses.SIGNED,
+            AgreementStatuses.ACTIVE,
+            AgreementStatuses.TERMINATED,
+        ],
+    )
+    def test_incorrect_agreement_status(
+        self, initial_agreement_status: AgreementStatuses, app: DjangoTestApp, dataset: Dataset
+    ):
         template = SmartContractTemplate.objects.create(
             file=ContentFile(
                 open(Path(__file__).parent / "files" / "contract_template.md").read(),
@@ -1373,7 +1346,7 @@ class TestAgreementForm:
             object_id=assignee_user.pk,
             content_type=ContentType.objects.get_for_model(User),
             email=assignee_user.email,
-            phone=assignee_user.phone
+            phone=assignee_user.phone,
         )
         assigner_contact = ContactFactory(
             organization=assigner_organization,
@@ -1456,7 +1429,7 @@ class TestAgreementInitiate:
                     agreement_one_signer.read_bytes(),
                     "text/plain",
                 )
-            ]
+            ],
         )
 
         # Assert
@@ -1503,7 +1476,7 @@ class TestAgreementInitiate:
                     agreement_one_signer.read_bytes(),
                     "text/plain",
                 )
-            ]
+            ],
         )
 
         # Assert
@@ -1512,14 +1485,17 @@ class TestAgreementInitiate:
         agreement.refresh_from_db()
         assert agreement.status == AgreementStatuses.FORMED
 
-    @pytest.mark.parametrize("initial_agreement_status", [
-        AgreementStatuses.CREATED,
-        AgreementStatuses.SUBMITTED,
-        AgreementStatuses.APPROVED,
-        AgreementStatuses.SIGNED,
-        AgreementStatuses.ACTIVE,
-        AgreementStatuses.TERMINATED,
-    ])
+    @pytest.mark.parametrize(
+        "initial_agreement_status",
+        [
+            AgreementStatuses.CREATED,
+            AgreementStatuses.SUBMITTED,
+            AgreementStatuses.APPROVED,
+            AgreementStatuses.SIGNED,
+            AgreementStatuses.ACTIVE,
+            AgreementStatuses.TERMINATED,
+        ],
+    )
     def test_incorrect_agreement_status(
         self,
         initial_agreement_status: AgreementStatuses,
@@ -1613,7 +1589,7 @@ class TestAgreementInitiate:
                     agreement_one_signer.read_bytes(),
                     "text/plain",
                 )
-            ]
+            ],
         )
 
         # Assert
@@ -1662,14 +1638,14 @@ class TestAgreementSign:
             object_id=assignee_user.pk,
             content_type=ContentType.objects.get_for_model(User),
             email=assignee_user.email,
-            phone=assignee_user.email
+            phone=assignee_user.email,
         )
         assigner_contact = ContactFactory(
             organization=assigner_organization,
             object_id=assigner_user.pk,
             content_type=ContentType.objects.get_for_model(User),
             email=assigner_user.email,
-            phone=assigner_user.email
+            phone=assigner_user.email,
         )
 
         project = ProjectFactory(organization=assignee_organization, datasets=[dataset])
@@ -1684,7 +1660,7 @@ class TestAgreementSign:
             other_assigner_legislations="Legislation D; Legislation E; Legislation F.",
             payment_terms="Payment term A; Payment term B.",
             created_by=assignee_user,
-            status=AgreementStatuses.INITIATED
+            status=AgreementStatuses.INITIATED,
         )
 
         AgreementJSONFileFactory(agreement=agreement, json_path=odrl_json)
@@ -1700,7 +1676,7 @@ class TestAgreementSign:
                     agreement_two_signers.read_bytes(),
                     "text/plain",
                 )
-            ]
+            ],
         )
 
         # Assert
@@ -1710,14 +1686,17 @@ class TestAgreementSign:
         assert agreement.status == AgreementStatuses.SIGNED
         assert agreement.is_agent_sync_enabled
 
-    @pytest.mark.parametrize("initial_agreement_status", [
-        AgreementStatuses.CREATED,
-        AgreementStatuses.SUBMITTED,
-        AgreementStatuses.APPROVED,
-        AgreementStatuses.SIGNED,
-        AgreementStatuses.ACTIVE,
-        AgreementStatuses.TERMINATED,
-    ])
+    @pytest.mark.parametrize(
+        "initial_agreement_status",
+        [
+            AgreementStatuses.CREATED,
+            AgreementStatuses.SUBMITTED,
+            AgreementStatuses.APPROVED,
+            AgreementStatuses.SIGNED,
+            AgreementStatuses.ACTIVE,
+            AgreementStatuses.TERMINATED,
+        ],
+    )
     def test_incorrect_agreement_status(
         self,
         initial_agreement_status: AgreementStatuses,
@@ -1757,14 +1736,14 @@ class TestAgreementSign:
             object_id=assignee_user.pk,
             content_type=ContentType.objects.get_for_model(User),
             email=assignee_user.email,
-            phone=assignee_user.email
+            phone=assignee_user.email,
         )
         assigner_contact = ContactFactory(
             organization=assigner_organization,
             object_id=assigner_user.pk,
             content_type=ContentType.objects.get_for_model(User),
             email=assigner_user.email,
-            phone=assigner_user.email
+            phone=assigner_user.email,
         )
 
         project = ProjectFactory(organization=assignee_organization, datasets=[dataset])
@@ -1779,7 +1758,7 @@ class TestAgreementSign:
             other_assigner_legislations="Legislation D; Legislation E; Legislation F.",
             payment_terms="Payment term A; Payment term B.",
             created_by=assignee_user,
-            status=initial_agreement_status
+            status=initial_agreement_status,
         )
 
         AgreementJSONFileFactory(agreement=agreement, json_path=odrl_json)
@@ -1796,7 +1775,7 @@ class TestAgreementSign:
                     "text/plain",
                 )
             ],
-            expect_errors = True,
+            expect_errors=True,
         )
 
         # Assert
@@ -1846,14 +1825,14 @@ class TestAgreementSign:
             object_id=assignee_user.pk,
             content_type=ContentType.objects.get_for_model(User),
             email=assignee_user.email,
-            phone=assignee_user.email
+            phone=assignee_user.email,
         )
         assigner_contact = ContactFactory(
             organization=assigner_organization,
             object_id=assigner_user.pk,
             content_type=ContentType.objects.get_for_model(User),
             email=assigner_user.email,
-            phone=assigner_user.email
+            phone=assigner_user.email,
         )
 
         project = ProjectFactory(organization=assignee_organization, datasets=[dataset])
@@ -1868,7 +1847,7 @@ class TestAgreementSign:
             other_assigner_legislations="Legislation D; Legislation E; Legislation F.",
             payment_terms="Payment term A; Payment term B.",
             created_by=assignee_user,
-            status=AgreementStatuses.INITIATED
+            status=AgreementStatuses.INITIATED,
         )
 
         AgreementJSONFileFactory(agreement=agreement, json_path=odrl_json)
@@ -1883,7 +1862,7 @@ class TestAgreementSign:
                     agreement_two_signers.read_bytes(),
                     "text/plain",
                 )
-            ]
+            ],
         )
 
         # Assert
@@ -1930,14 +1909,14 @@ class TestAgreementSign:
             object_id=assignee_user.pk,
             content_type=ContentType.objects.get_for_model(User),
             email=assignee_user.email,
-            phone=assignee_user.email
+            phone=assignee_user.email,
         )
         assigner_contact = ContactFactory(
             organization=assigner_organization,
             object_id=assigner_user.pk,
             content_type=ContentType.objects.get_for_model(User),
             email=assigner_user.email,
-            phone=assigner_user.email
+            phone=assigner_user.email,
         )
 
         project = ProjectFactory(organization=assignee_organization, datasets=[dataset])
@@ -1952,7 +1931,7 @@ class TestAgreementSign:
             other_assigner_legislations="Legislation D; Legislation E; Legislation F.",
             payment_terms="Payment term A; Payment term B.",
             created_by=assignee_user,
-            status=AgreementStatuses.INITIATED
+            status=AgreementStatuses.INITIATED,
         )
 
         AgreementJSONFileFactory(agreement=agreement, json_path=odrl_json)
@@ -1969,7 +1948,7 @@ class TestAgreementSign:
                     agreement_two_signers.read_bytes(),
                     "text/plain",
                 )
-            ]
+            ],
         )
 
         # Assert
@@ -1981,7 +1960,9 @@ class TestAgreementSign:
 
 class TestAgreementFileDownload:
     def test_cannot_download_file_if_unauthorized(
-        self, app: DjangoTestApp, agreement_pdf: Path,
+        self,
+        app: DjangoTestApp,
+        agreement_pdf: Path,
     ):
         assignee = OrganizationFactory()
         assigner = OrganizationFactory()
@@ -1996,11 +1977,14 @@ class TestAgreementFileDownload:
         response = app.get(url)
 
         assert response.status_code == 302
-        assert response.location == f'{reverse("login")}?next={url}'
+        assert response.location == f"{reverse('login')}?next={url}"
 
     @pytest.mark.parametrize("user_field", ["is_staff", "is_superuser"])
     def test_can_download_file_if_staff_or_superuser(
-        self, app: DjangoTestApp, agreement_pdf: Path, user_field: str,
+        self,
+        app: DjangoTestApp,
+        agreement_pdf: Path,
+        user_field: str,
     ):
         assignee = OrganizationFactory()
         assigner = OrganizationFactory()
@@ -2014,9 +1998,7 @@ class TestAgreementFileDownload:
             project=ProjectFactory(organization=assignee),
         )
         agreement_file = AgreementPDFFileFactory(agreement=agreement, pdf_path=agreement_pdf)
-        response = app.get(
-            reverse("agreement-file-download", args=[agreement.pk, agreement_file.pk])
-        )
+        response = app.get(reverse("agreement-file-download", args=[agreement.pk, agreement_file.pk]))
 
         assert response.status_code == 200
 
@@ -2029,7 +2011,7 @@ class TestAgreementFileDownload:
         ],
     )
     def test_can_download_file_if_assignee_or_assigner_organization_representative(
-       self, app: DjangoTestApp, agreement_pdf: Path, is_acting_user_assignee: bool, role: str
+        self, app: DjangoTestApp, agreement_pdf: Path, is_acting_user_assignee: bool, role: str
     ):
         assignee = OrganizationFactory()
         assigner = OrganizationFactory()
@@ -2050,9 +2032,7 @@ class TestAgreementFileDownload:
         )
         agreement_file = AgreementPDFFileFactory(agreement=agreement, pdf_path=agreement_pdf)
 
-        response = app.get(
-            reverse("agreement-file-download", args=[agreement.pk, agreement_file.pk])
-        )
+        response = app.get(reverse("agreement-file-download", args=[agreement.pk, agreement_file.pk]))
 
         assert response.status_code == 200
 
@@ -2097,9 +2077,7 @@ class TestAgreementFileDownload:
             Representative.RESOURCE_COORDINATOR,
         ],
     )
-    def test_return_file_as_attachment_if_debug_true(
-        self, app: DjangoTestApp, agreement_pdf: Path, role: str
-    ):
+    def test_return_file_as_attachment_if_debug_true(self, app: DjangoTestApp, agreement_pdf: Path, role: str):
         assignee = OrganizationFactory()
         assigner = OrganizationFactory()
 

--- a/tests/structure/test_admin.py
+++ b/tests/structure/test_admin.py
@@ -6,6 +6,7 @@ from django.test import override_settings
 from vitrina.structure.models import ManifestValidationEntry
 from vitrina.users.models import User
 
+
 @override_settings(
     CELERY_TASK_ALWAYS_EAGER=True,
     CELERY_TASK_EAGER_PROPAGATES=True,
@@ -17,7 +18,7 @@ def test_manifestvalidationentry_add_executes_task(app: DjangoTestApp):
 
     url = reverse("admin:vitrina_structure_manifestvalidationentry_add")
 
-    form = app.get(url).forms['manifestvalidationentry_form']
+    form = app.get(url).forms["manifestvalidationentry_form"]
 
     response = form.submit(upload_files=[("manifest_file", "test.csv", b"0")])
     assert response.status_code == 302
@@ -37,7 +38,7 @@ def test_manifestvalidationentry_does_not_execute_task_without_commit(app: Djang
 
     url = reverse("admin:vitrina_structure_manifestvalidationentry_add")
 
-    form = app.get(url).forms['manifestvalidationentry_form']
+    form = app.get(url).forms["manifestvalidationentry_form"]
 
     with patch("vitrina.structure.admin.validate_manifest_task.delay") as mocked_task:
         response = form.submit(upload_files=[("manifest_file", "test.csv", b"0")])

--- a/tests/structure/test_services.py
+++ b/tests/structure/test_services.py
@@ -13,8 +13,18 @@ from vitrina.datasets.models import Dataset
 from vitrina.resources.factories import DatasetDistributionFactory, FileFormat
 from vitrina.resources.models import DatasetDistribution
 from vitrina.structure.factories import VersionFactory
-from vitrina.structure.models import Metadata, Prefix, Model, Property, PropertyList, Enum, Param, EnumItem, \
-    ParamItem, Base
+from vitrina.structure.models import (
+    Metadata,
+    Prefix,
+    Model,
+    Property,
+    PropertyList,
+    Enum,
+    Param,
+    EnumItem,
+    ParamItem,
+    Base,
+)
 from vitrina.structure.services import create_structure_objects
 from vitrina.users.factories import UserFactory
 from vitrina.orgs.factories import ViispRepresentativeFactory
@@ -35,45 +45,31 @@ def setup_default_status_data():
 
 @pytest.mark.django_db
 def test_structure_with_file_error(app: DjangoTestApp):
-    manifest = 'id,dataset,unknown'
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    manifest = "id,dataset,unknown"
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
-    comments = Comment.objects.filter(
-        content_type=ContentType.objects.get_for_model(structure),
-        object_id=structure.pk
-    )
+    comments = Comment.objects.filter(content_type=ContentType.objects.get_for_model(structure), object_id=structure.pk)
     assert comments.count() == 1
     assert comments[0].body == "Unrecognized header name 'unknown'."
 
 
 @pytest.mark.django_db
 def test_structure_with_file_error_and_existing_comments(app: DjangoTestApp):
-    manifest = 'id,dataset,unknown'
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    manifest = "id,dataset,unknown"
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     CommentFactory(
         content_type=ContentType.objects.get_for_model(structure),
         object_id=structure.pk,
-        body='Existing error',
-        type=Comment.STRUCTURE_ERROR
+        body="Existing error",
+        type=Comment.STRUCTURE_ERROR,
     )
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
-    comments = Comment.objects.filter(
-        content_type=ContentType.objects.get_for_model(structure),
-        object_id=structure.pk
-    )
+    comments = Comment.objects.filter(content_type=ContentType.objects.get_for_model(structure), object_id=structure.pk)
     assert comments.count() == 1
     assert comments[0].body == "Unrecognized header name 'unknown'."
 
@@ -81,201 +77,187 @@ def test_structure_with_file_error_and_existing_comments(app: DjangoTestApp):
 @pytest.mark.django_db
 def test_structure_prefixes(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',,,,,,prefix,spinta,,,,,,,https://github.com/atviriduomenys/spinta/issues/,,,,\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,,,prefix,dcat,,,,,,,http://www.w3.org/ns/dcat#,,,,\n'
-        ',,,,,,,dct,,,,,,,http://purl.org/dc/terms/,,,,'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",,,,,,prefix,spinta,,,,,,,https://github.com/atviriduomenys/spinta/issues/,,,,\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,,,prefix,dcat,,,,,,,http://www.w3.org/ns/dcat#,,,,\n"
+        ",,,,,,,dct,,,,,,,http://purl.org/dc/terms/,,,,"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
     prefixes = Prefix.objects.all()
     assert prefixes.count() == 3
-    assert list(prefixes.filter(
-        content_type=ContentType.objects.get_for_model(structure.dataset),
-        object_id=structure.dataset.pk
-    ).values_list('metadata__name', flat=True)) == ['dcat', 'dct']
-    assert list(prefixes.filter(
-        content_type=ContentType.objects.get_for_model(structure),
-        object_id=structure.pk
-    ).values_list('metadata__name', flat=True)) == ['spinta']
+    assert list(
+        prefixes.filter(
+            content_type=ContentType.objects.get_for_model(structure.dataset), object_id=structure.dataset.pk
+        ).values_list("metadata__name", flat=True)
+    ) == ["dcat", "dct"]
+    assert list(
+        prefixes.filter(content_type=ContentType.objects.get_for_model(structure), object_id=structure.pk).values_list(
+            "metadata__name", flat=True
+        )
+    ) == ["spinta"]
 
 
 @pytest.mark.django_db
 def test_structure_prefix_after_enum(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
         ',,,,,,enum,Size,,"SMALL",,,,,,,,,\n'
         ',,,,,,,,,"MEDIUM",,,,,,,,,\n'
         ',,,,,,,,,"BIG",,,,,,,,,\n'
-        ',,,,,,,,,,,,,,,,,,\n'
-        ',,,,,,prefix,dcat,,,,,,,http://www.w3.org/ns/dcat#,,,,\n'
-        ',,,,,,,dct,,,,,,,http://purl.org/dc/terms/,,,,'
+        ",,,,,,,,,,,,,,,,,,\n"
+        ",,,,,,prefix,dcat,,,,,,,http://www.w3.org/ns/dcat#,,,,\n"
+        ",,,,,,,dct,,,,,,,http://purl.org/dc/terms/,,,,"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
     prefixes = Prefix.objects.all()
     assert prefixes.count() == 2
-    assert list(prefixes.filter(
-        content_type=ContentType.objects.get_for_model(structure.dataset),
-        object_id=structure.dataset.pk
-    ).values_list('metadata__name', flat=True)) == ['dcat', 'dct']
+    assert list(
+        prefixes.filter(
+            content_type=ContentType.objects.get_for_model(structure.dataset), object_id=structure.dataset.pk
+        ).values_list("metadata__name", flat=True)
+    ) == ["dcat", "dct"]
 
 
 @pytest.mark.django_db
 def test_structure_datasets(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',datasets/gov/ivpk/adp1,,,,,,,,,,,,,,,,,\n'
-        ',datasets/gov/ivpk/adp2,,,,,,,,,,,,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/ivpk/adp1,,,,,,,,,,,,,,,,,\n"
+        ",datasets/gov/ivpk/adp2,,,,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
     metadata_version = create_structure_objects(structure)
     metadata = Metadata.objects.filter(
-        content_type=ContentType.objects.get_for_model(Dataset),
-        metadata_version=metadata_version
+        content_type=ContentType.objects.get_for_model(Dataset), metadata_version=metadata_version
     )
     assert metadata.count() == 2
-    assert sorted(list(metadata.values_list('name', flat=True))) == [
-        'datasets/gov/ivpk/adp1',
-        'datasets/gov/ivpk/adp2',
+    assert sorted(list(metadata.values_list("name", flat=True))) == [
+        "datasets/gov/ivpk/adp1",
+        "datasets/gov/ivpk/adp2",
     ]
 
 
 @pytest.mark.django_db
 def test_structure_models_and_props(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n"
         ',,,,Licence,,,id,,"page(id)",,,,,,,Licence,,\n'
-        ',,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
-        ',,,,,title,string,,,,2,,,open,dct:title,,,,\n'
-        ',,,,,,,,,,,,,,,,,,\n'
-        ',,,,Catalog,,,id,,,,,,,,,Catalog,,\n'
-        ',,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
+        ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
+        ",,,,,title,string,,,,2,,,open,dct:title,,,,\n"
+        ",,,,,,,,,,,,,,,,,,\n"
+        ",,,,Catalog,,,id,,,,,,,,,Catalog,,\n"
+        ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
     metadata_version = create_structure_objects(structure)
     metadata = Metadata.objects.filter(
-        content_type=ContentType.objects.get_for_model(Dataset),
-        metadata_version=metadata_version
+        content_type=ContentType.objects.get_for_model(Dataset), metadata_version=metadata_version
     )
     assert metadata.count() == 1
-    assert list(metadata.values_list('name', flat=True)) == ['datasets/gov/ivpk/adp']
+    assert list(metadata.values_list("name", flat=True)) == ["datasets/gov/ivpk/adp"]
 
     models = Model.objects.filter(metadata_version=metadata_version)
     metadata = Metadata.objects.filter(
-        content_type=ContentType.objects.get_for_model(Model),
-        metadata_version=metadata_version
-    ).order_by('order')
+        content_type=ContentType.objects.get_for_model(Model), metadata_version=metadata_version
+    ).order_by("order")
     assert models.count() == 2
     assert models[0].dataset == structure.dataset
     assert metadata.count() == 2
-    assert list(metadata.values_list(
-        'name',
-        'ref',
-        'prepare',
-        'prepare_ast',
-        'title',
-    )) == [
-        ('datasets/gov/ivpk/adp/Licence', 'id', 'page(id)', {
-            'name': 'page',
-            'args': [{
-                'name': 'bind',
-                'args': ['id']
-            }]
-        }, 'Licence'),
-        ('datasets/gov/ivpk/adp/Catalog', 'id', '', {}, 'Catalog'),
+    assert list(
+        metadata.values_list(
+            "name",
+            "ref",
+            "prepare",
+            "prepare_ast",
+            "title",
+        )
+    ) == [
+        (
+            "datasets/gov/ivpk/adp/Licence",
+            "id",
+            "page(id)",
+            {"name": "page", "args": [{"name": "bind", "args": ["id"]}]},
+            "Licence",
+        ),
+        ("datasets/gov/ivpk/adp/Catalog", "id", "", {}, "Catalog"),
     ]
 
     props = Property.objects.filter(model=models[0], metadata_version=metadata_version)
     metadata = Metadata.objects.filter(
         content_type=ContentType.objects.get_for_model(Property),
-        object_id__in=props.values_list('pk', flat=True),
-        metadata_version=metadata_version
-    ).order_by('order')
+        object_id__in=props.values_list("pk", flat=True),
+        metadata_version=metadata_version,
+    ).order_by("order")
     assert props.count() == 2
     assert metadata.count() == 2
-    assert list(metadata.values_list(
-        'name',
-        'type',
-        'level',
-        'access',
-        'uri',
-        'title',
-    )) == [
-        ('id', 'integer', 5, Metadata.OPEN, 'dct:identifier', 'Identifikatorius'),
-        ('title', 'string', 2, Metadata.OPEN, 'dct:title', ''),
+    assert list(
+        metadata.values_list(
+            "name",
+            "type",
+            "level",
+            "access",
+            "uri",
+            "title",
+        )
+    ) == [
+        ("id", "integer", 5, Metadata.OPEN, "dct:identifier", "Identifikatorius"),
+        ("title", "string", 2, Metadata.OPEN, "dct:title", ""),
     ]
 
-    props = Property.objects.filter(model=models[1],metadata_version=metadata_version)
+    props = Property.objects.filter(model=models[1], metadata_version=metadata_version)
     metadata = Metadata.objects.filter(
         content_type=ContentType.objects.get_for_model(Property),
-        object_id__in=props.values_list('pk', flat=True),
-        metadata_version=metadata_version
+        object_id__in=props.values_list("pk", flat=True),
+        metadata_version=metadata_version,
     )
     assert props.count() == 1
     assert metadata.count() == 1
-    assert list(metadata.values_list(
-        'name',
-        'type',
-        'level',
-        'access',
-        'uri',
-        'title',
-    )) == [
-        ('id', 'integer', 5, Metadata.OPEN, 'dct:identifier', 'Identifikatorius'),
+    assert list(
+        metadata.values_list(
+            "name",
+            "type",
+            "level",
+            "access",
+            "uri",
+            "title",
+        )
+    ) == [
+        ("id", "integer", 5, Metadata.OPEN, "dct:identifier", "Identifikatorius"),
     ]
 
 
 @pytest.mark.django_db
 def test_structure_with_base_model(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,,,prefix,dct,,,,,,,http://www.w3.org/ns/dcat#,,,,\n'
-        ',,,,Base,,,,,,,,,,,,,,\n'
-        ',,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n'
-        ',,,,,,,,,,,,,,,,,,\n'
-        ',,,Base,,,,,,,,,,,,,,,\n'
-        ',,,,Catalog,,,,,,,,,,,,,,\n'
-        ',,,,,title,string,,,,2,,,open,dct:title,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,,,prefix,dct,,,,,,,http://www.w3.org/ns/dcat#,,,,\n"
+        ",,,,Base,,,,,,,,,,,,,,\n"
+        ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n"
+        ",,,,,,,,,,,,,,,,,,\n"
+        ",,,Base,,,,,,,,,,,,,,,\n"
+        ",,,,Catalog,,,,,,,,,,,,,,\n"
+        ",,,,,title,string,,,,2,,,open,dct:title,,,,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -284,44 +266,40 @@ def test_structure_with_base_model(app: DjangoTestApp):
     assert models.count() == 2
     assert Base.objects.count() == 1
     assert models.filter(base__isnull=False).count() == 1
-    assert models.filter(base__isnull=False)[0].base.metadata.first().name == 'datasets/gov/ivpk/adp/Base'
+    assert models.filter(base__isnull=False)[0].base.metadata.first().name == "datasets/gov/ivpk/adp/Base"
 
 
 @pytest.mark.django_db
 def test_structure_with_base_model_two_manifests(app: DjangoTestApp):
     manifest_base = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',datasets/gov/rc/ar/apskritis,,,,,,,,,,,,,,,,,\n'
-        ',,,,Apskritis,,,adm_kodas,,,4,,,,,,,,\n'
-        ',,,,,adm_kodas,integer,,,,4,,,open,,,,,,\n'
-        ',,,,,tipas,string,,,,3,,,open,,,,,,\n'
-        ',,,,,santrumpa,string,,,,3,,,open,,,,,,\n'
-        ',,,,,pavadinimas,string,,,,3,,,open,,,,,\n'
-        ',,,,,adm_nuo,date,D,,,4,,,open,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/rc/ar/apskritis,,,,,,,,,,,,,,,,,\n"
+        ",,,,Apskritis,,,adm_kodas,,,4,,,,,,,,\n"
+        ",,,,,adm_kodas,integer,,,,4,,,open,,,,,,\n"
+        ",,,,,tipas,string,,,,3,,,open,,,,,,\n"
+        ",,,,,santrumpa,string,,,,3,,,open,,,,,,\n"
+        ",,,,,pavadinimas,string,,,,3,,,open,,,,,\n"
+        ",,,,,adm_nuo,date,D,,,4,,,open,,,,,,\n"
     )
 
     base_structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest_base)
-        )
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest_base))
     )
 
     manifest_with_base = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',datasets/gov/rc/ar/savivaldybe,,,,,,,,,,,,,,,,,\n'
-        ',,,/datasets/gov/rc/ar/apskritis/Apskritis,,,,,,,,,,,,,,,\n'
-        ',,,,Savivaldybe,,,sav_kodas,,,4,,,,,,,,\n'
-        ',,,,,sav_kodas,integer,,,,4,,,open,,,,,,\n'
-        ',,,,,tipas,string,,,,3,,,open,,,,,,\n'
-        ',,,,,tipo_santrumpa,string,,,,3,,,open,,,,,,\n'
-        ',,,,,pavadinimas,string,,,,3,,,open,,,,,,\n'
-        ',,,,,sav_nuo,date,D,,,4,,,open,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/rc/ar/savivaldybe,,,,,,,,,,,,,,,,,\n"
+        ",,,/datasets/gov/rc/ar/apskritis/Apskritis,,,,,,,,,,,,,,,\n"
+        ",,,,Savivaldybe,,,sav_kodas,,,4,,,,,,,,\n"
+        ",,,,,sav_kodas,integer,,,,4,,,open,,,,,,\n"
+        ",,,,,tipas,string,,,,3,,,open,,,,,,\n"
+        ",,,,,tipo_santrumpa,string,,,,3,,,open,,,,,,\n"
+        ",,,,,pavadinimas,string,,,,3,,,open,,,,,,\n"
+        ",,,,,sav_nuo,date,D,,,4,,,open,,,,,,\n"
     )
 
     structure_with_base = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest_with_base)
-        )
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest_with_base))
     )
 
     base_structure.dataset.current_structure = base_structure
@@ -336,60 +314,54 @@ def test_structure_with_base_model_two_manifests(app: DjangoTestApp):
     assert models.count() == 2
     assert Base.objects.count() == 1
     assert models.filter(base__isnull=False).count() == 1
-    assert models.filter(base__isnull=False)[0].base.metadata.first().name == 'datasets/gov/rc/ar/apskritis/Apskritis'
+    assert models.filter(base__isnull=False)[0].base.metadata.first().name == "datasets/gov/rc/ar/apskritis/Apskritis"
 
 
 @pytest.mark.django_db
 def test_structure_with_property_ref(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,,,prefix,dct,,,,,,,http://www.purl.org/dc/terms/,,,,\n'
-        '1,,,,Country,,,,,,,,,,,,,,\n'
-        ',,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n'
-        ',,,,,title,string,,,,5,,,open,dct:title,,,,\n'
-        ',,,,,continent,ref,Continent[id],,,5,,,open,dct:continent,,,,\n'
-        '2,,,,Continent,,,,,,,,,,,,,,\n'
-        ',,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n'
-        ',,,,,,,,,,,,,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,,,prefix,dct,,,,,,,http://www.purl.org/dc/terms/,,,,\n"
+        "1,,,,Country,,,,,,,,,,,,,,\n"
+        ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n"
+        ",,,,,title,string,,,,5,,,open,dct:title,,,,\n"
+        ",,,,,continent,ref,Continent[id],,,5,,,open,dct:continent,,,,\n"
+        "2,,,,Continent,,,,,,,,,,,,,,\n"
+        ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n"
+        ",,,,,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
-    country = Model.objects.filter(metadata__uuid='1').first()
-    continent = Model.objects.filter(metadata__uuid='2').first()
+    country = Model.objects.filter(metadata__uuid="1").first()
+    continent = Model.objects.filter(metadata__uuid="2").first()
     props = Property.objects.filter(model=country)
     assert props.count() == 3
     assert props.filter(ref_model__isnull=False).count() == 1
     assert props.filter(ref_model__isnull=False).first().ref_model == continent
-    assert list(props.filter(ref_model__isnull=False).first().property_list.values_list(
-        'property__metadata__name', flat=True
-    )) == ['id']
+    assert list(
+        props.filter(ref_model__isnull=False).first().property_list.values_list("property__metadata__name", flat=True)
+    ) == ["id"]
 
 
 @pytest.mark.django_db
 def test_structure_with_property_ref_two_manifests(app: DjangoTestApp):
     ref_manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',datasets/gov/rc/ar/apskritis,,,,,,,,,,,,,,,,,\n'
-        '1,,,,Apskritis,,,adm_kodas,,,4,,,,,,,,\n'
-        ',,,,,adm_kodas,integer,,,,4,,,open,,,,,,\n'
-        ',,,,,tipas,string,,,,3,,,open,,,,,,\n'
-        ',,,,,santrumpa,string,,,,3,,,open,,,,,,\n'
-        ',,,,,pavadinimas,string,,,,3,,,open,,,,,\n'
-        ',,,,,adm_nuo,date,D,,,4,,,open,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/rc/ar/apskritis,,,,,,,,,,,,,,,,,\n"
+        "1,,,,Apskritis,,,adm_kodas,,,4,,,,,,,,\n"
+        ",,,,,adm_kodas,integer,,,,4,,,open,,,,,,\n"
+        ",,,,,tipas,string,,,,3,,,open,,,,,,\n"
+        ",,,,,santrumpa,string,,,,3,,,open,,,,,,\n"
+        ",,,,,pavadinimas,string,,,,3,,,open,,,,,\n"
+        ",,,,,adm_nuo,date,D,,,4,,,open,,,,,,\n"
     )
 
     ref_object_structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=ref_manifest)
-        )
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=ref_manifest))
     )
 
     ref_object_structure.dataset.current_structure = ref_object_structure
@@ -397,29 +369,27 @@ def test_structure_with_property_ref_two_manifests(app: DjangoTestApp):
     version = create_structure_objects(ref_object_structure)
 
     manifest_with_ref = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',datasets/gov/rc/ar/savivaldybe,,,,,,,,,,,,,,,,,\n'
-        '2,,,,Savivaldybe,,,sav_kodas,,,4,,,,,,,,\n'
-        ',,,,,sav_kodas,integer,,,,4,,,open,,,,,,\n'
-        ',,,,,tipas,string,,,,3,,,open,,,,,,\n'
-        ',,,,,tipo_santrumpa,string,,,,3,,,open,,,,,,\n'
-        ',,,,,pavadinimas,string,,,,3,,,open,,,,,,\n'
-        ',,,,,apskritis,ref,/datasets/gov/rc/ar/apskritis/Apskritis,,,4,,,open,,,,,,\n'
-        ',,,,,sav_nuo,date,D,,,4,,,open,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/rc/ar/savivaldybe,,,,,,,,,,,,,,,,,\n"
+        "2,,,,Savivaldybe,,,sav_kodas,,,4,,,,,,,,\n"
+        ",,,,,sav_kodas,integer,,,,4,,,open,,,,,,\n"
+        ",,,,,tipas,string,,,,3,,,open,,,,,,\n"
+        ",,,,,tipo_santrumpa,string,,,,3,,,open,,,,,,\n"
+        ",,,,,pavadinimas,string,,,,3,,,open,,,,,,\n"
+        ",,,,,apskritis,ref,/datasets/gov/rc/ar/apskritis/Apskritis,,,4,,,open,,,,,,\n"
+        ",,,,,sav_nuo,date,D,,,4,,,open,,,,,,\n"
     )
 
     structure_with_ref = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest_with_ref)
-        )
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest_with_ref))
     )
 
     structure_with_ref.dataset.current_structure = structure_with_ref
     structure_with_ref.dataset.save()
     create_structure_objects(structure_with_ref, version)
 
-    county = Model.objects.filter(metadata__uuid='1').first()
-    municipality = Model.objects.filter(metadata__uuid='2').first()
+    county = Model.objects.filter(metadata__uuid="1").first()
+    municipality = Model.objects.filter(metadata__uuid="2").first()
 
     props = Property.objects.filter(model=municipality)
     assert props.count() == 6
@@ -430,233 +400,204 @@ def test_structure_with_property_ref_two_manifests(app: DjangoTestApp):
 @pytest.mark.django_db
 def test_structure_with_model_ref(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,,,prefix,dct,,,,,,,http://www.purl.org/dc/terms/,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,,,prefix,dct,,,,,,,http://www.purl.org/dc/terms/,,,,\n"
         '1,,,,Country,,,"id,title",,,,,,,,,,,\n'
-        ',,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n'
-        ',,,,,title,string,,,,5,,,open,dct:title,,,,\n'
-        ',,,,,continent,ref,Continent,,,5,,,open,dct:continent,,,,\n'
+        ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n"
+        ",,,,,title,string,,,,5,,,open,dct:title,,,,\n"
+        ",,,,,continent,ref,Continent,,,5,,,open,dct:continent,,,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
-    country = Model.objects.filter(metadata__uuid='1').first()
-    assert list(PropertyList.objects.filter(
-        content_type=ContentType.objects.get_for_model(country),
-        object_id=country.pk
-    ).values_list(
-        'property__metadata__name', flat=True
-    )) == ['id', 'title']
+    country = Model.objects.filter(metadata__uuid="1").first()
+    assert list(
+        PropertyList.objects.filter(
+            content_type=ContentType.objects.get_for_model(country), object_id=country.pk
+        ).values_list("property__metadata__name", flat=True)
+    ) == ["id", "title"]
 
 
 @pytest.mark.django_db
 def test_structure_with_denorm_prop(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,,,prefix,dct,,,,,,,http://www.purl.org/dc/terms/,,,,\n'
-        '1,,,,Continent,,,,,,,,,,,,,,\n'
-        ',,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n'
-        ',,,,,,,,,,,,,,,,,,\n'
-        '2,,,,Country,,,,,,,,,,,,,,\n'
-        ',,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n'
-        ',,,,,title,string,,,,5,,,open,dct:title,,,,\n'
-        ',,,,,continent,ref,Continent,,,5,,,open,dct:continent,,,,\n'
-        ',,,,,,,,,,,,,,,,,,\n'
-        '3,,,,City,,,,,,,,,,,,,,\n'
-        ',,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n'
-        ',,,,,title,string,,,,5,,,open,dct:title,,,,\n'
-        ',,,,,country,ref,Country,,,5,,,open,,,,,,\n'
-        ',,,,,country.id,,,,,5,,,open,,,,,,\n'
-        ',,,,,country.continent.id,,,,,5,,,open,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,,,prefix,dct,,,,,,,http://www.purl.org/dc/terms/,,,,\n"
+        "1,,,,Continent,,,,,,,,,,,,,,\n"
+        ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n"
+        ",,,,,,,,,,,,,,,,,,\n"
+        "2,,,,Country,,,,,,,,,,,,,,\n"
+        ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n"
+        ",,,,,title,string,,,,5,,,open,dct:title,,,,\n"
+        ",,,,,continent,ref,Continent,,,5,,,open,dct:continent,,,,\n"
+        ",,,,,,,,,,,,,,,,,,\n"
+        "3,,,,City,,,,,,,,,,,,,,\n"
+        ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n"
+        ",,,,,title,string,,,,5,,,open,dct:title,,,,\n"
+        ",,,,,country,ref,Country,,,5,,,open,,,,,,\n"
+        ",,,,,country.id,,,,,5,,,open,,,,,,\n"
+        ",,,,,country.continent.id,,,,,5,,,open,,,,,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
-    city = Model.objects.filter(metadata__uuid='3').first()
+    city = Model.objects.filter(metadata__uuid="3").first()
     props = Property.objects.filter(model=city)
     assert props.count() == 6
     assert props.filter(given=True).count() == 5
-    assert props.filter(given=False).first().metadata.first().name == 'country.continent'
-    assert props.filter(metadata__name='country.continent.id')[0].property.metadata.first().name == 'country.continent'
-    assert props.filter(metadata__name='country.continent')[0].property.metadata.first().name == 'country'
-    assert props.filter(metadata__name='country.id')[0].property.metadata.first().name == 'country'
-    assert props.filter(metadata__name='country')[0].property is None
+    assert props.filter(given=False).first().metadata.first().name == "country.continent"
+    assert props.filter(metadata__name="country.continent.id")[0].property.metadata.first().name == "country.continent"
+    assert props.filter(metadata__name="country.continent")[0].property.metadata.first().name == "country"
+    assert props.filter(metadata__name="country.id")[0].property.metadata.first().name == "country"
+    assert props.filter(metadata__name="country")[0].property is None
 
 
 @pytest.mark.django_db
 def test_structure_with_existing_structure(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        '1,datasets/gov/ivpk/adp1,,,,,,,,,,,,,,,,,\n'
-        ',,resource1,,,,,,,,,,,,,,,,\n'
-        '2,datasets/gov/ivpk/adp2,,,,,,,,,,,,,,,,,\n'
-        ',,,,,,prefix,dct,,,,,,,http://www.purl.org/dc/terms/,,,,\n'
-        ',,resource2,,,,,,,,,,,,,,,,\n'
-        '3,,,,Country,,,,,,,,,,,,,,\n'
-        '4,,,,,id,integer,,,,5,,,open,,,Identifikatorius,,,\n'
-        '5,,,,,title,string,,,,5,,,open,dct:title,,,,\n'
-        '6,,,,,deprecated,string,,,,5,,,open,,,,,,\n'
-        ',,,,,,,,,,,,,,,,,,\n'
-        '7,,,,City,,,,,,,,,,,,,,\n'
-        '8,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        "1,datasets/gov/ivpk/adp1,,,,,,,,,,,,,,,,,\n"
+        ",,resource1,,,,,,,,,,,,,,,,\n"
+        "2,datasets/gov/ivpk/adp2,,,,,,,,,,,,,,,,,\n"
+        ",,,,,,prefix,dct,,,,,,,http://www.purl.org/dc/terms/,,,,\n"
+        ",,resource2,,,,,,,,,,,,,,,,\n"
+        "3,,,,Country,,,,,,,,,,,,,,\n"
+        "4,,,,,id,integer,,,,5,,,open,,,Identifikatorius,,,\n"
+        "5,,,,,title,string,,,,5,,,open,dct:title,,,,\n"
+        "6,,,,,deprecated,string,,,,5,,,open,,,,,,\n"
+        ",,,,,,,,,,,,,,,,,,\n"
+        "7,,,,City,,,,,,,,,,,,,,\n"
+        "8,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     metadata_version = create_structure_objects(structure)
     assert Metadata.objects.filter(dataset=structure.dataset, metadata_version=metadata_version).count() == 10
 
     new_manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        '2,datasets/gov/ivpk/adp2/updated,,,,,,,,,,,,,,,,,\n'
-        ',,,,,,prefix,dct,,,,,,,http://www.purl.org/dc/terms/,,,,\n'
-        ',,resource2,,,,,,,,,,,,,,,,\n'
-        '3,,,,CountryUpdated,,,,,,,,,,,,,,\n'
-        '4,,,,,id,string,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n'
-        '5,,,,,title,string,,,,5,,,open,dct:title,,,,\n'
-        '9,,,,,continent,ref,Continent,,,5,,,open,dct:continent,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        "2,datasets/gov/ivpk/adp2/updated,,,,,,,,,,,,,,,,,\n"
+        ",,,,,,prefix,dct,,,,,,,http://www.purl.org/dc/terms/,,,,\n"
+        ",,resource2,,,,,,,,,,,,,,,,\n"
+        "3,,,,CountryUpdated,,,,,,,,,,,,,,\n"
+        "4,,,,,id,string,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n"
+        "5,,,,,title,string,,,,5,,,open,dct:title,,,,\n"
+        "9,,,,,continent,ref,Continent,,,5,,,open,dct:continent,,,,\n"
     )
-    structure.file = FilerFileFactory(
-        file=FileField(filename='file.csv', data=new_manifest)
-    )
+    structure.file = FilerFileFactory(file=FileField(filename="file.csv", data=new_manifest))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     metadata_version = create_structure_objects(structure, metadata_version)
     assert Metadata.objects.filter(dataset=structure.dataset, metadata_version=metadata_version).count() == 7
-    assert Metadata.objects.get(uuid='2').name == 'datasets/gov/ivpk/adp2/updated'
-    assert Metadata.objects.get(uuid='3').name == 'datasets/gov/ivpk/adp2/updated/CountryUpdated'
-    assert Metadata.objects.get(uuid='4').type == 'string'
-    assert Metadata.objects.filter(uuid='1').count() == 0
-    assert Metadata.objects.filter(uuid='6').count() == 0
-    assert Metadata.objects.filter(uuid='7').count() == 0
-    assert Metadata.objects.filter(uuid='8').count() == 0
-    assert Model.objects.filter(metadata__uuid='7').count() == 0
-    assert Property.objects.filter(metadata__uuid='6').count() == 0
-    assert Property.objects.filter(metadata__uuid='8').count() == 0
+    assert Metadata.objects.get(uuid="2").name == "datasets/gov/ivpk/adp2/updated"
+    assert Metadata.objects.get(uuid="3").name == "datasets/gov/ivpk/adp2/updated/CountryUpdated"
+    assert Metadata.objects.get(uuid="4").type == "string"
+    assert Metadata.objects.filter(uuid="1").count() == 0
+    assert Metadata.objects.filter(uuid="6").count() == 0
+    assert Metadata.objects.filter(uuid="7").count() == 0
+    assert Metadata.objects.filter(uuid="8").count() == 0
+    assert Model.objects.filter(metadata__uuid="7").count() == 0
+    assert Property.objects.filter(metadata__uuid="6").count() == 0
+    assert Property.objects.filter(metadata__uuid="8").count() == 0
 
 
 @pytest.mark.django_db
 def test_structure_with_comments(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        '2,,,,,,comment,type,,,,,,open,,,Dataset comment,,\n'
-        '3,,,,Country,,,,,,,,,,,,,,\n'
-        '4,,,,,,comment,type,,,,,,open,,,Model comment,,\n'
-        '5,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
-        '6,,,,,,comment,type,,,,,,open,,,Property comment,,\n'
-        '7,,,,,title,string,,,,5,,,open,dct:title,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        "2,,,,,,comment,type,,,,,,open,,,Dataset comment,,\n"
+        "3,,,,Country,,,,,,,,,,,,,,\n"
+        "4,,,,,,comment,type,,,,,,open,,,Model comment,,\n"
+        "5,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
+        "6,,,,,,comment,type,,,,,,open,,,Property comment,,\n"
+        "7,,,,,title,string,,,,5,,,open,dct:title,,,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     metadata_version = VersionFactory(dataset=structure.dataset)
     DatasetDistributionFactory(
         dataset=structure.dataset,
-        type='URL',
-        download_url='https://get.data.gov.lt/datasets/gov/ivpk/adp/:ns',
-        format=FileFormat(title="Saugykla", extension='UAPI'),
+        type="URL",
+        download_url="https://get.data.gov.lt/datasets/gov/ivpk/adp/:ns",
+        format=FileFormat(title="Saugykla", extension="UAPI"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure, metadata_version)
-    assert Metadata.objects.filter(
-        content_type=ContentType.objects.get_for_model(Comment)
-    ).count() == 3
+    assert Metadata.objects.filter(content_type=ContentType.objects.get_for_model(Comment)).count() == 3
     assert Comment.objects.filter(type=Comment.STRUCTURE).count() == 3
-    assert Comment.objects.filter(
-        content_type=ContentType.objects.get_for_model(Dataset)
-    ).first().content_object == structure.dataset
-    assert Comment.objects.filter(
-        content_type=ContentType.objects.get_for_model(Model)
-    ).first().content_object == Metadata.objects.get(uuid='3').object
-    assert Comment.objects.filter(
-        content_type=ContentType.objects.get_for_model(Property)
-    ).first().content_object == Metadata.objects.get(uuid='5').object
+    assert (
+        Comment.objects.filter(content_type=ContentType.objects.get_for_model(Dataset)).first().content_object
+        == structure.dataset
+    )
+    assert (
+        Comment.objects.filter(content_type=ContentType.objects.get_for_model(Model)).first().content_object
+        == Metadata.objects.get(uuid="3").object
+    )
+    assert (
+        Comment.objects.filter(content_type=ContentType.objects.get_for_model(Property)).first().content_object
+        == Metadata.objects.get(uuid="5").object
+    )
 
 
 @pytest.mark.django_db
 def test_structure_with_resource_and_existing_distribution(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n'
-        '1,,resource,,,,,,http://www.example.com,,,,,,,,,,\n'
-        '2,,,,City,,,,,,,,,,,,,,\n'
-        '3,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
-        '4,,,,,title,string,,,,5,,,open,dct:title,,,,\n'
-        '5,,,,Country,,,,,,,,,,,,,,\n'
-        '6,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n"
+        "1,,resource,,,,,,http://www.example.com,,,,,,,,,,\n"
+        "2,,,,City,,,,,,,,,,,,,,\n"
+        "3,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
+        "4,,,,,title,string,,,,5,,,open,dct:title,,,,\n"
+        "5,,,,Country,,,,,,,,,,,,,,\n"
+        "6,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     metadata_version = VersionFactory(dataset=structure.dataset)
     distribution = DatasetDistributionFactory(
-        dataset=structure.dataset,
-        type='URL',
-        download_url='http://www.example.com',
-        metadata_version=metadata_version
+        dataset=structure.dataset, type="URL", download_url="http://www.example.com", metadata_version=metadata_version
     )
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure, metadata_version)
 
-    assert Metadata.objects.get(uuid='1').object == distribution
-    assert Model.objects.get(metadata__uuid='2').distribution == distribution
-    assert Model.objects.get(metadata__uuid='5').distribution == distribution
+    assert Metadata.objects.get(uuid="1").object == distribution
+    assert Model.objects.get(metadata__uuid="2").distribution == distribution
+    assert Model.objects.get(metadata__uuid="5").distribution == distribution
     assert structure.dataset.status == Dataset.HAS_DATA
 
 
 @pytest.mark.django_db
 def test_structure_with_resource_and_existing_distribution_without_title(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,,,prefix,dct,,,,,http://purl.org/dc/terms/,,,,,,\n'
-        '1,,resource,,,,,,http://www.example.com,,,,,,,,,,\n'
-        '2,,,,City,,,,,,,,,,,,,,\n'
-        '3,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
-        '4,,,,,title,string,,,,5,,,open,dct:title,,,,\n'
-        '5,,,,Country,,,,,,,,,,,,,,\n'
-        '6,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,,,prefix,dct,,,,,http://purl.org/dc/terms/,,,,,,\n"
+        "1,,resource,,,,,,http://www.example.com,,,,,,,,,,\n"
+        "2,,,,City,,,,,,,,,,,,,,\n"
+        "3,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
+        "4,,,,,title,string,,,,5,,,open,dct:title,,,,\n"
+        "5,,,,Country,,,,,,,,,,,,,,\n"
+        "6,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     metadata_version = VersionFactory(dataset=structure.dataset)
     distribution = DatasetDistributionFactory(
         dataset=structure.dataset,
-        type='URL',
-        download_url='http://www.example.com',
+        type="URL",
+        download_url="http://www.example.com",
         title="",
-        metadata_version=metadata_version
+        metadata_version=metadata_version,
     )
 
     structure.dataset.current_structure = structure
@@ -665,31 +606,27 @@ def test_structure_with_resource_and_existing_distribution_without_title(app: Dj
 
     distribution.refresh_from_db()
     distribution.set_current_language("lt")
-    assert Metadata.objects.get(uuid='1').object == distribution
-    assert Model.objects.get(metadata__uuid='2').distribution == distribution
-    assert Model.objects.get(metadata__uuid='5').distribution == distribution
+    assert Metadata.objects.get(uuid="1").object == distribution
+    assert Model.objects.get(metadata__uuid="2").distribution == distribution
+    assert Model.objects.get(metadata__uuid="5").distribution == distribution
     assert structure.dataset.status == Dataset.HAS_DATA
-    assert distribution.title == 'resource'
+    assert distribution.title == "resource"
 
 
 @pytest.mark.django_db
 def test_structure_with_resource_and_without_distribution(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,,,prefix,dct,,,,,http://www.purl.org/dc/terms/,,,,,\n'
-        '1,,resource,,,,,,http://www.example.com,,,,,,,,,,\n'
-        '2,,,,City,,,,,,,,,,,,,,\n'
-        '3,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
-        '4,,,,,title,string,,,,5,,,open,dct:title,,,,\n'
-        '5,,,,Country,,,,,,,,,,,,,,\n'
-        '6,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,,,prefix,dct,,,,,http://www.purl.org/dc/terms/,,,,,\n"
+        "1,,resource,,,,,,http://www.example.com,,,,,,,,,,\n"
+        "2,,,,City,,,,,,,,,,,,,,\n"
+        "3,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
+        "4,,,,,title,string,,,,5,,,open,dct:title,,,,\n"
+        "5,,,,Country,,,,,,,,,,,,,,\n"
+        "6,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -698,35 +635,31 @@ def test_structure_with_resource_and_without_distribution(app: DjangoTestApp):
     assert DatasetDistribution.objects.count() == 1
     distribution = DatasetDistribution.objects.first()
     assert distribution.metadata.count() == 1
-    assert distribution.metadata.first().source == 'http://www.example.com'
-    assert Model.objects.get(metadata__uuid='2').distribution == distribution
-    assert Model.objects.get(metadata__uuid='5').distribution == distribution
+    assert distribution.metadata.first().source == "http://www.example.com"
+    assert Model.objects.get(metadata__uuid="2").distribution == distribution
+    assert Model.objects.get(metadata__uuid="5").distribution == distribution
     assert structure.dataset.status == Dataset.HAS_DATA
 
 
 @pytest.mark.django_db
 def test_structure_without_resource_and_existing_distribution(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,,,prefix,dct,,,,,,,http://www.purl.org/dc/terms/,,,,\n'
-        '1,,,,City,,,,,,,,,,,,,,\n'
-        ',,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
-        ',,,,,title,string,,,,5,,,open,dct:title,,,,\n'
-        '2,,,,Country,,,,,,,,,,,,,,\n'
-        ',,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,,,prefix,dct,,,,,,,http://www.purl.org/dc/terms/,,,,\n"
+        "1,,,,City,,,,,,,,,,,,,,\n"
+        ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
+        ",,,,,title,string,,,,5,,,open,dct:title,,,,\n"
+        "2,,,,Country,,,,,,,,,,,,,,\n"
+        ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     metadata_version = VersionFactory(dataset=structure.dataset)
     DatasetDistributionFactory(
         dataset=structure.dataset,
-        type='URL',
-        download_url='https://get.data.gov.lt/datasets/gov/ivpk/adp/:ns',
-        format=FileFormat(title="Saugykla", extension='UAPI'),
+        type="URL",
+        download_url="https://get.data.gov.lt/datasets/gov/ivpk/adp/:ns",
+        format=FileFormat(title="Saugykla", extension="UAPI"),
     )
 
     structure.dataset.current_structure = structure
@@ -734,35 +667,31 @@ def test_structure_without_resource_and_existing_distribution(app: DjangoTestApp
     create_structure_objects(structure, metadata_version)
 
     assert DatasetDistribution.objects.count() == 1
-    assert Model.objects.get(metadata__uuid='1').distribution is None
-    assert Model.objects.get(metadata__uuid='2').distribution is None
+    assert Model.objects.get(metadata__uuid="1").distribution is None
+    assert Model.objects.get(metadata__uuid="2").distribution is None
     assert structure.dataset.status == Dataset.HAS_DATA
 
 
 @pytest.mark.django_db
 def test_structure_without_resource_and_existing_distribution_without_title(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,,,prefix,dct,,,,,,,http://www.purl.org/dc/terms/,,,,\n'
-        '1,,,,City,,,,,,,,,,,,,,\n'
-        ',,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
-        ',,,,,title,string,,,,5,,,open,dct:title,,,,\n'
-        '2,,,,Country,,,,,,,,,,,,,,\n'
-        ',,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,,,prefix,dct,,,,,,,http://www.purl.org/dc/terms/,,,,\n"
+        "1,,,,City,,,,,,,,,,,,,,\n"
+        ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
+        ",,,,,title,string,,,,5,,,open,dct:title,,,,\n"
+        "2,,,,Country,,,,,,,,,,,,,,\n"
+        ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     metadata_version = VersionFactory(dataset=structure.dataset)
     distribution = DatasetDistributionFactory(
         dataset=structure.dataset,
-        type='URL',
-        download_url='https://get.data.gov.lt/datasets/gov/ivpk/adp/:ns',
-        format=FileFormat(title="Saugykla", extension='UAPI'),
-        title="adp"
+        type="URL",
+        download_url="https://get.data.gov.lt/datasets/gov/ivpk/adp/:ns",
+        format=FileFormat(title="Saugykla", extension="UAPI"),
+        title="adp",
     )
 
     structure.dataset.current_structure = structure
@@ -772,8 +701,8 @@ def test_structure_without_resource_and_existing_distribution_without_title(app:
     distribution.refresh_from_db()
     distribution.set_current_language("lt")
     assert DatasetDistribution.objects.count() == 1
-    assert Model.objects.get(metadata__uuid='1').distribution is None
-    assert Model.objects.get(metadata__uuid='2').distribution is None
+    assert Model.objects.get(metadata__uuid="1").distribution is None
+    assert Model.objects.get(metadata__uuid="2").distribution is None
     assert structure.dataset.status == Dataset.HAS_DATA
     assert distribution.title == "adp"
 
@@ -781,26 +710,22 @@ def test_structure_without_resource_and_existing_distribution_without_title(app:
 @pytest.mark.django_db
 def test_structure_without_resource_and_existing_distribution_without_ns(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,,,prefix,dct,,,,,,,http://www.purl.org/dc/terms/,,,,\n'
-        '1,,,,City,,,,,,,,,,,,,,\n'
-        ',,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
-        ',,,,,title,string,,,,5,,,open,dct:title,,,,\n'
-        '2,,,,Country,,,,,,,,,,,,,,\n'
-        ',,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,,,prefix,dct,,,,,,,http://www.purl.org/dc/terms/,,,,\n"
+        "1,,,,City,,,,,,,,,,,,,,\n"
+        ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
+        ",,,,,title,string,,,,5,,,open,dct:title,,,,\n"
+        "2,,,,Country,,,,,,,,,,,,,,\n"
+        ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     metadata_version = VersionFactory(dataset=structure.dataset)
     DatasetDistributionFactory(
         dataset=structure.dataset,
-        type='URL',
-        download_url='https://get.data.gov.lt/datasets/gov/ivpk/adp/',
-        format=FileFormat(title="Saugykla", extension='UAPI'),
+        type="URL",
+        download_url="https://get.data.gov.lt/datasets/gov/ivpk/adp/",
+        format=FileFormat(title="Saugykla", extension="UAPI"),
     )
 
     structure.dataset.current_structure = structure
@@ -808,28 +733,24 @@ def test_structure_without_resource_and_existing_distribution_without_ns(app: Dj
     create_structure_objects(structure, metadata_version)
 
     assert DatasetDistribution.objects.count() == 1
-    assert Model.objects.get(metadata__uuid='1').distribution is None
-    assert Model.objects.get(metadata__uuid='2').distribution is None
+    assert Model.objects.get(metadata__uuid="1").distribution is None
+    assert Model.objects.get(metadata__uuid="2").distribution is None
     assert structure.dataset.status == Dataset.HAS_DATA
 
 
 @pytest.mark.django_db
 def test_structure_without_resource_and_distribution(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,,,prefix,dct,,,,,,,http://www.purl.org/dc/terms/,,,,\n'
-        '1,,,,City,,,,,,,,,,,,,,\n'
-        ',,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
-        ',,,,,title,string,,,,5,,,open,dct:title,,,,\n'
-        '2,,,,Country,,,,,,,,,,,,,,\n'
-        ',,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,,,prefix,dct,,,,,,,http://www.purl.org/dc/terms/,,,,\n"
+        "1,,,,City,,,,,,,,,,,,,,\n"
+        ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
+        ",,,,,title,string,,,,5,,,open,dct:title,,,,\n"
+        "2,,,,Country,,,,,,,,,,,,,,\n"
+        ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -843,193 +764,164 @@ def test_structure_without_resource_and_distribution(app: DjangoTestApp):
 @pytest.mark.django_db
 def test_structure_with_enums(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n"
         '2,,,,,,enum,Size,,"SMALL",,,,,,,,,\n'
         '3,,,,,,,,,"MEDIUM",,,,,,,,,\n'
         '4,,,,,,,,,"BIG",,,,,,,,,\n'
-        '5,,,,City,,,,,,,,,,,,,,\n'
-        '6,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
-        '7,,,,,size,Size,,,,5,,,open,dct:size,,,,\n'
-        '8,,,,,type,string,,,,5,,,open,dct:type,,,,\n'
+        "5,,,,City,,,,,,,,,,,,,,\n"
+        "6,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
+        "7,,,,,size,Size,,,,5,,,open,dct:size,,,,\n"
+        "8,,,,,type,string,,,,5,,,open,dct:type,,,,\n"
         '9,,,,,,enum,Type,,"CREATED",,,,,,,,,\n'
         '10,,,,,,,,,"MODIFIED",,,,,,,,,\n'
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
 
     dataset = structure.dataset
-    dataset_enum = Enum.objects.filter(
-        content_type=ContentType.objects.get_for_model(dataset),
-        object_id=dataset.pk
-    )
+    dataset_enum = Enum.objects.filter(content_type=ContentType.objects.get_for_model(dataset), object_id=dataset.pk)
     assert dataset_enum.count() == 1
-    assert dataset_enum[0].name == 'Size'
-    assert list(dataset_enum[0].enumitem_set.values_list('metadata__prepare', flat=True)) == ['SMALL', 'MEDIUM', 'BIG']
+    assert dataset_enum[0].name == "Size"
+    assert list(dataset_enum[0].enumitem_set.values_list("metadata__prepare", flat=True)) == ["SMALL", "MEDIUM", "BIG"]
 
-    prop = Property.objects.get(metadata__uuid='8')
-    prop_enum = Enum.objects.filter(
-        content_type=ContentType.objects.get_for_model(prop),
-        object_id=prop.pk
-    )
+    prop = Property.objects.get(metadata__uuid="8")
+    prop_enum = Enum.objects.filter(content_type=ContentType.objects.get_for_model(prop), object_id=prop.pk)
     assert prop_enum.count() == 1
-    assert prop_enum[0].name == 'Type'
-    assert list(prop_enum[0].enumitem_set.values_list('metadata__prepare', flat=True)) == ['CREATED', 'MODIFIED']
+    assert prop_enum[0].name == "Type"
+    assert list(prop_enum[0].enumitem_set.values_list("metadata__prepare", flat=True)) == ["CREATED", "MODIFIED"]
 
 
 @pytest.mark.django_db
 def test_structure_with_enum_and_null_value(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,,,prefix,dct,,,,,,,http://www.purl.org/dc/terms/,,,,\n'
-        ',,,,City,,,,,,,,,,,,,,\n'
-        '1,,,,,type,string,,,,5,,,open,dct:type,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,,,prefix,dct,,,,,,,http://www.purl.org/dc/terms/,,,,\n"
+        ",,,,City,,,,,,,,,,,,,,\n"
+        "1,,,,,type,string,,,,5,,,open,dct:type,,,,\n"
         ',,,,,,enum,Type,,"CREATED",,,,,,,,,\n'
-        ',,,,,,,,,null,,,,,,,,,\n'
+        ",,,,,,,,,null,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
 
-    prop = Property.objects.get(metadata__uuid='1')
-    prop_enum = Enum.objects.filter(
-        content_type=ContentType.objects.get_for_model(prop),
-        object_id=prop.pk
-    )
+    prop = Property.objects.get(metadata__uuid="1")
+    prop_enum = Enum.objects.filter(content_type=ContentType.objects.get_for_model(prop), object_id=prop.pk)
     assert prop_enum.count() == 1
-    assert prop_enum[0].name == 'Type'
-    assert list(prop_enum[0].enumitem_set.values_list('metadata__prepare', flat=True)) == ['CREATED', 'null']
+    assert prop_enum[0].name == "Type"
+    assert list(prop_enum[0].enumitem_set.values_list("metadata__prepare", flat=True)) == ["CREATED", "null"]
 
 
 @pytest.mark.django_db
 def test_structure_with_params(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n"
         '2,,,,,,param,country,,"lt",,,,,,,,,\n'
         '3,,,,,,,,,"lv",,,,,,,,,\n'
         '4,,,,,,,,,"ee",,,,,,,,,\n'
-        '5,,,,City,,,,,,,,,,,,,,\n'
+        "5,,,,City,,,,,,,,,,,,,,\n"
         '6,,,,,,param,type,,"created",,,,,,,,,\n'
         '7,,,,,,,,,"modified",,,,,,,,,\n'
-        '8,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
-        '9,,,,,type,string,,,,5,,,open,dct:type,,,,\n'
+        "8,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
+        "9,,,,,type,string,,,,5,,,open,dct:type,,,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
 
     dataset = structure.dataset
-    dataset_params = Param.objects.filter(
-        content_type=ContentType.objects.get_for_model(dataset),
-        object_id=dataset.pk
-    )
+    dataset_params = Param.objects.filter(content_type=ContentType.objects.get_for_model(dataset), object_id=dataset.pk)
     assert dataset_params.count() == 1
-    assert dataset_params[0].name == 'country'
-    assert list(dataset_params[0].paramitem_set.values_list('metadata__prepare', flat=True)) == ['lt', 'lv', 'ee']
+    assert dataset_params[0].name == "country"
+    assert list(dataset_params[0].paramitem_set.values_list("metadata__prepare", flat=True)) == ["lt", "lv", "ee"]
 
-    model = Model.objects.get(metadata__uuid='5')
-    model_params = Param.objects.filter(
-        content_type=ContentType.objects.get_for_model(model),
-        object_id=model.pk
-    )
+    model = Model.objects.get(metadata__uuid="5")
+    model_params = Param.objects.filter(content_type=ContentType.objects.get_for_model(model), object_id=model.pk)
     assert model_params.count() == 1
-    assert model_params[0].name == 'type'
-    assert list(model_params[0].paramitem_set.values_list('metadata__prepare', flat=True)) == ['created', 'modified']
+    assert model_params[0].name == "type"
+    assert list(model_params[0].paramitem_set.values_list("metadata__prepare", flat=True)) == ["created", "modified"]
 
 
 @pytest.mark.django_db
 def test_structure_with_deleted_enums(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,,,prefix,dct,,,,,,,http://www.purl.org/dc/terms/,,,,\n'
-        '2,,resource,,,,,,,,,,,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,,,prefix,dct,,,,,,,http://www.purl.org/dc/terms/,,,,\n"
+        "2,,resource,,,,,,,,,,,,,,,,\n"
         '3,,,,,,enum,Size,,"SMALL",,,,,,,,,\n'
         '4,,,,,,,,,"MEDIUM",,,,,,,,,\n'
         '5,,,,,,,,,"BIG",,,,,,,,,\n'
         '6,,,,,,enum,Deprecated,,"SMALL",,,,,,,,,\n'
         '7,,,,,,,,,"MEDIUM",,,,,,,,,\n'
         '8,,,,,,,,,"BIG",,,,,,,,,\n'
-        '9,,,,City,,,,,,,,,,,,,,\n'
-        '10,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n'
-        '11,,,,,size,Size,,,,5,,,open,dct:size,,,,\n'
-        '12,,,,,type,string,,,,5,,,open,dct:type,,,,\n'
+        "9,,,,City,,,,,,,,,,,,,,\n"
+        "10,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n"
+        "11,,,,,size,Size,,,,5,,,open,dct:size,,,,\n"
+        "12,,,,,type,string,,,,5,,,open,dct:type,,,,\n"
         '13,,,,,,enum,Type,,"CREATED",,,,,,,,,\n'
         '14,,,,,,,,,"MODIFIED",,,,,,,,,\n'
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     metadata_version = create_structure_objects(structure)
     assert Metadata.objects.filter(dataset=structure.dataset, metadata_version=metadata_version).count() == 15
-    assert list(Enum.objects.values_list('name', flat=True)) == ['Size', 'Deprecated', 'Type']
-    assert list(EnumItem.objects.filter(enum__name='Size').values_list(
-        'metadata__prepare', flat=True
-    )) == ['SMALL', 'MEDIUM', 'BIG']
-    assert list(EnumItem.objects.filter(enum__name='Deprecated').values_list(
-        'metadata__prepare', flat=True
-    )) == ['SMALL', 'MEDIUM', 'BIG']
-    assert list(EnumItem.objects.filter(enum__name='Type').values_list(
-        'metadata__prepare', flat=True
-    )) == ['CREATED', 'MODIFIED']
+    assert list(Enum.objects.values_list("name", flat=True)) == ["Size", "Deprecated", "Type"]
+    assert list(EnumItem.objects.filter(enum__name="Size").values_list("metadata__prepare", flat=True)) == [
+        "SMALL",
+        "MEDIUM",
+        "BIG",
+    ]
+    assert list(EnumItem.objects.filter(enum__name="Deprecated").values_list("metadata__prepare", flat=True)) == [
+        "SMALL",
+        "MEDIUM",
+        "BIG",
+    ]
+    assert list(EnumItem.objects.filter(enum__name="Type").values_list("metadata__prepare", flat=True)) == [
+        "CREATED",
+        "MODIFIED",
+    ]
 
     new_manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,,,prefix,dct,,,,,,,http://www.purl.org/dc/terms/,,,,\n'
-        '2,,resource,,,,,,,,,,,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,,,prefix,dct,,,,,,,http://www.purl.org/dc/terms/,,,,\n"
+        "2,,resource,,,,,,,,,,,,,,,,\n"
         '3,,,,,,enum,Size,,"SMALL",,,,,,,,,\n'
         '5,,,,,,,,,"BIG",,,,,,,,,\n'
-        '9,,,,City,,,,,,,,,,,,,,\n'
-        '10,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n'
-        '11,,,,,size,Size,,,,5,,,open,dct:size,,,,\n'
-        '12,,,,,type,string,,,,5,,,open,dct:type,,,,\n'
+        "9,,,,City,,,,,,,,,,,,,,\n"
+        "10,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n"
+        "11,,,,,size,Size,,,,5,,,open,dct:size,,,,\n"
+        "12,,,,,type,string,,,,5,,,open,dct:type,,,,\n"
         '13,,,,,,enum,Type,,"CREATED",,,,,,,,,\n'
     )
-    structure.file = FilerFileFactory(
-        file=FileField(filename='file.csv', data=new_manifest)
-    )
+    structure.file = FilerFileFactory(file=FileField(filename="file.csv", data=new_manifest))
     metadata_version = create_structure_objects(structure, metadata_version)
     assert Metadata.objects.filter(dataset=structure.dataset, metadata_version=metadata_version).count() == 10
-    assert list(Enum.objects.values_list('name', flat=True)) == ['Size', 'Type']
-    assert list(EnumItem.objects.filter(enum__name='Size').values_list(
-        'metadata__prepare', flat=True
-    )) == ['SMALL', 'BIG']
-    assert list(EnumItem.objects.filter(enum__name='Type').values_list(
-        'metadata__prepare', flat=True
-    )) == ['CREATED']
+    assert list(Enum.objects.values_list("name", flat=True)) == ["Size", "Type"]
+    assert list(EnumItem.objects.filter(enum__name="Size").values_list("metadata__prepare", flat=True)) == [
+        "SMALL",
+        "BIG",
+    ]
+    assert list(EnumItem.objects.filter(enum__name="Type").values_list("metadata__prepare", flat=True)) == ["CREATED"]
 
 
 @pytest.mark.django_db
 def test_structure_with_deleted_params(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        '2,,resource,,,,,,,,,,,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        "2,,resource,,,,,,,,,,,,,,,,\n"
         '3,,,,,,param,Size,,"SMALL",,,,,,,,,\n'
         '4,,,,,,,,,"MEDIUM",,,,,,,,,\n'
         '5,,,,,,,,,"BIG",,,,,,,,,\n'
@@ -1037,68 +929,61 @@ def test_structure_with_deleted_params(app: DjangoTestApp):
         '7,,,,,,,,,"MEDIUM",,,,,,,,,\n'
         '8,,,,,,,,,"BIG",,,,,,,,,\n'
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     metadata_version = create_structure_objects(structure)
     assert Metadata.objects.filter(dataset=structure.dataset, metadata_version=metadata_version).count() == 8
-    assert list(Param.objects.values_list('name', flat=True)) == ['Size', 'Deprecated']
-    assert list(ParamItem.objects.filter(param__name='Size').values_list(
-        'metadata__prepare', flat=True
-    )) == ['SMALL', 'MEDIUM', 'BIG']
-    assert list(ParamItem.objects.filter(param__name='Deprecated').values_list(
-        'metadata__prepare', flat=True
-    )) == ['SMALL', 'MEDIUM', 'BIG']
+    assert list(Param.objects.values_list("name", flat=True)) == ["Size", "Deprecated"]
+    assert list(ParamItem.objects.filter(param__name="Size").values_list("metadata__prepare", flat=True)) == [
+        "SMALL",
+        "MEDIUM",
+        "BIG",
+    ]
+    assert list(ParamItem.objects.filter(param__name="Deprecated").values_list("metadata__prepare", flat=True)) == [
+        "SMALL",
+        "MEDIUM",
+        "BIG",
+    ]
 
     new_manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        '2,,resource,,,,,,,,,,,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        "2,,resource,,,,,,,,,,,,,,,,\n"
         '3,,,,,,param,Size,,"SMALL",,,,,,,,,\n'
         '5,,,,,,,,,"BIG",,,,,,,,,\n'
     )
-    structure.file = FilerFileFactory(
-        file=FileField(filename='file.csv', data=new_manifest)
-    )
+    structure.file = FilerFileFactory(file=FileField(filename="file.csv", data=new_manifest))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     metadata_version = create_structure_objects(structure, metadata_version)
     assert Metadata.objects.filter(dataset=structure.dataset, metadata_version=metadata_version).count() == 4
-    assert list(Param.objects.values_list('name', flat=True)) == ['Size']
-    assert list(ParamItem.objects.filter(param__name='Size').values_list(
-        'metadata__prepare', flat=True
-    )) == ['SMALL', 'BIG']
+    assert list(Param.objects.values_list("name", flat=True)) == ["Size"]
+    assert list(ParamItem.objects.filter(param__name="Size").values_list("metadata__prepare", flat=True)) == [
+        "SMALL",
+        "BIG",
+    ]
 
 
 @pytest.mark.django_db
 def test_structure_without_ids__prefixes(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,,,prefix,dcat,,,,,,,http://www.w3.org/ns/dcat#,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,,,prefix,dcat,,,,,,,http://www.w3.org/ns/dcat#,,,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
     assert Comment.objects.filter(type=Comment.STRUCTURE_ERROR).count() == 0
 
     new_manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,,,prefix,dcat,,,,,,,http://www.w3.org/ns/dcat#,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,,,prefix,dcat,,,,,,,http://www.w3.org/ns/dcat#,,,,\n"
     )
-    structure.file = FilerFileFactory(
-        file=FileField(filename='file.csv', data=new_manifest)
-    )
+    structure.file = FilerFileFactory(file=FileField(filename="file.csv", data=new_manifest))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1108,30 +993,24 @@ def test_structure_without_ids__prefixes(app: DjangoTestApp):
 @pytest.mark.django_db
 def test_structure_without_ids__enums(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
         ',,,,,,enum,Size,,"SMALL",,,,,,,,,\n'
         ',,,,,,,,,"BIG",,,,,,,,,\n'
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
     assert Comment.objects.filter(type=Comment.STRUCTURE_ERROR).count() == 0
 
     new_manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
         ',,,,,,enum,Size,,"SMALL",,,,,,,,,\n'
         ',,,,,,,,,"BIG",,,,,,,,,\n'
     )
-    structure.file = FilerFileFactory(
-        file=FileField(filename='file.csv', data=new_manifest)
-    )
+    structure.file = FilerFileFactory(file=FileField(filename="file.csv", data=new_manifest))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1141,30 +1020,24 @@ def test_structure_without_ids__enums(app: DjangoTestApp):
 @pytest.mark.django_db
 def test_structure_without_ids__params(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
         ',,,,,,param,ParamSize,,"SMALL",,,,,,,,,\n'
         ',,,,,,,,,"BIG",,,,,,,,,\n'
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
     assert Comment.objects.filter(type=Comment.STRUCTURE_ERROR).count() == 0
 
     new_manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
         ',,,,,,param,ParamSize,,"SMALL",,,,,,,,,\n'
         ',,,,,,,,,"BIG",,,,,,,,,\n'
     )
-    structure.file = FilerFileFactory(
-        file=FileField(filename='file.csv', data=new_manifest)
-    )
+    structure.file = FilerFileFactory(file=FileField(filename="file.csv", data=new_manifest))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1174,28 +1047,22 @@ def test_structure_without_ids__params(app: DjangoTestApp):
 @pytest.mark.django_db
 def test_structure_without_ids__models(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,City,,,,,,,,,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,City,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
     assert Comment.objects.filter(type=Comment.STRUCTURE_ERROR).count() == 0
 
     new_manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,City,,,,,,,,,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,City,,,,,,,,,,,,,,\n"
     )
-    structure.file = FilerFileFactory(
-        file=FileField(filename='file.csv', data=new_manifest)
-    )
+    structure.file = FilerFileFactory(file=FileField(filename="file.csv", data=new_manifest))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1205,32 +1072,26 @@ def test_structure_without_ids__models(app: DjangoTestApp):
 @pytest.mark.django_db
 def test_structure_without_ids__properties(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,,,prefix,dct,,,,,,,http://www.purl.org/dc/terms/,,,,\n'
-        '2,,,,City,,,,,,,,,,,,,\n'
-        ',,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,,,prefix,dct,,,,,,,http://www.purl.org/dc/terms/,,,,\n"
+        "2,,,,City,,,,,,,,,,,,,\n"
+        ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
     assert Comment.objects.filter(type=Comment.STRUCTURE_ERROR).count() == 0
 
     new_manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,,,prefix,dct,,,,,,,http://www.purl.org/dc/terms/,,,,\n'
-        '2,,,,City,,,,,,,,,,,,,\n'
-        ',,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,,,prefix,dct,,,,,,,http://www.purl.org/dc/terms/,,,,\n"
+        "2,,,,City,,,,,,,,,,,,,\n"
+        ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n"
     )
-    structure.file = FilerFileFactory(
-        file=FileField(filename='file.csv', data=new_manifest)
-    )
+    structure.file = FilerFileFactory(file=FileField(filename="file.csv", data=new_manifest))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1240,32 +1101,26 @@ def test_structure_without_ids__properties(app: DjangoTestApp):
 @pytest.mark.django_db
 def test_structure_without_ids__base(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        '2,,,,Base,,,,,,,,,,,,,,\n'
-        ',,,Base,,,,,,,,,,,,,,,\n'
-        '3,,,,City,,,,,,,,,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        "2,,,,Base,,,,,,,,,,,,,,\n"
+        ",,,Base,,,,,,,,,,,,,,,\n"
+        "3,,,,City,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
     assert Comment.objects.filter(type=Comment.STRUCTURE_ERROR).count() == 0
 
     new_manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        '2,,,,Base,,,,,,,,,,,,,,\n'
-        ',,,Base,,,,,,,,,,,,,,,\n'
-        '3,,,,City,,,,,,,,,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        "2,,,,Base,,,,,,,,,,,,,,\n"
+        ",,,Base,,,,,,,,,,,,,,,\n"
+        "3,,,,City,,,,,,,,,,,,,,\n"
     )
-    structure.file = FilerFileFactory(
-        file=FileField(filename='file.csv', data=new_manifest)
-    )
+    structure.file = FilerFileFactory(file=FileField(filename="file.csv", data=new_manifest))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1275,138 +1130,114 @@ def test_structure_without_ids__base(app: DjangoTestApp):
 @pytest.mark.django_db
 def test_structure_with_existing_prefixes(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,,,prefix,dcat,,,,,,,http://www.w3.org/ns/dcat#,,,,\n'
-        ',,,,,,prefix,dcat,,,,,,,http://www.w3.org/ns/dcat#,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,,,prefix,dcat,,,,,,,http://www.w3.org/ns/dcat#,,,,\n"
+        ",,,,,,prefix,dcat,,,,,,,http://www.w3.org/ns/dcat#,,,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
-    assert list(Comment.objects.filter(
-        type=Comment.STRUCTURE_ERROR,
-        content_type=ContentType.objects.get_for_model(structure),
-    ).values_list('body', flat=True)) == [
-       'Prefiksas "dcat" jau egzistuoja.'
-    ]
+    assert list(
+        Comment.objects.filter(
+            type=Comment.STRUCTURE_ERROR,
+            content_type=ContentType.objects.get_for_model(structure),
+        ).values_list("body", flat=True)
+    ) == ['Prefiksas "dcat" jau egzistuoja.']
 
 
 @pytest.mark.django_db
 def test_structure_with_existing_enums(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
         ',,,,,,enum,Size,,"SMALL",,,,,,,,,\n'
         ',,,,,,,,,"SMALL",,,,,,,,,\n'
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
-    assert list(Comment.objects.filter(
-        type=Comment.STRUCTURE_ERROR,
-        content_type=ContentType.objects.get_for_model(structure),
-    ).values_list('body', flat=True)) == [
-       'Galima reikšmė "SMALL" jau egzistuoja.'
-    ]
+    assert list(
+        Comment.objects.filter(
+            type=Comment.STRUCTURE_ERROR,
+            content_type=ContentType.objects.get_for_model(structure),
+        ).values_list("body", flat=True)
+    ) == ['Galima reikšmė "SMALL" jau egzistuoja.']
 
 
 @pytest.mark.django_db
 def test_structure_with_existing_params(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
         ',,,,,,param,ParamSize,,"SMALL",,,,,,,,,\n'
         ',,,,,,,,,"SMALL",,,,,,,,,\n'
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
-    assert list(Comment.objects.filter(
-        type=Comment.STRUCTURE_ERROR,
-        content_type=ContentType.objects.get_for_model(structure),
-    ).values_list('body', flat=True)) == [
-       'Parametras "SMALL" jau egzistuoja.'
-    ]
+    assert list(
+        Comment.objects.filter(
+            type=Comment.STRUCTURE_ERROR,
+            content_type=ContentType.objects.get_for_model(structure),
+        ).values_list("body", flat=True)
+    ) == ['Parametras "SMALL" jau egzistuoja.']
 
 
 @pytest.mark.django_db
 def test_structure_with_existing_models(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,City,,,,,,,,,,,,,,\n'
-        ',,,,City,,,,,,,,,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,City,,,,,,,,,,,,,,\n"
+        ",,,,City,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
-    assert list(Comment.objects.filter(
-        type=Comment.STRUCTURE_ERROR,
-        content_type=ContentType.objects.get_for_model(structure),
-    ).values_list('body', flat=True)) == [
-       'Modelis "datasets/gov/ivpk/adp/City" jau egzistuoja.'
-    ]
+    assert list(
+        Comment.objects.filter(
+            type=Comment.STRUCTURE_ERROR,
+            content_type=ContentType.objects.get_for_model(structure),
+        ).values_list("body", flat=True)
+    ) == ['Modelis "datasets/gov/ivpk/adp/City" jau egzistuoja.']
 
 
 @pytest.mark.django_db
 def test_structure_with_existing_properties(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,City,,,,,,,,,,,\n'
-        ',,,,,id,integer,,,,5,,,open,,,Identifikatorius,,\n'
-        ',,,,,id,integer,,,,5,,,open,,,Identifikatorius,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,City,,,,,,,,,,,\n"
+        ",,,,,id,integer,,,,5,,,open,,,Identifikatorius,,\n"
+        ",,,,,id,integer,,,,5,,,open,,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
-    assert list(Comment.objects.filter(
-        type=Comment.STRUCTURE_ERROR,
-        content_type=ContentType.objects.get_for_model(Model),
-    ).values_list('body', flat=True)) == [
-       'Savybė "id" jau egzistuoja.'
-    ]
+    assert list(
+        Comment.objects.filter(
+            type=Comment.STRUCTURE_ERROR,
+            content_type=ContentType.objects.get_for_model(Model),
+        ).values_list("body", flat=True)
+    ) == ['Savybė "id" jau egzistuoja.']
 
 
 @pytest.mark.django_db
 def test_structure_with_existing_dataset(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,resource1,,,,,,,,,,,,,,,,\n'
-        ',,,,City,,,,,,,,,,,\n'
-        ',,,,,id,integer,,,,5,,,open,,,Identifikatorius,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,resource1,,,,,,,,,,,,,,,,\n"
+        ",,,,City,,,,,,,,,,,\n"
+        ",,,,,id,integer,,,,5,,,open,,,Identifikatorius,,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -1414,91 +1245,77 @@ def test_structure_with_existing_dataset(app: DjangoTestApp):
     assert Metadata.objects.filter(dataset=structure.dataset, metadata_version=version).count() == 4
 
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,resource1,,,,,,,,,,,,,,,,\n'
-        ',,,,City,,,,,,,,,,,,,,\n'
-        ',,,,,id,integer,,,,5,,,open,,,Identifikatorius,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,resource1,,,,,,,,,,,,,,,,\n"
+        ",,,,City,,,,,,,,,,,,,,\n"
+        ",,,,,id,integer,,,,5,,,open,,,Identifikatorius,,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure, version)
-    assert list(Comment.objects.filter(
-        type=Comment.STRUCTURE_ERROR,
-        content_type=ContentType.objects.get_for_model(structure),
-    ).values_list('body', flat=True)) == [
-       'Duomenų išteklius "datasets/gov/ivpk/adp" jau egzistuoja.'
-    ]
+    assert list(
+        Comment.objects.filter(
+            type=Comment.STRUCTURE_ERROR,
+            content_type=ContentType.objects.get_for_model(structure),
+        ).values_list("body", flat=True)
+    ) == ['Duomenų išteklius "datasets/gov/ivpk/adp" jau egzistuoja.']
     assert Metadata.objects.filter(dataset=structure.dataset, metadata_version=version).count() == 0
 
 
 @pytest.mark.django_db
 def test_structure_with_deleted_base(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        '2,,,,Base,,,,,,,,,,,,,,\n'
-        '3,,,Base,,,,,,,,,,,,,,,\n'
-        '4,,,,City,,,,,,,,,,,,,,\n'
-        '5,,,,Country,,,,,,,,,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        "2,,,,Base,,,,,,,,,,,,,,\n"
+        "3,,,Base,,,,,,,,,,,,,,,\n"
+        "4,,,,City,,,,,,,,,,,,,,\n"
+        "5,,,,Country,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
     assert Base.objects.count() == 1
-    assert Base.objects.get(metadata__uuid='3').model == Model.objects.get(metadata__uuid='2')
-    assert Model.objects.get(metadata__uuid='4').base == Base.objects.get(metadata__uuid='3')
-    assert Model.objects.get(metadata__uuid='5').base == Base.objects.get(metadata__uuid='3')
+    assert Base.objects.get(metadata__uuid="3").model == Model.objects.get(metadata__uuid="2")
+    assert Model.objects.get(metadata__uuid="4").base == Base.objects.get(metadata__uuid="3")
+    assert Model.objects.get(metadata__uuid="5").base == Base.objects.get(metadata__uuid="3")
 
     new_manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        '2,,,,Base,,,,,,,,,,,,,,\n'
-        '4,,,,City,,,,,,,,,,,,,,\n'
-        '5,,,,Country,,,,,,,,,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        "2,,,,Base,,,,,,,,,,,,,,\n"
+        "4,,,,City,,,,,,,,,,,,,,\n"
+        "5,,,,Country,,,,,,,,,,,,,,\n"
     )
-    structure.file = FilerFileFactory(
-        file=FileField(filename='file.csv', data=new_manifest)
-    )
+    structure.file = FilerFileFactory(file=FileField(filename="file.csv", data=new_manifest))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure, version)
 
     assert Base.objects.count() == 0
-    assert Model.objects.get(metadata__uuid='4').base is None
-    assert Model.objects.get(metadata__uuid='5').base is None
+    assert Model.objects.get(metadata__uuid="4").base is None
+    assert Model.objects.get(metadata__uuid="5").base is None
 
 
 @pytest.mark.django_db
 def test_average_level(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        '1,,,,Base,,,,,,4,,,,,,,,,\n'
-        ',,,Base,,,,,,,4,,,,,,,,,\n'
-        '2,,,,City,,,,,,5,,,,,,,,,\n'
-        ',,,,,id,integer,,,,5,,,,,,,,,\n'
-        ',,,,,title,string,,,,5,,,,,,,,,\n'
-        ',,,,,country,ref,Country,,,4,,,,,,,,,\n'
-        '3,,,,Country,,,,,,4,,,,,,,,,\n'
-        ',,,,,id,integer,,,,3,,,,,,,,,\n'
-        ',,,,,title,string,,,,2,,,,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        "1,,,,Base,,,,,,4,,,,,,,,,\n"
+        ",,,Base,,,,,,,4,,,,,,,,,\n"
+        "2,,,,City,,,,,,5,,,,,,,,,\n"
+        ",,,,,id,integer,,,,5,,,,,,,,,\n"
+        ",,,,,title,string,,,,5,,,,,,,,,\n"
+        ",,,,,country,ref,Country,,,4,,,,,,,,,\n"
+        "3,,,,Country,,,,,,4,,,,,,,,,\n"
+        ",,,,,id,integer,,,,3,,,,,,,,,\n"
+        ",,,,,title,string,,,,2,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1511,21 +1328,17 @@ def test_average_level(app: DjangoTestApp):
 @pytest.mark.django_db
 def test_average_level_without_given_level(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n'
-        '1,,,,Base,,,,,,,,,,,,,,\n'                             # level 3
-        ',,,Base,,,,,,,,,,,,,,,\n'                              # level 3
-        '2,,,,City,,,,,,,,,,,,,,\n'                             # level 3
-        ',,,,,id,integer,,,,,,,,dcat:id,,,\n'                  # level 3
-        ',,,,,country1,ref,Country,,,,,,,,,,,\n'                # level 4
-        ',,,,,country2,ref,Country,,,,,,,dcat:country,,,,\n'    # level 5
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n"
+        "1,,,,Base,,,,,,,,,,,,,,\n"  # level 3
+        ",,,Base,,,,,,,,,,,,,,,\n"  # level 3
+        "2,,,,City,,,,,,,,,,,,,,\n"  # level 3
+        ",,,,,id,integer,,,,,,,,dcat:id,,,\n"  # level 3
+        ",,,,,country1,ref,Country,,,,,,,,,,,\n"  # level 4
+        ",,,,,country2,ref,Country,,,,,,,dcat:country,,,,\n"  # level 5
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1537,109 +1350,149 @@ def test_average_level_without_given_level(app: DjangoTestApp):
 @pytest.mark.django_db
 def test_uri_format(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n'
-        '2,,,,City,,,,,,,,,,dct:City,,,,\n'
-        '3,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
-        '4,,,,Country,,,,,,,,,,https://example.com#Country,,,,\n'
-        '5,,,,,id,integer,,,,5,,,open,,https://example.com#id,Identifikatorius,,\n'
-        '6,,,,Continent,,,,,,,,,,dct.Continent,,,,\n'
-        '7,,,,,id,integer,,,,5,,,open,dct.identifier,,Identifikatorius,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n"
+        "2,,,,City,,,,,,,,,,dct:City,,,,\n"
+        "3,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
+        "4,,,,Country,,,,,,,,,,https://example.com#Country,,,,\n"
+        "5,,,,,id,integer,,,,5,,,open,,https://example.com#id,Identifikatorius,,\n"
+        "6,,,,Continent,,,,,,,,,,dct.Continent,,,,\n"
+        "7,,,,,id,integer,,,,5,,,open,dct.identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
-    assert list(Comment.objects.filter(
-        content_type=ContentType.objects.get_for_model(Model),
-        object_id=Model.objects.get(metadata__uuid=2).pk,
-        type=Comment.STRUCTURE_ERROR
-    ).values_list('body', flat=True)) == []
-    assert list(Comment.objects.filter(
-        content_type=ContentType.objects.get_for_model(Property),
-        object_id=Property.objects.get(metadata__uuid=3).pk,
-        type=Comment.STRUCTURE_ERROR
-    ).values_list('body', flat=True)) == []
-    assert list(Comment.objects.filter(
-        content_type=ContentType.objects.get_for_model(Model),
-        object_id=Model.objects.get(metadata__uuid=4).pk,
-        type=Comment.STRUCTURE_ERROR
-    ).values_list('body', flat=True)) == []
-    assert list(Comment.objects.filter(
-        content_type=ContentType.objects.get_for_model(Property),
-        object_id=Property.objects.get(metadata__uuid=5).pk,
-        type=Comment.STRUCTURE_ERROR
-    ).values_list('body', flat=True)) == []
-    assert list(Comment.objects.filter(
-        content_type=ContentType.objects.get_for_model(Model),
-        object_id=Model.objects.get(metadata__uuid=6).pk,
-        type=Comment.STRUCTURE_ERROR
-    ).values_list('body', flat=True)) == ['Neteisingas uri "dct.Continent" formatas.']
-    assert list(Comment.objects.filter(
-        content_type=ContentType.objects.get_for_model(Property),
-        object_id=Property.objects.get(metadata__uuid=7).pk,
-        type=Comment.STRUCTURE_ERROR
-    ).values_list('body', flat=True)) == ['Neteisingas uri "dct.identifier" formatas.']
+    assert (
+        list(
+            Comment.objects.filter(
+                content_type=ContentType.objects.get_for_model(Model),
+                object_id=Model.objects.get(metadata__uuid=2).pk,
+                type=Comment.STRUCTURE_ERROR,
+            ).values_list("body", flat=True)
+        )
+        == []
+    )
+    assert (
+        list(
+            Comment.objects.filter(
+                content_type=ContentType.objects.get_for_model(Property),
+                object_id=Property.objects.get(metadata__uuid=3).pk,
+                type=Comment.STRUCTURE_ERROR,
+            ).values_list("body", flat=True)
+        )
+        == []
+    )
+    assert (
+        list(
+            Comment.objects.filter(
+                content_type=ContentType.objects.get_for_model(Model),
+                object_id=Model.objects.get(metadata__uuid=4).pk,
+                type=Comment.STRUCTURE_ERROR,
+            ).values_list("body", flat=True)
+        )
+        == []
+    )
+    assert (
+        list(
+            Comment.objects.filter(
+                content_type=ContentType.objects.get_for_model(Property),
+                object_id=Property.objects.get(metadata__uuid=5).pk,
+                type=Comment.STRUCTURE_ERROR,
+            ).values_list("body", flat=True)
+        )
+        == []
+    )
+    assert list(
+        Comment.objects.filter(
+            content_type=ContentType.objects.get_for_model(Model),
+            object_id=Model.objects.get(metadata__uuid=6).pk,
+            type=Comment.STRUCTURE_ERROR,
+        ).values_list("body", flat=True)
+    ) == ['Neteisingas uri "dct.Continent" formatas.']
+    assert list(
+        Comment.objects.filter(
+            content_type=ContentType.objects.get_for_model(Property),
+            object_id=Property.objects.get(metadata__uuid=7).pk,
+            type=Comment.STRUCTURE_ERROR,
+        ).values_list("body", flat=True)
+    ) == ['Neteisingas uri "dct.identifier" formatas.']
 
 
 @pytest.mark.django_db
 def test_uri_prefix(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',,,,,,prefix,dcat,,,,,,,http://www.w3.org/ns/dcat#,,,,\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        '2,,,,City,,,,,,,,,,dcat:City,,,,\n'
-        '3,,,,,id,integer,,,,5,,,open,dcat:identifier,,Identifikatorius,,\n'
-        '4,,,,Country,,,,,,,,,,dct:Country,,,,\n'
-        '5,,,,,id,integer,,,,5,,,open,dct:integer,,Identifikatorius,,\n'
-        '6,,,,Continent,,,,,,,,,,spinta:Continent,,,,\n'
-        '7,,,,,id,integer,,,,5,,,open,spinta:identifier,,Identifikatorius,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",,,,,,prefix,dcat,,,,,,,http://www.w3.org/ns/dcat#,,,,\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        "2,,,,City,,,,,,,,,,dcat:City,,,,\n"
+        "3,,,,,id,integer,,,,5,,,open,dcat:identifier,,Identifikatorius,,\n"
+        "4,,,,Country,,,,,,,,,,dct:Country,,,,\n"
+        "5,,,,,id,integer,,,,5,,,open,dct:integer,,Identifikatorius,,\n"
+        "6,,,,Continent,,,,,,,,,,spinta:Continent,,,,\n"
+        "7,,,,,id,integer,,,,5,,,open,spinta:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
-    assert list(Comment.objects.filter(
-        content_type=ContentType.objects.get_for_model(Model),
-        object_id=Model.objects.get(metadata__uuid=2).pk,
-        type=Comment.STRUCTURE_ERROR
-    ).values_list('body', flat=True)) == []
-    assert list(Comment.objects.filter(
-        content_type=ContentType.objects.get_for_model(Property),
-        object_id=Property.objects.get(metadata__uuid=3).pk,
-        type=Comment.STRUCTURE_ERROR
-    ).values_list('body', flat=True)) == []
-    assert list(Comment.objects.filter(
-        content_type=ContentType.objects.get_for_model(Model),
-        object_id=Model.objects.get(metadata__uuid=4).pk,
-        type=Comment.STRUCTURE_ERROR
-    ).values_list('body', flat=True)) == []
-    assert list(Comment.objects.filter(
-        content_type=ContentType.objects.get_for_model(Property),
-        object_id=Property.objects.get(metadata__uuid=5).pk,
-        type=Comment.STRUCTURE_ERROR
-    ).values_list('body', flat=True)) == []
-    assert list(Comment.objects.filter(
-        content_type=ContentType.objects.get_for_model(Model),
-        object_id=Model.objects.get(metadata__uuid=6).pk,
-        type=Comment.STRUCTURE_ERROR
-    ).values_list('body', flat=True)) == ['Prefiksas "spinta" duomenų ištekliuje neegzistuoja.']
-    assert list(Comment.objects.filter(
-        content_type=ContentType.objects.get_for_model(Property),
-        object_id=Property.objects.get(metadata__uuid=7).pk,
-        type=Comment.STRUCTURE_ERROR
-    ).values_list('body', flat=True)) == ['Prefiksas "spinta" duomenų ištekliuje neegzistuoja.']
+    assert (
+        list(
+            Comment.objects.filter(
+                content_type=ContentType.objects.get_for_model(Model),
+                object_id=Model.objects.get(metadata__uuid=2).pk,
+                type=Comment.STRUCTURE_ERROR,
+            ).values_list("body", flat=True)
+        )
+        == []
+    )
+    assert (
+        list(
+            Comment.objects.filter(
+                content_type=ContentType.objects.get_for_model(Property),
+                object_id=Property.objects.get(metadata__uuid=3).pk,
+                type=Comment.STRUCTURE_ERROR,
+            ).values_list("body", flat=True)
+        )
+        == []
+    )
+    assert (
+        list(
+            Comment.objects.filter(
+                content_type=ContentType.objects.get_for_model(Model),
+                object_id=Model.objects.get(metadata__uuid=4).pk,
+                type=Comment.STRUCTURE_ERROR,
+            ).values_list("body", flat=True)
+        )
+        == []
+    )
+    assert (
+        list(
+            Comment.objects.filter(
+                content_type=ContentType.objects.get_for_model(Property),
+                object_id=Property.objects.get(metadata__uuid=5).pk,
+                type=Comment.STRUCTURE_ERROR,
+            ).values_list("body", flat=True)
+        )
+        == []
+    )
+    assert list(
+        Comment.objects.filter(
+            content_type=ContentType.objects.get_for_model(Model),
+            object_id=Model.objects.get(metadata__uuid=6).pk,
+            type=Comment.STRUCTURE_ERROR,
+        ).values_list("body", flat=True)
+    ) == ['Prefiksas "spinta" duomenų ištekliuje neegzistuoja.']
+    assert list(
+        Comment.objects.filter(
+            content_type=ContentType.objects.get_for_model(Property),
+            object_id=Property.objects.get(metadata__uuid=7).pk,
+            type=Comment.STRUCTURE_ERROR,
+        ).values_list("body", flat=True)
+    ) == ['Prefiksas "spinta" duomenų ištekliuje neegzistuoja.']
 
 
 @pytest.mark.django_db
@@ -1647,20 +1500,15 @@ def test_structure_export__prefixes(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n'
-        '1,,,,,,prefix,spinta,,,,,,,,https://github.com/atviriduomenys/spinta/issues/,,,\n'
-        '2,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        '3,,,,,,prefix,dcat,,,,,,,,http://www.w3.org/ns/dcat#,,,\n'
-        '4,,,,,,,dct,,,,,,,,http://purl.org/dc/terms/,,,'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n"
+        "1,,,,,,prefix,spinta,,,,,,,,https://github.com/atviriduomenys/spinta/issues/,,,\n"
+        "2,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        "3,,,,,,prefix,dcat,,,,,,,,http://www.w3.org/ns/dcat#,,,\n"
+        "4,,,,,,,dct,,,,,,,,http://purl.org/dc/terms/,,,"
     )
     structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        ),
-        dataset=DatasetFactory(
-            title="Title",
-            description="Description"
-        )
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=DatasetFactory(title="Title", description="Description"),
     )
 
     structure.dataset.current_structure = structure
@@ -1669,38 +1517,34 @@ def test_structure_export__prefixes(app: DjangoTestApp):
     create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
     resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk]))
     assert resp.text == (
-        'id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n'
-        '1,,,,,,prefix,spinta,,,,,,,,,,https://github.com/atviriduomenys/spinta/issues/,,,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
-        '2,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n'
-        '3,,,,,,prefix,dcat,,,,,,,,,,http://www.w3.org/ns/dcat#,,,\r\n'
-        '4,,,,,,,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
+        "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
+        "1,,,,,,prefix,spinta,,,,,,,,,,https://github.com/atviriduomenys/spinta/issues/,,,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
+        "2,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n"
+        "3,,,,,,prefix,dcat,,,,,,,,,,http://www.w3.org/ns/dcat#,,,\r\n"
+        "4,,,,,,,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
     )
+
 
 @pytest.mark.django_db
 def test_structure_export__with_resource_params(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        '1,,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n'
-        '2,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        '3,,rc_wsdl,,,,wsdl,,https://test-data.data.gov.lt/api/v1/rc/get-data/?wsdl,,,,,,,,,,\n'
-        '4,,get_data,,,,soap,,Get.GetPort.GetPort.GetData,wsdl(rc_wsdl),,,,,,,,,\n'
-        '5,,,,,,param,action_type,input/ActionType,,,,,,,,,,\n'
-        '6,,,,Country,,,,,,,,,,,,,,\n'
-        '7,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
-        '8,,,,,title,string,,,,5,,,private,dct:title,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        "1,,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n"
+        "2,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        "3,,rc_wsdl,,,,wsdl,,https://test-data.data.gov.lt/api/v1/rc/get-data/?wsdl,,,,,,,,,,\n"
+        "4,,get_data,,,,soap,,Get.GetPort.GetPort.GetData,wsdl(rc_wsdl),,,,,,,,,\n"
+        "5,,,,,,param,action_type,input/ActionType,,,,,,,,,,\n"
+        "6,,,,Country,,,,,,,,,,,,,,\n"
+        "7,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
+        "8,,,,,title,string,,,,5,,,private,dct:title,,,,\n"
     )
     structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        ),
-        dataset=DatasetFactory(
-            title="Title",
-            description="Description"
-        )
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=DatasetFactory(title="Title", description="Description"),
     )
 
     structure.dataset.current_structure = structure
@@ -1710,43 +1554,39 @@ def test_structure_export__with_resource_params(app: DjangoTestApp):
 
     resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk]))
     assert resp.text == (
-        'id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n'
-        '1,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
-        '2,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n'
-        '3,,rc_wsdl,,,,wsdl,,https://test-data.data.gov.lt/api/v1/rc/get-data/?wsdl,,,,,,,,,,,rc_wsdl,\r\n'
-        '4,,get_data,,,,soap,,Get.GetPort.GetPort.GetData,,wsdl(rc_wsdl),,,,,,,,,get_data,\r\n'
-        '5,,,,,,param,action_type,input/ActionType,,,,,,develop,,,,,,\r\n'
-        '6,,,,Country,,,,,,,,,,develop,,,,,,\r\n'
-        '7,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n'
-        '8,,,,,title,string,,,,,,,5,develop,,private,dct:title,,,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
+        "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
+        "1,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
+        "2,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n"
+        "3,,rc_wsdl,,,,wsdl,,https://test-data.data.gov.lt/api/v1/rc/get-data/?wsdl,,,,,,,,,,,rc_wsdl,\r\n"
+        "4,,get_data,,,,soap,,Get.GetPort.GetPort.GetData,,wsdl(rc_wsdl),,,,,,,,,get_data,\r\n"
+        "5,,,,,,param,action_type,input/ActionType,,,,,,develop,,,,,,\r\n"
+        "6,,,,Country,,,,,,,,,,develop,,,,,,\r\n"
+        "7,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
+        "8,,,,,title,string,,,,,,,5,develop,,private,dct:title,,,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
     )
+
 
 @pytest.mark.django_db
 def test_structure_export__models_and_props(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        '2,,,,,,prefix,dct,,,,,,,,http://purl.org/dc/terms/,,,\n'
-        '3,,resource,,,,,,http://www.example.com,,,,,,,,,Title,Description\n'
-        '4,,,,Licence,,,id,,page(id),,,,,,,,Licence,\n'
-        '5,,,,,id,integer,,,,,5,,,open,dct:identifier,,Identifikatorius,\n'
-        '6,,,,,title,string,,,,,2,,,open,dct:title,,,\n'
-        ',,,,,,,,,,,,,,,,,,\n'
-        '7,,,,Catalog,,,id,,,,,,,,,,Catalog,\n'
-        '8,,,,,id,integer,,,,,5,,,open,dct:identifier,,Identifikatorius,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        "2,,,,,,prefix,dct,,,,,,,,http://purl.org/dc/terms/,,,\n"
+        "3,,resource,,,,,,http://www.example.com,,,,,,,,,Title,Description\n"
+        "4,,,,Licence,,,id,,page(id),,,,,,,,Licence,\n"
+        "5,,,,,id,integer,,,,,5,,,open,dct:identifier,,Identifikatorius,\n"
+        "6,,,,,title,string,,,,,2,,,open,dct:title,,,\n"
+        ",,,,,,,,,,,,,,,,,,\n"
+        "7,,,,Catalog,,,id,,,,,,,,,,Catalog,\n"
+        "8,,,,,id,integer,,,,,5,,,open,dct:identifier,,Identifikatorius,\n"
     )
     structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        ),
-        dataset=DatasetFactory(
-            title="Title",
-            description="Description"
-        )
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=DatasetFactory(title="Title", description="Description"),
     )
 
     structure.dataset.current_structure = structure
@@ -1755,18 +1595,18 @@ def test_structure_export__models_and_props(app: DjangoTestApp):
 
     resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk]))
     assert resp.text == (
-        'id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n'
-        '2,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
-        '3,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n'
-        '4,,,,Licence,,,id,,,page(id),,,,develop,,,,,Licence,\r\n'
-        '5,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n'
-        '6,,,,,title,string,,,,,,,2,develop,,open,dct:title,,,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
-        '7,,,,Catalog,,,id,,,,,,,develop,,,,,Catalog,\r\n'
-        '8,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
+        "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n"
+        "2,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
+        "3,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n"
+        "4,,,,Licence,,,id,,,page(id),,,,develop,,,,,Licence,\r\n"
+        "5,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
+        "6,,,,,title,string,,,,,,,2,develop,,open,dct:title,,,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
+        "7,,,,Catalog,,,id,,,,,,,develop,,,,,Catalog,\r\n"
+        "8,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
     )
 
 
@@ -1775,25 +1615,20 @@ def test_structure_export__base_model(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        '2,,,,,,prefix,dct,,,,,,,,http://purl.org/dc/terms/,,,\n'
-        '3,,resource,,,,,,http://www.example.com,,,,,,,,,Title,Description\n'
-        '4,,,,Base,,,,,,,,,,,,,,\n'
-        '5,,,,,id,integer,,,,,5,,,open,dct:identifier,,Identifikatorius,\n'
-        ',,,,,,,,,,,,,,,,,,\n'
-        '6,,,Base,,,,,,,,,,,,,,,\n'
-        '7,,,,Catalog,,,,,,,,,,,,,,\n'
-        '8,,,,,title,string,,,,,2,,,open,dct:title,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        "2,,,,,,prefix,dct,,,,,,,,http://purl.org/dc/terms/,,,\n"
+        "3,,resource,,,,,,http://www.example.com,,,,,,,,,Title,Description\n"
+        "4,,,,Base,,,,,,,,,,,,,,\n"
+        "5,,,,,id,integer,,,,,5,,,open,dct:identifier,,Identifikatorius,\n"
+        ",,,,,,,,,,,,,,,,,,\n"
+        "6,,,Base,,,,,,,,,,,,,,,\n"
+        "7,,,,Catalog,,,,,,,,,,,,,,\n"
+        "8,,,,,title,string,,,,,2,,,open,dct:title,,,\n"
     )
     structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        ),
-        dataset=DatasetFactory(
-            title="Title",
-            description="Description"
-        )
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=DatasetFactory(title="Title", description="Description"),
     )
 
     structure.dataset.current_structure = structure
@@ -1802,18 +1637,18 @@ def test_structure_export__base_model(app: DjangoTestApp):
 
     resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk]))
     assert resp.text == (
-        'id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n'
-        '2,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
-        '3,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n'
-        '4,,,,Base,,,,,,,,,,develop,,,,,,\r\n'
-        '5,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
-        '6,,,Base,,,,,,,,,,,,,,,,,\r\n'
-        '7,,,,Catalog,,,,,,,,,,develop,,,,,,\r\n'
-        '8,,,,,title,string,,,,,,,2,develop,,open,dct:title,,,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
+        "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n"
+        "2,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
+        "3,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n"
+        "4,,,,Base,,,,,,,,,,develop,,,,,,\r\n"
+        "5,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
+        "6,,,Base,,,,,,,,,,,,,,,,,\r\n"
+        "7,,,,Catalog,,,,,,,,,,develop,,,,,,\r\n"
+        "8,,,,,title,string,,,,,,,2,develop,,open,dct:title,,,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
     )
 
 
@@ -1822,25 +1657,20 @@ def test_structure_export__property_ref(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        '2,,,,,,prefix,dct,,,,,,,,http://purl.org/dc/terms/,,,\n'
-        '3,,resource,,,,,,http://www.example.com,,,,,,,,,Title,Description\n'
-        '4,,,,Country,,,,,,,,,,,,,,\n'
-        '5,,,,,id,integer,,,,,5,,,open,dct:identifier,,Identifikatorius,\n'
-        '6,,,,,title,string,,,,,5,,,open,dct:title,,,\n'
-        '7,,,,,continent,ref,Continent[id],,,,5,,,open,dct:continent,,,\n'
-        '8,,,,Continent,,,,,,,,,,,,,,\n'
-        '9,,,,,id,integer,,,,,5,,,open,dct:identifier,,Identifikatorius,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        "2,,,,,,prefix,dct,,,,,,,,http://purl.org/dc/terms/,,,\n"
+        "3,,resource,,,,,,http://www.example.com,,,,,,,,,Title,Description\n"
+        "4,,,,Country,,,,,,,,,,,,,,\n"
+        "5,,,,,id,integer,,,,,5,,,open,dct:identifier,,Identifikatorius,\n"
+        "6,,,,,title,string,,,,,5,,,open,dct:title,,,\n"
+        "7,,,,,continent,ref,Continent[id],,,,5,,,open,dct:continent,,,\n"
+        "8,,,,Continent,,,,,,,,,,,,,,\n"
+        "9,,,,,id,integer,,,,,5,,,open,dct:identifier,,Identifikatorius,\n"
     )
     structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        ),
-        dataset=DatasetFactory(
-            title="Title",
-            description="Description"
-        )
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=DatasetFactory(title="Title", description="Description"),
     )
 
     structure.dataset.current_structure = structure
@@ -1849,19 +1679,19 @@ def test_structure_export__property_ref(app: DjangoTestApp):
 
     resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk]))
     assert resp.text == (
-        'id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n'
-        '2,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
-        '3,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n'
-        '4,,,,Country,,,,,,,,,,develop,,,,,,\r\n'
-        '5,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n'
-        '6,,,,,title,string,,,,,,,5,develop,,open,dct:title,,,\r\n'
-        '7,,,,,continent,ref,Continent[id],,,,,,5,develop,,open,dct:continent,,,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
-        '8,,,,Continent,,,,,,,,,,develop,,,,,,\r\n'
-        '9,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
+        "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n"
+        "2,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
+        "3,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n"
+        "4,,,,Country,,,,,,,,,,develop,,,,,,\r\n"
+        "5,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
+        "6,,,,,title,string,,,,,,,5,develop,,open,dct:title,,,\r\n"
+        "7,,,,,continent,ref,Continent[id],,,,,,5,develop,,open,dct:continent,,,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
+        "8,,,,Continent,,,,,,,,,,develop,,,,,,\r\n"
+        "9,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
     )
 
 
@@ -1870,23 +1700,18 @@ def test_structure_export__model_ref(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        '2,,,,,,prefix,dct,,,,,,,,http://purl.org/dc/terms/,,,\n'
-        '3,,resource,,,,,,http://www.example.com,,,,,,,,,Title,Description\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        "2,,,,,,prefix,dct,,,,,,,,http://purl.org/dc/terms/,,,\n"
+        "3,,resource,,,,,,http://www.example.com,,,,,,,,,Title,Description\n"
         '4,,,,Country,,,"id, title",,,,,,,,,,,\n'
-        '5,,,,,id,integer,,,,,5,,,open,dct:identifier,,Identifikatorius,\n'
-        '6,,,,,title,string,,,,,5,,,open,dct:title,,,\n'
-        '7,,,,,continent,ref,Continent,,,,5,,,open,dct:continent,,,\n'
+        "5,,,,,id,integer,,,,,5,,,open,dct:identifier,,Identifikatorius,\n"
+        "6,,,,,title,string,,,,,5,,,open,dct:title,,,\n"
+        "7,,,,,continent,ref,Continent,,,,5,,,open,dct:continent,,,\n"
     )
     structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        ),
-        dataset=DatasetFactory(
-            title="Title",
-            description="Description"
-        )
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=DatasetFactory(title="Title", description="Description"),
     )
 
     structure.dataset.current_structure = structure
@@ -1895,16 +1720,16 @@ def test_structure_export__model_ref(app: DjangoTestApp):
 
     resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk]))
     assert resp.text == (
-        'id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n'
-        '2,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
-        '3,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n'
+        "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n"
+        "2,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
+        "3,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n"
         '4,,,,Country,,,"id, title",,,,,,,develop,,,,,,\r\n'
-        '5,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n'
-        '6,,,,,title,string,,,,,,,5,develop,,open,dct:title,,,\r\n'
-        '7,,,,,continent,ref,Continent,,,,,,5,develop,,open,dct:continent,,,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
+        "5,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
+        "6,,,,,title,string,,,,,,,5,develop,,open,dct:title,,,\r\n"
+        "7,,,,,continent,ref,Continent,,,,,,5,develop,,open,dct:continent,,,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
     )
 
 
@@ -1913,23 +1738,18 @@ def test_structure_export__comments(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        '2,,,,,,prefix,dct,,,,,,,,http://purl.org/dc/terms/,,,\n'
-        '3,,resource,,,,,,http://www.example.com,,,,,,,,,Title,Description\n'
-        '4,,,,Country,,,,,,,,,,,,,,\n'
-        '5,,,,,,comment,type,,,,,,,open,,,Model comment,\n'
-        '6,,,,,id,integer,,,,,5,,,open,dct:identifier,,Identifikatorius,\n'
-        '7,,,,,,comment,type,,,,,,,open,,,Property comment,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        "2,,,,,,prefix,dct,,,,,,,,http://purl.org/dc/terms/,,,\n"
+        "3,,resource,,,,,,http://www.example.com,,,,,,,,,Title,Description\n"
+        "4,,,,Country,,,,,,,,,,,,,,\n"
+        "5,,,,,,comment,type,,,,,,,open,,,Model comment,\n"
+        "6,,,,,id,integer,,,,,5,,,open,dct:identifier,,Identifikatorius,\n"
+        "7,,,,,,comment,type,,,,,,,open,,,Property comment,\n"
     )
     structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        ),
-        dataset=DatasetFactory(
-            title="Title",
-            description="Description"
-        )
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=DatasetFactory(title="Title", description="Description"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -1937,16 +1757,16 @@ def test_structure_export__comments(app: DjangoTestApp):
 
     resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk]))
     assert resp.text == (
-        'id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n'
-        '2,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
-        '3,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n'
-        '4,,,,Country,,,,,,,,,,develop,,,,,,\r\n'
-        '5,,,,,,comment,type,,,,,,,,,open,,,Model comment,\r\n'
-        '6,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n'
-        '7,,,,,,comment,type,,,,,,,,,open,,,Property comment,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
+        "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n"
+        "2,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
+        "3,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n"
+        "4,,,,Country,,,,,,,,,,develop,,,,,,\r\n"
+        "5,,,,,,comment,type,,,,,,,,,open,,,Model comment,\r\n"
+        "6,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
+        "7,,,,,,comment,type,,,,,,,,,open,,,Property comment,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
     )
 
 
@@ -1955,28 +1775,23 @@ def test_structure_export__enums(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        '2,,,,,,prefix,dct,,,,,,,,http://purl.org/dc/terms/,,,\n'
-        '3,,,,,,enum,Size,,SMALL,,,,,,,,,,\n'
-        '4,,,,,,,,,MEDIUM,,,,,,,,,\n'
-        '5,,,,,,,,,BIG,,,,,,,,,\n'
-        '6,,resource,,,,,,http://www.example.com,,,,,,,,,Title,Description\n'
-        '7,,,,City,,,,,,,,,,,,,,\n'
-        '8,,,,,id,integer,,,,,5,,,open,dct:identifier,,Identifikatorius,\n'
-        '9,,,,,size,Size,,,,,5,,,open,dct:size,,,\n'
-        '10,,,,,type,string,,,,,5,,,open,dct:type,,,\n'
-        '11,,,,,,enum,Type,,CREATED,,,,,,,,,\n'
-        '12,,,,,,,,,MODIFIED,,,,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        "2,,,,,,prefix,dct,,,,,,,,http://purl.org/dc/terms/,,,\n"
+        "3,,,,,,enum,Size,,SMALL,,,,,,,,,,\n"
+        "4,,,,,,,,,MEDIUM,,,,,,,,,\n"
+        "5,,,,,,,,,BIG,,,,,,,,,\n"
+        "6,,resource,,,,,,http://www.example.com,,,,,,,,,Title,Description\n"
+        "7,,,,City,,,,,,,,,,,,,,\n"
+        "8,,,,,id,integer,,,,,5,,,open,dct:identifier,,Identifikatorius,\n"
+        "9,,,,,size,Size,,,,,5,,,open,dct:size,,,\n"
+        "10,,,,,type,string,,,,,5,,,open,dct:type,,,\n"
+        "11,,,,,,enum,Type,,CREATED,,,,,,,,,\n"
+        "12,,,,,,,,,MODIFIED,,,,,,,,,\n"
     )
     structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        ),
-        dataset=DatasetFactory(
-            title="Title",
-            description="Description"
-        )
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=DatasetFactory(title="Title", description="Description"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -1984,22 +1799,22 @@ def test_structure_export__enums(app: DjangoTestApp):
 
     resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk]))
     assert resp.text == (
-        'id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n'
-        '2,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
-        '3,,,,,,enum,Size,,,SMALL,,,,develop,,,,,,\r\n'
-        '4,,,,,,,,,,MEDIUM,,,,develop,,,,,,\r\n'
-        '5,,,,,,,,,,BIG,,,,develop,,,,,,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
-        '6,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n'
-        '7,,,,City,,,,,,,,,,develop,,,,,,\r\n'
-        '8,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n'
-        '9,,,,,size,Size,,,,,,,5,develop,,open,dct:size,,,\r\n'
-        '10,,,,,type,string,,,,,,,5,develop,,open,dct:type,,,\r\n'
-        '11,,,,,,enum,Type,,,CREATED,,,,develop,,,,,,\r\n'
-        '12,,,,,,,,,,MODIFIED,,,,develop,,,,,,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
+        "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n"
+        "2,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
+        "3,,,,,,enum,Size,,,SMALL,,,,develop,,,,,,\r\n"
+        "4,,,,,,,,,,MEDIUM,,,,develop,,,,,,\r\n"
+        "5,,,,,,,,,,BIG,,,,develop,,,,,,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
+        "6,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n"
+        "7,,,,City,,,,,,,,,,develop,,,,,,\r\n"
+        "8,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
+        "9,,,,,size,Size,,,,,,,5,develop,,open,dct:size,,,\r\n"
+        "10,,,,,type,string,,,,,,,5,develop,,open,dct:type,,,\r\n"
+        "11,,,,,,enum,Type,,,CREATED,,,,develop,,,,,,\r\n"
+        "12,,,,,,,,,,MODIFIED,,,,develop,,,,,,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
     )
 
 
@@ -2008,27 +1823,22 @@ def test_structure_export__params(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        '2,,,,,,prefix,dct,,,,,,,,http://purl.org/dc/terms/,,,\n'
-        '3,,,,,,param,country,,lt,,,,,,,,,\n'
-        '4,,,,,,,,,lv,,,,,,,,,\n'
-        '5,,,,,,,,,ee,,,,,,,,,\n'
-        '6,,resource,,,,,,http://www.example.com,,,,,,,,,Title,Description\n'
-        '7,,,,City,,,,,,,,,,,,,,\n'
-        '8,,,,,,param,type,,created,,,,,,,,,\n'
-        '9,,,,,,,,,modified,,,,,,,,,\n'
-        '10,,,,,id,integer,,,,,5,,,open,dct:identifier,,Identifikatorius,\n'
-        '11,,,,,type,string,,,,,5,,,open,dct:type,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        "2,,,,,,prefix,dct,,,,,,,,http://purl.org/dc/terms/,,,\n"
+        "3,,,,,,param,country,,lt,,,,,,,,,\n"
+        "4,,,,,,,,,lv,,,,,,,,,\n"
+        "5,,,,,,,,,ee,,,,,,,,,\n"
+        "6,,resource,,,,,,http://www.example.com,,,,,,,,,Title,Description\n"
+        "7,,,,City,,,,,,,,,,,,,,\n"
+        "8,,,,,,param,type,,created,,,,,,,,,\n"
+        "9,,,,,,,,,modified,,,,,,,,,\n"
+        "10,,,,,id,integer,,,,,5,,,open,dct:identifier,,Identifikatorius,\n"
+        "11,,,,,type,string,,,,,5,,,open,dct:type,,,\n"
     )
     structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        ),
-        dataset=DatasetFactory(
-            title="Title",
-            description="Description"
-        )
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=DatasetFactory(title="Title", description="Description"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -2036,35 +1846,31 @@ def test_structure_export__params(app: DjangoTestApp):
 
     resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk]))
     assert resp.text == (
-        'id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n'
-        '2,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
-        '3,,,,,,param,country,,,lt,,,,develop,,,,,,\r\n'
-        '4,,,,,,,,,,lv,,,,develop,,,,,,\r\n'
-        '5,,,,,,,,,,ee,,,,develop,,,,,,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
-        '6,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n'
-        '7,,,,City,,,,,,,,,,develop,,,,,,\r\n'
-        '8,,,,,,param,type,,,created,,,,develop,,,,,,\r\n'
-        '9,,,,,,,,,,modified,,,,develop,,,,,,\r\n'
-        '10,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n'
-        '11,,,,,type,string,,,,,,,5,develop,,open,dct:type,,,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
+        "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,Title,Description\r\n"
+        "2,,,,,,prefix,dct,,,,,,,,,,http://purl.org/dc/terms/,,,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
+        "3,,,,,,param,country,,,lt,,,,develop,,,,,,\r\n"
+        "4,,,,,,,,,,lv,,,,develop,,,,,,\r\n"
+        "5,,,,,,,,,,ee,,,,develop,,,,,,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
+        "6,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n"
+        "7,,,,City,,,,,,,,,,develop,,,,,,\r\n"
+        "8,,,,,,param,type,,,created,,,,develop,,,,,,\r\n"
+        "9,,,,,,,,,,modified,,,,develop,,,,,,\r\n"
+        "10,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
+        "11,,,,,type,string,,,,,,,5,develop,,open,dct:type,,,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
     )
 
 
 @pytest.mark.django_db
 def test_import_structure_with_wrong_datasets_name(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',datasets/gov/ivpk/adp/ššš,,,,,,,,,,,,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/ivpk/adp/ššš,,,,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -2074,32 +1880,25 @@ def test_import_structure_with_wrong_datasets_name(app: DjangoTestApp):
         metadata_version=metadata_version,
     )
     assert metadata.count() == 0
-    comments = Comment.objects.filter(
-        content_type=ContentType.objects.get_for_model(structure),
-        object_id=structure.pk
-    )
+    comments = Comment.objects.filter(content_type=ContentType.objects.get_for_model(structure), object_id=structure.pk)
     assert comments.count() == 1
-    assert 'kodiniame pavadinime gali būti naudojamos tik lotyniškos raidės.' in comments[0].body
+    assert "kodiniame pavadinime gali būti naudojamos tik lotyniškos raidės." in comments[0].body
 
 
 @pytest.mark.django_db
 def test_structure_resource__resource_title(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n'
-        '1,,resource,,,,,,http://www.example.com,,,,,,,,Test resource,,\n'
-        '2,,,,City,,,,,,,,,,,,,,\n'
-        '3,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
-        '4,,,,,title,string,,,,5,,,open,dct:title,,,,\n'
-        '5,,,,Country,,,,,,,,,,,,,,\n'
-        '6,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n"
+        "1,,resource,,,,,,http://www.example.com,,,,,,,,Test resource,,\n"
+        "2,,,,City,,,,,,,,,,,,,,\n"
+        "3,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
+        "4,,,,,title,string,,,,5,,,open,dct:title,,,,\n"
+        "5,,,,Country,,,,,,,,,,,,,,\n"
+        "6,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -2111,21 +1910,17 @@ def test_structure_resource__resource_title(app: DjangoTestApp):
 @pytest.mark.django_db
 def test_structure_with_resource__dataset_title(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,Test dataset,,\n'
-        ',,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n'
-        '1,,resource,,,,,,http://www.example.com,,,,,,,,,,\n'
-        '2,,,,City,,,,,,,,,,,,,,\n'
-        '3,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
-        '4,,,,,title,string,,,,5,,,open,dct:title,,,,\n'
-        '5,,,,Country,,,,,,,,,,,,,,\n'
-        '6,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,Test dataset,,\n"
+        ",,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n"
+        "1,,resource,,,,,,http://www.example.com,,,,,,,,,,\n"
+        "2,,,,City,,,,,,,,,,,,,,\n"
+        "3,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
+        "4,,,,,title,string,,,,5,,,open,dct:title,,,,\n"
+        "5,,,,Country,,,,,,,,,,,,,,\n"
+        "6,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -2137,21 +1932,17 @@ def test_structure_with_resource__dataset_title(app: DjangoTestApp):
 @pytest.mark.django_db
 def test_structure_with_resource__no_title(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n'
-        '1,,resource,,,,,,http://www.example.com,,,,,,,,,,\n'
-        '2,,,,City,,,,,,,,,,,,,,\n'
-        '3,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
-        '4,,,,,title,string,,,,5,,,open,dct:title,,,,\n'
-        '5,,,,Country,,,,,,,,,,,,,,\n'
-        '6,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n"
+        "1,,resource,,,,,,http://www.example.com,,,,,,,,,,\n"
+        "2,,,,City,,,,,,,,,,,,,,\n"
+        "3,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
+        "4,,,,,title,string,,,,5,,,open,dct:title,,,,\n"
+        "5,,,,Country,,,,,,,,,,,,,,\n"
+        "6,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -2163,21 +1954,17 @@ def test_structure_with_resource__no_title(app: DjangoTestApp):
 @pytest.mark.django_db
 def test_structure_without_resource__dataset_title(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,Test dataset,,\n'
-        ',,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n'
-        ',,,,,,,,,,,,,,,,,,\n'
-        '1,,,,City,,,,,,,,,,,,,,\n'
-        '2,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
-        '3,,,,,title,string,,,,5,,,open,dct:title,,,,\n'
-        '4,,,,Country,,,,,,,,,,,,,,\n'
-        '5,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,Test dataset,,\n"
+        ",,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n"
+        ",,,,,,,,,,,,,,,,,,\n"
+        "1,,,,City,,,,,,,,,,,,,,\n"
+        "2,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
+        "3,,,,,title,string,,,,5,,,open,dct:title,,,,\n"
+        "4,,,,Country,,,,,,,,,,,,,,\n"
+        "5,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -2190,79 +1977,68 @@ def test_structure_export_after_changing_model_name(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n'
-        '1,test_dataset,,,,,,,,,,,,,,,,,\n'
-        '2,,resource1,,,,,,http://www.example.com,,,,,,,,,Title,Description\n'
-        '3,,,,Model,,,id,,,,,,,,,,,\n'
-        '4,,,,,id,integer,,,,,,,,,,,,\n'
-        ',,,,,,,,,,,,,,,,,,\n'
-        '5,,,Model,,,,,,,,,,,,,,,\n'
-        '6,,,,Country,,,id,,,,,,,,,,,\n'
-        '7,,,,,id,int,,,,,,,,,,,,\n'
-        '8,,,,,code,string,,,,,,,,,,,,\n'
-        ',,,,,,,,,,,,,,,,,,\n'
-        ',,,/,,,,,,,,,,,,,,,\n'
-        '9,,,,City,,,id,,,,,,,,,,,\n'
-        '10,,,,,id,int,,,,,,,,,,,,\n'
-        '11,,,,,country,ref,Country,code,,,,,,,,,,\n'
-        ',,,,,,,,,,,,,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n"
+        "1,test_dataset,,,,,,,,,,,,,,,,,\n"
+        "2,,resource1,,,,,,http://www.example.com,,,,,,,,,Title,Description\n"
+        "3,,,,Model,,,id,,,,,,,,,,,\n"
+        "4,,,,,id,integer,,,,,,,,,,,,\n"
+        ",,,,,,,,,,,,,,,,,,\n"
+        "5,,,Model,,,,,,,,,,,,,,,\n"
+        "6,,,,Country,,,id,,,,,,,,,,,\n"
+        "7,,,,,id,int,,,,,,,,,,,,\n"
+        "8,,,,,code,string,,,,,,,,,,,,\n"
+        ",,,,,,,,,,,,,,,,,,\n"
+        ",,,/,,,,,,,,,,,,,,,\n"
+        "9,,,,City,,,id,,,,,,,,,,,\n"
+        "10,,,,,id,int,,,,,,,,,,,,\n"
+        "11,,,,,country,ref,Country,code,,,,,,,,,,\n"
+        ",,,,,,,,,,,,,,,,,,\n"
     )
     structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        ),
-        dataset=DatasetFactory(
-            title="Title",
-            description="Description"
-        )
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=DatasetFactory(title="Title", description="Description"),
     )
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
 
-    model = Model.objects.get(
-        dataset=structure.dataset,
-        metadata__name="test_dataset/Model"
-    )
-    form = app.get(reverse('model-update', args=[structure.dataset.pk, version.pk, model.name])).forms['model-form']
-    form['name'] = "Modelis"
+    model = Model.objects.get(dataset=structure.dataset, metadata__name="test_dataset/Model")
+    form = app.get(reverse("model-update", args=[structure.dataset.pk, version.pk, model.name])).forms["model-form"]
+    form["name"] = "Modelis"
     resp = form.submit()
     assert resp.url == model.get_absolute_url()
-    assert model.metadata.first().name == 'test_dataset/Modelis'
+    assert model.metadata.first().name == "test_dataset/Modelis"
     assert model.ref_model_base.count() == 1
-    assert model.ref_model_base.first().metadata.first().name == 'test_dataset/Modelis'
+    assert model.ref_model_base.first().metadata.first().name == "test_dataset/Modelis"
 
-    model = Model.objects.get(
-        dataset=structure.dataset,
-        metadata__name="test_dataset/Country"
-    )
-    form = app.get(reverse('model-update', args=[structure.dataset.pk, version.pk, model.name])).forms['model-form']
-    form['name'] = "Salis"
+    model = Model.objects.get(dataset=structure.dataset, metadata__name="test_dataset/Country")
+    form = app.get(reverse("model-update", args=[structure.dataset.pk, version.pk, model.name])).forms["model-form"]
+    form["name"] = "Salis"
     resp = form.submit()
     assert resp.url == model.get_absolute_url()
-    assert model.metadata.first().name == 'test_dataset/Salis'
+    assert model.metadata.first().name == "test_dataset/Salis"
     assert model.ref_model_properties.count() == 1
-    assert model.ref_model_properties.first().metadata.first().ref == 'test_dataset/Salis'
+    assert model.ref_model_properties.first().metadata.first().ref == "test_dataset/Salis"
 
     resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk]))
     assert resp.text == (
-        'id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n'
-        '1,test_dataset,,,,,,,,,,,,,,,,,,Title,Description\r\n'
-        '2,,resource1,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n'
-        '3,,,,Modelis,,,id,,,,,,,develop,,,,,,\r\n'
-        '4,,,,,id,integer,,,,,,,,develop,,,,,,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
-        '5,,,Modelis,,,,,,,,,,,,,,,,,\r\n'
-        '6,,,,Salis,,,id,,,,,,,develop,,,,,,\r\n'
-        '7,,,,,id,int,,,,,,,,develop,,,,,,\r\n'
-        '8,,,,,code,string,,,,,,,,develop,,,,,,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
-        ',,,/,,,,,,,,,,,,,,,,,\r\n'
-        '9,,,,City,,,id,,,,,,,develop,,,,,,\r\n'
-        '10,,,,,id,int,,,,,,,,develop,,,,,,\r\n'
-        '11,,,,,country,ref,Salis,code,,,,,,develop,,,,,,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
+        "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
+        "1,test_dataset,,,,,,,,,,,,,,,,,,Title,Description\r\n"
+        "2,,resource1,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n"
+        "3,,,,Modelis,,,id,,,,,,,develop,,,,,,\r\n"
+        "4,,,,,id,integer,,,,,,,,develop,,,,,,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
+        "5,,,Modelis,,,,,,,,,,,,,,,,,\r\n"
+        "6,,,,Salis,,,id,,,,,,,develop,,,,,,\r\n"
+        "7,,,,,id,int,,,,,,,,develop,,,,,,\r\n"
+        "8,,,,,code,string,,,,,,,,develop,,,,,,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
+        ",,,/,,,,,,,,,,,,,,,,,\r\n"
+        "9,,,,City,,,id,,,,,,,develop,,,,,,\r\n"
+        "10,,,,,id,int,,,,,,,,develop,,,,,,\r\n"
+        "11,,,,,country,ref,Salis,code,,,,,,develop,,,,,,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
     )
 
 
@@ -2272,34 +2048,30 @@ def test_structure_export_after_changing_dataset_title_and_description(app: Djan
     user = representative.user
     app.set_user(user)
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,prepare,level,status,visibility,access,uri,eli,title,description\n'
-        '1,test_dataset,,,,,,,,,,,,,,,,Title,Description\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,prepare,level,status,visibility,access,uri,eli,title,description\n"
+        "1,test_dataset,,,,,,,,,,,,,,,,Title,Description\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
 
     structure.dataset.current_structure = structure
     structure.dataset.organization = representative.content_object
     structure.dataset.save()
     version = create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
 
-    form = app.get(reverse('dataset-change', kwargs={'pk': structure.dataset.pk})).forms['dataset-form']
-    form['title'] = 'Edited title'
-    form['description'] = 'Edited description'
-    form['name'] = structure.dataset.organization.name + "edited_dataset"
+    form = app.get(reverse("dataset-change", kwargs={"pk": structure.dataset.pk})).forms["dataset-form"]
+    form["title"] = "Edited title"
+    form["description"] = "Edited description"
+    form["name"] = structure.dataset.organization.name + "edited_dataset"
     resp = form.submit()
-    assert resp.url == reverse('dataset-detail', kwargs={'pk': structure.dataset.pk})
+    assert resp.url == reverse("dataset-detail", kwargs={"pk": structure.dataset.pk})
     assert structure.dataset.metadata.filter(metadata_version=version).count() == 1
     assert structure.dataset.metadata.first().title == "Edited title"
     assert structure.dataset.metadata.first().description == "Edited description"
 
     resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk]))
     assert resp.text == (
-        'id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n'
-        f'1,{structure.dataset.organization.name + "edited_dataset"},,,,,,,,,,,,,,,,,,Edited title,Edited description\r\n'
+        "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
+        f"1,{structure.dataset.organization.name + 'edited_dataset'},,,,,,,,,,,,,,,,,,Edited title,Edited description\r\n"
     )
 
 
@@ -2308,19 +2080,14 @@ def test_structure_export_after_changing_distribution_title_and_description(app:
     user = UserFactory(is_staff=True)
     app.set_user(user)
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n'
-        '1,test_dataset,,,,,,,,,,,,,,,,Dataset,Dataset description\n'
-        '2,,test_resource,,,,,,https://example.com,,,,,,,,,Resource,Resource description\n'
-        '3,,,,Model,,,,,,,,,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n"
+        "1,test_dataset,,,,,,,,,,,,,,,,Dataset,Dataset description\n"
+        "2,,test_resource,,,,,,https://example.com,,,,,,,,,Resource,Resource description\n"
+        "3,,,,Model,,,,,,,,,,,,,,\n"
     )
     structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        ),
-        dataset=DatasetFactory(
-            title="Dataset",
-            description="Dataset description"
-        )
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=DatasetFactory(title="Dataset", description="Dataset description"),
     )
 
     structure.dataset.current_structure = structure
@@ -2329,23 +2096,27 @@ def test_structure_export_after_changing_distribution_title_and_description(app:
     dist_format = FileFormat()
 
     distribution = DatasetDistribution.objects.first()
-    form = app.get(reverse('resource-change', kwargs={'pk': distribution.pk, 'version_id': distribution.metadata_version.pk})).forms['resource-form']
-    form['title'] = 'Edited title'
-    form['description'] = 'Edited description'
-    form['format'] = dist_format.pk
+    form = app.get(
+        reverse("resource-change", kwargs={"pk": distribution.pk, "version_id": distribution.metadata_version.pk})
+    ).forms["resource-form"]
+    form["title"] = "Edited title"
+    form["description"] = "Edited description"
+    form["format"] = dist_format.pk
     resp = form.submit()
-    assert resp.url == reverse('resource-detail', args=[structure.dataset.pk, distribution.metadata_version.pk, distribution.pk])
+    assert resp.url == reverse(
+        "resource-detail", args=[structure.dataset.pk, distribution.metadata_version.pk, distribution.pk]
+    )
     assert distribution.metadata.count() == 1
     assert distribution.metadata.first().title == "Edited title"
     assert distribution.metadata.first().description == "Edited description"
 
     resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk]))
     assert resp.text == (
-        'id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n'
-        '1,test_dataset,,,,,,,,,,,,,,,,,,Dataset,Dataset description\r\n'
-        '2,,test_resource,,,,,,https://example.com,,,,,,,,,,,Edited title,Edited description\r\n'
-        '3,,,,Model,,,,,,,,,,develop,,,,,,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
+        "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
+        "1,test_dataset,,,,,,,,,,,,,,,,,,Dataset,Dataset description\r\n"
+        "2,,test_resource,,,,,,https://example.com,,,,,,,,,,,Edited title,Edited description\r\n"
+        "3,,,,Model,,,,,,,,,,develop,,,,,,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
     )
 
 
@@ -2354,19 +2125,14 @@ def test_structure_export_after_changing_distribution_level(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n'
-        '1,test_dataset,,,,,,,,,,,,,,,,Dataset,Dataset description\n'
-        '2,,test_resource,,,,,,https://example.com,,,,,,,,,Resource,Resource description\n'
-        '3,,,,Model,,,,,,,,,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n"
+        "1,test_dataset,,,,,,,,,,,,,,,,Dataset,Dataset description\n"
+        "2,,test_resource,,,,,,https://example.com,,,,,,,,,Resource,Resource description\n"
+        "3,,,,Model,,,,,,,,,,,,,,\n"
     )
     structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        ),
-        dataset=DatasetFactory(
-            title="Dataset",
-            description="Dataset description"
-        )
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=DatasetFactory(title="Dataset", description="Dataset description"),
     )
 
     structure.dataset.current_structure = structure
@@ -2375,22 +2141,27 @@ def test_structure_export_after_changing_distribution_level(app: DjangoTestApp):
     dist_format = FileFormat()
 
     distribution = DatasetDistribution.objects.first()
-    form = app.get(reverse('resource-change', kwargs={'pk': distribution.pk, 'version_id': distribution.metadata_version.pk})).forms['resource-form']
-    form['level'] = 2
-    form['format'] = dist_format.pk
+    form = app.get(
+        reverse("resource-change", kwargs={"pk": distribution.pk, "version_id": distribution.metadata_version.pk})
+    ).forms["resource-form"]
+    form["level"] = 2
+    form["format"] = dist_format.pk
     resp = form.submit()
-    assert resp.url == reverse('resource-detail', args=[structure.dataset.pk, distribution.metadata_version.pk, distribution.pk])
+    assert resp.url == reverse(
+        "resource-detail", args=[structure.dataset.pk, distribution.metadata_version.pk, distribution.pk]
+    )
     assert distribution.metadata.count() == 1
     assert distribution.metadata.first().level_given == 2
 
     resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk]))
     assert resp.text == (
-        'id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n'
-        '1,test_dataset,,,,,,,,,,,,,,,,,,Dataset,Dataset description\r\n'
-        '2,,test_resource,,,,,,https://example.com,,,,,2,,,,,,Resource,Resource description\r\n'
-        '3,,,,Model,,,,,,,,,,develop,,,,,,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
+        "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
+        "1,test_dataset,,,,,,,,,,,,,,,,,,Dataset,Dataset description\r\n"
+        "2,,test_resource,,,,,,https://example.com,,,,,2,,,,,,Resource,Resource description\r\n"
+        "3,,,,Model,,,,,,,,,,develop,,,,,,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
     )
+
 
 @pytest.mark.django_db
 def test_structure_export__visibility_row(app: DjangoTestApp):
@@ -2398,23 +2169,18 @@ def test_structure_export__visibility_row(app: DjangoTestApp):
     app.set_user(user)
 
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n'
-        '1,example,,,,,,,,,,,,,,,,,\n'
-        '2,,resource,,,,xml,,resource.xml,,,,,,,,,,\n'
-        ',,,,,,,,,,,,,,,,,,\n'
-        '3,,,,Pavadinimas,,,id,,,,4,,package,protected,,,Pavadinimas,\n'
-        '4,,,,,id,integer,,,,,4,,package,protected,,,ID,\n'
-        '5,,,,,class,integer,,,,,4,,package,protected,,,class,\n'
-        '6,,,,,,enum,,1,,,4,,package,protected,,,Class One,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n"
+        "1,example,,,,,,,,,,,,,,,,,\n"
+        "2,,resource,,,,xml,,resource.xml,,,,,,,,,,\n"
+        ",,,,,,,,,,,,,,,,,,\n"
+        "3,,,,Pavadinimas,,,id,,,,4,,package,protected,,,Pavadinimas,\n"
+        "4,,,,,id,integer,,,,,4,,package,protected,,,ID,\n"
+        "5,,,,,class,integer,,,,,4,,package,protected,,,class,\n"
+        "6,,,,,,enum,,1,,,4,,package,protected,,,Class One,\n"
     )
     structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        ),
-        dataset=DatasetFactory(
-            title="Pavadinimas",
-            description="Aprašymas"
-        )
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=DatasetFactory(title="Pavadinimas", description="Aprašymas"),
     )
 
     structure.dataset.current_structure = structure
@@ -2423,15 +2189,16 @@ def test_structure_export__visibility_row(app: DjangoTestApp):
 
     resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk]))
     assert resp.text == (
-        'id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n'
-        '1,example,,,,,,,,,,,,,,,,,,Pavadinimas,Aprašymas\r\n'
-        '2,,resource,,,,xml,,resource.xml,,,,,,,,,,,resource,\r\n'
-        '3,,,,Pavadinimas,,,id,,,,,,4,develop,package,protected,,,Pavadinimas,\r\n'
-        '4,,,,,id,integer,,,,,,,4,develop,package,protected,,,ID,\r\n'
-        '5,,,,,class,integer,,,,,,,4,develop,package,protected,,,class,\r\n'
-        '6,,,,,,enum,,1,,,,,,develop,package,protected,,,Class One,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
+        "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
+        "1,example,,,,,,,,,,,,,,,,,,Pavadinimas,Aprašymas\r\n"
+        "2,,resource,,,,xml,,resource.xml,,,,,,,,,,,resource,\r\n"
+        "3,,,,Pavadinimas,,,id,,,,,,4,develop,package,protected,,,Pavadinimas,\r\n"
+        "4,,,,,id,integer,,,,,,,4,develop,package,protected,,,ID,\r\n"
+        "5,,,,,class,integer,,,,,,,4,develop,package,protected,,,class,\r\n"
+        "6,,,,,,enum,,1,,,,,,develop,package,protected,,,Class One,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
     )
+
 
 @pytest.mark.django_db
 def test_structure_export__eli_row(app: DjangoTestApp):
@@ -2439,23 +2206,18 @@ def test_structure_export__eli_row(app: DjangoTestApp):
     app.set_user(user)
 
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n'
-        '1,example,,,,,,,,,,,,,,,,,\n'
-        '2,,resource,,,,xml,,resource.xml,,,,,,,,,,\n'
-        ',,,,,,,,,,,,,,,,,,\n'
-        '3,,,,Pavadinimas,,,id,,,,4,,,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.1,Pavadinimas,\n'
-        '4,,,,,id,integer,,,,,4,,,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.2,ID,\n'
-        '5,,,,,class,integer,,,,,4,,,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.3,class,\n'
-        '6,,,,,,enum,,1,,,4,,,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.3.1,Class One,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n"
+        "1,example,,,,,,,,,,,,,,,,,\n"
+        "2,,resource,,,,xml,,resource.xml,,,,,,,,,,\n"
+        ",,,,,,,,,,,,,,,,,,\n"
+        "3,,,,Pavadinimas,,,id,,,,4,,,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.1,Pavadinimas,\n"
+        "4,,,,,id,integer,,,,,4,,,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.2,ID,\n"
+        "5,,,,,class,integer,,,,,4,,,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.3,class,\n"
+        "6,,,,,,enum,,1,,,4,,,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.3.1,Class One,\n"
     )
     structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        ),
-        dataset=DatasetFactory(
-            title="Pavadinimas",
-            description="Aprašymas"
-        )
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=DatasetFactory(title="Pavadinimas", description="Aprašymas"),
     )
 
     structure.dataset.current_structure = structure
@@ -2464,15 +2226,16 @@ def test_structure_export__eli_row(app: DjangoTestApp):
 
     resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk]))
     assert resp.text == (
-        'id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n'
-        '1,example,,,,,,,,,,,,,,,,,,Pavadinimas,Aprašymas\r\n'
-        '2,,resource,,,,xml,,resource.xml,,,,,,,,,,,resource,\r\n'
-        '3,,,,Pavadinimas,,,id,,,,,,4,develop,,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.1,Pavadinimas,\r\n'
-        '4,,,,,id,integer,,,,,,,4,develop,,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.2,ID,\r\n'
-        '5,,,,,class,integer,,,,,,,4,develop,,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.3,class,\r\n'
-        '6,,,,,,enum,,1,,,,,,develop,,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.3.1,Class One,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
+        "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
+        "1,example,,,,,,,,,,,,,,,,,,Pavadinimas,Aprašymas\r\n"
+        "2,,resource,,,,xml,,resource.xml,,,,,,,,,,,resource,\r\n"
+        "3,,,,Pavadinimas,,,id,,,,,,4,develop,,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.1,Pavadinimas,\r\n"
+        "4,,,,,id,integer,,,,,,,4,develop,,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.2,ID,\r\n"
+        "5,,,,,class,integer,,,,,,,4,develop,,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.3,class,\r\n"
+        "6,,,,,,enum,,1,,,,,,develop,,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.3.1,Class One,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
     )
+
 
 @pytest.mark.django_db
 def test_structure_export__status_row(app: DjangoTestApp, setup_default_status_data):
@@ -2480,23 +2243,18 @@ def test_structure_export__status_row(app: DjangoTestApp, setup_default_status_d
     app.set_user(user)
 
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n'
-        '1,example,,,,,,,,,,,,,,,,,\n'
-        '2,,resource,,,,xml,,resource.xml,,,,,,,,,,\n'
-        ',,,,,,,,,,,,,,,,,,\n'
-        '3,,,,Pavadinimas,,,id,,,,4,completed,,protected,,,Pavadinimas,\n'
-        '4,,,,,id,integer,,,,,4,withdrawn,,protected,,,ID,\n'
-        '5,,,,,class,integer,,,,,4,deprecated,,protected,,,class,\n'
-        '6,,,,,,enum,,1,,,4,discont,,protected,,,Class One,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n"
+        "1,example,,,,,,,,,,,,,,,,,\n"
+        "2,,resource,,,,xml,,resource.xml,,,,,,,,,,\n"
+        ",,,,,,,,,,,,,,,,,,\n"
+        "3,,,,Pavadinimas,,,id,,,,4,completed,,protected,,,Pavadinimas,\n"
+        "4,,,,,id,integer,,,,,4,withdrawn,,protected,,,ID,\n"
+        "5,,,,,class,integer,,,,,4,deprecated,,protected,,,class,\n"
+        "6,,,,,,enum,,1,,,4,discont,,protected,,,Class One,\n"
     )
     structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        ),
-        dataset=DatasetFactory(
-            title="Pavadinimas",
-            description="Aprašymas"
-        )
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=DatasetFactory(title="Pavadinimas", description="Aprašymas"),
     )
 
     structure.dataset.current_structure = structure
@@ -2505,98 +2263,84 @@ def test_structure_export__status_row(app: DjangoTestApp, setup_default_status_d
 
     resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk]))
     assert resp.text == (
-        'id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n'
-        '1,example,,,,,,,,,,,,,,,,,,Pavadinimas,Aprašymas\r\n'
-        '2,,resource,,,,xml,,resource.xml,,,,,,,,,,,resource,\r\n'
-        '3,,,,Pavadinimas,,,id,,,,,,4,completed,,protected,,,Pavadinimas,\r\n'
-        '4,,,,,id,integer,,,,,,,4,withdrawn,,protected,,,ID,\r\n'
-        '5,,,,,class,integer,,,,,,,4,deprecated,,protected,,,class,\r\n'
-        '6,,,,,,enum,,1,,,,,,discont,,protected,,,Class One,\r\n'
-        ',,,,,,,,,,,,,,,,,,,,\r\n'
+        "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
+        "1,example,,,,,,,,,,,,,,,,,,Pavadinimas,Aprašymas\r\n"
+        "2,,resource,,,,xml,,resource.xml,,,,,,,,,,,resource,\r\n"
+        "3,,,,Pavadinimas,,,id,,,,,,4,completed,,protected,,,Pavadinimas,\r\n"
+        "4,,,,,id,integer,,,,,,,4,withdrawn,,protected,,,ID,\r\n"
+        "5,,,,,class,integer,,,,,,,4,deprecated,,protected,,,class,\r\n"
+        "6,,,,,,enum,,1,,,,,,discont,,protected,,,Class One,\r\n"
+        ",,,,,,,,,,,,,,,,,,,,\r\n"
     )
+
 
 @pytest.mark.django_db
 def test_structure_models_props_and_enums_with_visibility_status_eli(app: DjangoTestApp, setup_default_status_data):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        '1,example,,,,,,,,,,,,,,,,,\n'
-        '2,,resource,,,,xml,,resource.xml,,,,,,,,,,\n'
-        ',,,,,,,,,,,,,,,,,,\n'
-        '3,,,,Pavadinimas,,,id,,,4,completed,package,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.1,Pavadinimas,,\n'
-        '4,,,,,id,integer,,,,4,completed,package,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.2,ID,,\n'
-        '5,,,,,class,integer,,,,4,discont,protected,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.3,class,,\n'
-        '6,,,,,,enum,,1,,4,deprecated,protected,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.3.1,Class One,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        "1,example,,,,,,,,,,,,,,,,,\n"
+        "2,,resource,,,,xml,,resource.xml,,,,,,,,,,\n"
+        ",,,,,,,,,,,,,,,,,,\n"
+        "3,,,,Pavadinimas,,,id,,,4,completed,package,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.1,Pavadinimas,,\n"
+        "4,,,,,id,integer,,,,4,completed,package,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.2,ID,,\n"
+        "5,,,,,class,integer,,,,4,discont,protected,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.3,class,,\n"
+        "6,,,,,,enum,,1,,4,deprecated,protected,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.3.1,Class One,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
 
     models = Model.objects.all()
-    metadata = Metadata.objects.filter(
-        content_type=ContentType.objects.get_for_model(Model)
-    )
-    completed_status_id = Status.objects.filter(codename='completed').values_list('id', flat=True).first()
+    metadata = Metadata.objects.filter(content_type=ContentType.objects.get_for_model(Model))
+    completed_status_id = Status.objects.filter(codename="completed").values_list("id", flat=True).first()
 
     assert models.count() == 1
     assert models[0].dataset == structure.dataset
     assert metadata.count() == 1
-    assert list(metadata.values_list(
-        'visibility',
-        'status',
-        'eli'
-    )) == [
-        (Metadata.PACKAGE, completed_status_id, 'https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.1')
+    assert list(metadata.values_list("visibility", "status", "eli")) == [
+        (Metadata.PACKAGE, completed_status_id, "https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.1")
     ]
 
     props = Property.objects.filter(model=models[0])
     metadata = Metadata.objects.filter(
-        content_type=ContentType.objects.get_for_model(Property),
-        object_id__in=props.values_list('pk', flat=True)
+        content_type=ContentType.objects.get_for_model(Property), object_id__in=props.values_list("pk", flat=True)
     )
-    discont_status_id = Status.objects.filter(codename='discont').values_list('id', flat=True).first()
+    discont_status_id = Status.objects.filter(codename="discont").values_list("id", flat=True).first()
 
     assert props.count() == 2
     assert metadata.count() == 2
-    assert set(metadata.values_list(
-        'visibility',
-        'status',
-        'eli'
-    )) == {
-        (Metadata.PACKAGE, completed_status_id, 'https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.2'),
-        (Metadata.PROTECTED, discont_status_id, 'https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.3'),
+    assert set(metadata.values_list("visibility", "status", "eli")) == {
+        (Metadata.PACKAGE, completed_status_id, "https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.2"),
+        (Metadata.PROTECTED, discont_status_id, "https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.3"),
     }
 
-    prop = Property.objects.get(metadata__uuid='5')
-    prop_enum = Enum.objects.filter(
-        content_type=ContentType.objects.get_for_model(prop),
-        object_id=prop.pk
-    )
-    deprecated_status_id = Status.objects.filter(codename='deprecated').values_list('id', flat=True).first()
+    prop = Property.objects.get(metadata__uuid="5")
+    prop_enum = Enum.objects.filter(content_type=ContentType.objects.get_for_model(prop), object_id=prop.pk)
+    deprecated_status_id = Status.objects.filter(codename="deprecated").values_list("id", flat=True).first()
 
     assert prop_enum.count() == 1
-    assert list(prop_enum[0].enumitem_set.values_list('metadata__eli', 'metadata__visibility', 'metadata__status')) == [('https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.3.1', Metadata.PROTECTED, deprecated_status_id)]
+    assert list(prop_enum[0].enumitem_set.values_list("metadata__eli", "metadata__visibility", "metadata__status")) == [
+        (
+            "https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.3.1",
+            Metadata.PROTECTED,
+            deprecated_status_id,
+        )
+    ]
+
 
 @pytest.mark.django_db
 def test_structure_with_property_level_higher_then_model(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        '1,example,,,,,,,,,,,,,,,,,\n'
-        '2,,resource,,,,xml,,resource.xml,,,,,,,,,,\n'
-        ',,,,,,,,,,,,,,,,,,\n'
-        '3,,,,Pavadinimas,,,id,,,4,,package,protected,,,Pavadinimas,,\n'
-        '4,,,,,id,integer,,,,4,,public,protected,,,ID,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        "1,example,,,,,,,,,,,,,,,,,\n"
+        "2,,resource,,,,xml,,resource.xml,,,,,,,,,,\n"
+        ",,,,,,,,,,,,,,,,,,\n"
+        "3,,,,Pavadinimas,,,id,,,4,,package,protected,,,Pavadinimas,,\n"
+        "4,,,,,id,integer,,,,4,,public,protected,,,ID,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -2604,29 +2348,26 @@ def test_structure_with_property_level_higher_then_model(app: DjangoTestApp):
         Comment.objects.filter(
             type=Comment.STRUCTURE_ERROR,
             content_type=ContentType.objects.get_for_model(Model),
-        ).values_list('body', flat=True)
+        ).values_list("body", flat=True)
     ) == [
-               'Duomenų lauko "id" metaduomenų matomumo lygis "public" '
-               'negali būti aukštesnis už modelio metaduomenų matomumo lygį "package". '
+        'Duomenų lauko "id" metaduomenų matomumo lygis "public" '
+        'negali būti aukštesnis už modelio metaduomenų matomumo lygį "package". '
     ]
+
 
 @pytest.mark.django_db
 def test_structure_with_enum_level_higher_then_property(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        '1,example,,,,,,,,,,,,,,,,,\n'
-        '2,,resource,,,,xml,,resource.xml,,,,,,,,,,\n'
-        ',,,,,,,,,,,,,,,,,,\n'
-        '3,,,,Pavadinimas,,,id,,,4,,package,protected,,,Pavadinimas,,\n'
-        '4,,,,,id,integer,,,,4,,package,protected,,,ID,,\n'
-        '5,,,,,class,integer,,,,4,,package,protected,,,class,,\n'
-        '6,,,,,,enum,,1,,4,,public,protected,,,Class One,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        "1,example,,,,,,,,,,,,,,,,,\n"
+        "2,,resource,,,,xml,,resource.xml,,,,,,,,,,\n"
+        ",,,,,,,,,,,,,,,,,,\n"
+        "3,,,,Pavadinimas,,,id,,,4,,package,protected,,,Pavadinimas,,\n"
+        "4,,,,,id,integer,,,,4,,package,protected,,,ID,,\n"
+        "5,,,,,class,integer,,,,4,,package,protected,,,class,,\n"
+        "6,,,,,,enum,,1,,4,,public,protected,,,Class One,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -2634,29 +2375,26 @@ def test_structure_with_enum_level_higher_then_property(app: DjangoTestApp):
         Comment.objects.filter(
             type=Comment.STRUCTURE_ERROR,
             content_type=ContentType.objects.get_for_model(Property),
-        ).values_list('body', flat=True)
+        ).values_list("body", flat=True)
     ) == [
-               'Duomenų reikšmės "Class One" metaduomenų matomumo lygis "public" '
-               'negali būti aukštesnis už duomenų lauko metaduomenų matomumo lygį "package". '
+        'Duomenų reikšmės "Class One" metaduomenų matomumo lygis "public" '
+        'negali būti aukštesnis už duomenų lauko metaduomenų matomumo lygį "package". '
     ]
+
 
 @pytest.mark.django_db
 def test_structure_with_enum_level_higher_then_model(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        '1,example,,,,,,,,,,,,,,,,,\n'
-        '2,,resource,,,,xml,,resource.xml,,,,,,,,,,\n'
-        ',,,,,,,,,,,,,,,,,,\n'
-        '3,,,,Pavadinimas,,,id,,,4,,package,protected,,,Pavadinimas,,\n'
-        '4,,,,,id,integer,,,,4,,package,protected,,,ID,,\n'
-        '5,,,,,class,integer,,,,4,,,protected,,,class,,\n'
-        '6,,,,,,enum,,1,,4,,public,protected,,,Class One,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        "1,example,,,,,,,,,,,,,,,,,\n"
+        "2,,resource,,,,xml,,resource.xml,,,,,,,,,,\n"
+        ",,,,,,,,,,,,,,,,,,\n"
+        "3,,,,Pavadinimas,,,id,,,4,,package,protected,,,Pavadinimas,,\n"
+        "4,,,,,id,integer,,,,4,,package,protected,,,ID,,\n"
+        "5,,,,,class,integer,,,,4,,,protected,,,class,,\n"
+        "6,,,,,,enum,,1,,4,,public,protected,,,Class One,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -2664,24 +2402,21 @@ def test_structure_with_enum_level_higher_then_model(app: DjangoTestApp):
         Comment.objects.filter(
             type=Comment.STRUCTURE_ERROR,
             content_type=ContentType.objects.get_for_model(Property),
-        ).values_list('body', flat=True)
+        ).values_list("body", flat=True)
     ) == [
-               'Duomenų reikšmės "Class One" metaduomenų matomumo lygis "public" '
-               'negali būti aukštesnis už duomenų modelio metaduomenų matomumo lygį "package". '
+        'Duomenų reikšmės "Class One" metaduomenų matomumo lygis "public" '
+        'negali būti aukštesnis už duomenų modelio metaduomenų matomumo lygį "package". '
     ]
+
 
 @pytest.mark.django_db
 def test_structure_with_origin_source_type_headers(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,level,status,visibility,access,uri,eli,title,description,count\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,,\n'
-        ',,,,City,,,,,,,,,,,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,level,status,visibility,access,uri,eli,title,description,count\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,,\n"
+        ",,,,City,,,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     metadata_version = create_structure_objects(structure)
@@ -2690,7 +2425,7 @@ def test_structure_with_origin_source_type_headers(app: DjangoTestApp):
         metadata_version=metadata_version,
     )
     assert metadata.count() == 1
-    assert sorted(list(metadata.values_list('name', flat=True))) == [
-        'datasets/gov/ivpk/adp',
+    assert sorted(list(metadata.values_list("name", flat=True))) == [
+        "datasets/gov/ivpk/adp",
     ]
     assert Comment.objects.filter(type=Comment.STRUCTURE_ERROR).count() == 0

--- a/tests/structure/test_services.py
+++ b/tests/structure/test_services.py
@@ -734,8 +734,8 @@ def test_structure_without_resource_and_existing_distribution(app: DjangoTestApp
     create_structure_objects(structure, metadata_version)
 
     assert DatasetDistribution.objects.count() == 1
-    assert Model.objects.get(metadata__uuid='1').distribution == None
-    assert Model.objects.get(metadata__uuid='2').distribution == None
+    assert Model.objects.get(metadata__uuid='1').distribution is None
+    assert Model.objects.get(metadata__uuid='2').distribution is None
     assert structure.dataset.status == Dataset.HAS_DATA
 
 
@@ -772,8 +772,8 @@ def test_structure_without_resource_and_existing_distribution_without_title(app:
     distribution.refresh_from_db()
     distribution.set_current_language("lt")
     assert DatasetDistribution.objects.count() == 1
-    assert Model.objects.get(metadata__uuid='1').distribution == None
-    assert Model.objects.get(metadata__uuid='2').distribution == None
+    assert Model.objects.get(metadata__uuid='1').distribution is None
+    assert Model.objects.get(metadata__uuid='2').distribution is None
     assert structure.dataset.status == Dataset.HAS_DATA
     assert distribution.title == "adp"
 
@@ -808,8 +808,8 @@ def test_structure_without_resource_and_existing_distribution_without_ns(app: Dj
     create_structure_objects(structure, metadata_version)
 
     assert DatasetDistribution.objects.count() == 1
-    assert Model.objects.get(metadata__uuid='1').distribution == None
-    assert Model.objects.get(metadata__uuid='2').distribution == None
+    assert Model.objects.get(metadata__uuid='1').distribution is None
+    assert Model.objects.get(metadata__uuid='2').distribution is None
     assert structure.dataset.status == Dataset.HAS_DATA
 
 

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -26,8 +26,18 @@ from vitrina.resources.factories import DatasetDistributionFactory
 from vitrina.resources.models import DatasetDistribution
 from vitrina.settings import SPINTA_SERVER_URL
 from vitrina.structure import VersionStatus
-from vitrina.structure.factories import ModelFactory, MetadataFactory, PropertyFactory, EnumFactory, EnumItemFactory, \
-    PrefixFactory, ParamItemFactory, ParamFactory, BaseFactory, VersionFactory
+from vitrina.structure.factories import (
+    ModelFactory,
+    MetadataFactory,
+    PropertyFactory,
+    EnumFactory,
+    EnumItemFactory,
+    PrefixFactory,
+    ParamItemFactory,
+    ParamFactory,
+    BaseFactory,
+    VersionFactory,
+)
 from vitrina.structure.models import Metadata, Enum, EnumItem, VersionType, Model, Property, Base
 from vitrina.structure.services import create_structure_objects
 from vitrina.users.factories import UserFactory
@@ -60,43 +70,30 @@ def test_model_data(app: DjangoTestApp):
         content_type=ContentType.objects.get_for_model(prop_1),
         object_id=prop_1.pk,
         dataset=dataset,
-        name='prop_1',
-        type='string',
+        name="prop_1",
+        type="string",
         metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop_2),
         object_id=prop_2.pk,
         dataset=dataset,
-        name='prop_2',
-        type='integer',
-        metadata_version = version,
+        name="prop_2",
+        type="integer",
+        metadata_version=version,
     )
     data = {
-        '_data': [
-            {
-                '_id': 'c7d66fa2-a880-443d-8ab5-2ab7f9c79886',
-                'prop_1': "test 1",
-                'prop_2': 1
-            },
-            {
-                '_id': '5bfd5a54-0ded-4803-9363-349f6e1b4523',
-                'prop_1': "test 2",
-                'prop_2': 2
-            }
+        "_data": [
+            {"_id": "c7d66fa2-a880-443d-8ab5-2ab7f9c79886", "prop_1": "test 1", "prop_2": 1},
+            {"_id": "5bfd5a54-0ded-4803-9363-349f6e1b4523", "prop_1": "test 2", "prop_2": 2},
         ]
     }
-    resp = app.post(reverse('model-data-table', args=[dataset.pk, version.pk, model.name]), {
-        'data': json.dumps(data)
-    })
-    assert resp.context['headers'] == ['_id', 'prop_1', 'prop_2']
-    assert resp.context['properties'] == {
-        'prop_1': prop_1,
-        'prop_2': prop_2
-    }
-    assert resp.context['tags'] == []
-    assert resp.context['select'] == 'select(*)'
-    assert resp.context['selected_cols'] == ['_id', 'prop_1', 'prop_2']
+    resp = app.post(reverse("model-data-table", args=[dataset.pk, version.pk, model.name]), {"data": json.dumps(data)})
+    assert resp.context["headers"] == ["_id", "prop_1", "prop_2"]
+    assert resp.context["properties"] == {"prop_1": prop_1, "prop_2": prop_2}
+    assert resp.context["tags"] == []
+    assert resp.context["select"] == "select(*)"
+    assert resp.context["selected_cols"] == ["_id", "prop_1", "prop_2"]
 
 
 @pytest.mark.django_db
@@ -109,7 +106,7 @@ def test_model_data_select(app: DjangoTestApp):
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        metadata_version = version,
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
@@ -124,34 +121,31 @@ def test_model_data_select(app: DjangoTestApp):
         content_type=ContentType.objects.get_for_model(prop_1),
         object_id=prop_1.pk,
         dataset=dataset,
-        name='prop_1',
-        type='string',
+        name="prop_1",
+        type="string",
         metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop_2),
         object_id=prop_2.pk,
         dataset=dataset,
-        name='prop_2',
-        type='integer',
+        name="prop_2",
+        type="integer",
         metadata_version=version,
     )
 
-    data = {
-        '_data': [
-            {'prop_1': 'test 1'},
-            {'prop_1': 'test 2'}
-        ]
-    }
-    resp = app.post(reverse(
-        'model-data-table', args=[dataset.pk, version.pk, model.name]), {
-        'data': json.dumps(data),
-        'query': "?select(prop_1)",
-    })
-    assert resp.context['headers'] == ['prop_1']
-    assert resp.context['tags'] == []
-    assert resp.context['select'] == 'select(prop_1)'
-    assert resp.context['selected_cols'] == ['prop_1']
+    data = {"_data": [{"prop_1": "test 1"}, {"prop_1": "test 2"}]}
+    resp = app.post(
+        reverse("model-data-table", args=[dataset.pk, version.pk, model.name]),
+        {
+            "data": json.dumps(data),
+            "query": "?select(prop_1)",
+        },
+    )
+    assert resp.context["headers"] == ["prop_1"]
+    assert resp.context["tags"] == []
+    assert resp.context["select"] == "select(prop_1)"
+    assert resp.context["selected_cols"] == ["prop_1"]
 
 
 @pytest.mark.django_db
@@ -164,7 +158,7 @@ def test_model_data_sort(app: DjangoTestApp):
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        metadata_version = version,
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
@@ -179,38 +173,40 @@ def test_model_data_sort(app: DjangoTestApp):
         content_type=ContentType.objects.get_for_model(prop_1),
         object_id=prop_1.pk,
         dataset=dataset,
-        name='prop_1',
-        type='string',
+        name="prop_1",
+        type="string",
         metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop_2),
         object_id=prop_2.pk,
         dataset=dataset,
-        name='prop_2',
-        type='integer',
+        name="prop_2",
+        type="integer",
         metadata_version=version,
     )
 
     data = {
-        '_data': [
-            {'prop_1': 'test 2'},
-            {'prop_1': 'test 1'},
+        "_data": [
+            {"prop_1": "test 2"},
+            {"prop_1": "test 1"},
         ]
     }
-    resp = app.post(reverse(
-        'model-data-table', args=[dataset.pk, version.pk, model.name]), {
-        'data': json.dumps(data),
-        'query': "?select(prop_1)&sort(-prop_1)",
-    })
-    assert resp.context['headers'] == ['prop_1']
-    assert resp.context['tags'] == ['sort(-prop_1)']
-    assert resp.context['select'] == 'select(prop_1)'
-    assert resp.context['selected_cols'] == ['prop_1']
+    resp = app.post(
+        reverse("model-data-table", args=[dataset.pk, version.pk, model.name]),
+        {
+            "data": json.dumps(data),
+            "query": "?select(prop_1)&sort(-prop_1)",
+        },
+    )
+    assert resp.context["headers"] == ["prop_1"]
+    assert resp.context["tags"] == ["sort(-prop_1)"]
+    assert resp.context["select"] == "select(prop_1)"
+    assert resp.context["selected_cols"] == ["prop_1"]
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("operator", ['=', '<' '>' '<=', '>='])
+@pytest.mark.parametrize("operator", ["=", "<><=", ">="])
 def test_model_data_with_compare_operators(app: DjangoTestApp, operator: str):
     version = VersionFactory()
     model = ModelFactory(dataset=version.dataset, metadata_version=version)
@@ -220,7 +216,7 @@ def test_model_data_with_compare_operators(app: DjangoTestApp, operator: str):
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        metadata_version = version,
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
@@ -235,37 +231,39 @@ def test_model_data_with_compare_operators(app: DjangoTestApp, operator: str):
         content_type=ContentType.objects.get_for_model(prop_1),
         object_id=prop_1.pk,
         dataset=dataset,
-        name='prop_1',
-        type='string',
+        name="prop_1",
+        type="string",
         metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop_2),
         object_id=prop_2.pk,
         dataset=dataset,
-        name='prop_2',
-        type='integer',
+        name="prop_2",
+        type="integer",
         metadata_version=version,
     )
 
     data = {
-        '_data': [
-            {'prop_2': 2},
+        "_data": [
+            {"prop_2": 2},
         ]
     }
-    resp = app.post(reverse(
-        'model-data-table', args=[dataset.pk, version.pk, model.name]), {
-        'data': json.dumps(data),
-        'query': f"?select(prop_2)&prop_2{operator}2",
-    })
-    assert resp.context['headers'] == ['prop_2']
-    assert resp.context['tags'] == [f'prop_2{operator}2']
-    assert resp.context['select'] == 'select(prop_2)'
-    assert resp.context['selected_cols'] == ['prop_2']
+    resp = app.post(
+        reverse("model-data-table", args=[dataset.pk, version.pk, model.name]),
+        {
+            "data": json.dumps(data),
+            "query": f"?select(prop_2)&prop_2{operator}2",
+        },
+    )
+    assert resp.context["headers"] == ["prop_2"]
+    assert resp.context["tags"] == [f"prop_2{operator}2"]
+    assert resp.context["select"] == "select(prop_2)"
+    assert resp.context["selected_cols"] == ["prop_2"]
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("operator", ['contains', 'startswith', 'endswith'])
+@pytest.mark.parametrize("operator", ["contains", "startswith", "endswith"])
 def test_model_data_with_string_operators(app: DjangoTestApp, operator: str):
     version = VersionFactory()
     model = ModelFactory(dataset=version.dataset, metadata_version=version)
@@ -275,7 +273,7 @@ def test_model_data_with_string_operators(app: DjangoTestApp, operator: str):
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        metadata_version = version,
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
@@ -290,33 +288,35 @@ def test_model_data_with_string_operators(app: DjangoTestApp, operator: str):
         content_type=ContentType.objects.get_for_model(prop_1),
         object_id=prop_1.pk,
         dataset=dataset,
-        name='prop_1',
-        type='string',
+        name="prop_1",
+        type="string",
         metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop_2),
         object_id=prop_2.pk,
         dataset=dataset,
-        name='prop_2',
-        type='integer',
+        name="prop_2",
+        type="integer",
         metadata_version=version,
     )
 
     data = {
-        '_data': [
-            {'prop_1': 'test 1'},
+        "_data": [
+            {"prop_1": "test 1"},
         ]
     }
-    resp = app.post(reverse(
-        'model-data-table', args=[dataset.pk, version.pk, model.name]), {
-        'data': json.dumps(data),
-        'query': f"?select(prop_1)&{operator}('test')",
-    })
-    assert resp.context['headers'] == ['prop_1']
-    assert resp.context['tags'] == [f"{operator}('test')"]
-    assert resp.context['select'] == 'select(prop_1)'
-    assert resp.context['selected_cols'] == ['prop_1']
+    resp = app.post(
+        reverse("model-data-table", args=[dataset.pk, version.pk, model.name]),
+        {
+            "data": json.dumps(data),
+            "query": f"?select(prop_1)&{operator}('test')",
+        },
+    )
+    assert resp.context["headers"] == ["prop_1"]
+    assert resp.context["tags"] == [f"{operator}('test')"]
+    assert resp.context["select"] == "select(prop_1)"
+    assert resp.context["selected_cols"] == ["prop_1"]
 
 
 @pytest.mark.django_db
@@ -329,7 +329,7 @@ def test_object_data(app: DjangoTestApp):
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        metadata_version = version,
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
@@ -344,38 +344,28 @@ def test_object_data(app: DjangoTestApp):
         content_type=ContentType.objects.get_for_model(prop_1),
         object_id=prop_1.pk,
         dataset=dataset,
-        name='prop_1',
-        type='string',
+        name="prop_1",
+        type="string",
         metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop_2),
         object_id=prop_2.pk,
         dataset=dataset,
-        name='prop_2',
-        type='integer',
+        name="prop_2",
+        type="integer",
         metadata_version=version,
     )
 
-    data = {
-        '_id': 'c7d66fa2-a880-443d-8ab5-2ab7f9c79886',
-        'prop_1': "test 1",
-        'prop_2': 1
-    }
-    resp = app.post(reverse(
-        'object-data-table', args=[
-            dataset.pk,
-            version.pk,
-            model.name,
-            'c7d66fa2-a880-443d-8ab5-2ab7f9c79886'
-        ]), {
-        'data': json.dumps(data),
-    })
-    assert resp.context['headers'] == ['_id', 'prop_1', 'prop_2']
-    assert resp.context['properties'] == {
-        'prop_1': prop_1,
-        'prop_2': prop_2
-    }
+    data = {"_id": "c7d66fa2-a880-443d-8ab5-2ab7f9c79886", "prop_1": "test 1", "prop_2": 1}
+    resp = app.post(
+        reverse("object-data-table", args=[dataset.pk, version.pk, model.name, "c7d66fa2-a880-443d-8ab5-2ab7f9c79886"]),
+        {
+            "data": json.dumps(data),
+        },
+    )
+    assert resp.context["headers"] == ["_id", "prop_1", "prop_2"]
+    assert resp.context["properties"] == {"prop_1": prop_1, "prop_2": prop_2}
 
 
 @pytest.mark.django_db
@@ -402,14 +392,14 @@ def test_structure_tab_from_dataset_detail(app: DjangoTestApp):
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
+        name="prop",
+        type="string",
         metadata_version=version,
     )
 
     resp = app.get(dataset.get_absolute_url()).follow()
-    resp = resp.click(linkid='structure_tab').follow()
-    assert resp.request.path == reverse('dataset-structure', args=[dataset.pk, version.pk])
+    resp = resp.click(linkid="structure_tab").follow()
+    assert resp.request.path == reverse("dataset-structure", args=[dataset.pk, version.pk])
 
 
 @pytest.mark.django_db
@@ -436,14 +426,14 @@ def test_structure_tab_from_model_structure(app: DjangoTestApp):
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
+        name="prop",
+        type="string",
         metadata_version=version,
     )
 
     resp = app.get(model.get_absolute_url())
-    resp = resp.click(linkid='structure_tab')
-    assert resp.request.path == reverse('dataset-structure', args=[dataset.pk, version.pk])
+    resp = resp.click(linkid="structure_tab")
+    assert resp.request.path == reverse("dataset-structure", args=[dataset.pk, version.pk])
 
 
 @pytest.mark.django_db
@@ -470,14 +460,14 @@ def test_structure_tab_from_property_structure(app: DjangoTestApp):
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
+        name="prop",
+        type="string",
         metadata_version=version,
     )
 
     resp = app.get(prop.get_absolute_url())
-    resp = resp.click(linkid='structure_tab')
-    assert resp.request.path == reverse('dataset-structure', args=[dataset.pk, version.pk])
+    resp = resp.click(linkid="structure_tab")
+    assert resp.request.path == reverse("dataset-structure", args=[dataset.pk, version.pk])
 
 
 @pytest.mark.django_db
@@ -504,14 +494,15 @@ def test_structure_tab_from_model_data(app: DjangoTestApp):
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
+        name="prop",
+        type="string",
         metadata_version=version,
     )
 
     resp = app.get(model.get_data_url())
-    resp = resp.click(linkid='structure_tab')
+    resp = resp.click(linkid="structure_tab")
     assert resp.request.path == model.get_absolute_url()
+
 
 @pytest.mark.skip(reason="Not sure if test is correct")
 @pytest.mark.django_db
@@ -538,14 +529,14 @@ def test_data_tab_from_dataset_detail(app: DjangoTestApp):
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
+        name="prop",
+        type="string",
         metadata_version=version,
     )
 
     resp = app.get(dataset.get_absolute_url())
 
-    resp = resp.click(linkid='data_tab')
+    resp = resp.click(linkid="data_tab")
     assert resp.request.path == model.get_data_url()
 
 
@@ -573,13 +564,13 @@ def test_data_tab_from_dataset_structure(app: DjangoTestApp):
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
+        name="prop",
+        type="string",
         metadata_version=version,
     )
 
-    resp = app.get(reverse('dataset-structure', args=[dataset.pk, version.pk]))
-    resp = resp.click(linkid='data_tab')
+    resp = app.get(reverse("dataset-structure", args=[dataset.pk, version.pk]))
+    resp = resp.click(linkid="data_tab")
     assert resp.request.path == model.get_data_url()
 
 
@@ -607,13 +598,13 @@ def test_data_tab_from_model_structure(app: DjangoTestApp):
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
+        name="prop",
+        type="string",
         metadata_version=version,
     )
 
     resp = app.get(model.get_absolute_url())
-    resp = resp.click(linkid='data_tab')
+    resp = resp.click(linkid="data_tab")
     assert resp.request.path == model.get_data_url()
 
 
@@ -641,13 +632,13 @@ def test_data_tab_from_property_structure(app: DjangoTestApp):
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
+        name="prop",
+        type="string",
         metadata_version=version,
     )
 
     resp = app.get(prop.get_absolute_url())
-    resp = resp.click(linkid='data_tab')
+    resp = resp.click(linkid="data_tab")
     assert resp.request.path == model.get_data_url()
 
 
@@ -675,13 +666,13 @@ def test_data_tab_from_object_data(app: DjangoTestApp):
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
+        name="prop",
+        type="string",
         metadata_version=version,
     )
 
-    resp = app.get(reverse('object-data', args=[dataset.pk, version.pk, model.name, str(uuid.uuid4())]))
-    resp = resp.click(linkid='data_tab')
+    resp = app.get(reverse("object-data", args=[dataset.pk, version.pk, model.name, str(uuid.uuid4())]))
+    resp = resp.click(linkid="data_tab")
     assert resp.request.path == model.get_data_url()
 
 
@@ -690,71 +681,59 @@ def test_private_model(app: DjangoTestApp):
     user = UserFactory()
     app.set_user(user)
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,Country,,,,,,,,,,,,,,\n'
-        ',,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
-        ',,,,,title,string,,,,5,,,private,,dct:title,,,\n'
-        ',,,,City,,,,,,,,,,,,,,\n'
-        ',,,,,id,integer,,,,5,,,private,dct:identifier,,Identifikatorius,,\n'
-        ',,,,,title,string,,,,5,,,private,dct:title,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,Country,,,,,,,,,,,,,,\n"
+        ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
+        ",,,,,title,string,,,,5,,,private,,dct:title,,,\n"
+        ",,,,City,,,,,,,,,,,,,,\n"
+        ",,,,,id,integer,,,,5,,,private,dct:identifier,,Identifikatorius,,\n"
+        ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
 
-    resp = app.get(reverse('dataset-structure', args=[structure.dataset.pk, version.pk]))
-    assert list(resp.context['models'].values_list('metadata__name', flat=True)) == [
-        'datasets/gov/ivpk/adp/Country'
-    ]
+    resp = app.get(reverse("dataset-structure", args=[structure.dataset.pk, version.pk]))
+    assert list(resp.context["models"].values_list("metadata__name", flat=True)) == ["datasets/gov/ivpk/adp/Country"]
 
-    resp = app.get(reverse('model-structure', args=[structure.dataset.pk, version.pk, 'City']), expect_errors=True)
+    resp = app.get(reverse("model-structure", args=[structure.dataset.pk, version.pk, "City"]), expect_errors=True)
     assert resp.status_code == 403
 
 
 @pytest.mark.django_db
 def test_private_model_with_access(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,Country,,,,,,,,,,,,,,\n'
-        ',,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
-        ',,,,,title,string,,,,5,,,private,dct:title,,,,\n'
-        ',,,,City,,,,,,,,,,,,,,\n'
-        ',,,,,id,integer,,,,5,,,private,dct:identifier,,Identifikatorius,,\n'
-        ',,,,,title,string,,,,5,,,private,dct:title,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,Country,,,,,,,,,,,,,,\n"
+        ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
+        ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
+        ",,,,City,,,,,,,,,,,,,,\n"
+        ",,,,,id,integer,,,,5,,,private,dct:identifier,,Identifikatorius,,\n"
+        ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
 
     ct = ContentType.objects.get_for_model(structure.dataset)
     representative = RepresentativeFactory(
-        content_type=ct,
-        object_id=structure.dataset.pk,
-        role=Representative.RESOURCE_MANAGER
+        content_type=ct, object_id=structure.dataset.pk, role=Representative.RESOURCE_MANAGER
     )
     app.set_user(representative.user)
 
-    resp = app.get(reverse('dataset-structure', args=[structure.dataset.pk, version.pk]))
-    assert list(resp.context['models'].values_list('metadata__name', flat=True)) == [
-        'datasets/gov/ivpk/adp/City',
-        'datasets/gov/ivpk/adp/Country'
+    resp = app.get(reverse("dataset-structure", args=[structure.dataset.pk, version.pk]))
+    assert list(resp.context["models"].values_list("metadata__name", flat=True)) == [
+        "datasets/gov/ivpk/adp/City",
+        "datasets/gov/ivpk/adp/Country",
     ]
 
-    resp = app.get(reverse('model-structure', args=[structure.dataset.pk, version.pk, 'City']))
+    resp = app.get(reverse("model-structure", args=[structure.dataset.pk, version.pk, "City"]))
     assert resp.status_code == 200
 
 
@@ -763,49 +742,38 @@ def test_private_property(app: DjangoTestApp):
     user = UserFactory()
     app.set_user(user)
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,Country,,,,,,,,,,,,,,\n'
-        ',,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
-        ',,,,,title,string,,,,5,,,private,dct:title,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,Country,,,,,,,,,,,,,,\n"
+        ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
+        ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
 
-    resp = app.get(reverse('model-structure', args=[structure.dataset.pk, version.pk, 'Country']))
-    assert list(resp.context['props'].values_list('metadata__name', flat=True)) == ['id']
+    resp = app.get(reverse("model-structure", args=[structure.dataset.pk, version.pk, "Country"]))
+    assert list(resp.context["props"].values_list("metadata__name", flat=True)) == ["id"]
 
-    resp = app.get(reverse('property-structure', args=[
-        structure.dataset.pk,
-        version.pk,
-        'Country',
-        'title'
-    ]), expect_errors=True)
+    resp = app.get(
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "Country", "title"]), expect_errors=True
+    )
     assert resp.status_code == 403
 
 
 @pytest.mark.django_db
 def test_private_property_with_access(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,Country,,,,,,,,,,,,,,\n'
-        ',,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
-        ',,,,,title,string,,,,5,,,private,dct:title,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,Country,,,,,,,,,,,,,,\n"
+        ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
+        ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -817,15 +785,12 @@ def test_private_property_with_access(app: DjangoTestApp):
     )
     app.set_user(representative.user)
 
-    resp = app.get(reverse('model-structure', args=[structure.dataset.pk, version.pk, 'Country']))
-    assert list(resp.context['props'].values_list('metadata__name', flat=True)) == ['id', 'title']
+    resp = app.get(reverse("model-structure", args=[structure.dataset.pk, version.pk, "Country"]))
+    assert list(resp.context["props"].values_list("metadata__name", flat=True)) == ["id", "title"]
 
-    resp = app.get(reverse('property-structure', args=[
-        structure.dataset.pk,
-        version.pk,
-        'Country',
-        'title'
-    ]), expect_errors=True)
+    resp = app.get(
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "Country", "title"]), expect_errors=True
+    )
     assert resp.status_code == 200
 
 
@@ -834,45 +799,35 @@ def test_private_comment(app: DjangoTestApp):
     user = UserFactory()
     app.set_user(user)
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,Country,,,,,,,,,,,,,,\n'
-        ',,,,,,comment,type,,,,,,public,,,Public comment,,\n'
-        ',,,,,,comment,type,,,,,,private,,,Private comment,,\n'
-        ',,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,Country,,,,,,,,,,,,,,\n"
+        ",,,,,,comment,type,,,,,,public,,,Public comment,,\n"
+        ",,,,,,comment,type,,,,,,private,,,Private comment,,\n"
+        ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
 
-    resp = app.get(reverse('model-structure', args=[structure.dataset.pk, version.pk, 'Country']))
-    assert sorted([comment.body for comment, _, _ in resp.context['comments']]) == [
-        'Public comment'
-    ]
+    resp = app.get(reverse("model-structure", args=[structure.dataset.pk, version.pk, "Country"]))
+    assert sorted([comment.body for comment, _, _ in resp.context["comments"]]) == ["Public comment"]
 
 
 @pytest.mark.django_db
 def test_private_comment_with_access(app: DjangoTestApp):
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,Country,,,,,,,,,,,\n'
-        ',,,,,,comment,type,,,,public,,,,,Public comment,,\n'
-        ',,,,,,comment,type,,,,private,,,,,Private comment,,\n'
-        ',,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,Country,,,,,,,,,,,\n"
+        ",,,,,,comment,type,,,,public,,,,,Public comment,,\n"
+        ",,,,,,comment,type,,,,private,,,,,Private comment,,\n"
+        ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -884,10 +839,10 @@ def test_private_comment_with_access(app: DjangoTestApp):
     )
     app.set_user(representative.user)
 
-    resp = app.get(reverse('model-structure', args=[structure.dataset.pk, version.pk, 'Country']))
-    assert sorted([comment.body for comment, _, _ in resp.context['comments']]) == [
-        'Private comment',
-        'Public comment',
+    resp = app.get(reverse("model-structure", args=[structure.dataset.pk, version.pk, "Country"]))
+    assert sorted([comment.body for comment, _, _ in resp.context["comments"]]) == [
+        "Private comment",
+        "Public comment",
     ]
 
 
@@ -915,58 +870,47 @@ def test_getall(app: DjangoTestApp):
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
+        name="prop",
+        type="string",
         metadata_version=version,
     )
 
-    with patch('vitrina.structure.services.requests.get') as mock_get:
+    with patch("vitrina.structure.services.requests.get") as mock_get:
         data = {
-            '_data': [
-                {
-                    '_id': 'c7d66fa2-a880-443d-8ab5-2ab7f9c79886',
-                    'prop_1': "test 1",
-                    'prop_2': 1
-                },
+            "_data": [
+                {"_id": "c7d66fa2-a880-443d-8ab5-2ab7f9c79886", "prop_1": "test 1", "prop_2": 1},
             ]
         }
         mock_get.return_value = Mock(content=json.dumps(data))
-        resp = app.get(reverse('getall-api', args=[dataset.pk, version.pk, model.name]))
-        assert resp.context['tabs'] == {
-            'http': {
-                'name': 'HTTP',
-                'query': highlight(
-                    f"{SPINTA_SERVER_URL}/test/dataset/TestModel",
-                    TextLexer(), HtmlFormatter()
-                )
+        resp = app.get(reverse("getall-api", args=[dataset.pk, version.pk, model.name]))
+        assert resp.context["tabs"] == {
+            "http": {
+                "name": "HTTP",
+                "query": highlight(f"{SPINTA_SERVER_URL}/test/dataset/TestModel", TextLexer(), HtmlFormatter()),
             },
-            'httpie': {
-                'name': 'HTTPie',
-                'query': highlight(
-                    f'http GET "{SPINTA_SERVER_URL}/test/dataset/TestModel"',
-                    TextLexer(), HtmlFormatter()
-                )
+            "httpie": {
+                "name": "HTTPie",
+                "query": highlight(
+                    f'http GET "{SPINTA_SERVER_URL}/test/dataset/TestModel"', TextLexer(), HtmlFormatter()
+                ),
             },
-            'curl': {
-                'name': 'curl',
-                'query': highlight(
-                    f'curl "{SPINTA_SERVER_URL}/test/dataset/TestModel"',
-                    TextLexer(), HtmlFormatter()
-                )
-            }
+            "curl": {
+                "name": "curl",
+                "query": highlight(f'curl "{SPINTA_SERVER_URL}/test/dataset/TestModel"', TextLexer(), HtmlFormatter()),
+            },
         }
-        assert resp.context['response'] == highlight(
-            json.dumps({
-                '_data': [
-                    {
-                        '_id': 'c7d66fa2-a880-443d-8ab5-2ab7f9c79886',
-                        'prop_1': "test 1",
-                        'prop_2': 1
-                    },
-                ]
-            }, indent=2, ensure_ascii=False),
+        assert resp.context["response"] == highlight(
+            json.dumps(
+                {
+                    "_data": [
+                        {"_id": "c7d66fa2-a880-443d-8ab5-2ab7f9c79886", "prop_1": "test 1", "prop_2": 1},
+                    ]
+                },
+                indent=2,
+                ensure_ascii=False,
+            ),
             JsonLexer(),
-            HtmlFormatter(style=get_style_by_name('borland'), noclasses=True)
+            HtmlFormatter(style=get_style_by_name("borland"), noclasses=True),
         )
 
 
@@ -994,59 +938,60 @@ def test_getall_with_query(app: DjangoTestApp):
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
+        name="prop",
+        type="string",
         metadata_version=version,
     )
 
-    with patch('vitrina.structure.services.requests.get') as mock_get:
+    with patch("vitrina.structure.services.requests.get") as mock_get:
         data = {
-            '_data': [
-                {
-                    '_id': '5bfd5a54-0ded-4803-9363-349f6e1b4523',
-                    'prop_2': 2
-                },
+            "_data": [
+                {"_id": "5bfd5a54-0ded-4803-9363-349f6e1b4523", "prop_2": 2},
             ]
         }
         mock_get.return_value = Mock(content=json.dumps(data))
-        resp = app.get("%s%s" % (
-            reverse('getall-api', args=[dataset.pk, version.pk, model.name]),
-            "?select(_id,prop_2)&sort(-prop2)"
-        ))
-        assert resp.context['tabs'] == {
-            'http': {
-                'name': 'HTTP',
-                'query': highlight(
+        resp = app.get(
+            "%s%s"
+            % (reverse("getall-api", args=[dataset.pk, version.pk, model.name]), "?select(_id,prop_2)&sort(-prop2)")
+        )
+        assert resp.context["tabs"] == {
+            "http": {
+                "name": "HTTP",
+                "query": highlight(
                     f"{SPINTA_SERVER_URL}/test/dataset/TestModel?select(_id,prop_2)&sort(-prop2)",
-                    TextLexer(), HtmlFormatter()
-                )
+                    TextLexer(),
+                    HtmlFormatter(),
+                ),
             },
-            'httpie': {
-                'name': 'HTTPie',
-                'query': highlight(
+            "httpie": {
+                "name": "HTTPie",
+                "query": highlight(
                     f'http GET "{SPINTA_SERVER_URL}/test/dataset/TestModel?select(_id,prop_2)&sort(-prop2)"',
-                    TextLexer(), HtmlFormatter()
-                )
+                    TextLexer(),
+                    HtmlFormatter(),
+                ),
             },
-            'curl': {
-                'name': 'curl',
-                'query': highlight(
+            "curl": {
+                "name": "curl",
+                "query": highlight(
                     f'curl "{SPINTA_SERVER_URL}/test/dataset/TestModel?select(_id,prop_2)&sort(-prop2)"',
-                    TextLexer(), HtmlFormatter()
-                )
-            }
+                    TextLexer(),
+                    HtmlFormatter(),
+                ),
+            },
         }
-        assert resp.context['response'] == highlight(
-            json.dumps({
-                '_data': [
-                    {
-                        '_id': '5bfd5a54-0ded-4803-9363-349f6e1b4523',
-                        'prop_2': 2
-                    },
-                ]
-            }, indent=2, ensure_ascii=False),
+        assert resp.context["response"] == highlight(
+            json.dumps(
+                {
+                    "_data": [
+                        {"_id": "5bfd5a54-0ded-4803-9363-349f6e1b4523", "prop_2": 2},
+                    ]
+                },
+                indent=2,
+                ensure_ascii=False,
+            ),
             JsonLexer(),
-            HtmlFormatter(style=get_style_by_name('borland'), noclasses=True)
+            HtmlFormatter(style=get_style_by_name("borland"), noclasses=True),
         )
 
 
@@ -1074,50 +1019,51 @@ def test_getone(app: DjangoTestApp):
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
+        name="prop",
+        type="string",
         metadata_version=version,
     )
 
-    with patch('vitrina.structure.services.requests.get') as mock_get:
-        data = {
-            '_id': 'c7d66fa2-a880-443d-8ab5-2ab7f9c79886',
-            'prop_1': "test 1",
-            'prop_2': 1
-        }
+    with patch("vitrina.structure.services.requests.get") as mock_get:
+        data = {"_id": "c7d66fa2-a880-443d-8ab5-2ab7f9c79886", "prop_1": "test 1", "prop_2": 1}
         mock_get.return_value = Mock(content=json.dumps(data))
-        resp = app.get(reverse('getone-api', args=[dataset.pk, version.pk, model.name, "c7d66fa2-a880-443d-8ab5-2ab7f9c79886"]))
-        assert resp.context['tabs'] == {
-            'http': {
-                'name': 'HTTP',
-                'query': highlight(
+        resp = app.get(
+            reverse("getone-api", args=[dataset.pk, version.pk, model.name, "c7d66fa2-a880-443d-8ab5-2ab7f9c79886"])
+        )
+        assert resp.context["tabs"] == {
+            "http": {
+                "name": "HTTP",
+                "query": highlight(
                     f"{SPINTA_SERVER_URL}/test/dataset/TestModel/c7d66fa2-a880-443d-8ab5-2ab7f9c79886",
-                    TextLexer(), HtmlFormatter()
-                )
+                    TextLexer(),
+                    HtmlFormatter(),
+                ),
             },
-            'httpie': {
-                'name': 'HTTPie',
-                'query': highlight(
+            "httpie": {
+                "name": "HTTPie",
+                "query": highlight(
                     f'http GET "{SPINTA_SERVER_URL}/test/dataset/TestModel/c7d66fa2-a880-443d-8ab5-2ab7f9c79886"',
-                    TextLexer(), HtmlFormatter()
-                )
+                    TextLexer(),
+                    HtmlFormatter(),
+                ),
             },
-            'curl': {
-                'name': 'curl',
-                'query': highlight(
+            "curl": {
+                "name": "curl",
+                "query": highlight(
                     f'curl "{SPINTA_SERVER_URL}/test/dataset/TestModel/c7d66fa2-a880-443d-8ab5-2ab7f9c79886"',
-                    TextLexer(), HtmlFormatter()
-                )
-            }
+                    TextLexer(),
+                    HtmlFormatter(),
+                ),
+            },
         }
-        assert resp.context['response'] == highlight(
-            json.dumps({
-                '_id': 'c7d66fa2-a880-443d-8ab5-2ab7f9c79886',
-                'prop_1': "test 1",
-                'prop_2': 1
-            }, indent=2, ensure_ascii=False),
+        assert resp.context["response"] == highlight(
+            json.dumps(
+                {"_id": "c7d66fa2-a880-443d-8ab5-2ab7f9c79886", "prop_1": "test 1", "prop_2": 1},
+                indent=2,
+                ensure_ascii=False,
+            ),
             JsonLexer(),
-            HtmlFormatter(style=get_style_by_name('borland'), noclasses=True)
+            HtmlFormatter(style=get_style_by_name("borland"), noclasses=True),
         )
 
 
@@ -1145,60 +1091,54 @@ def test_changes(app: DjangoTestApp):
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
+        name="prop",
+        type="string",
         metadata_version=version,
     )
 
-    with patch('vitrina.structure.services.requests.get') as mock_get:
+    with patch("vitrina.structure.services.requests.get") as mock_get:
         data = {
-            '_data': [
-                {
-                    '_id': 'c7d66fa2-a880-443d-8ab5-2ab7f9c79886',
-                    '_op': 'insert',
-                    'prop_1': "test 1",
-                    'prop_2': 1
-                }
-            ]
+            "_data": [{"_id": "c7d66fa2-a880-443d-8ab5-2ab7f9c79886", "_op": "insert", "prop_1": "test 1", "prop_2": 1}]
         }
         mock_get.return_value = Mock(content=json.dumps(data))
-        resp = app.get(reverse('changes-api', args=[dataset.pk, version.pk, model.name]))
-        assert resp.context['tabs'] == {
-            'http': {
-                'name': 'HTTP',
-                'query': highlight(
-                    f"{SPINTA_SERVER_URL}/test/dataset/TestModel/:changes",
-                    TextLexer(), HtmlFormatter()
-                )
+        resp = app.get(reverse("changes-api", args=[dataset.pk, version.pk, model.name]))
+        assert resp.context["tabs"] == {
+            "http": {
+                "name": "HTTP",
+                "query": highlight(
+                    f"{SPINTA_SERVER_URL}/test/dataset/TestModel/:changes", TextLexer(), HtmlFormatter()
+                ),
             },
-            'httpie': {
-                'name': 'HTTPie',
-                'query': highlight(
-                    f'http GET "{SPINTA_SERVER_URL}/test/dataset/TestModel/:changes"',
-                    TextLexer(), HtmlFormatter()
-                )
+            "httpie": {
+                "name": "HTTPie",
+                "query": highlight(
+                    f'http GET "{SPINTA_SERVER_URL}/test/dataset/TestModel/:changes"', TextLexer(), HtmlFormatter()
+                ),
             },
-            'curl': {
-                'name': 'curl',
-                'query': highlight(
-                    f'curl "{SPINTA_SERVER_URL}/test/dataset/TestModel/:changes"',
-                    TextLexer(), HtmlFormatter()
-                )
-            }
+            "curl": {
+                "name": "curl",
+                "query": highlight(
+                    f'curl "{SPINTA_SERVER_URL}/test/dataset/TestModel/:changes"', TextLexer(), HtmlFormatter()
+                ),
+            },
         }
-        assert resp.context['response'] == highlight(
-            json.dumps({
-                '_data': [
-                    {
-                        '_id': 'c7d66fa2-a880-443d-8ab5-2ab7f9c79886',
-                        '_op': 'insert',
-                        'prop_1': "test 1",
-                        'prop_2': 1
-                    },
-                ]
-            }, indent=2, ensure_ascii=False),
+        assert resp.context["response"] == highlight(
+            json.dumps(
+                {
+                    "_data": [
+                        {
+                            "_id": "c7d66fa2-a880-443d-8ab5-2ab7f9c79886",
+                            "_op": "insert",
+                            "prop_1": "test 1",
+                            "prop_2": 1,
+                        },
+                    ]
+                },
+                indent=2,
+                ensure_ascii=False,
+            ),
             JsonLexer(),
-            HtmlFormatter(style=get_style_by_name('borland'), noclasses=True)
+            HtmlFormatter(style=get_style_by_name("borland"), noclasses=True),
         )
 
 
@@ -1226,13 +1166,13 @@ def test_api_tab_from_model_data(app: DjangoTestApp):
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
+        name="prop",
+        type="string",
         metadata_version=version,
     )
 
-    resp = app.get(reverse('model-data', args=[dataset.pk, version.pk, model.name]))
-    resp = resp.click(linkid='api_tab')
+    resp = app.get(reverse("model-data", args=[dataset.pk, version.pk, model.name]))
+    resp = resp.click(linkid="api_tab")
     assert resp.request.path == model.get_api_url()
 
 
@@ -1260,20 +1200,14 @@ def test_api_tab_from_model_data_with_query(app: DjangoTestApp):
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
+        name="prop",
+        type="string",
         metadata_version=version,
     )
 
-    resp = app.get("%s%s" % (
-        reverse('model-data', args=[dataset.pk, version.pk, model.name]),
-        "?select(prop)"
-    ))
-    resp = resp.click(linkid='api_tab')
-    assert resp.request.path_qs == "%s%s" % (
-        model.get_api_url(),
-        "?select(prop)"
-    )
+    resp = app.get("%s%s" % (reverse("model-data", args=[dataset.pk, version.pk, model.name]), "?select(prop)"))
+    resp = resp.click(linkid="api_tab")
+    assert resp.request.path_qs == "%s%s" % (model.get_api_url(), "?select(prop)")
 
 
 @pytest.mark.django_db
@@ -1300,15 +1234,15 @@ def test_api_tab_from_object_data(app: DjangoTestApp):
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
+        name="prop",
+        type="string",
         metadata_version=version,
     )
 
     _id = str(uuid.uuid4())
-    resp = app.get(reverse('object-data', args=[dataset.pk, version.pk, model.name, _id]))
-    resp = resp.click(linkid='api_tab')
-    assert resp.request.path == reverse('getone-api', args=[dataset.pk, version.pk, model.name, _id])
+    resp = app.get(reverse("object-data", args=[dataset.pk, version.pk, model.name, _id]))
+    resp = resp.click(linkid="api_tab")
+    assert resp.request.path == reverse("getone-api", args=[dataset.pk, version.pk, model.name, _id])
 
 
 @pytest.mark.django_db
@@ -1335,15 +1269,15 @@ def test_data_tab_from_getone(app: DjangoTestApp):
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
+        name="prop",
+        type="string",
         metadata_version=version,
     )
 
     _id = str(uuid.uuid4())
-    resp = app.get(reverse('getone-api', args=[dataset.pk, version.pk, model.name, _id]))
-    resp = resp.click(linkid='data_tab')
-    assert resp.request.path == reverse('object-data', args=[dataset.pk, version.pk, model.name, _id])
+    resp = app.get(reverse("getone-api", args=[dataset.pk, version.pk, model.name, _id]))
+    resp = resp.click(linkid="data_tab")
+    assert resp.request.path == reverse("object-data", args=[dataset.pk, version.pk, model.name, _id])
 
 
 @pytest.mark.django_db
@@ -1370,14 +1304,14 @@ def test_data_tab_from_getall(app: DjangoTestApp):
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
+        name="prop",
+        type="string",
         metadata_version=version,
     )
 
-    resp = app.get(reverse('getall-api', args=[dataset.pk, version.pk, model.name]))
-    resp = resp.click(linkid='data_tab')
-    assert resp.request.path == reverse('model-data', args=[dataset.pk, version.pk, model.name])
+    resp = app.get(reverse("getall-api", args=[dataset.pk, version.pk, model.name]))
+    resp = resp.click(linkid="data_tab")
+    assert resp.request.path == reverse("model-data", args=[dataset.pk, version.pk, model.name])
 
 
 @pytest.mark.django_db
@@ -1404,20 +1338,14 @@ def test_data_tab_from_getall_with_query(app: DjangoTestApp):
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
+        name="prop",
+        type="string",
         metadata_version=version,
     )
 
-    resp = app.get("%s%s" % (
-        reverse('getall-api', args=[dataset.pk, version.pk, model.name]),
-        "?select(prop)"
-    ))
-    resp = resp.click(linkid='data_tab')
-    assert resp.request.path_qs == "%s%s" % (
-        model.get_data_url(),
-        "?select(prop)"
-    )
+    resp = app.get("%s%s" % (reverse("getall-api", args=[dataset.pk, version.pk, model.name]), "?select(prop)"))
+    resp = resp.click(linkid="data_tab")
+    assert resp.request.path_qs == "%s%s" % (model.get_data_url(), "?select(prop)")
 
 
 @pytest.mark.django_db
@@ -1447,40 +1375,34 @@ def test_property_enum_item_create__string(app: DjangoTestApp):
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
+        name="prop",
+        type="string",
         metadata_version=version,
     )
 
-    form = app.get(reverse('enum-create', args=[dataset.pk, version.pk, model.name, prop.name])).forms['enum-form']
-    form['value'] = "test"
-    form['source'] = "TEST"
-    form['access'] = Metadata.OPEN
-    form['title'] = 'Test value'
-    form['description'] = 'For testing'
+    form = app.get(reverse("enum-create", args=[dataset.pk, version.pk, model.name, prop.name])).forms["enum-form"]
+    form["value"] = "test"
+    form["source"] = "TEST"
+    form["access"] = Metadata.OPEN
+    form["title"] = "Test value"
+    form["description"] = "For testing"
     resp = form.submit()
 
     assert resp.url == prop.get_absolute_url()
-    assert Enum.objects.filter(
-        content_type=ContentType.objects.get_for_model(prop),
-        object_id=prop.pk
-    ).count() == 1
-    assert list(EnumItem.objects.filter(
-        enum__content_type=ContentType.objects.get_for_model(prop),
-        enum__object_id=prop.pk
-    ).values(
-        'metadata__prepare',
-        'metadata__source',
-        'metadata__access',
-        'metadata__title',
-        'metadata__description'
-    )) == [
+    assert Enum.objects.filter(content_type=ContentType.objects.get_for_model(prop), object_id=prop.pk).count() == 1
+    assert list(
+        EnumItem.objects.filter(
+            enum__content_type=ContentType.objects.get_for_model(prop), enum__object_id=prop.pk
+        ).values(
+            "metadata__prepare", "metadata__source", "metadata__access", "metadata__title", "metadata__description"
+        )
+    ) == [
         {
-            'metadata__prepare': '"test"',
-            'metadata__source': "TEST",
-            'metadata__access': Metadata.OPEN,
-            'metadata__title': "Test value",
-            'metadata__description': "For testing"
+            "metadata__prepare": '"test"',
+            "metadata__source": "TEST",
+            "metadata__access": Metadata.OPEN,
+            "metadata__title": "Test value",
+            "metadata__description": "For testing",
         }
     ]
 
@@ -1512,40 +1434,34 @@ def test_property_enum_item_create__integer(app: DjangoTestApp):
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='integer',
+        name="prop",
+        type="integer",
         metadata_version=version,
     )
 
-    form = app.get(reverse('enum-create', args=[dataset.pk, version.pk, model.name, prop.name])).forms['enum-form']
-    form['value'] = 1
-    form['source'] = "TEST"
-    form['access'] = Metadata.OPEN
-    form['title'] = 'Test value'
-    form['description'] = 'For testing'
+    form = app.get(reverse("enum-create", args=[dataset.pk, version.pk, model.name, prop.name])).forms["enum-form"]
+    form["value"] = 1
+    form["source"] = "TEST"
+    form["access"] = Metadata.OPEN
+    form["title"] = "Test value"
+    form["description"] = "For testing"
     resp = form.submit()
 
     assert resp.url == prop.get_absolute_url()
-    assert Enum.objects.filter(
-        content_type=ContentType.objects.get_for_model(prop),
-        object_id=prop.pk
-    ).count() == 1
-    assert list(EnumItem.objects.filter(
-        enum__content_type=ContentType.objects.get_for_model(prop),
-        enum__object_id=prop.pk
-    ).values(
-        'metadata__prepare',
-        'metadata__source',
-        'metadata__access',
-        'metadata__title',
-        'metadata__description'
-    )) == [
+    assert Enum.objects.filter(content_type=ContentType.objects.get_for_model(prop), object_id=prop.pk).count() == 1
+    assert list(
+        EnumItem.objects.filter(
+            enum__content_type=ContentType.objects.get_for_model(prop), enum__object_id=prop.pk
+        ).values(
+            "metadata__prepare", "metadata__source", "metadata__access", "metadata__title", "metadata__description"
+        )
+    ) == [
         {
-            'metadata__prepare': '1',
-            'metadata__source': "TEST",
-            'metadata__access': Metadata.OPEN,
-            'metadata__title': "Test value",
-            'metadata__description': "For testing"
+            "metadata__prepare": "1",
+            "metadata__source": "TEST",
+            "metadata__access": Metadata.OPEN,
+            "metadata__title": "Test value",
+            "metadata__description": "For testing",
         }
     ]
     assert Version.objects.get_for_object(prop).count() == 1
@@ -1579,19 +1495,19 @@ def test_property_enum_item_create__integer_with_error(app: DjangoTestApp):
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='integer',
+        name="prop",
+        type="integer",
         metadata_version=version,
     )
 
-    form = app.get(reverse('enum-create', args=[dataset.pk, version.pk, model.name, prop.name])).forms['enum-form']
-    form['value'] = "invalid"
-    form['source'] = "TEST"
-    form['access'] = Metadata.OPEN
-    form['title'] = 'Test value'
-    form['description'] = 'For testing'
+    form = app.get(reverse("enum-create", args=[dataset.pk, version.pk, model.name, prop.name])).forms["enum-form"]
+    form["value"] = "invalid"
+    form["source"] = "TEST"
+    form["access"] = Metadata.OPEN
+    form["title"] = "Test value"
+    form["description"] = "For testing"
     resp = form.submit()
-    assert list(resp.context['form'].errors.values()) == [["Reikšmė turi būti integer tipo."]]
+    assert list(resp.context["form"].errors.values()) == [["Reikšmė turi būti integer tipo."]]
 
 
 @pytest.mark.django_db
@@ -1607,75 +1523,63 @@ def test_property_enum_item_update(app: DjangoTestApp):
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        metadata_version=version
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
         name="test/dataset",
-        metadata_version=version
+        metadata_version=version,
     )
     prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='integer',
-        metadata_version=version
+        name="prop",
+        type="integer",
+        metadata_version=version,
     )
 
     enum = EnumFactory(
-        content_type=ContentType.objects.get_for_model(prop),
-        object_id=prop.pk,
-        metadata_version=version
+        content_type=ContentType.objects.get_for_model(prop), object_id=prop.pk, metadata_version=version
     )
     enum_item = EnumItemFactory(enum=enum, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(enum_item),
         object_id=enum_item.pk,
         dataset=dataset,
-        title='Test value',
-        description='For testing',
-        prepare='1',
+        title="Test value",
+        description="For testing",
+        prepare="1",
         access=Metadata.OPEN,
         source="TEST",
-        metadata_version=version
+        metadata_version=version,
     )
 
-    form = app.get(reverse('enum-update', args=[
-        dataset.pk,
-        version.pk,
-        model.name,
-        prop.name,
-        enum_item.pk
-    ])).forms['enum-form']
-    form['access'] = Metadata.PUBLIC
-    form['title'] = 'Test value (updated)'
+    form = app.get(reverse("enum-update", args=[dataset.pk, version.pk, model.name, prop.name, enum_item.pk])).forms[
+        "enum-form"
+    ]
+    form["access"] = Metadata.PUBLIC
+    form["title"] = "Test value (updated)"
     resp = form.submit()
 
     assert resp.url == prop.get_absolute_url()
-    assert Enum.objects.filter(
-        content_type=ContentType.objects.get_for_model(prop),
-        object_id=prop.pk
-    ).count() == 1
-    assert list(EnumItem.objects.filter(
-        enum__content_type=ContentType.objects.get_for_model(prop),
-        enum__object_id=prop.pk
-    ).values(
-        'metadata__prepare',
-        'metadata__source',
-        'metadata__access',
-        'metadata__title',
-        'metadata__description'
-    )) == [
+    assert Enum.objects.filter(content_type=ContentType.objects.get_for_model(prop), object_id=prop.pk).count() == 1
+    assert list(
+        EnumItem.objects.filter(
+            enum__content_type=ContentType.objects.get_for_model(prop), enum__object_id=prop.pk
+        ).values(
+            "metadata__prepare", "metadata__source", "metadata__access", "metadata__title", "metadata__description"
+        )
+    ) == [
         {
-            'metadata__prepare': '1',
-            'metadata__source': "TEST",
-            'metadata__access': Metadata.PUBLIC,
-            'metadata__title': "Test value (updated)",
-            'metadata__description': "For testing"
+            "metadata__prepare": "1",
+            "metadata__source": "TEST",
+            "metadata__access": Metadata.PUBLIC,
+            "metadata__title": "Test value (updated)",
+            "metadata__description": "For testing",
         }
     ]
     assert Version.objects.get_for_object(prop).count() == 1
@@ -1695,57 +1599,51 @@ def test_property_enum_item_delete(app: DjangoTestApp):
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        metadata_version=version
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
         name="test/dataset",
-        metadata_version=version
+        metadata_version=version,
     )
     prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='integer',
-        metadata_version=version
+        name="prop",
+        type="integer",
+        metadata_version=version,
     )
 
     enum = EnumFactory(
-        content_type=ContentType.objects.get_for_model(prop),
-        object_id=prop.pk,
-        metadata_version=version
+        content_type=ContentType.objects.get_for_model(prop), object_id=prop.pk, metadata_version=version
     )
     enum_item = EnumItemFactory(enum=enum, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(enum_item),
         object_id=enum_item.pk,
         dataset=dataset,
-        title='Test value',
-        description='For testing',
-        prepare='1',
+        title="Test value",
+        description="For testing",
+        prepare="1",
         access=Metadata.OPEN,
         source="TEST",
-        metadata_version=version
+        metadata_version=version,
     )
 
-    resp = app.post(reverse('enum-delete', args=[
-        dataset.pk,
-        version.pk,
-        model.name,
-        prop.name,
-        enum_item.pk
-    ]))
+    resp = app.post(reverse("enum-delete", args=[dataset.pk, version.pk, model.name, prop.name, enum_item.pk]))
 
     assert resp.url == prop.get_absolute_url()
     assert EnumItem.objects.filter(pk=enum_item.pk).count() == 0
-    assert Metadata.objects.filter(
-        content_type=ContentType.objects.get_for_model(enum_item),
-        object_id=enum_item.pk
-    ).count() == 0
+    assert (
+        Metadata.objects.filter(
+            content_type=ContentType.objects.get_for_model(enum_item), object_id=enum_item.pk
+        ).count()
+        == 0
+    )
     assert Version.objects.get_for_object(prop).count() == 1
     assert Version.objects.get_for_object(prop).first().revision.user == user
 
@@ -1763,41 +1661,39 @@ def test_property_enum_item_delete_in_pre_released_property(app: DjangoTestApp):
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        metadata_version=version
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
         name="test/dataset",
-        metadata_version=version
+        metadata_version=version,
     )
     prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='integer',
-        metadata_version=version
+        name="prop",
+        type="integer",
+        metadata_version=version,
     )
 
     enum = EnumFactory(
-        content_type=ContentType.objects.get_for_model(prop),
-        object_id=prop.pk,
-        metadata_version=version
+        content_type=ContentType.objects.get_for_model(prop), object_id=prop.pk, metadata_version=version
     )
     enum_item = EnumItemFactory(enum=enum, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(enum_item),
         object_id=enum_item.pk,
         dataset=dataset,
-        title='Test value',
-        description='For testing',
-        prepare='1',
+        title="Test value",
+        description="For testing",
+        prepare="1",
         access=Metadata.OPEN,
         source="TEST",
-        metadata_version=version
+        metadata_version=version,
     )
 
     response = app.post(
@@ -1821,12 +1717,12 @@ def test_model_create_with_lowercase_first_name_letter(app: DjangoTestApp):
     app.set_user(user)
     dataset = DatasetFactory()
 
-    form = app.get(reverse('model-create-no-version', args=[dataset.pk])).forms['model-form']
-    form['name'] = "invalidName"
+    form = app.get(reverse("model-create-no-version", args=[dataset.pk])).forms["model-form"]
+    form["name"] = "invalidName"
     resp = form.submit()
-    assert list(resp.context['form'].errors.values()) == [[
-        "Pirmas kodinio pavadinimo simbolis turi būti didžioji raidė."
-    ]]
+    assert list(resp.context["form"].errors.values()) == [
+        ["Pirmas kodinio pavadinimo simbolis turi būti didžioji raidė."]
+    ]
 
 
 @pytest.mark.parametrize("status", [s for s in VersionStatus.values if s != VersionStatus.DRAFT])
@@ -1847,12 +1743,12 @@ def test_model_create_with_number_as_first_name_letter(app: DjangoTestApp):
     app.set_user(user)
     dataset = DatasetFactory()
 
-    form = app.get(reverse('model-create-no-version', args=[dataset.pk])).forms['model-form']
-    form['name'] = "1nvalidName"
+    form = app.get(reverse("model-create-no-version", args=[dataset.pk])).forms["model-form"]
+    form["name"] = "1nvalidName"
     resp = form.submit()
-    assert list(resp.context['form'].errors.values()) == [[
-        "Pirmas kodinio pavadinimo simbolis turi būti didžioji raidė."
-    ]]
+    assert list(resp.context["form"].errors.values()) == [
+        ["Pirmas kodinio pavadinimo simbolis turi būti didžioji raidė."]
+    ]
 
 
 @pytest.mark.django_db
@@ -1861,12 +1757,12 @@ def test_model_create_with_special_symbol_in_name(app: DjangoTestApp):
     app.set_user(user)
     dataset = DatasetFactory()
 
-    form = app.get(reverse('model-create-no-version', args=[dataset.pk])).forms['model-form']
-    form['name'] = "Invalid_name1"
+    form = app.get(reverse("model-create-no-version", args=[dataset.pk])).forms["model-form"]
+    form["name"] = "Invalid_name1"
     resp = form.submit()
-    assert list(resp.context['form'].errors.values()) == [[
-        "Pavadinime gali būti didžiosos/mažosios raidės ir skaičiai, jokie kiti simboliai negalimi."
-    ]]
+    assert list(resp.context["form"].errors.values()) == [
+        ["Pavadinime gali būti didžiosos/mažosios raidės ir skaičiai, jokie kiti simboliai negalimi."]
+    ]
 
 
 @pytest.mark.django_db
@@ -1875,13 +1771,13 @@ def test_model_create_with_invalid_prepare(app: DjangoTestApp):
     app.set_user(user)
     dataset = DatasetFactory()
 
-    form = app.get(reverse('model-create-no-version', args=[dataset.pk])).forms['model-form']
-    form['name'] = "Model"
-    form['prepare'] = 'sort(id)'
+    form = app.get(reverse("model-create-no-version", args=[dataset.pk])).forms["model-form"]
+    form["name"] = "Model"
+    form["prepare"] = "sort(id)"
     resp = form.submit()
-    assert list(resp.context['form'].errors.values()) == [[
-        'Duomenų filtre nurodytas modelyje neegzistuojantis laukas: "id".'
-    ]]
+    assert list(resp.context["form"].errors.values()) == [
+        ['Duomenų filtre nurodytas modelyje neegzistuojantis laukas: "id".']
+    ]
 
 
 @pytest.mark.django_db
@@ -1890,13 +1786,11 @@ def test_model_create_with_invalid_uri(app: DjangoTestApp):
     app.set_user(user)
     dataset = DatasetFactory()
 
-    form = app.get(reverse('model-create-no-version', args=[dataset.pk])).forms['model-form']
-    form['name'] = "Model"
-    form['uri'] = 'dcat:invalid:format'
+    form = app.get(reverse("model-create-no-version", args=[dataset.pk])).forms["model-form"]
+    form["name"] = "Model"
+    form["uri"] = "dcat:invalid:format"
     resp = form.submit()
-    assert list(resp.context['form'].errors.values()) == [[
-        'Nevalidus uri "dcat:invalid:format" formatas.'
-    ]]
+    assert list(resp.context["form"].errors.values()) == [['Nevalidus uri "dcat:invalid:format" formatas.']]
 
 
 @pytest.mark.django_db
@@ -1905,13 +1799,11 @@ def test_model_create_with_invalid_uri_prefix(app: DjangoTestApp):
     app.set_user(user)
     dataset = DatasetFactory()
 
-    form = app.get(reverse('model-create-no-version', args=[dataset.pk])).forms['model-form']
-    form['name'] = "Model"
-    form['uri'] = 'dcat:invalid'
+    form = app.get(reverse("model-create-no-version", args=[dataset.pk])).forms["model-form"]
+    form["name"] = "Model"
+    form["uri"] = "dcat:invalid"
     resp = form.submit()
-    assert list(resp.context['form'].errors.values()) == [[
-        'Neatpažintas "dcat" prefiksas.'
-    ]]
+    assert list(resp.context["form"].errors.values()) == [['Neatpažintas "dcat" prefiksas.']]
 
 
 @pytest.mark.django_db
@@ -1930,50 +1822,50 @@ def test_model_create(app: DjangoTestApp):
         dataset=dataset,
         name="test/dataset/TestModel",
         uri="dcat:TestModel",
-        metadata_version=version
+        metadata_version=version,
     )
     prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='integer',
-        metadata_version=version
+        name="prop",
+        type="integer",
+        metadata_version=version,
     )
 
-    url = reverse('model-create', args=[dataset.pk, version.pk])
+    url = reverse("model-create", args=[dataset.pk, version.pk])
     revision_comment = RevisionComment(
         source=RevisionSource.VIEW,
         action="model-create",
         http_method="POST",
         path=url,
         args=(),
-        kwargs={"pk": dataset.pk, "version_id": version.pk}
+        kwargs={"pk": dataset.pk, "version_id": version.pk},
     )
-    form = app.get(url).forms['model-form']
-    form['name'] = "Model"
-    form['uri'] = 'dcat:model'
-    form['source'] = "MODEL"
-    form['level'] = 3
-    form['title'] = 'Test model'
-    form['description'] = 'Model for testing'
-    form['base'].force_value([model.pk])
-    form['base_level'] = 4
-    form['base_ref'].force_value([prop.pk])
-    form['comment'] = 'Added Model'
+    form = app.get(url).forms["model-form"]
+    form["name"] = "Model"
+    form["uri"] = "dcat:model"
+    form["source"] = "MODEL"
+    form["level"] = 3
+    form["title"] = "Test model"
+    form["description"] = "Model for testing"
+    form["base"].force_value([model.pk])
+    form["base_level"] = 4
+    form["base_ref"].force_value([prop.pk])
+    form["comment"] = "Added Model"
     resp = form.submit()
 
     new_model = dataset.model_set.exclude(pk=model.pk).first()
     assert resp.url == new_model.get_absolute_url()
     assert new_model.metadata.count() == 1
-    assert new_model.metadata.first().name == 'test/dataset/Model'
-    assert new_model.metadata.first().uri == 'dcat:model'
-    assert new_model.metadata.first().source == 'MODEL'
+    assert new_model.metadata.first().name == "test/dataset/Model"
+    assert new_model.metadata.first().uri == "dcat:model"
+    assert new_model.metadata.first().source == "MODEL"
     assert new_model.metadata.first().level == 5
     assert new_model.metadata.first().level_given == 3
-    assert new_model.metadata.first().title == 'Test model'
-    assert new_model.metadata.first().description == 'Model for testing'
+    assert new_model.metadata.first().title == "Test model"
+    assert new_model.metadata.first().description == "Model for testing"
     assert new_model.metadata.first().metadata_version == version
 
     assert new_model.base.model == model
@@ -1981,12 +1873,12 @@ def test_model_create(app: DjangoTestApp):
     assert new_model.base.property_list.first().property == prop
     assert new_model.base.metadata.first().level == 5
     assert new_model.base.metadata.first().level_given == 4
-    assert new_model.base.metadata.first().name == 'test/dataset/TestModel'
-    assert new_model.base.metadata.first().ref == 'prop'
+    assert new_model.base.metadata.first().name == "test/dataset/TestModel"
+    assert new_model.base.metadata.first().ref == "prop"
     assert new_model.base.metadata.first().metadata_version == version
 
     assert Version.objects.get_for_object(new_model).count() == 1
-    version = (Version.objects.get_for_object(new_model).select_related("revision").first())
+    version = Version.objects.get_for_object(new_model).select_related("revision").first()
     assert version.revision.comment == revision_comment.to_json()
     assert version.revision.user == user
 
@@ -2007,32 +1899,32 @@ def test_model_update(app: DjangoTestApp):
         dataset=dataset,
         name="test/dataset/TestModel",
         uri="dcat:TestModel",
-        metadata_version=version
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
         name="test/dataset",
-        metadata_version=version
+        metadata_version=version,
     )
     prop1 = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop1),
         object_id=prop1.pk,
         dataset=dataset,
-        name='prop1',
-        type='integer',
-        metadata_version=version
+        name="prop1",
+        type="integer",
+        metadata_version=version,
     )
     prop2 = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop2),
         object_id=prop2.pk,
         dataset=dataset,
-        name='prop2',
-        type='integer',
-        metadata_version=version
+        name="prop2",
+        type="integer",
+        metadata_version=version,
     )
 
     base_model = ModelFactory(dataset=dataset, metadata_version=version)
@@ -2041,35 +1933,30 @@ def test_model_update(app: DjangoTestApp):
         object_id=base_model.pk,
         dataset=dataset,
         name="test/dataset/BaseModel",
-        metadata_version = version
+        metadata_version=version,
     )
-    kwargs_dict = {"pk": dataset.pk, "version_id":  version.pk, "model": model.name}
-    url = reverse('model-update', kwargs=kwargs_dict)
+    kwargs_dict = {"pk": dataset.pk, "version_id": version.pk, "model": model.name}
+    url = reverse("model-update", kwargs=kwargs_dict)
     revision_comment = RevisionComment(
-        source=RevisionSource.VIEW,
-        action="model-update",
-        http_method="POST",
-        path=url,
-        args=(),
-        kwargs=kwargs_dict
+        source=RevisionSource.VIEW, action="model-update", http_method="POST", path=url, args=(), kwargs=kwargs_dict
     )
-    form = app.get(url).forms['model-form']
-    form['name'] = "UpdatedModel"
-    form['prepare'] = "sort(prop1)"
-    form['ref'].force_value([prop2.pk, prop1.pk])
-    form['base'].force_value([base_model.pk])
-    form['comment'] = 'Updated Model'
+    form = app.get(url).forms["model-form"]
+    form["name"] = "UpdatedModel"
+    form["prepare"] = "sort(prop1)"
+    form["ref"].force_value([prop2.pk, prop1.pk])
+    form["base"].force_value([base_model.pk])
+    form["comment"] = "Updated Model"
     resp = form.submit()
     model.refresh_from_db()
     assert resp.url == model.get_absolute_url()
     assert model.metadata.count() == 1
-    assert model.metadata.first().name == 'test/dataset/UpdatedModel'
-    assert model.metadata.first().prepare == 'sort(prop1)'
-    assert model.metadata.first().prepare_ast == {'args': [{'args': ['prop1'], 'name': 'bind'}], 'name': 'sort'}
+    assert model.metadata.first().name == "test/dataset/UpdatedModel"
+    assert model.metadata.first().prepare == "sort(prop1)"
+    assert model.metadata.first().prepare_ast == {"args": [{"args": ["prop1"], "name": "bind"}], "name": "sort"}
 
     assert model.base.model == base_model
-    assert model.base.metadata.first().name == 'test/dataset/BaseModel'
-    assert model.base.metadata.first().ref == ''
+    assert model.base.metadata.first().name == "test/dataset/BaseModel"
+    assert model.base.metadata.first().ref == ""
 
     assert Version.objects.get_for_object(model).count() == 1
     version = Version.objects.get_for_object(model).select_related("revision").first()
@@ -2079,50 +1966,46 @@ def test_model_update(app: DjangoTestApp):
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-        "role",
-        [
-            Representative.OPEN_DATA_MANAGER,
-            Representative.RESOURCE_MANAGER,
-        ],
+    "role",
+    [
+        Representative.OPEN_DATA_MANAGER,
+        Representative.RESOURCE_MANAGER,
+    ],
 )
 def test_param_create_for_resource(app: DjangoTestApp, role: str):
     distribution = DatasetDistributionFactory(is_parameterized=True)
     dataset = distribution.dataset
     ct = ContentType.objects.get_for_model(dataset)
-    representative = RepresentativeFactory(
-        content_type=ct,
-        object_id=dataset.pk,
-        role=role
-    )
+    representative = RepresentativeFactory(content_type=ct, object_id=dataset.pk, role=role)
     app.set_user(representative.user)
 
     ct = ContentType.objects.get_for_model(distribution)
-    form = app.get(reverse('param-create', args=[dataset.pk, ct.pk, distribution.pk])).forms['param-form']
-    form['name'] = 'test'
-    form['prepare'] = 'param'
-    form['title'] = 'Test param'
-    form['source'] = 'src'
-    form['description'] = 'Param for testing'
+    form = app.get(reverse("param-create", args=[dataset.pk, ct.pk, distribution.pk])).forms["param-form"]
+    form["name"] = "test"
+    form["prepare"] = "param"
+    form["title"] = "Test param"
+    form["source"] = "src"
+    form["description"] = "Param for testing"
     resp = form.submit()
 
     assert resp.url == distribution.get_absolute_url()
-    assert list(distribution.params.values_list('name', flat=True)) == ['test']
+    assert list(distribution.params.values_list("name", flat=True)) == ["test"]
     assert distribution.params.first().paramitem_set.count() == 1
-    assert distribution.params.first().paramitem_set.first().metadata.first().name == 'test'
-    assert distribution.params.first().paramitem_set.first().metadata.first().prepare == 'param'
-    assert distribution.params.first().paramitem_set.first().metadata.first().title == 'Test param'
-    assert distribution.params.first().paramitem_set.first().metadata.first().source == 'src'
-    assert distribution.params.first().paramitem_set.first().metadata.first().description == 'Param for testing'
+    assert distribution.params.first().paramitem_set.first().metadata.first().name == "test"
+    assert distribution.params.first().paramitem_set.first().metadata.first().prepare == "param"
+    assert distribution.params.first().paramitem_set.first().metadata.first().title == "Test param"
+    assert distribution.params.first().paramitem_set.first().metadata.first().source == "src"
+    assert distribution.params.first().paramitem_set.first().metadata.first().description == "Param for testing"
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-        "role",
-        [
-            Representative.OPEN_DATA_COORDINATOR,
-            Representative.RESOURCE_COORDINATOR,
-        ],
-    )
+    "role",
+    [
+        Representative.OPEN_DATA_COORDINATOR,
+        Representative.RESOURCE_COORDINATOR,
+    ],
+)
 def test_param_create_for_model(app: DjangoTestApp, role: str):
     dataset = DatasetFactory()
     model = ModelFactory(dataset=dataset, is_parameterized=True)
@@ -2133,42 +2016,38 @@ def test_param_create_for_model(app: DjangoTestApp, role: str):
         name="test/dataset/TestModel",
     )
     ct = ContentType.objects.get_for_model(dataset)
-    representative = RepresentativeFactory(
-        content_type=ct,
-        object_id=dataset.pk,
-        role=role
-    )
+    representative = RepresentativeFactory(content_type=ct, object_id=dataset.pk, role=role)
     app.set_user(representative.user)
 
     ct = ContentType.objects.get_for_model(model)
-    form = app.get(reverse('param-create', args=[dataset.pk, ct.pk, model.pk])).forms['param-form']
-    form['name'] = 'test'
-    form['prepare'] = 'param'
-    form['title'] = 'Test param'
-    form['source'] = 'src'
-    form['description'] = 'Param for testing'
+    form = app.get(reverse("param-create", args=[dataset.pk, ct.pk, model.pk])).forms["param-form"]
+    form["name"] = "test"
+    form["prepare"] = "param"
+    form["title"] = "Test param"
+    form["source"] = "src"
+    form["description"] = "Param for testing"
     resp = form.submit()
 
     assert resp.url == model.get_absolute_url()
-    assert list(model.params.values_list('name', flat=True)) == ['test']
+    assert list(model.params.values_list("name", flat=True)) == ["test"]
     assert model.params.first().paramitem_set.count() == 1
-    assert model.params.first().paramitem_set.first().metadata.first().name == 'test'
-    assert model.params.first().paramitem_set.first().metadata.first().prepare == 'param'
-    assert model.params.first().paramitem_set.first().metadata.first().title == 'Test param'
-    assert model.params.first().paramitem_set.first().metadata.first().source == 'src'
-    assert model.params.first().paramitem_set.first().metadata.first().description == 'Param for testing'
+    assert model.params.first().paramitem_set.first().metadata.first().name == "test"
+    assert model.params.first().paramitem_set.first().metadata.first().prepare == "param"
+    assert model.params.first().paramitem_set.first().metadata.first().title == "Test param"
+    assert model.params.first().paramitem_set.first().metadata.first().source == "src"
+    assert model.params.first().paramitem_set.first().metadata.first().description == "Param for testing"
     assert Version.objects.get_for_object(model).count() == 1
     assert Version.objects.get_for_object(model).first().revision.user == representative.user
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-        "role",
-        [
-            Representative.OPEN_DATA_COORDINATOR,
-            Representative.RESOURCE_COORDINATOR,
-        ],
-    )
+    "role",
+    [
+        Representative.OPEN_DATA_COORDINATOR,
+        Representative.RESOURCE_COORDINATOR,
+    ],
+)
 def test_param_update(app: DjangoTestApp, role: str):
     distribution = DatasetDistributionFactory(is_parameterized=True)
     dataset = distribution.dataset
@@ -2180,65 +2059,56 @@ def test_param_update(app: DjangoTestApp, role: str):
     )
     app.set_user(representative.user)
     ct = ContentType.objects.get_for_model(distribution)
-    param = ParamFactory(
-        content_type=ct,
-        object_id=distribution.pk
-    )
+    param = ParamFactory(content_type=ct, object_id=distribution.pk)
     param_item = ParamItemFactory(param=param)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(param_item),
         object_id=param_item.pk,
         dataset=dataset,
         name="test",
-        title='Test param',
-        prepare='param'
+        title="Test param",
+        prepare="param",
     )
 
-    form = app.get(reverse('param-update', args=[dataset.pk, param_item.pk])).forms['param-form']
-    form['title'] = 'Updated test param'
+    form = app.get(reverse("param-update", args=[dataset.pk, param_item.pk])).forms["param-form"]
+    form["title"] = "Updated test param"
     resp = form.submit()
 
     assert resp.url == distribution.get_absolute_url()
     assert distribution.params.first().paramitem_set.count() == 1
-    assert distribution.params.first().paramitem_set.first().metadata.first().title == 'Updated test param'
+    assert distribution.params.first().paramitem_set.first().metadata.first().title == "Updated test param"
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-        "role",
-        [
-            Representative.OPEN_DATA_MANAGER,
-            Representative.RESOURCE_MANAGER,
-        ],
-    )
+    "role",
+    [
+        Representative.OPEN_DATA_MANAGER,
+        Representative.RESOURCE_MANAGER,
+    ],
+)
 def test_param_delete(app: DjangoTestApp, role: str):
     distribution = DatasetDistributionFactory(is_parameterized=True)
     dataset = distribution.dataset
     ct = ContentType.objects.get_for_model(dataset)
-    representative = RepresentativeFactory(
-        content_type=ct,
-        object_id=dataset.pk,
-        role=role
-    )
+    representative = RepresentativeFactory(content_type=ct, object_id=dataset.pk, role=role)
     app.set_user(representative.user)
     ct = ContentType.objects.get_for_model(distribution)
-    param = ParamFactory(
-        content_type=ct,
-        object_id=distribution.pk
-    )
+    param = ParamFactory(content_type=ct, object_id=distribution.pk)
     param_item = ParamItemFactory(param=param)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(param_item),
         object_id=param_item.pk,
         dataset=dataset,
         name="test",
-        title='Test param',
-        prepare='param'
+        title="Test param",
+        prepare="param",
     )
 
-    resp = app.post(reverse('param-delete', args=[dataset.pk, param_item.pk]))
+    resp = app.post(reverse("param-delete", args=[dataset.pk, param_item.pk]))
     assert resp.url == distribution.get_absolute_url()
     assert distribution.params.first().paramitem_set.count() == 0
+
 
 @pytest.mark.parametrize("status", [s for s in VersionStatus.values if s != VersionStatus.DRAFT])
 @pytest.mark.django_db
@@ -2256,13 +2126,11 @@ def test_new_version_with_released_date_earlier_than_two_weeks(app: DjangoTestAp
     user = UserFactory(is_staff=True)
     app.set_user(user)
     version = VersionFactory()
-    form = app.get(reverse('version-create', args=[version.dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today()
-    form['version_type'] = "MAJOR"
+    form = app.get(reverse("version-create", args=[version.dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today()
+    form["version_type"] = "MAJOR"
     resp = form.submit()
-    assert list(resp.context['form'].errors.values()) == [[
-        "Versija gali įsigalioti ne anksčiau kaip po 2 savaičių."
-    ]]
+    assert list(resp.context["form"].errors.values()) == [["Versija gali įsigalioti ne anksčiau kaip po 2 savaičių."]]
 
 
 @pytest.mark.django_db
@@ -2275,24 +2143,22 @@ def test_new_version_with_released_date_earlier_than_last_version(app: DjangoTes
         dataset=version.dataset,
         metadata_version=version,
         content_type=ContentType.objects.get_for_model(Dataset),
-        object_id=version.dataset.pk
+        object_id=version.dataset.pk,
     )
 
-    form = app.get(reverse('version-create', args=[version.dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['metadata'] = [dataset_metadata.pk]
-    form['version_type'] = "MAJOR"
+    form = app.get(reverse("version-create", args=[version.dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["metadata"] = [dataset_metadata.pk]
+    form["version_type"] = "MAJOR"
     form.submit()
 
-    form = app.get(reverse('version-create', args=[version.dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=14)
-    form['metadata'] = [dataset_metadata.pk]
-    form['version_type'] = "MAJOR"
+    form = app.get(reverse("version-create", args=[version.dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=14)
+    form["metadata"] = [dataset_metadata.pk]
+    form["version_type"] = "MAJOR"
     resp = form.submit()
 
-    assert list(resp.context['form'].errors.values()) == [[
-        "Versija negali įsigalioti anksčiau už praėjusią versiją."
-    ]]
+    assert list(resp.context["form"].errors.values()) == [["Versija negali įsigalioti anksčiau už praėjusią versiją."]]
 
 
 @pytest.mark.django_db
@@ -2308,7 +2174,7 @@ def test_new_version_with_new_structure(app: DjangoTestApp):
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        metadata_version=version
+        metadata_version=version,
     )
 
     prop = PropertyFactory(model=model, metadata_version=version)
@@ -2316,23 +2182,26 @@ def test_new_version_with_new_structure(app: DjangoTestApp):
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
-        metadata_version=version
+        name="prop",
+        type="string",
+        metadata_version=version,
     )
 
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=14)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
-    form['description'] = "Add new structure to version"
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=14)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
+    form["description"] = "Add new structure to version"
     form.submit()
 
     assert _Version.objects.filter(dataset=dataset).count() == 2
     assert _Version.objects.exclude(status=VersionStatus.DRAFT).first().dataset == dataset
-    assert len(list(_Version.objects.exclude(status=VersionStatus.DRAFT).first().metadata_set.values_list(
-        'pk', flat=True
-    ))) == 3
+    assert (
+        len(
+            list(_Version.objects.exclude(status=VersionStatus.DRAFT).first().metadata_set.values_list("pk", flat=True))
+        )
+        == 3
+    )
 
 
 @pytest.mark.django_db
@@ -2348,50 +2217,52 @@ def test_new_version_with_updated_structure__dataset_name(app: DjangoTestApp):
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        metadata_version=version
+        metadata_version=version,
     )
     prop = PropertyFactory(model=model, metadata_version=version)
     prop_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
-        metadata_version=version
+        name="prop",
+        type="string",
+        metadata_version=version,
     )
 
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=14)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
-    form['description'] = "Add new structure to version"
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=14)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
+    form["description"] = "Add new structure to version"
     form.submit()
-    first_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    first_published_version = _Version.objects.filter(dataset=dataset).order_by("-created").first()
     first_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=first_published_version).all()
 
     dataset_meta.name = "test/dataset1"
     dataset_meta.draft = True
     dataset_meta.save()
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [dataset_meta.pk]
-    form['description'] = "Update structure version"
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [dataset_meta.pk]
+    form["description"] = "Update structure version"
     form.submit()
-    second_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    second_published_version = _Version.objects.filter(dataset=dataset).order_by("-created").first()
     second_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=second_published_version).all()
 
     assert dataset.dataset_version.count() == 3
 
     assert first_version_metadata.count() == 3
-    assert first_version_metadata.filter(
-        content_type=ContentType.objects.get_for_model(dataset),
-        object_id=dataset.pk
-    ).first().name == 'test/dataset'
+    assert (
+        first_version_metadata.filter(content_type=ContentType.objects.get_for_model(dataset), object_id=dataset.pk)
+        .first()
+        .name
+        == "test/dataset"
+    )
 
     assert second_version_metadata.count() == 1
     assert second_version_metadata.first().object == dataset
-    assert second_version_metadata.first().name == 'test/dataset1'
+    assert second_version_metadata.first().name == "test/dataset1"
 
 
 @pytest.mark.django_db
@@ -2407,49 +2278,57 @@ def test_new_version_with_updated_structure__model_name(app: DjangoTestApp):
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        metadata_version=version
+        metadata_version=version,
     )
     prop = PropertyFactory(model=model, metadata_version=version)
     prop_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
-        metadata_version=version
+        name="prop",
+        type="string",
+        metadata_version=version,
     )
 
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=14)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
-    form['description'] = "Add new structure to version"
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=14)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
+    form["description"] = "Add new structure to version"
     form.submit()
-    first_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    first_published_version = _Version.objects.filter(dataset=dataset).order_by("-created").first()
     first_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=first_published_version).all()
 
     model_meta.name = "test/dataset/TestModel1"
     model_meta.draft = True
     model_meta.save()
 
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [dataset_meta.pk, model_meta.pk]
-    form['description'] = "Update structure version"
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [dataset_meta.pk, model_meta.pk]
+    form["description"] = "Update structure version"
     form.submit()
-    second_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    second_published_version = _Version.objects.filter(dataset=dataset).order_by("-created").first()
     second_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=second_published_version).all()
 
     assert dataset.dataset_version.count() == 3
 
-    assert first_version_metadata.filter(
-        content_type=ContentType.objects.get_for_model(model),
-    ).first().name == "test/dataset/TestModel"
+    assert (
+        first_version_metadata.filter(
+            content_type=ContentType.objects.get_for_model(model),
+        )
+        .first()
+        .name
+        == "test/dataset/TestModel"
+    )
 
     assert second_version_metadata.count() == 2
     assert second_version_metadata.first().object.pk != model.pk
-    assert second_version_metadata.filter(content_type=ContentType.objects.get_for_model(Model)).first().name == "test/dataset/TestModel1"
+    assert (
+        second_version_metadata.filter(content_type=ContentType.objects.get_for_model(Model)).first().name
+        == "test/dataset/TestModel1"
+    )
 
 
 @pytest.mark.django_db
@@ -2465,53 +2344,68 @@ def test_new_version_with_updated_structure__property_name(app: DjangoTestApp):
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        metadata_version=version
+        metadata_version=version,
     )
     prop = PropertyFactory(model=model, metadata_version=version)
     prop_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
-        metadata_version=version
+        name="prop",
+        type="string",
+        metadata_version=version,
     )
 
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=14)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
-    form['description'] = "Add new structure to version"
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=14)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
+    form["description"] = "Add new structure to version"
     form.submit()
-    first_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    first_published_version = _Version.objects.filter(dataset=dataset).order_by("-created").first()
     first_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=first_published_version).all()
 
     prop_meta.name = "prop1"
     prop_meta.draft = True
     prop_meta.save()
 
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
-    form['description'] = "Update structure version"
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
+    form["description"] = "Update structure version"
     form.submit()
-    second_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    second_published_version = _Version.objects.filter(dataset=dataset).order_by("-created").first()
     second_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=second_published_version).all()
 
     assert dataset.dataset_version.count() == 3
 
-    assert first_version_metadata.filter(
-        content_type=ContentType.objects.get_for_model(prop),
-    ).first().name == "prop"
+    assert (
+        first_version_metadata.filter(
+            content_type=ContentType.objects.get_for_model(prop),
+        )
+        .first()
+        .name
+        == "prop"
+    )
 
     assert second_version_metadata.count() == 3
-    assert second_version_metadata.filter(
-        content_type=ContentType.objects.get_for_model(prop),
-    ).first().object.pk != prop.pk
-    assert second_version_metadata.filter(
-        content_type=ContentType.objects.get_for_model(prop),
-    ).first().name == 'prop1'
+    assert (
+        second_version_metadata.filter(
+            content_type=ContentType.objects.get_for_model(prop),
+        )
+        .first()
+        .object.pk
+        != prop.pk
+    )
+    assert (
+        second_version_metadata.filter(
+            content_type=ContentType.objects.get_for_model(prop),
+        )
+        .first()
+        .name
+        == "prop1"
+    )
 
 
 @pytest.mark.django_db
@@ -2527,37 +2421,43 @@ def test_new_version_with_updated_structure__model_base(app: DjangoTestApp):
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        metadata_version=version
+        metadata_version=version,
     )
     prop = PropertyFactory(model=model, metadata_version=version)
     prop_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
+        name="prop",
+        type="string",
         metadata_version=version,
     )
 
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=14)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
-    form['description'] = "Add new structure to version"
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=14)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
+    form["description"] = "Add new structure to version"
     form.submit()
-    first_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    first_published_version = _Version.objects.filter(dataset=dataset).order_by("-created").first()
     first_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=first_published_version).all()
 
-    base_model = ModelFactory(dataset=dataset, metadata_version=version)
-    MetadataFactory(
+    base_model = ModelFactory(
+        dataset=dataset,
+        metadata_version=version,
+    )
+    base_model_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(base_model),
         object_id=base_model.pk,
         dataset=dataset,
         name="test/dataset/BaseModel",
         metadata_version=version,
     )
-    base = BaseFactory(model=base_model, metadata_version=version)
-    base_model_meta = MetadataFactory(
+    base = BaseFactory(
+        model=base_model,
+        metadata_version=version,
+    )
+    MetadataFactory(
         content_type=ContentType.objects.get_for_model(base),
         object_id=base.pk,
         dataset=dataset,
@@ -2569,31 +2469,47 @@ def test_new_version_with_updated_structure__model_base(app: DjangoTestApp):
     model_meta.draft = True
     model_meta.save()
 
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [dataset_meta.pk, base_model_meta.pk, model_meta.pk]
-    form['description'] = "Update structure version"
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [dataset_meta.pk, base_model_meta.pk, model_meta.pk]
+    form["description"] = "Update structure version"
     form.submit()
 
-    second_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    second_published_version = _Version.objects.filter(dataset=dataset).order_by("-created").first()
     second_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=second_published_version).all()
 
     assert dataset.dataset_version.count() == 3
 
     assert first_version_metadata.count() == 3
-    assert first_version_metadata.filter(
-        content_type=ContentType.objects.get_for_model(model),
-    ).first().object.base is None
+    assert (
+        first_version_metadata.filter(
+            content_type=ContentType.objects.get_for_model(model),
+        )
+        .first()
+        .object.base
+        is None
+    )
 
     assert second_version_metadata.count() == 4
-    assert second_version_metadata.filter(
-        content_type=ContentType.objects.get_for_model(model),
-    ).first().object.pk != model.pk
-    assert second_version_metadata.filter(
-        content_type=ContentType.objects.get_for_model(model),
-        name="test/dataset/TestModel",
-    ).first().object.base is not None
+    assert (
+        second_version_metadata.filter(
+            content_type=ContentType.objects.get_for_model(model),
+        )
+        .first()
+        .object.pk
+        != model.pk
+    )
+    assert (
+        second_version_metadata.filter(
+            content_type=ContentType.objects.get_for_model(model),
+            name="test/dataset/TestModel",
+        )
+        .first()
+        .object.base
+        is not None
+    )
+
 
 @pytest.mark.django_db
 def test_new_version_with_updated_structure__model_ref(app: DjangoTestApp):
@@ -2608,44 +2524,52 @@ def test_new_version_with_updated_structure__model_ref(app: DjangoTestApp):
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        metadata_version=version
+        metadata_version=version,
     )
-    prop = PropertyFactory(model=model, metadata_version=version,)
+    prop = PropertyFactory(
+        model=model,
+        metadata_version=version,
+    )
     prop_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
+        name="prop",
+        type="string",
         metadata_version=version,
     )
 
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=14)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
-    form['description'] = "Add new structure to version"
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=14)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
+    form["description"] = "Add new structure to version"
     form.submit()
-    first_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    first_published_version = _Version.objects.filter(dataset=dataset).order_by("-created").first()
     first_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=first_published_version).all()
 
-    model_meta.ref = 'id'
+    model_meta.ref = "id"
     model_meta.draft = True
     model_meta.save()
 
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [dataset_meta.pk, model_meta.pk]
-    form['description'] = "Update structure version"
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [dataset_meta.pk, model_meta.pk]
+    form["description"] = "Update structure version"
     form.submit()
-    second_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    second_published_version = _Version.objects.filter(dataset=dataset).order_by("-created").first()
     second_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=second_published_version).all()
 
     assert dataset.dataset_version.count() == 3
-    assert first_version_metadata.filter(
-        content_type=ContentType.objects.get_for_model(model),
-    ).first().ref == ""
+    assert (
+        first_version_metadata.filter(
+            content_type=ContentType.objects.get_for_model(model),
+        )
+        .first()
+        .ref
+        == ""
+    )
 
     assert second_version_metadata.count() == 2
     assert second_version_metadata.first().object.pk != model.pk
@@ -2665,52 +2589,70 @@ def test_new_version_with_updated_structure__property_type(app: DjangoTestApp):
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        metadata_version=version
+        metadata_version=version,
     )
-    prop = PropertyFactory(model=model, metadata_version=version,)
+    prop = PropertyFactory(
+        model=model,
+        metadata_version=version,
+    )
     prop_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
+        name="prop",
+        type="string",
         metadata_version=version,
     )
 
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=14)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
-    form['description'] = "Add new structure to version"
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=14)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
+    form["description"] = "Add new structure to version"
     form.submit()
-    first_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    first_published_version = _Version.objects.filter(dataset=dataset).order_by("-created").first()
     first_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=first_published_version).all()
 
-    prop_meta.type = 'integer'
+    prop_meta.type = "integer"
     prop_meta.draft = True
     prop_meta.save()
 
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
-    form['description'] = "Update structure version"
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
+    form["description"] = "Update structure version"
     form.submit()
-    second_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    second_published_version = _Version.objects.filter(dataset=dataset).order_by("-created").first()
     second_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=second_published_version).all()
 
     assert dataset.dataset_version.count() == 3
-    assert first_version_metadata.filter(
-        content_type=ContentType.objects.get_for_model(prop),
-    ).first().type == 'string'
+    assert (
+        first_version_metadata.filter(
+            content_type=ContentType.objects.get_for_model(prop),
+        )
+        .first()
+        .type
+        == "string"
+    )
 
     assert second_version_metadata.count() == 3
-    assert second_version_metadata.filter(
-        content_type=ContentType.objects.get_for_model(prop),
-    ).first().object.pk != prop.pk
-    assert second_version_metadata.filter(
-        content_type=ContentType.objects.get_for_model(prop),
-    ).first().type == 'integer'
+    assert (
+        second_version_metadata.filter(
+            content_type=ContentType.objects.get_for_model(prop),
+        )
+        .first()
+        .object.pk
+        != prop.pk
+    )
+    assert (
+        second_version_metadata.filter(
+            content_type=ContentType.objects.get_for_model(prop),
+        )
+        .first()
+        .type
+        == "integer"
+    )
 
 
 @pytest.mark.django_db
@@ -2726,52 +2668,71 @@ def test_new_version_with_updated_structure__property_ref(app: DjangoTestApp):
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        metadata_version=version
+        metadata_version=version,
     )
-    prop = PropertyFactory(model=model, metadata_version=version,)
+    prop = PropertyFactory(
+        model=model,
+        metadata_version=version,
+    )
     prop_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
+        name="prop",
+        type="string",
         metadata_version=version,
     )
 
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=14)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
-    form['description'] = "Add new structure to version"
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=14)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
+    form["description"] = "Add new structure to version"
     form.submit()
-    first_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    first_published_version = _Version.objects.filter(dataset=dataset).order_by("-created").first()
     first_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=first_published_version).all()
 
     prop_meta.ref = "test/dataset/TestModel"
     prop_meta.draft = True
     prop_meta.save()
 
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
-    form['description'] = "Update structure version"
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
+    form["description"] = "Update structure version"
     form.submit()
-    second_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    second_published_version = _Version.objects.filter(dataset=dataset).order_by("-created").first()
     second_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=second_published_version).all()
 
     assert dataset.dataset_version.count() == 3
-    assert first_version_metadata.filter(
-        content_type=ContentType.objects.get_for_model(prop),
-    ).first().ref == ''
+    assert (
+        first_version_metadata.filter(
+            content_type=ContentType.objects.get_for_model(prop),
+        )
+        .first()
+        .ref
+        == ""
+    )
 
     assert second_version_metadata.count() == 3
-    assert second_version_metadata.filter(
-        content_type=ContentType.objects.get_for_model(prop),
-    ).first().object.pk != prop.pk
-    assert second_version_metadata.filter(
-        content_type=ContentType.objects.get_for_model(prop),
-    ).first().ref == "test/dataset/TestModel"
+    assert (
+        second_version_metadata.filter(
+            content_type=ContentType.objects.get_for_model(prop),
+        )
+        .first()
+        .object.pk
+        != prop.pk
+    )
+    assert (
+        second_version_metadata.filter(
+            content_type=ContentType.objects.get_for_model(prop),
+        )
+        .first()
+        .ref
+        == "test/dataset/TestModel"
+    )
+
 
 @pytest.mark.django_db
 def test_new_version_with_updated_structure__model_level(app: DjangoTestApp):
@@ -2789,46 +2750,56 @@ def test_new_version_with_updated_structure__model_level(app: DjangoTestApp):
         level_given=3,
         metadata_version=version,
     )
-    prop = PropertyFactory(model=model, metadata_version=version,)
+    prop = PropertyFactory(
+        model=model,
+        metadata_version=version,
+    )
     prop_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
+        name="prop",
+        type="string",
         metadata_version=version,
     )
 
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=14)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
-    form['description'] = "Add new structure to version"
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=14)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
+    form["description"] = "Add new structure to version"
     form.submit()
-    first_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    first_published_version = _Version.objects.filter(dataset=dataset).order_by("-created").first()
     first_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=first_published_version).all()
 
     model_meta.level_given = 5
     model_meta.draft = True
     model_meta.save()
 
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [dataset_meta.pk, model_meta.pk]
-    form['description'] = "Update structure version"
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [dataset_meta.pk, model_meta.pk]
+    form["description"] = "Update structure version"
     form.submit()
-    second_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    second_published_version = _Version.objects.filter(dataset=dataset).order_by("-created").first()
     second_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=second_published_version).all()
 
     assert dataset.dataset_version.count() == 3
-    assert first_version_metadata.filter(
-        content_type=ContentType.objects.get_for_model(model),
-    ).first().level_given == 3
+    assert (
+        first_version_metadata.filter(
+            content_type=ContentType.objects.get_for_model(model),
+        )
+        .first()
+        .level_given
+        == 3
+    )
 
     assert second_version_metadata.count() == 2
     assert second_version_metadata.first().object.pk != model.pk
-    assert second_version_metadata.filter(content_type=ContentType.objects.get_for_model(Model)).first().level_given == 5
+    assert (
+        second_version_metadata.filter(content_type=ContentType.objects.get_for_model(Model)).first().level_given == 5
+    )
 
 
 @pytest.mark.django_db
@@ -2844,53 +2815,71 @@ def test_new_version_with_updated_structure__property_level(app: DjangoTestApp):
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        metadata_version=version
+        metadata_version=version,
     )
-    prop = PropertyFactory(model=model, metadata_version=version, )
+    prop = PropertyFactory(
+        model=model,
+        metadata_version=version,
+    )
     prop_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
+        name="prop",
+        type="string",
         level_given=3,
         metadata_version=version,
     )
 
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=14)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
-    form['description'] = "Add new structure to version"
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=14)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
+    form["description"] = "Add new structure to version"
     form.submit()
-    first_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    first_published_version = _Version.objects.filter(dataset=dataset).order_by("-created").first()
     first_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=first_published_version).all()
 
     prop_meta.level_given = 5
     prop_meta.draft = True
     prop_meta.save()
 
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
-    form['description'] = "Update structure version"
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
+    form["description"] = "Update structure version"
     form.submit()
-    second_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    second_published_version = _Version.objects.filter(dataset=dataset).order_by("-created").first()
     second_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=second_published_version).all()
 
     assert dataset.dataset_version.count() == 3
-    assert first_version_metadata.filter(
-        content_type=ContentType.objects.get_for_model(prop),
-    ).first().level_given == 3
+    assert (
+        first_version_metadata.filter(
+            content_type=ContentType.objects.get_for_model(prop),
+        )
+        .first()
+        .level_given
+        == 3
+    )
 
     assert second_version_metadata.count() == 3
-    assert second_version_metadata.filter(
-        content_type=ContentType.objects.get_for_model(prop),
-    ).first().object.pk != prop.pk
-    assert second_version_metadata.filter(
-        content_type=ContentType.objects.get_for_model(prop),
-    ).first().level_given == 5
+    assert (
+        second_version_metadata.filter(
+            content_type=ContentType.objects.get_for_model(prop),
+        )
+        .first()
+        .object.pk
+        != prop.pk
+    )
+    assert (
+        second_version_metadata.filter(
+            content_type=ContentType.objects.get_for_model(prop),
+        )
+        .first()
+        .level_given
+        == 5
+    )
 
 
 @pytest.mark.django_db
@@ -2906,53 +2895,71 @@ def test_new_version_with_updated_structure__property_access(app: DjangoTestApp)
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        metadata_version=version
+        metadata_version=version,
     )
-    prop = PropertyFactory(model=model, metadata_version=version, )
+    prop = PropertyFactory(
+        model=model,
+        metadata_version=version,
+    )
     prop_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
+        name="prop",
+        type="string",
         access=3,
         metadata_version=version,
     )
 
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=14)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
-    form['description'] = "Add new structure to version"
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=14)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
+    form["description"] = "Add new structure to version"
     form.submit()
-    first_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    first_published_version = _Version.objects.filter(dataset=dataset).order_by("-created").first()
     first_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=first_published_version).all()
 
     prop_meta.access = 5
     prop_meta.draft = True
     prop_meta.save()
 
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
-    form['description'] = "Update structure version"
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
+    form["description"] = "Update structure version"
     form.submit()
-    second_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    second_published_version = _Version.objects.filter(dataset=dataset).order_by("-created").first()
     second_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=second_published_version).all()
 
     assert dataset.dataset_version.count() == 3
-    assert first_version_metadata.filter(
-        content_type=ContentType.objects.get_for_model(prop),
-    ).first().access == 3
+    assert (
+        first_version_metadata.filter(
+            content_type=ContentType.objects.get_for_model(prop),
+        )
+        .first()
+        .access
+        == 3
+    )
 
     assert second_version_metadata.count() == 3
-    assert second_version_metadata.filter(
-        content_type=ContentType.objects.get_for_model(prop),
-    ).first().object.pk != prop.pk
-    assert second_version_metadata.filter(
-        content_type=ContentType.objects.get_for_model(prop),
-    ).first().access == 5
+    assert (
+        second_version_metadata.filter(
+            content_type=ContentType.objects.get_for_model(prop),
+        )
+        .first()
+        .object.pk
+        != prop.pk
+    )
+    assert (
+        second_version_metadata.filter(
+            content_type=ContentType.objects.get_for_model(prop),
+        )
+        .first()
+        .access
+        == 5
+    )
 
 
 @pytest.mark.django_db
@@ -2968,15 +2975,18 @@ def test_new_version_with_updated_structure__enum_prepare(app: DjangoTestApp):
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        metadata_version=version
+        metadata_version=version,
     )
-    prop = PropertyFactory(model=model, metadata_version=version,)
+    prop = PropertyFactory(
+        model=model,
+        metadata_version=version,
+    )
     prop_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
+        name="prop",
+        type="string",
         access=3,
         metadata_version=version,
     )
@@ -2985,51 +2995,62 @@ def test_new_version_with_updated_structure__enum_prepare(app: DjangoTestApp):
         object_id=prop.pk,
         metadata_version=version,
     )
-    enum_item = EnumItemFactory(enum=enum, metadata_version=version,)
+    enum_item = EnumItemFactory(
+        enum=enum,
+        metadata_version=version,
+    )
     enum_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(enum_item),
         object_id=enum_item.pk,
         dataset=dataset,
-        title='Test value',
-        description='For testing',
-        prepare='1',
+        title="Test value",
+        description="For testing",
+        prepare="1",
         access=Metadata.OPEN,
         source="TEST",
         metadata_version=version,
     )
 
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=14)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk, enum_meta.pk]
-    form['description'] = "Add new structure to version"
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=14)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [dataset_meta.pk, model_meta.pk, prop_meta.pk, enum_meta.pk]
+    form["description"] = "Add new structure to version"
     form.submit()
-    first_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    first_published_version = _Version.objects.filter(dataset=dataset).order_by("-created").first()
     first_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=first_published_version).all()
 
-    enum_meta.prepare = '2'
+    enum_meta.prepare = "2"
     enum_meta.draft = True
     enum_meta.save()
 
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk, enum_meta.pk]
-    form['description'] = "Update structure version"
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [dataset_meta.pk, model_meta.pk, prop_meta.pk, enum_meta.pk]
+    form["description"] = "Update structure version"
     form.submit()
-    second_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    second_published_version = _Version.objects.filter(dataset=dataset).order_by("-created").first()
     second_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=second_published_version).all()
 
     assert dataset.dataset_version.count() == 3
-    assert first_version_metadata.filter(
-        content_type=ContentType.objects.get_for_model(enum_item),
-    ).first().prepare == '1'
+    assert (
+        first_version_metadata.filter(
+            content_type=ContentType.objects.get_for_model(enum_item),
+        )
+        .first()
+        .prepare
+        == "1"
+    )
 
     assert second_version_metadata.count() == 4
-    assert second_version_metadata.filter(
-        content_type=ContentType.objects.get_for_model(enum_item)).first().object.pk != enum_item.pk
-    assert second_version_metadata.filter(
-        content_type=ContentType.objects.get_for_model(enum_item)).first().prepare == '2'
+    assert (
+        second_version_metadata.filter(content_type=ContentType.objects.get_for_model(enum_item)).first().object.pk
+        != enum_item.pk
+    )
+    assert (
+        second_version_metadata.filter(content_type=ContentType.objects.get_for_model(enum_item)).first().prepare == "2"
+    )
 
 
 @pytest.mark.django_db
@@ -3045,15 +3066,18 @@ def test_new_version_with_updated_structure__enum_source(app: DjangoTestApp):
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        metadata_version=version
+        metadata_version=version,
     )
-    prop = PropertyFactory(model=model, metadata_version=version,)
+    prop = PropertyFactory(
+        model=model,
+        metadata_version=version,
+    )
     prop_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
+        name="prop",
+        type="string",
         access=3,
         metadata_version=version,
     )
@@ -3062,51 +3086,63 @@ def test_new_version_with_updated_structure__enum_source(app: DjangoTestApp):
         object_id=prop.pk,
         metadata_version=version,
     )
-    enum_item = EnumItemFactory(enum=enum, metadata_version=version,)
+    enum_item = EnumItemFactory(
+        enum=enum,
+        metadata_version=version,
+    )
     enum_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(enum_item),
         object_id=enum_item.pk,
         dataset=dataset,
-        title='Test value',
-        description='For testing',
-        prepare='1',
+        title="Test value",
+        description="For testing",
+        prepare="1",
         access=Metadata.OPEN,
         source="TEST",
         metadata_version=version,
     )
 
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=14)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk, enum_meta.pk]
-    form['description'] = "Add new structure to version"
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=14)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [dataset_meta.pk, model_meta.pk, prop_meta.pk, enum_meta.pk]
+    form["description"] = "Add new structure to version"
     form.submit()
-    first_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    first_published_version = _Version.objects.filter(dataset=dataset).order_by("-created").first()
     first_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=first_published_version).all()
 
-    enum_meta.source = 'TEST1'
+    enum_meta.source = "TEST1"
     enum_meta.draft = True
     enum_meta.save()
 
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk, enum_meta.pk]
-    form['description'] = "Update structure version"
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [dataset_meta.pk, model_meta.pk, prop_meta.pk, enum_meta.pk]
+    form["description"] = "Update structure version"
     form.submit()
-    second_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
+    second_published_version = _Version.objects.filter(dataset=dataset).order_by("-created").first()
     second_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=second_published_version).all()
 
     assert dataset.dataset_version.count() == 3
-    assert first_version_metadata.filter(
-        content_type=ContentType.objects.get_for_model(enum_item),
-    ).first().source == 'TEST'
+    assert (
+        first_version_metadata.filter(
+            content_type=ContentType.objects.get_for_model(enum_item),
+        )
+        .first()
+        .source
+        == "TEST"
+    )
 
     assert second_version_metadata.count() == 4
-    assert second_version_metadata.filter(
-        content_type=ContentType.objects.get_for_model(enum_item)).first().object.pk != enum_item.pk
-    assert second_version_metadata.filter(
-        content_type=ContentType.objects.get_for_model(enum_item)).first().source == 'TEST1'
+    assert (
+        second_version_metadata.filter(content_type=ContentType.objects.get_for_model(enum_item)).first().object.pk
+        != enum_item.pk
+    )
+    assert (
+        second_version_metadata.filter(content_type=ContentType.objects.get_for_model(enum_item)).first().source
+        == "TEST1"
+    )
 
 
 @pytest.mark.django_db
@@ -3114,20 +3150,18 @@ def test_structure_tab_with_non_public_dataset_without_access(app: DjangoTestApp
     dataset = DatasetFactory(is_public=False)
     user = UserFactory()
     app.set_user(user)
-    response = app.get(
-        reverse('dataset-structure-no-version', args=[dataset.pk])
-    ).follow(expect_errors=True)
+    response = app.get(reverse("dataset-structure-no-version", args=[dataset.pk])).follow(expect_errors=True)
     assert response.status_code == 403
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-        "role",
-        [
-            Representative.OPEN_DATA_MANAGER,
-            Representative.RESOURCE_MANAGER,
-        ],
-    )
+    "role",
+    [
+        Representative.OPEN_DATA_MANAGER,
+        Representative.RESOURCE_MANAGER,
+    ],
+)
 def test_structure_tab_with_non_public_dataset_with_access(app: DjangoTestApp, role: str):
     dataset = DatasetFactory(is_public=False)
     user = UserFactory()
@@ -3138,8 +3172,8 @@ def test_structure_tab_with_non_public_dataset_with_access(app: DjangoTestApp, r
         role=role,
     )
     app.set_user(user)
-    response = app.get(reverse('dataset-structure-no-version', args=[dataset.pk])).follow()
-    assert response.context['dataset'] == dataset
+    response = app.get(reverse("dataset-structure-no-version", args=[dataset.pk])).follow()
+    assert response.context["dataset"] == dataset
 
 
 @pytest.mark.django_db
@@ -3148,31 +3182,28 @@ def test_version_list_with_non_public_dataset_without_access(app: DjangoTestApp)
     VersionFactory(dataset=dataset)
     user = UserFactory()
     app.set_user(user)
-    response = app.get(reverse('version-list', args=[dataset.pk]), expect_errors=True)
+    response = app.get(reverse("version-list", args=[dataset.pk]), expect_errors=True)
     assert response.status_code == 403
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-        "role",
-        [
-            Representative.OPEN_DATA_MANAGER,
-            Representative.RESOURCE_MANAGER,
-        ],
-    )
+    "role",
+    [
+        Representative.OPEN_DATA_MANAGER,
+        Representative.RESOURCE_MANAGER,
+    ],
+)
 def test_version_list_with_non_public_dataset_with_access(app: DjangoTestApp, role: str):
     dataset = DatasetFactory(is_public=False)
     VersionFactory(dataset=dataset)
     user = UserFactory()
     RepresentativeFactory(
-        content_type=ContentType.objects.get_for_model(dataset),
-        object_id=dataset.pk,
-        user=user,
-        role=role
+        content_type=ContentType.objects.get_for_model(dataset), object_id=dataset.pk, user=user, role=role
     )
     app.set_user(user)
-    response = app.get(reverse('version-list', args=[dataset.pk]))
-    assert list(response.context['versions']) == [] # Version that gets created is Draft which is not displayed
+    response = app.get(reverse("version-list", args=[dataset.pk]))
+    assert list(response.context["versions"]) == []  # Version that gets created is Draft which is not displayed
 
 
 @pytest.mark.django_db
@@ -3181,31 +3212,28 @@ def test_version_detail_with_non_public_dataset_without_access(app: DjangoTestAp
     version = VersionFactory(dataset=dataset)
     user = UserFactory()
     app.set_user(user)
-    response = app.get(reverse('version-detail', args=[dataset.pk, version.pk]), expect_errors=True)
+    response = app.get(reverse("version-detail", args=[dataset.pk, version.pk]), expect_errors=True)
     assert response.status_code == 403
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-        "role",
-        [
-            Representative.OPEN_DATA_MANAGER,
-            Representative.RESOURCE_MANAGER,
-        ],
-    )
+    "role",
+    [
+        Representative.OPEN_DATA_MANAGER,
+        Representative.RESOURCE_MANAGER,
+    ],
+)
 def test_version_detail_with_non_public_dataset_with_access(app: DjangoTestApp, role: str):
     dataset = DatasetFactory(is_public=False)
     version = VersionFactory(dataset=dataset)
     user = UserFactory()
     RepresentativeFactory(
-        content_type=ContentType.objects.get_for_model(dataset),
-        object_id=dataset.pk,
-        user=user,
-        role=role
+        content_type=ContentType.objects.get_for_model(dataset), object_id=dataset.pk, user=user, role=role
     )
     app.set_user(user)
-    response = app.get(reverse('version-detail', args=[dataset.pk, version.pk]))
-    assert response.context['version'] == version
+    response = app.get(reverse("version-detail", args=[dataset.pk, version.pk]))
+    assert response.context["version"] == version
 
 
 @pytest.mark.django_db
@@ -3218,38 +3246,38 @@ def test_model_structure_with_non_public_dataset_without_access(app: DjangoTestA
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        metadata_version=version
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
         name="test/dataset",
-        metadata_version=version
+        metadata_version=version,
     )
     prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
-        metadata_version=version
+        name="prop",
+        type="string",
+        metadata_version=version,
     )
     user = UserFactory()
     app.set_user(user)
-    response = app.get(reverse('model-structure', args=[dataset.pk, version.pk, model.name]), expect_errors=True)
+    response = app.get(reverse("model-structure", args=[dataset.pk, version.pk, model.name]), expect_errors=True)
     assert response.status_code == 403
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-        "role",
-        [
-            Representative.OPEN_DATA_MANAGER,
-            Representative.RESOURCE_MANAGER,
-        ],
-    )
+    "role",
+    [
+        Representative.OPEN_DATA_MANAGER,
+        Representative.RESOURCE_MANAGER,
+    ],
+)
 def test_model_structure_with_non_public_dataset_with_access(app: DjangoTestApp, role: str):
     dataset = DatasetFactory(is_public=False)
     version = VersionFactory(dataset=dataset)
@@ -3259,34 +3287,31 @@ def test_model_structure_with_non_public_dataset_with_access(app: DjangoTestApp,
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        metadata_version=version
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
         name="test/dataset",
-        metadata_version=version
+        metadata_version=version,
     )
     prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
-        metadata_version=version
+        name="prop",
+        type="string",
+        metadata_version=version,
     )
     user = UserFactory()
     RepresentativeFactory(
-        content_type=ContentType.objects.get_for_model(dataset),
-        object_id=dataset.pk,
-        user=user,
-        role=role
+        content_type=ContentType.objects.get_for_model(dataset), object_id=dataset.pk, user=user, role=role
     )
     app.set_user(user)
-    response = app.get(reverse('model-structure', args=[dataset.pk, version.pk, model.name]))
-    assert response.context['model'] == model
+    response = app.get(reverse("model-structure", args=[dataset.pk, version.pk, model.name]))
+    assert response.context["model"] == model
 
 
 @pytest.mark.django_db
@@ -3299,38 +3324,40 @@ def test_property_structure_with_non_public_dataset_without_access(app: DjangoTe
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        metadata_version=version
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
         name="test/dataset",
-        metadata_version=version
+        metadata_version=version,
     )
     prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
-        metadata_version=version
+        name="prop",
+        type="string",
+        metadata_version=version,
     )
     user = UserFactory()
     app.set_user(user)
-    response = app.get(reverse('property-structure', args=[dataset.pk, version.pk, model.name, prop.name]), expect_errors=True)
+    response = app.get(
+        reverse("property-structure", args=[dataset.pk, version.pk, model.name, prop.name]), expect_errors=True
+    )
     assert response.status_code == 403
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-        "role",
-        [
-            Representative.OPEN_DATA_MANAGER,
-            Representative.RESOURCE_MANAGER,
-        ],
-    )
+    "role",
+    [
+        Representative.OPEN_DATA_MANAGER,
+        Representative.RESOURCE_MANAGER,
+    ],
+)
 def test_property_structure_with_non_public_dataset_with_access(app: DjangoTestApp, role: str):
     dataset = DatasetFactory(is_public=False)
     version = VersionFactory(dataset=dataset)
@@ -3340,34 +3367,31 @@ def test_property_structure_with_non_public_dataset_with_access(app: DjangoTestA
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        metadata_version=version
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
         name="test/dataset",
-        metadata_version=version
+        metadata_version=version,
     )
     prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
-        metadata_version=version
+        name="prop",
+        type="string",
+        metadata_version=version,
     )
     user = UserFactory()
     RepresentativeFactory(
-        content_type=ContentType.objects.get_for_model(dataset),
-        object_id=dataset.pk,
-        user=user,
-        role=role
+        content_type=ContentType.objects.get_for_model(dataset), object_id=dataset.pk, user=user, role=role
     )
     app.set_user(user)
-    response = app.get(reverse('property-structure', args=[dataset.pk, version.pk, model.name, prop.name]))
-    assert response.context['prop'] == prop
+    response = app.get(reverse("property-structure", args=[dataset.pk, version.pk, model.name, prop.name]))
+    assert response.context["prop"] == prop
 
 
 @pytest.mark.django_db
@@ -3380,38 +3404,38 @@ def test_model_data_with_non_public_dataset_without_access(app: DjangoTestApp):
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        metadata_version=version
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
         name="test/dataset",
-        metadata_version=version
+        metadata_version=version,
     )
     prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
-        metadata_version=version
+        name="prop",
+        type="string",
+        metadata_version=version,
     )
     user = UserFactory()
     app.set_user(user)
-    response = app.get(reverse('model-data', args=[dataset.pk, version.pk, model.name]), expect_errors=True)
+    response = app.get(reverse("model-data", args=[dataset.pk, version.pk, model.name]), expect_errors=True)
     assert response.status_code == 403
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-        "role",
-        [
-            Representative.OPEN_DATA_MANAGER,
-            Representative.RESOURCE_MANAGER,
-        ],
-    )
+    "role",
+    [
+        Representative.OPEN_DATA_MANAGER,
+        Representative.RESOURCE_MANAGER,
+    ],
+)
 def test_model_data_with_non_public_dataset_with_access(app: DjangoTestApp, role: str):
     dataset = DatasetFactory(is_public=False)
     version = VersionFactory(dataset=dataset)
@@ -3421,34 +3445,31 @@ def test_model_data_with_non_public_dataset_with_access(app: DjangoTestApp, role
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        metadata_version=version
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
         name="test/dataset",
-        metadata_version=version
+        metadata_version=version,
     )
     prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
-        metadata_version=version
+        name="prop",
+        type="string",
+        metadata_version=version,
     )
     user = UserFactory()
     RepresentativeFactory(
-        content_type=ContentType.objects.get_for_model(dataset),
-        object_id=dataset.pk,
-        user=user,
-        role=role
+        content_type=ContentType.objects.get_for_model(dataset), object_id=dataset.pk, user=user, role=role
     )
     app.set_user(user)
-    response = app.get(reverse('model-data', args=[dataset.pk, version.pk, model.name]))
-    assert response.context['model'] == model
+    response = app.get(reverse("model-data", args=[dataset.pk, version.pk, model.name]))
+    assert response.context["model"] == model
 
 
 @pytest.mark.django_db
@@ -3461,38 +3482,40 @@ def test_object_data_with_non_public_dataset_without_access(app: DjangoTestApp):
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        metadata_version=version
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
         name="test/dataset",
-        metadata_version=version
+        metadata_version=version,
     )
     prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
-        metadata_version=version
+        name="prop",
+        type="string",
+        metadata_version=version,
     )
     user = UserFactory()
     app.set_user(user)
-    response = app.get(reverse('object-data', args=[dataset.pk, version.pk, model.name, "123456789"]), expect_errors=True)
+    response = app.get(
+        reverse("object-data", args=[dataset.pk, version.pk, model.name, "123456789"]), expect_errors=True
+    )
     assert response.status_code == 403
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-        "role",
-        [
-            Representative.OPEN_DATA_MANAGER,
-            Representative.RESOURCE_MANAGER,
-        ],
-    )
+    "role",
+    [
+        Representative.OPEN_DATA_MANAGER,
+        Representative.RESOURCE_MANAGER,
+    ],
+)
 def test_object_data_with_non_public_dataset_with_access(app: DjangoTestApp, role: str):
     dataset = DatasetFactory(is_public=False)
     version = VersionFactory(dataset=dataset)
@@ -3502,34 +3525,31 @@ def test_object_data_with_non_public_dataset_with_access(app: DjangoTestApp, rol
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        metadata_version=version
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
         name="test/dataset",
-        metadata_version=version
+        metadata_version=version,
     )
     prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
-        metadata_version=version
+        name="prop",
+        type="string",
+        metadata_version=version,
     )
     user = UserFactory()
     RepresentativeFactory(
-        content_type=ContentType.objects.get_for_model(dataset),
-        object_id=dataset.pk,
-        user=user,
-        role=role
+        content_type=ContentType.objects.get_for_model(dataset), object_id=dataset.pk, user=user, role=role
     )
     app.set_user(user)
-    response = app.get(reverse('object-data', args=[dataset.pk, version.pk, model.name, "123456789"]))
-    assert response.context['model'] == model
+    response = app.get(reverse("object-data", args=[dataset.pk, version.pk, model.name, "123456789"]))
+    assert response.context["model"] == model
 
 
 @pytest.mark.django_db
@@ -3542,38 +3562,38 @@ def test_api_with_non_public_dataset_without_access(app: DjangoTestApp):
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        metadata_version=version
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
         name="test/dataset",
-        metadata_version=version
+        metadata_version=version,
     )
     prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
-        metadata_version=version
+        name="prop",
+        type="string",
+        metadata_version=version,
     )
     user = UserFactory()
     app.set_user(user)
-    response = app.get(reverse('getall-api', args=[dataset.pk, version.pk, model.name]), expect_errors=True)
+    response = app.get(reverse("getall-api", args=[dataset.pk, version.pk, model.name]), expect_errors=True)
     assert response.status_code == 403
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-        "role",
-        [
-            Representative.OPEN_DATA_MANAGER,
-            Representative.RESOURCE_MANAGER,
-        ],
-    )
+    "role",
+    [
+        Representative.OPEN_DATA_MANAGER,
+        Representative.RESOURCE_MANAGER,
+    ],
+)
 def test_api_with_non_public_dataset_with_access(app: DjangoTestApp, role: str):
     dataset = DatasetFactory(is_public=False)
     version = VersionFactory(dataset=dataset)
@@ -3583,34 +3603,31 @@ def test_api_with_non_public_dataset_with_access(app: DjangoTestApp, role: str):
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        metadata_version=version
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
         name="test/dataset",
-        metadata_version=version
+        metadata_version=version,
     )
     prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
-        metadata_version=version
+        name="prop",
+        type="string",
+        metadata_version=version,
     )
     user = UserFactory()
     RepresentativeFactory(
-        content_type=ContentType.objects.get_for_model(dataset),
-        object_id=dataset.pk,
-        user=user,
-        role=role
+        content_type=ContentType.objects.get_for_model(dataset), object_id=dataset.pk, user=user, role=role
     )
     app.set_user(user)
-    response = app.get(reverse('getall-api', args=[dataset.pk, version.pk, model.name]))
-    assert response.context['model'] == model
+    response = app.get(reverse("getall-api", args=[dataset.pk, version.pk, model.name]))
+    assert response.context["model"] == model
 
 
 @pytest.mark.django_db
@@ -3636,9 +3653,7 @@ def test_visibility_without_access(app: DjangoTestApp):
         ",,,,,number,string,,,,5,,package,open,dct:number,,,,\n"
         ",,,,,residence,string,,,,5,,public,open,dct:residence,,,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest))
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -3646,7 +3661,7 @@ def test_visibility_without_access(app: DjangoTestApp):
     resp = app.get(reverse("dataset-structure", args=[structure.dataset.pk, version.pk]))
     assert list(resp.context["models"].values_list("metadata__name", flat=True)) == [
         "datasets/gov/ivpk/adp/Province",
-        "datasets/gov/ivpk/adp/State"
+        "datasets/gov/ivpk/adp/State",
     ]
 
     resp = app.get(
@@ -3679,7 +3694,6 @@ def test_visibility_without_access(app: DjangoTestApp):
     )
     assert resp.status_code == 403
 
-
     resp = app.get(
         reverse("model-structure", args=[structure.dataset.pk, version.pk, "Province"]),
         expect_errors=True,
@@ -3703,7 +3717,6 @@ def test_visibility_without_access(app: DjangoTestApp):
         expect_errors=True,
     )
     assert resp.status_code == 200
-
 
     resp = app.get(
         reverse("model-structure", args=[structure.dataset.pk, version.pk, "State"]),
@@ -3758,18 +3771,14 @@ def test_model_visibility_with_manager_access(app: DjangoTestApp):
         ",,,,,residence,string,,,,5,,public,open,dct:residence,,,,\n"
     )
 
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest))
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
 
     ct = ContentType.objects.get_for_model(structure.dataset)
     representative = RepresentativeFactory(
-        content_type=ct,
-        object_id=structure.dataset.pk,
-        role=Representative.RESOURCE_MANAGER
+        content_type=ct, object_id=structure.dataset.pk, role=Representative.RESOURCE_MANAGER
     )
     app.set_user(representative.user)
 
@@ -3887,9 +3896,7 @@ def test_model_visibility_with_open_data_representative_access(app: DjangoTestAp
         ",,,,,residence,string,,,,5,,public,open,dct:residence,,,,\n"
     )
     organization = OrganizationFactory(kind=Organization.GOV)
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest))
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.organization = organization
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -4013,9 +4020,7 @@ def test_model_visibility_with_information_system_representative_access(app: Dja
         ",,,,,residence,string,,,,5,,public,open,dct:residence,,,,\n"
     )
     organization = OrganizationFactory(kind=Organization.GOV)
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest))
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.organization = organization
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -4172,9 +4177,7 @@ def test_property_create__higher_visibility_with_error(app: DjangoTestApp):
         visibility=Metadata.PRIVATE,
         metadata_version=version,
     )
-    form = app.get(reverse("property-create", args=[dataset.pk, version.pk, model.name])).forms[
-        "property-form"
-    ]
+    form = app.get(reverse("property-create", args=[dataset.pk, version.pk, model.name])).forms["property-form"]
     form["name"] = "property"
     form["access"] = Metadata.OPEN
     form["visibility"] = Metadata.PROTECTED
@@ -4198,14 +4201,14 @@ def test_property_enum_item_create__higher_visibility_with_error(app: DjangoTest
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        metadata_version=version
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
         name="test/dataset",
-        metadata_version=version
+        metadata_version=version,
     )
     prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
@@ -4215,11 +4218,9 @@ def test_property_enum_item_create__higher_visibility_with_error(app: DjangoTest
         name="prop",
         type="integer",
         visibility=Metadata.PRIVATE,
-        metadata_version=version
+        metadata_version=version,
     )
-    form = app.get(
-        reverse("enum-create", args=[dataset.pk, version.pk, model.name, prop.name])
-    ).forms["enum-form"]
+    form = app.get(reverse("enum-create", args=[dataset.pk, version.pk, model.name, prop.name])).forms["enum-form"]
     form["value"] = 2
     form["source"] = 2
     form["access"] = Metadata.OPEN
@@ -4228,10 +4229,9 @@ def test_property_enum_item_create__higher_visibility_with_error(app: DjangoTest
     form["visibility"] = Metadata.PROTECTED
     resp = form.submit()
     assert list(resp.context["form"].errors.values()) == [
-        [
-            "Metaduomenų matomumas 'protected' negali būti didesnis nei duomenų lauko matomumas 'private'."
-        ]
+        ["Metaduomenų matomumas 'protected' negali būti didesnis nei duomenų lauko matomumas 'private'."]
     ]
+
 
 @pytest.mark.django_db
 def test_property_enum_create_with_in_released_version(app: DjangoTestApp):
@@ -4247,14 +4247,14 @@ def test_property_enum_create_with_in_released_version(app: DjangoTestApp):
         dataset=dataset,
         name="test/dataset/TestModel",
         visibility=Metadata.PRIVATE,
-        metadata_version=version
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
         name="test/dataset",
-        metadata_version=version
+        metadata_version=version,
     )
     prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
@@ -4263,13 +4263,14 @@ def test_property_enum_create_with_in_released_version(app: DjangoTestApp):
         dataset=dataset,
         name="prop",
         type="integer",
-        metadata_version=version
+        metadata_version=version,
     )
     resp = app.get(
         reverse("enum-create", args=[dataset.pk, version.pk, model.name, prop.name]),
     )
     assert resp.status_code == 302
     assert resp.location == prop.get_absolute_url()
+
 
 @pytest.mark.django_db
 def test_property_enum_item_create__higher_visibility_then_model_with_error(app: DjangoTestApp):
@@ -4285,14 +4286,14 @@ def test_property_enum_item_create__higher_visibility_then_model_with_error(app:
         dataset=dataset,
         name="test/dataset/TestModel",
         visibility=Metadata.PRIVATE,
-        metadata_version=version
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
         name="test/dataset",
-        metadata_version=version
+        metadata_version=version,
     )
     prop = PropertyFactory(model=model, metadata_version=version)
     MetadataFactory(
@@ -4301,11 +4302,9 @@ def test_property_enum_item_create__higher_visibility_then_model_with_error(app:
         dataset=dataset,
         name="prop",
         type="integer",
-        metadata_version=version
+        metadata_version=version,
     )
-    form = app.get(
-        reverse("enum-create", args=[dataset.pk, version.pk, model.name, prop.name])
-    ).forms["enum-form"]
+    form = app.get(reverse("enum-create", args=[dataset.pk, version.pk, model.name, prop.name])).forms["enum-form"]
     form["value"] = 2
     form["source"] = 2
     form["access"] = Metadata.OPEN
@@ -4314,27 +4313,22 @@ def test_property_enum_item_create__higher_visibility_then_model_with_error(app:
     form["visibility"] = Metadata.PROTECTED
     resp = form.submit()
     assert list(resp.context["form"].errors.values()) == [
-        [
-            "Metaduomenų matomumas 'protected' negali būti didesnis nei duomenų modelio matomumas 'private'."
-        ]
+        ["Metaduomenų matomumas 'protected' negali būti didesnis nei duomenų modelio matomumas 'private'."]
     ]
+
 
 @pytest.mark.django_db
 def test_manifest_export_openapi(app: DjangoTestApp):
     """Test OpenAPI manifest export returns valid spec with correct metadata, schemas, tags, and paths."""
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,Country,,,,,,,,,,,,,,\n'
-        ',,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
-        ',,,,,title,string,,,,5,,,private,dct:title,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,Country,,,,,,,,,,,,,,\n"
+        ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
+        ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
@@ -4345,22 +4339,22 @@ def test_manifest_export_openapi(app: DjangoTestApp):
         object_id=structure.dataset.pk,
     )
     app.set_user(representative.user)
-    resp = app.get(reverse('dataset-structure-export-openapi', args=[structure.dataset.pk]))
+    resp = app.get(reverse("dataset-structure-export-openapi", args=[structure.dataset.pk]))
 
     assert resp.status_code == 200
-    assert resp.content_type == 'application/json'
+    assert resp.content_type == "application/json"
 
     openapi_spec = resp.json
 
-    expected_keys = ['openapi', 'info', 'externalDocs', 'servers', 'tags', 'components', 'paths']
+    expected_keys = ["openapi", "info", "externalDocs", "servers", "tags", "components", "paths"]
     assert list(openapi_spec.keys()) == expected_keys, "OpenAPI spec missing required top-level fields"
 
-    info = openapi_spec['info']
-    assert info['summary'] == structure.dataset.title, "Info summary should match dataset title"
-    assert info['description'] == structure.dataset.description, "Info description should match dataset description"
-    assert info['version'] == '1.0.0', "API version should be 1.0.0"
+    info = openapi_spec["info"]
+    assert info["summary"] == structure.dataset.title, "Info summary should match dataset title"
+    assert info["description"] == structure.dataset.description, "Info description should match dataset description"
+    assert info["version"] == "1.0.0", "API version should be 1.0.0"
 
-    schemas = set(openapi_spec['components']['schemas'].keys())
+    schemas = set(openapi_spec["components"]["schemas"].keys())
     expected_schemas = {"Country", "CountryCollection", "CountryChange", "CountryChanges"}
     assert expected_schemas <= schemas, f"Missing required schemas: {expected_schemas - schemas}"
 
@@ -4372,13 +4366,12 @@ def test_manifest_export_openapi(app: DjangoTestApp):
     model_paths = {
         "/datasets/gov/ivpk/adp/Country",
         "/datasets/gov/ivpk/adp/Country/{id}",
-        "/datasets/gov/ivpk/adp/Country/:changes/{cid}"
+        "/datasets/gov/ivpk/adp/Country/:changes/{cid}",
     }
     expected_paths = utility_paths | model_paths
     actual_paths = set(openapi_spec["paths"].keys())
     assert actual_paths == expected_paths, (
-        f"Paths mismatch. Missing: {expected_paths - actual_paths}, "
-        f"Extra: {actual_paths - expected_paths}"
+        f"Paths mismatch. Missing: {expected_paths - actual_paths}, Extra: {actual_paths - expected_paths}"
     )
 
 
@@ -4386,21 +4379,17 @@ def test_manifest_export_openapi(app: DjangoTestApp):
 def test_manifest_export_openapi_soap_params(app: DjangoTestApp):
     """Test OpenAPI manifest export returns valid spec with correct metadata, schemas, tags, and paths."""
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,rc_wsdl,,,,wsdl,,https://test-data.data.gov.lt/api/v1/rc/get-data/?wsdl,,,,,,,,,,\n'
-        ',,get_data,,,,soap,,Get.GetPort.GetPort.GetData,wsdl(rc_wsdl),,,,,,,,,\n'
-        ',,,,,,param,action_type,input/ActionType,,,,,,,,,,\n'
-        ',,,,Country,,,,,,,,,,,,,,\n'
-        ',,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
-        ',,,,,title,string,,,,5,,,private,dct:title,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,rc_wsdl,,,,wsdl,,https://test-data.data.gov.lt/api/v1/rc/get-data/?wsdl,,,,,,,,,,\n"
+        ",,get_data,,,,soap,,Get.GetPort.GetPort.GetData,wsdl(rc_wsdl),,,,,,,,,\n"
+        ",,,,,,param,action_type,input/ActionType,,,,,,,,,,\n"
+        ",,,,Country,,,,,,,,,,,,,,\n"
+        ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
+        ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -4411,14 +4400,14 @@ def test_manifest_export_openapi_soap_params(app: DjangoTestApp):
         object_id=structure.dataset.pk,
     )
     app.set_user(representative.user)
-    resp = app.get(reverse('dataset-structure-export-openapi', args=[structure.dataset.pk]))
+    resp = app.get(reverse("dataset-structure-export-openapi", args=[structure.dataset.pk]))
 
     assert resp.status_code == 200
-    assert resp.content_type == 'application/json'
+    assert resp.content_type == "application/json"
 
     openapi_spec = resp.json
 
-    expected_keys = ['openapi', 'info', 'externalDocs', 'servers', 'tags', 'components', 'paths']
+    expected_keys = ["openapi", "info", "externalDocs", "servers", "tags", "components", "paths"]
     assert list(openapi_spec.keys()) == expected_keys, "OpenAPI spec missing required top-level fields"
 
 
@@ -4439,18 +4428,18 @@ def test_imported_metadata_gets_develop_status(app: DjangoTestApp):
         ",,,,,,,,,BIG,,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename="file.csv", data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
 
     resp_models = app.get(reverse("model-structure", args=[structure.dataset.pk, version.pk, "Country"]))
     assert list(resp_models.context["models"].values_list("metadata__status__codename", flat=True)) == ["develop"]
-    assert list(resp_models.context["props"].values_list("metadata__status__codename", flat=True)) == ["develop", "develop", "develop"]
+    assert list(resp_models.context["props"].values_list("metadata__status__codename", flat=True)) == [
+        "develop",
+        "develop",
+        "develop",
+    ]
 
     resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, version.pk, "Country", "id"]))
     assert list(resp_props.context["models"].values_list("metadata__status__codename", flat=True)) == ["develop"]
@@ -4460,7 +4449,9 @@ def test_imported_metadata_gets_develop_status(app: DjangoTestApp):
     assert list(resp_props.context["models"].values_list("metadata__status__codename", flat=True)) == ["develop"]
     assert resp_props.context["prop"].metadata.get().status.codename == "develop"
 
-    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, version.pk, "Country", "administration"]))
+    resp_props = app.get(
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "Country", "administration"])
+    )
     assert list(resp_props.context["models"].values_list("metadata__status__codename", flat=True)) == ["develop"]
 
     prop = resp_props.context["prop"]
@@ -4543,11 +4534,7 @@ def test_published_metadata_gets_completed_status(app: DjangoTestApp):
         ",,,,,,,,,BIG,,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename="file.csv", data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -4556,30 +4543,40 @@ def test_published_metadata_gets_completed_status(app: DjangoTestApp):
         Metadata.objects.filter(
             dataset=structure.dataset,
             draft=True,
-        ).values_list('id', flat=True)
+        ).values_list("id", flat=True)
     )
 
-    form = app.get(reverse('version-create', args=[structure.dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = metadata_ids
+    form = app.get(reverse("version-create", args=[structure.dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = metadata_ids
     form.submit()
 
     published_version = _Version.objects.exclude(status=VersionStatus.DRAFT).first()
 
     resp_models = app.get(reverse("model-structure", args=[structure.dataset.pk, published_version.pk, "Country"]))
     assert list(resp_models.context["models"].values_list("metadata__status__codename", flat=True)) == ["completed"]
-    assert list(resp_models.context["props"].values_list("metadata__status__codename", flat=True)) == ["completed", "completed", "completed"]
+    assert list(resp_models.context["props"].values_list("metadata__status__codename", flat=True)) == [
+        "completed",
+        "completed",
+        "completed",
+    ]
 
-    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, published_version.pk, "Country", "id"]))
+    resp_props = app.get(
+        reverse("property-structure", args=[structure.dataset.pk, published_version.pk, "Country", "id"])
+    )
     assert list(resp_props.context["models"].values_list("metadata__status__codename", flat=True)) == ["completed"]
     assert resp_props.context["prop"].metadata.get().status.codename == "completed"
 
-    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, published_version.pk, "Country", "title"]))
+    resp_props = app.get(
+        reverse("property-structure", args=[structure.dataset.pk, published_version.pk, "Country", "title"])
+    )
     assert list(resp_props.context["models"].values_list("metadata__status__codename", flat=True)) == ["completed"]
     assert resp_props.context["prop"].metadata.get().status.codename == "completed"
 
-    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, published_version.pk, "Country", "administration"]))
+    resp_props = app.get(
+        reverse("property-structure", args=[structure.dataset.pk, published_version.pk, "Country", "administration"])
+    )
     assert list(resp_props.context["models"].values_list("metadata__status__codename", flat=True)) == ["completed"]
 
     prop = resp_props.context["prop"]
@@ -4602,11 +4599,7 @@ def test_changed_metadata_keeps_status_after_publishing(app: DjangoTestApp):
         ",,,,,,enum,small,,SMALL,,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename="file.csv", data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -4621,41 +4614,55 @@ def test_changed_metadata_keeps_status_after_publishing(app: DjangoTestApp):
             dataset=structure.dataset,
             draft=True,
             metadata_version=version,
-        ).values_list('id', flat=True)
+        ).values_list("id", flat=True)
     )
 
-    model_form = app.get(reverse('model-update', args=[structure.dataset.pk, version.pk, "Country"])).forms['model-form']
-    model_form['status'] = Status.objects.filter(codename="discont").first().id
+    model_form = app.get(reverse("model-update", args=[structure.dataset.pk, version.pk, "Country"])).forms[
+        "model-form"
+    ]
+    model_form["status"] = Status.objects.filter(codename="discont").first().id
     model_form.submit()
 
-    property_form = app.get(reverse('property-update', args=[structure.dataset.pk, version.pk, "Country", "administration"])).forms['property-form']
-    property_form['status'] = Status.objects.filter(codename="deprecated").first().id
+    property_form = app.get(
+        reverse("property-update", args=[structure.dataset.pk, version.pk, "Country", "administration"])
+    ).forms["property-form"]
+    property_form["status"] = Status.objects.filter(codename="deprecated").first().id
     property_form.submit()
 
-    enum_form = app.get(reverse('enum-update', args=[structure.dataset.pk, version.pk, "Country", "administration", enum_id])).forms['enum-form']
-    enum_form['status'] = Status.objects.filter(codename="withdrawn").first().id
+    enum_form = app.get(
+        reverse("enum-update", args=[structure.dataset.pk, version.pk, "Country", "administration", enum_id])
+    ).forms["enum-form"]
+    enum_form["status"] = Status.objects.filter(codename="withdrawn").first().id
     enum_form.submit()
 
-    form = app.get(reverse('version-create', args=[structure.dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = metadata_ids
+    form = app.get(reverse("version-create", args=[structure.dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = metadata_ids
     form.submit()
     published_version = _Version.objects.exclude(status=VersionStatus.DRAFT).first()
 
     resp_models = app.get(reverse("model-structure", args=[structure.dataset.pk, published_version.pk, "Country"]))
     assert list(resp_models.context["models"].values_list("metadata__status__codename", flat=True)) == ["discont"]
 
-    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, published_version.pk, "Country", "id"]))
+    resp_props = app.get(
+        reverse("property-structure", args=[structure.dataset.pk, published_version.pk, "Country", "id"])
+    )
     assert resp_props.context["prop"].metadata.get().status.codename == "discont"
 
-    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, published_version.pk, "Country", "title"]))
+    resp_props = app.get(
+        reverse("property-structure", args=[structure.dataset.pk, published_version.pk, "Country", "title"])
+    )
     assert resp_props.context["prop"].metadata.get().status.codename == "completed"
 
-    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, published_version.pk, "Country", "administration"]))
+    resp_props = app.get(
+        reverse("property-structure", args=[structure.dataset.pk, published_version.pk, "Country", "administration"])
+    )
     assert resp_props.context["prop"].metadata.get().status.codename == "deprecated"
 
-    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, published_version.pk, "Country", "administration"]))
+    resp_props = app.get(
+        reverse("property-structure", args=[structure.dataset.pk, published_version.pk, "Country", "administration"])
+    )
     prop = resp_props.context["prop"]
     for enum_item in prop.enums.first().enumitem_set.all():
         assert enum_item.metadata.first().status.codename == "withdrawn"
@@ -4677,11 +4684,7 @@ def test_draft_metadata_defaults_to_develop_after_hard_change(app: DjangoTestApp
         ",,,,,,,big,,BIG,,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename="file.csv", data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -4692,29 +4695,40 @@ def test_draft_metadata_defaults_to_develop_after_hard_change(app: DjangoTestApp
     enum_id = enum.id
     new_enum_name = "Largety"
 
-    model_form = app.get(reverse('model-update', args=[structure.dataset.pk, version.pk, "Country"])).forms['model-form']
-    model_form['level'] = 3
+    model_form = app.get(reverse("model-update", args=[structure.dataset.pk, version.pk, "Country"])).forms[
+        "model-form"
+    ]
+    model_form["level"] = 3
     model_form.submit()
 
-    property_form = app.get(reverse('property-update', args=[structure.dataset.pk, version.pk, "Country", "administration"])).forms['property-form']
-    property_form['access'] = 2
+    property_form = app.get(
+        reverse("property-update", args=[structure.dataset.pk, version.pk, "Country", "administration"])
+    ).forms["property-form"]
+    property_form["access"] = 2
     property_form.submit()
 
-    enum_form = app.get(reverse('enum-update', args=[structure.dataset.pk, version.pk, "Country", "administration", enum_id])).forms['enum-form']
-    enum_form['value'] = new_enum_name
+    enum_form = app.get(
+        reverse("enum-update", args=[structure.dataset.pk, version.pk, "Country", "administration", enum_id])
+    ).forms["enum-form"]
+    enum_form["value"] = new_enum_name
     enum_form.submit()
 
     resp_models = app.get(reverse("model-structure", args=[structure.dataset.pk, version.pk, "Country"]))
     assert list(resp_models.context["models"].values_list("metadata__status__codename", flat=True)) == ["develop"]
 
-    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, version.pk, "Country", "administration"]))
+    resp_props = app.get(
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "Country", "administration"])
+    )
     assert resp_props.context["prop"].metadata.get().status.codename == "develop"
 
-    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, version.pk, "Country", "administration"]))
+    resp_props = app.get(
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "Country", "administration"])
+    )
     prop = resp_props.context["prop"]
     for enum_item in prop.enums.first().enumitem_set.all():
         enum_metadata = enum_item.metadata.first()
         assert enum_metadata.status.codename == "develop"
+
 
 @pytest.mark.django_db
 def test_changing_multiple_fields_in_draft_structure_respects_status(app: DjangoTestApp):
@@ -4732,11 +4746,7 @@ def test_changing_multiple_fields_in_draft_structure_respects_status(app: Django
         ",,,,,,,big,,BIG,,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename="file.csv", data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -4747,28 +4757,38 @@ def test_changing_multiple_fields_in_draft_structure_respects_status(app: Django
     enum_id = enum.id
     new_enum_name = "Largety"
 
-    model_form = app.get(reverse('model-update', args=[structure.dataset.pk, version.pk, "Country"])).forms['model-form']
-    model_form['level'] = 2
+    model_form = app.get(reverse("model-update", args=[structure.dataset.pk, version.pk, "Country"])).forms[
+        "model-form"
+    ]
+    model_form["level"] = 2
     model_form["status"] = 5
     model_form.submit()
 
-    property_form = app.get(reverse('property-update', args=[structure.dataset.pk, version.pk, "Country", "administration"])).forms['property-form']
-    property_form['access'] = 2
+    property_form = app.get(
+        reverse("property-update", args=[structure.dataset.pk, version.pk, "Country", "administration"])
+    ).forms["property-form"]
+    property_form["access"] = 2
     property_form["status"] = 5
     property_form.submit()
 
-    enum_form = app.get(reverse('enum-update', args=[structure.dataset.pk, version.pk, "Country", "administration", enum_id])).forms['enum-form']
-    enum_form['value'] = new_enum_name
+    enum_form = app.get(
+        reverse("enum-update", args=[structure.dataset.pk, version.pk, "Country", "administration", enum_id])
+    ).forms["enum-form"]
+    enum_form["value"] = new_enum_name
     enum_form["status"] = 5
     enum_form.submit()
 
     resp_models = app.get(reverse("model-structure", args=[structure.dataset.pk, version.pk, "Country"]))
     assert list(resp_models.context["models"].values_list("metadata__status__codename", flat=True)) == ["deprecated"]
 
-    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, version.pk, "Country", "administration"]))
+    resp_props = app.get(
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "Country", "administration"])
+    )
     assert resp_props.context["prop"].metadata.get().status.codename == "deprecated"
 
-    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, version.pk, "Country", "administration"]))
+    resp_props = app.get(
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "Country", "administration"])
+    )
     prop = resp_props.context["prop"]
     for enum_item in prop.enums.first().enumitem_set.all():
         enum_metadata = enum_item.metadata.first()
@@ -4794,11 +4814,7 @@ def test_draft_metadata_form_does_not_change_status_is_kept(app: DjangoTestApp):
         ",,,,,,,big,,BIG,,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename="file.csv", data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -4808,27 +4824,38 @@ def test_draft_metadata_form_does_not_change_status_is_kept(app: DjangoTestApp):
     enum = enum_meta.object
     enum_id = enum.id
 
-    model_form = app.get(reverse('model-update', args=[structure.dataset.pk, version.pk, "Country"])).forms['model-form']
+    model_form = app.get(reverse("model-update", args=[structure.dataset.pk, version.pk, "Country"])).forms[
+        "model-form"
+    ]
     model_form.submit()
 
-    property_form = app.get(reverse('property-update', args=[structure.dataset.pk, version.pk, "Country", "administration"])).forms['property-form']
+    property_form = app.get(
+        reverse("property-update", args=[structure.dataset.pk, version.pk, "Country", "administration"])
+    ).forms["property-form"]
     property_form.submit()
 
-    enum_form = app.get(reverse('enum-update', args=[structure.dataset.pk, version.pk, "Country", "administration", enum_id])).forms['enum-form']
+    enum_form = app.get(
+        reverse("enum-update", args=[structure.dataset.pk, version.pk, "Country", "administration", enum_id])
+    ).forms["enum-form"]
     enum_form.submit()
 
     resp_models = app.get(reverse("model-structure", args=[structure.dataset.pk, version.pk, "Country"]))
     assert list(resp_models.context["models"].values_list("metadata__status__codename", flat=True)) == ["develop"]
 
-    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, version.pk, "Country", "administration"]))
+    resp_props = app.get(
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "Country", "administration"])
+    )
     assert resp_props.context["prop"].metadata.get().status.codename == "develop"
 
-    resp_props = app.get(reverse("property-structure", args=[structure.dataset.pk, version.pk, "Country", "administration"]))
+    resp_props = app.get(
+        reverse("property-structure", args=[structure.dataset.pk, version.pk, "Country", "administration"])
+    )
     prop = resp_props.context["prop"]
     # TODO the status of enum should also be completed but because of a bug the name of the enum is changed even though nothing is submited. Change after bug fix
     for enum_item in prop.enums.first().enumitem_set.all():
         enum_metadata = enum_item.metadata.first()
         assert enum_metadata.status.codename == "develop"
+
 
 @pytest.mark.django_db
 def test_props_metadata_rendering(app: DjangoTestApp) -> None:
@@ -4841,14 +4868,14 @@ def test_props_metadata_rendering(app: DjangoTestApp) -> None:
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        metadata_version=version
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(dataset),
         object_id=dataset.pk,
         dataset=dataset,
         name="test/dataset",
-        metadata_version=version
+        metadata_version=version,
     )
 
     prop_1 = PropertyFactory(model=model, metadata_version=version)
@@ -4861,7 +4888,7 @@ def test_props_metadata_rendering(app: DjangoTestApp) -> None:
         name="prop_1",
         type="string",
         eli="https://example.com/prop_1",
-        metadata_version=version
+        metadata_version=version,
     )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop_2),
@@ -4870,10 +4897,12 @@ def test_props_metadata_rendering(app: DjangoTestApp) -> None:
         name="prop_2",
         type="integer",
         eli="https://example.com/prop_2",
-        metadata_version=version
+        metadata_version=version,
     )
 
-    response = app.get(reverse("model-structure", kwargs={"pk": dataset.pk, "version_id": version.pk, "model": model.name}))
+    response = app.get(
+        reverse("model-structure", kwargs={"pk": dataset.pk, "version_id": version.pk, "model": model.name})
+    )
 
     assert response.status_code == 200
     assert 'href="https://example.com/prop_1"' in response.content.decode()
@@ -4902,7 +4931,7 @@ def test_minor_version_available_if_major_exists(app: DjangoTestApp):
         dataset=version.dataset,
         metadata_version=version,
         content_type=ContentType.objects.get_for_model(Dataset),
-        object_id=version.dataset.pk
+        object_id=version.dataset.pk,
     )
 
     form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
@@ -4926,7 +4955,7 @@ def test_patch_version_available_if_minor_exists(app: DjangoTestApp):
         dataset=version.dataset,
         metadata_version=version,
         content_type=ContentType.objects.get_for_model(Dataset),
-        object_id=version.dataset.pk
+        object_id=version.dataset.pk,
     )
     major_version_form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
     major_version_form["released"] = datetime.date.today() + datetime.timedelta(days=15)
@@ -4958,7 +4987,7 @@ def test_form_errors_if_major_not_selected(app: DjangoTestApp):
         dataset=version.dataset,
         metadata_version=version,
         content_type=ContentType.objects.get_for_model(Dataset),
-        object_id=version.dataset.pk
+        object_id=version.dataset.pk,
     )
 
     major_version_form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
@@ -4987,7 +5016,7 @@ def test_form_errors_if_minor_not_selected(app: DjangoTestApp):
         dataset=version.dataset,
         metadata_version=version,
         content_type=ContentType.objects.get_for_model(Dataset),
-        object_id=version.dataset.pk
+        object_id=version.dataset.pk,
     )
 
     major_version_form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
@@ -5025,7 +5054,7 @@ def test_multiple_major_versions_increment_external_version(app: DjangoTestApp):
         dataset=version.dataset,
         metadata_version=version,
         content_type=ContentType.objects.get_for_model(Dataset),
-        object_id=version.dataset.pk
+        object_id=version.dataset.pk,
     )
 
     major_version_form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
@@ -5056,7 +5085,7 @@ def test_multiple_minor_versions_increment_external_version(app: DjangoTestApp):
         dataset=version.dataset,
         metadata_version=version,
         content_type=ContentType.objects.get_for_model(Dataset),
-        object_id=version.dataset.pk
+        object_id=version.dataset.pk,
     )
 
     major_version_form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
@@ -5099,7 +5128,7 @@ def test_multiple_patch_versions_increment_external_version(app: DjangoTestApp):
         dataset=version.dataset,
         metadata_version=version,
         content_type=ContentType.objects.get_for_model(Dataset),
-        object_id=version.dataset.pk
+        object_id=version.dataset.pk,
     )
 
     major_version_form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
@@ -5145,23 +5174,19 @@ def test_publish_form_shows_all_metadata_rows_params(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        ',,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n"
         '2,,,,,,param,country,,"lt",,,,,,,,,\n'
         '3,,,,,,,,,"lv",,,,,,,,,\n'
         '4,,,,,,,,,"ee",,,,,,,,,\n'
-        '5,,,,City,,,,,,,,,,,,,,\n'
+        "5,,,,City,,,,,,,,,,,,,,\n"
         '6,,,,,,param,type,,"created",,,,,,,,,\n'
         '7,,,,,,,,,"modified",,,,,,,,,\n'
-        '8,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n'
-        '9,,,,,type,string,,,,5,,,open,dct:type,,,,\n'
+        "8,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
+        "9,,,,,type,string,,,,5,,,open,dct:type,,,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -5174,23 +5199,19 @@ def test_publish_form_shows_all_metadata_rows_base(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        ',datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        '1,,,,Base,,,,,,4,,,,,,,,,\n'
-        ',,,Base,,,,,,,4,,,,,,,,,\n'
-        '2,,,,City,,,,,,5,,,,,,,,,\n'
-        ',,,,,id,integer,,,,5,,,,,,,,,\n'
-        ',,,,,title,string,,,,5,,,,,,,,,\n'
-        ',,,,,country,ref,Country,,,4,,,,,,,,,\n'
-        '3,,,,Country,,,,,,4,,,,,,,,,\n'
-        ',,,,,id,integer,,,,3,,,,,,,,,\n'
-        ',,,,,title,string,,,,2,,,,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        "1,,,,Base,,,,,,4,,,,,,,,,\n"
+        ",,,Base,,,,,,,4,,,,,,,,,\n"
+        "2,,,,City,,,,,,5,,,,,,,,,\n"
+        ",,,,,id,integer,,,,5,,,,,,,,,\n"
+        ",,,,,title,string,,,,5,,,,,,,,,\n"
+        ",,,,,country,ref,Country,,,4,,,,,,,,,\n"
+        "3,,,,Country,,,,,,4,,,,,,,,,\n"
+        ",,,,,id,integer,,,,3,,,,,,,,,\n"
+        ",,,,,title,string,,,,2,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -5203,24 +5224,20 @@ def test_publish_form_shows_all_metadata_rows_enum(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n'
-        '1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        '2,,,,,,prefix,dct,,,,,,,,http://purl.org/dc/terms/,,,\n'
-        '3,,,,,,enum,Size,,SMALL,,,,,,,,,,\n'
-        '4,,,,,,,,,MEDIUM,,,,,,,,,\n'
-        '5,,,,,,,,,BIG,,,,,,,,,\n'
-        '6,,,,City,,,,,,,,,,,,,,\n'
-        '7,,,,,id,integer,,,,,5,,,open,dct:identifier,,Identifikatorius,\n'
-        '8,,,,,size,Size,,,,,5,,,open,dct:size,,,\n'
-        '9,,,,,type,string,,,,,5,,,open,dct:type,,,\n'
-        '10,,,,,,enum,Type,,CREATED,,,,,,,,,\n'
-        '11,,,,,,,,,MODIFIED,,,,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        "2,,,,,,prefix,dct,,,,,,,,http://purl.org/dc/terms/,,,\n"
+        "3,,,,,,enum,Size,,SMALL,,,,,,,,,,\n"
+        "4,,,,,,,,,MEDIUM,,,,,,,,,\n"
+        "5,,,,,,,,,BIG,,,,,,,,,\n"
+        "6,,,,City,,,,,,,,,,,,,,\n"
+        "7,,,,,id,integer,,,,,5,,,open,dct:identifier,,Identifikatorius,\n"
+        "8,,,,,size,Size,,,,,5,,,open,dct:size,,,\n"
+        "9,,,,,type,string,,,,,5,,,open,dct:type,,,\n"
+        "10,,,,,,enum,Type,,CREATED,,,,,,,,,\n"
+        "11,,,,,,,,,MODIFIED,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -5233,23 +5250,19 @@ def test_publish_form_shows_all_metadata_rows_single_defined_resource(app: Djang
     user = UserFactory(is_staff=True)
     app.set_user(user)
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        '1,datasets/govsssss/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        '2,,,,City,,,,,,5,,,,,,,,,\n'
-        '3,,,,,id,integer,,,,5,,,,,,,,,\n'
-        '4,,,,,title,string,,,,5,,,,,,,,,\n'
-        '5,,,,,country,ref,Country,,,4,,,,,,,,,\n'
-        '6,,resource,,,,,,http://www.example.com,,,,,,,,,Title,Description\n'
-        '7,,,,Country,,,,,,4,,,,,,,,,\n'
-        '8,,,,,id,integer,,,,3,,,,,,,,,\n'
-        '9,,,,,title,string,,,,2,,,,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        "1,datasets/govsssss/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        "2,,,,City,,,,,,5,,,,,,,,,\n"
+        "3,,,,,id,integer,,,,5,,,,,,,,,\n"
+        "4,,,,,title,string,,,,5,,,,,,,,,\n"
+        "5,,,,,country,ref,Country,,,4,,,,,,,,,\n"
+        "6,,resource,,,,,,http://www.example.com,,,,,,,,,Title,Description\n"
+        "7,,,,Country,,,,,,4,,,,,,,,,\n"
+        "8,,,,,id,integer,,,,3,,,,,,,,,\n"
+        "9,,,,,title,string,,,,2,,,,,,,,,\n"
     )
 
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -5262,24 +5275,20 @@ def test_publish_form_shows_all_metadata_rows_multiple_resources(app: DjangoTest
     user = UserFactory(is_staff=True)
     app.set_user(user)
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        '1,datasets/govsssss/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        '2,,resource1,,,,,,http://www.example.com,,,,,,,,,Title,Description\n'
-        '3,,,,City,,,,,,5,,,,,,,,,\n'
-        '4,,,,,id,integer,,,,5,,,,,,,,,\n'
-        '5,,,,,title,string,,,,5,,,,,,,,,\n'
-        '6,,,,,country,ref,Country,,,4,,,,,,,,,\n'
-        '7,,resource,,,,,,http://www.example2.com,,,,,,,,,Title,Description\n'
-        '8,,,,Country,,,,,,4,,,,,,,,,\n'
-        '9,,,,,id,integer,,,,3,,,,,,,,,\n'
-        '10,,,,,title,string,,,,2,,,,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        "1,datasets/govsssss/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        "2,,resource1,,,,,,http://www.example.com,,,,,,,,,Title,Description\n"
+        "3,,,,City,,,,,,5,,,,,,,,,\n"
+        "4,,,,,id,integer,,,,5,,,,,,,,,\n"
+        "5,,,,,title,string,,,,5,,,,,,,,,\n"
+        "6,,,,,country,ref,Country,,,4,,,,,,,,,\n"
+        "7,,resource,,,,,,http://www.example2.com,,,,,,,,,Title,Description\n"
+        "8,,,,Country,,,,,,4,,,,,,,,,\n"
+        "9,,,,,id,integer,,,,3,,,,,,,,,\n"
+        "10,,,,,title,string,,,,2,,,,,,,,,\n"
     )
 
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -5297,31 +5306,27 @@ def test_publish_form_shows_all_metadata_rows_denorm_props(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        '1,datasets/govsssss/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        '2,,,,City,,,,,,,,,,,,,,\n'
-        '3,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n'
-        '4,,,,,title,string,,,,5,,,open,dct:title,,,,\n'
-        '5,,,,,country,ref,Country,,,5,,,open,,,,,,\n'
-        '6,,,,,country.id,,,,,5,,,open,,,,,,\n'
-        '7,,,,,country.continent.id,,,,,5,,,open,,,,,,\n'
-        '8,,resource,,,,,,http://www.example.com,,,,,,,,,Title,Description\n'
-        '9,,,,Country,,,,,,4,,,,,,,,,\n'
-        '10,,,,,id,integer,,,,3,,,,,,,,,\n'
-        '11,,,,,title,string,,,,2,,,,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        "1,datasets/govsssss/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        "2,,,,City,,,,,,,,,,,,,,\n"
+        "3,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n"
+        "4,,,,,title,string,,,,5,,,open,dct:title,,,,\n"
+        "5,,,,,country,ref,Country,,,5,,,open,,,,,,\n"
+        "6,,,,,country.id,,,,,5,,,open,,,,,,\n"
+        "7,,,,,country.continent.id,,,,,5,,,open,,,,,,\n"
+        "8,,resource,,,,,,http://www.example.com,,,,,,,,,Title,Description\n"
+        "9,,,,Country,,,,,,4,,,,,,,,,\n"
+        "10,,,,,id,integer,,,,3,,,,,,,,,\n"
+        "11,,,,,title,string,,,,2,,,,,,,,,\n"
     )
 
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
 
     form = app.get(reverse("version-create", args=[structure.dataset.pk, version.pk])).forms["version-form"]
-    assert len(form.fields["metadata"]) == 12 # Denorm props create an additional property country.continent
+    assert len(form.fields["metadata"]) == 12  # Denorm props create an additional property country.continent
 
 
 def test_publishing_dataset_duplicates_metadata_but_not_dataset(app: DjangoTestApp):
@@ -5334,17 +5339,17 @@ def test_publishing_dataset_duplicates_metadata_but_not_dataset(app: DjangoTestA
     origin_version_count = 1
 
     assert Metadata.objects.filter(dataset=dataset).count() == original_metadata_count
-    assert Dataset.objects.count() == 2 # One Dataset created through a migration
+    assert Dataset.objects.count() == 2  # One Dataset created through a migration
     assert _Version.objects.filter(dataset=dataset).count() == origin_version_count
 
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = dataset_meta.pk
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = dataset_meta.pk
     form.submit()
 
     assert Metadata.objects.filter(dataset=dataset).count() == original_metadata_count * 2
-    assert Dataset.objects.count() == 2 # One Dataset created through a migration
+    assert Dataset.objects.count() == 2  # One Dataset created through a migration
     assert _Version.objects.filter(dataset=dataset).count() == origin_version_count * 2
 
 
@@ -5359,21 +5364,21 @@ def test_if_dataset_not_published_error(app: DjangoTestApp):
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset",
-        metadata_version=version
+        metadata_version=version,
     )
     assert Metadata.objects.filter(dataset=dataset).count() == 2
-    assert Dataset.objects.count() == 2 # One Dataset created through a migration
+    assert Dataset.objects.count() == 2  # One Dataset created through a migration
     assert _Version.objects.filter(dataset=dataset).count() == 1
 
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [model_meta]
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [model_meta]
     response = form.submit()
 
     assert response.status_code == 200
-    assert response.context['form'].errors
-    assert "Privalote publikuoti duomenų rinkinį." in response.context['form'].errors['__all__'][0]
+    assert response.context["form"].errors
+    assert "Privalote publikuoti duomenų rinkinį." in response.context["form"].errors["__all__"][0]
 
 
 def test_publishing_model_duplicates_metadata_and_model(app: DjangoTestApp):
@@ -5388,7 +5393,7 @@ def test_publishing_model_duplicates_metadata_and_model(app: DjangoTestApp):
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        metadata_version=version
+        metadata_version=version,
     )
 
     original_metadata_count = 2
@@ -5399,10 +5404,10 @@ def test_publishing_model_duplicates_metadata_and_model(app: DjangoTestApp):
     assert Model.objects.filter(dataset=dataset).count() == original_model_count
     assert _Version.objects.filter(dataset=dataset).count() == original_version_count
 
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [dataset_meta.pk, model_meta.pk]
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [dataset_meta.pk, model_meta.pk]
     form.submit()
 
     assert Metadata.objects.filter(dataset=dataset).count() == original_metadata_count * 2
@@ -5423,7 +5428,7 @@ def test_publishing_model_duplicates_metadata_and_dataset_distribution(app: Djan
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        metadata_version=version
+        metadata_version=version,
     )
 
     original_metadata_count = 3
@@ -5437,10 +5442,10 @@ def test_publishing_model_duplicates_metadata_and_dataset_distribution(app: Djan
     assert DatasetDistribution.objects.filter(dataset=dataset).count() == original_distribution_count
     assert _Version.objects.filter(dataset=dataset).count() == original_version_count
 
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [dataset_meta.pk, distribution_meta.pk, model_meta.pk]
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [dataset_meta.pk, distribution_meta.pk, model_meta.pk]
     form.submit()
 
     assert Metadata.objects.filter(dataset=dataset).count() == original_metadata_count * 2
@@ -5462,7 +5467,7 @@ def test_publishing_model_without_resource_error(app: DjangoTestApp):
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        metadata_version=version
+        metadata_version=version,
     )
 
     original_metadata_count = 3
@@ -5475,15 +5480,15 @@ def test_publishing_model_without_resource_error(app: DjangoTestApp):
     assert DatasetDistribution.objects.filter(dataset=dataset).count() == original_distribution_count
     assert _Version.objects.filter(dataset=dataset).count() == original_version_count
 
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [dataset_meta.pk, model_meta.pk]
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [dataset_meta.pk, model_meta.pk]
     response = form.submit()
 
     assert response.status_code == 200
-    assert response.context['form'].errors
-    assert "laukas TestModel turi nuorodą į jį" in response.context['form'].errors['__all__'][0]
+    assert response.context["form"].errors
+    assert "laukas TestModel turi nuorodą į jį" in response.context["form"].errors["__all__"][0]
 
     assert Metadata.objects.filter(dataset=dataset).count() == original_metadata_count
     assert Model.objects.filter(dataset=dataset).count() == original_model_count
@@ -5503,16 +5508,16 @@ def test_publishing_property_duplicates_metadata_and_property(app: DjangoTestApp
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        metadata_version=version
+        metadata_version=version,
     )
     prop = PropertyFactory(model=model, metadata_version=version)
     prop_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
-        metadata_version=version
+        name="prop",
+        type="string",
+        metadata_version=version,
     )
 
     original_metadata_count = 3
@@ -5523,10 +5528,10 @@ def test_publishing_property_duplicates_metadata_and_property(app: DjangoTestApp
     assert Property.objects.count() == original_property_count
     assert _Version.objects.filter(dataset=dataset).count() == original_version_count
 
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [dataset_meta.pk, model_meta.pk, prop_meta.pk]
     form.submit()
 
     assert Metadata.objects.filter(dataset=dataset).count() == original_metadata_count * 2
@@ -5546,16 +5551,16 @@ def test_publishing_property_without_model_error(app: DjangoTestApp):
         object_id=model.pk,
         dataset=dataset,
         name="test/dataset/TestModel",
-        metadata_version=version
+        metadata_version=version,
     )
     prop = PropertyFactory(model=model, metadata_version=version)
     prop_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
-        metadata_version=version
+        name="prop",
+        type="string",
+        metadata_version=version,
     )
 
     original_metadata_count = 3
@@ -5566,15 +5571,15 @@ def test_publishing_property_without_model_error(app: DjangoTestApp):
     assert Property.objects.count() == original_property_count
     assert _Version.objects.filter(dataset=dataset).count() == original_version_count
 
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [dataset_meta.pk, prop_meta.pk]
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [dataset_meta.pk, prop_meta.pk]
     response = form.submit()
 
     assert response.status_code == 200
-    assert response.context['form'].errors
-    assert "laukas prop turi nuorodą į jį" in response.context['form'].errors['__all__'][0]
+    assert response.context["form"].errors
+    assert "laukas prop turi nuorodą į jį" in response.context["form"].errors["__all__"][0]
 
     assert Metadata.objects.filter(dataset=dataset).count() == original_metadata_count
     assert Property.objects.count() == original_property_count
@@ -5595,13 +5600,16 @@ def test_publishing_enum_duplicates_enum_item_and_enum(app: DjangoTestApp):
         name="test/dataset/TestModel",
         metadata_version=version,
     )
-    prop = PropertyFactory(model=model, metadata_version=version,)
+    prop = PropertyFactory(
+        model=model,
+        metadata_version=version,
+    )
     prop_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
+        name="prop",
+        type="string",
         access=3,
         metadata_version=version,
     )
@@ -5610,14 +5618,17 @@ def test_publishing_enum_duplicates_enum_item_and_enum(app: DjangoTestApp):
         object_id=prop.pk,
         metadata_version=version,
     )
-    enum_item = EnumItemFactory(enum=enum, metadata_version=version,)
+    enum_item = EnumItemFactory(
+        enum=enum,
+        metadata_version=version,
+    )
     enum_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(enum_item),
         object_id=enum_item.pk,
         dataset=dataset,
-        title='Test value',
-        description='For testing',
-        prepare='1',
+        title="Test value",
+        description="For testing",
+        prepare="1",
         access=Metadata.OPEN,
         source="TEST",
         metadata_version=version,
@@ -5633,10 +5644,10 @@ def test_publishing_enum_duplicates_enum_item_and_enum(app: DjangoTestApp):
     assert Enum.objects.count() == original_enum_count
     assert _Version.objects.filter(dataset=dataset).count() == original_version_count
 
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [dataset_meta.pk, model_meta.pk, prop_meta.pk, enum_meta.pk]
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [dataset_meta.pk, model_meta.pk, prop_meta.pk, enum_meta.pk]
     form.submit()
 
     assert Metadata.objects.filter(dataset=dataset).count() == original_metadata_count * 2
@@ -5659,13 +5670,16 @@ def test_publishing_enum_without_property_error(app: DjangoTestApp):
         name="test/dataset/TestModel",
         metadata_version=version,
     )
-    prop = PropertyFactory(model=model, metadata_version=version,)
+    prop = PropertyFactory(
+        model=model,
+        metadata_version=version,
+    )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
+        name="prop",
+        type="string",
         access=3,
         metadata_version=version,
     )
@@ -5674,14 +5688,17 @@ def test_publishing_enum_without_property_error(app: DjangoTestApp):
         object_id=prop.pk,
         metadata_version=version,
     )
-    enum_item = EnumItemFactory(enum=enum, metadata_version=version,)
+    enum_item = EnumItemFactory(
+        enum=enum,
+        metadata_version=version,
+    )
     enum_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(enum_item),
         object_id=enum_item.pk,
         dataset=dataset,
-        title='Test value',
-        description='For testing',
-        prepare='1',
+        title="Test value",
+        description="For testing",
+        prepare="1",
         access=Metadata.OPEN,
         source="TEST",
         metadata_version=version,
@@ -5697,15 +5714,18 @@ def test_publishing_enum_without_property_error(app: DjangoTestApp):
     assert Enum.objects.count() == original_enum_count
     assert _Version.objects.filter(dataset=dataset).count() == original_version_count
 
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [dataset_meta.pk, enum_meta.pk]
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [dataset_meta.pk, enum_meta.pk]
     response = form.submit()
 
     assert response.status_code == 200
-    assert response.context['form'].errors
-    assert response.context['form'].errors['__all__'][0] == "Laukas 1 turi nuorodą į nepublikuojamą lauką tame pačiame duomenų ištekliuje."
+    assert response.context["form"].errors
+    assert (
+        response.context["form"].errors["__all__"][0]
+        == "Laukas 1 turi nuorodą į nepublikuojamą lauką tame pačiame duomenų ištekliuje."
+    )
 
     assert Metadata.objects.filter(dataset=dataset).count() == original_metadata_count
     assert EnumItem.objects.count() == original_enum_item_count
@@ -5727,7 +5747,7 @@ def test_publishing_model_with_base_duplicates_model_and_base(app: DjangoTestApp
         dataset=dataset,
         name="test/dataset/TestModel",
         uri="dcat:TestModel",
-        metadata_version=version
+        metadata_version=version,
     )
     base_model = ModelFactory(dataset=dataset, metadata_version=version)
     base_model_meta = MetadataFactory(
@@ -5737,7 +5757,10 @@ def test_publishing_model_with_base_duplicates_model_and_base(app: DjangoTestApp
         name="test/dataset/BaseModel",
         metadata_version=version,
     )
-    base = BaseFactory(model=base_model, metadata_version=version,)
+    base = BaseFactory(
+        model=base_model,
+        metadata_version=version,
+    )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(base),
         object_id=base.pk,
@@ -5759,10 +5782,10 @@ def test_publishing_model_with_base_duplicates_model_and_base(app: DjangoTestApp
     assert Base.objects.count() == original_base_count
     assert _Version.objects.filter(dataset=dataset).count() == original_version_count
 
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [dataset_meta.pk, base_model_meta.pk, model_meta.pk]
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [dataset_meta.pk, base_model_meta.pk, model_meta.pk]
     form.submit()
 
     assert Metadata.objects.filter(dataset=dataset).count() == original_metadata_count * 2
@@ -5785,7 +5808,7 @@ def test_publishing_model_with_without_base_error(app: DjangoTestApp):
         dataset=dataset,
         name="test/dataset/TestModel",
         uri="dcat:TestModel",
-        metadata_version=version
+        metadata_version=version,
     )
     base_model = ModelFactory(dataset=dataset, metadata_version=version)
     MetadataFactory(
@@ -5795,7 +5818,10 @@ def test_publishing_model_with_without_base_error(app: DjangoTestApp):
         name="test/dataset/BaseModel",
         metadata_version=version,
     )
-    base = BaseFactory(model=base_model, metadata_version=version,)
+    base = BaseFactory(
+        model=base_model,
+        metadata_version=version,
+    )
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(base),
         object_id=base.pk,
@@ -5817,15 +5843,15 @@ def test_publishing_model_with_without_base_error(app: DjangoTestApp):
     assert Base.objects.count() == original_base_count
     assert _Version.objects.filter(dataset=dataset).count() == original_version_count
 
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [dataset_meta.pk, model_meta.pk]
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [dataset_meta.pk, model_meta.pk]
     response = form.submit()
 
     assert response.status_code == 200
-    assert response.context['form'].errors
-    assert "laukas test/dataset/BaseModel turi nuorodą į jį." in response.context['form'].errors['__all__'][0]
+    assert response.context["form"].errors
+    assert "laukas test/dataset/BaseModel turi nuorodą į jį." in response.context["form"].errors["__all__"][0]
 
     assert Metadata.objects.filter(dataset=dataset).count() == original_metadata_count
     assert Model.objects.filter(dataset=dataset).count() == original_model_count
@@ -5837,18 +5863,14 @@ def test_publishing_property_with_ref_to_another_model(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        '1,datasets/govsssss/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        '3,,,,City,,,,,,5,,,,,,,City,,\n'
-        '4,,,,,id,ref,Country,,,5,,,,,,,Id,,\n'
-        '8,,,,Country,,,,,,4,,,,,,,Country,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        "1,datasets/govsssss/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        "3,,,,City,,,,,,5,,,,,,,City,,\n"
+        "4,,,,,id,ref,Country,,,5,,,,,,,Id,,\n"
+        "8,,,,Country,,,,,,4,,,,,,,Country,,\n"
     )
 
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
@@ -5864,17 +5886,22 @@ def test_publishing_property_with_ref_to_another_model(app: DjangoTestApp):
     assert _Version.objects.filter(dataset=structure.dataset).count() == original_version_count
 
     publish_metadata = list(
-        Metadata.objects.filter(dataset=structure.dataset, name__in=["datasets/govsssss/ivpk/adp", "datasets/govsssss/ivpk/adp/City", "id"]).values_list('pk', flat=True)
+        Metadata.objects.filter(
+            dataset=structure.dataset, name__in=["datasets/govsssss/ivpk/adp", "datasets/govsssss/ivpk/adp/City", "id"]
+        ).values_list("pk", flat=True)
     )
-    form = app.get(reverse('version-create', args=[structure.dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = publish_metadata
+    form = app.get(reverse("version-create", args=[structure.dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = publish_metadata
     response = form.submit()
 
     assert response.status_code == 200
-    assert response.context['form'].errors
-    assert response.context['form'].errors['__all__'][0] == "Laukas Country privalo būti publikuojamas, nes laukas id turi nuorodą į jį."
+    assert response.context["form"].errors
+    assert (
+        response.context["form"].errors["__all__"][0]
+        == "Laukas Country privalo būti publikuojamas, nes laukas id turi nuorodą į jį."
+    )
 
     assert Metadata.objects.filter(dataset=structure.dataset).count() == original_metadata_count
     assert Model.objects.filter(dataset=structure.dataset).count() == original_model_count
@@ -5886,19 +5913,15 @@ def test_publishing_property_with_ref_to_another_property(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        '1,datasets/govsssss/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        '3,,,,City,,,,,,5,,,,,,,City,,\n'
-        '4,,,,,country,integer,Country,,,5,,,,,,,country_prop,,\n'
-        '5,,,,,country.id,integer,,,,5,,,,,,,country_id,,\n'
-        '8,,,,Country,,,,,,4,,,,,,,Country,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        "1,datasets/govsssss/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        "3,,,,City,,,,,,5,,,,,,,City,,\n"
+        "4,,,,,country,integer,Country,,,5,,,,,,,country_prop,,\n"
+        "5,,,,,country.id,integer,,,,5,,,,,,,country_id,,\n"
+        "8,,,,Country,,,,,,4,,,,,,,Country,,\n"
     )
 
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
@@ -5909,33 +5932,40 @@ def test_publishing_property_with_ref_to_another_property(app: DjangoTestApp):
     assert _Version.objects.filter(dataset=structure.dataset).count() == 1
 
     publish_metadata = list(
-        Metadata.objects.filter(dataset=structure.dataset, name__in=["datasets/govsssss/ivpk/adp", "datasets/govsssss/ivpk/adp/City", "datasets/govsssss/ivpk/adp/Country", "country.id"]).values_list('pk', flat=True)
+        Metadata.objects.filter(
+            dataset=structure.dataset,
+            name__in=[
+                "datasets/govsssss/ivpk/adp",
+                "datasets/govsssss/ivpk/adp/City",
+                "datasets/govsssss/ivpk/adp/Country",
+                "country.id",
+            ],
+        ).values_list("pk", flat=True)
     )
-    form = app.get(reverse('version-create', args=[structure.dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = publish_metadata
+    form = app.get(reverse("version-create", args=[structure.dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = publish_metadata
     response = form.submit()
 
     assert response.status_code == 200
-    assert response.context['form'].errors
-    assert "Laukas country privalo būti publikuojamas, nes laukas country.id turi nuorodą į jį." in response.context['form'].errors['__all__'][0]
+    assert response.context["form"].errors
+    assert (
+        "Laukas country privalo būti publikuojamas, nes laukas country.id turi nuorodą į jį."
+        in response.context["form"].errors["__all__"][0]
+    )
 
 
 def test_publishing_model_with_base_from_published_version_same_dataset(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n'
-        '1,datasets/govsssss/ivpk/adp,,,,,,,,,,,,,,,,,\n'
-        '3,,,,City,,,,,,5,,,,,,,City,,\n'
-        '8,,,,Country,,,,,,4,,,,,,,Country,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        "1,datasets/govsssss/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        "3,,,,City,,,,,,5,,,,,,,City,,\n"
+        "8,,,,Country,,,,,,4,,,,,,,Country,,\n"
     )
-    structure = DatasetStructureFactory(
-        file=FilerFileFactory(
-            file=FileField(filename='file.csv', data=manifest)
-        )
-    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
@@ -5945,12 +5975,14 @@ def test_publishing_model_with_base_from_published_version_same_dataset(app: Dja
     assert Base.objects.count() == 0
 
     publish_metadata = list(
-        Metadata.objects.filter(dataset=structure.dataset, name__in=["datasets/govsssss/ivpk/adp", "datasets/govsssss/ivpk/adp/City"]).values_list('pk', flat=True)
+        Metadata.objects.filter(
+            dataset=structure.dataset, name__in=["datasets/govsssss/ivpk/adp", "datasets/govsssss/ivpk/adp/City"]
+        ).values_list("pk", flat=True)
     )
-    form = app.get(reverse('version-create', args=[structure.dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = publish_metadata
+    form = app.get(reverse("version-create", args=[structure.dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = publish_metadata
     form.submit()
 
     assert Metadata.objects.filter(dataset=structure.dataset).count() == 5
@@ -5960,21 +5992,23 @@ def test_publishing_model_with_base_from_published_version_same_dataset(app: Dja
     published_version = _Version.objects.filter(dataset=structure.dataset).order_by("-created").first()
     base_model = Model.objects.filter(dataset=structure.dataset, metadata_version=published_version).first()
 
-    form = app.get(reverse('model-update', args=[structure.dataset.pk, version.pk, "Country"])).forms['model-form']
-    form['base'].force_value(str(base_model.pk))
+    form = app.get(reverse("model-update", args=[structure.dataset.pk, version.pk, "Country"])).forms["model-form"]
+    form["base"].force_value(str(base_model.pk))
     form.submit()
 
     assert Metadata.objects.filter(dataset=structure.dataset).count() == 6
     assert Base.objects.count() == 1
 
     publish_metadata = list(
-        Metadata.objects.filter(dataset=structure.dataset, name__in=["datasets/govsssss/ivpk/adp", "datasets/govsssss/ivpk/adp/Country"]).values_list('pk', flat=True)
+        Metadata.objects.filter(
+            dataset=structure.dataset, name__in=["datasets/govsssss/ivpk/adp", "datasets/govsssss/ivpk/adp/Country"]
+        ).values_list("pk", flat=True)
     )
 
-    form = app.get(reverse('version-create', args=[structure.dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = publish_metadata
+    form = app.get(reverse("version-create", args=[structure.dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = publish_metadata
     form.submit()
     published_version = _Version.objects.filter(dataset=structure.dataset).order_by("-created").first()
     published_model = Model.objects.filter(dataset=structure.dataset, metadata_version=published_version).first()
@@ -6018,10 +6052,10 @@ def test_publishing_model_with_base_from_published_version_different_dataset(app
     assert _Version.objects.filter(dataset__in=[first_dataset, second_dataset]).count() == 2
     assert Base.objects.count() == 0
 
-    form = app.get(reverse('version-create', args=[first_dataset.pk, first_version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [first_dataset_meta.pk, first_model_meta.pk]
+    form = app.get(reverse("version-create", args=[first_dataset.pk, first_version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [first_dataset_meta.pk, first_model_meta.pk]
     form.submit()
 
     assert Metadata.objects.filter(dataset__in=[first_dataset, second_dataset]).count() == 6
@@ -6030,10 +6064,14 @@ def test_publishing_model_with_base_from_published_version_different_dataset(app
     assert Base.objects.count() == 0
 
     first_published_version = _Version.objects.filter(dataset=first_dataset).order_by("-created").first()
-    first_published_model = Model.objects.filter(dataset=first_dataset, metadata_version=first_published_version).first()
+    first_published_model = Model.objects.filter(
+        dataset=first_dataset, metadata_version=first_published_version
+    ).first()
 
-    form = app.get(reverse('model-update', args=[second_dataset.pk, second_version.pk, "TestModel2"])).forms['model-form']
-    form['base'].force_value(str(first_published_model.pk))
+    form = app.get(reverse("model-update", args=[second_dataset.pk, second_version.pk, "TestModel2"])).forms[
+        "model-form"
+    ]
+    form["base"].force_value(str(first_published_model.pk))
     form.submit()
 
     assert Metadata.objects.filter(dataset__in=[first_dataset, second_dataset]).count() == 7
@@ -6041,10 +6079,10 @@ def test_publishing_model_with_base_from_published_version_different_dataset(app
     assert _Version.objects.filter(dataset__in=[first_dataset, second_dataset]).count() == 3
     assert Base.objects.count() == 1
 
-    form = app.get(reverse('version-create', args=[second_dataset.pk, second_version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [second_dataset_meta.pk, second_model_meta.pk]
+    form = app.get(reverse("version-create", args=[second_dataset.pk, second_version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [second_dataset_meta.pk, second_model_meta.pk]
     form.submit()
     published_version = _Version.objects.filter(dataset=second_dataset).order_by("-created").first()
     published_model_with_base = Model.objects.filter(dataset=second_dataset, metadata_version=published_version).first()
@@ -6088,8 +6126,10 @@ def test_publishing_model_with_base_from_draft_version_different_dataset(app: Dj
     assert _Version.objects.filter(dataset__in=[first_dataset, second_dataset]).count() == 2
     assert Base.objects.count() == 0
 
-    form = app.get(reverse('model-update', args=[second_dataset.pk, second_version.pk, "TestModel2"])).forms['model-form']
-    form['base'].force_value(str(first_model.pk))
+    form = app.get(reverse("model-update", args=[second_dataset.pk, second_version.pk, "TestModel2"])).forms[
+        "model-form"
+    ]
+    form["base"].force_value(str(first_model.pk))
     form.submit()
     second_model.refresh_from_db()
 
@@ -6098,15 +6138,18 @@ def test_publishing_model_with_base_from_draft_version_different_dataset(app: Dj
     assert _Version.objects.filter(dataset__in=[first_dataset, second_dataset]).count() == 2
     assert Base.objects.count() == 1
 
-    form = app.get(reverse('version-create', args=[second_dataset.pk, second_version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [second_dataset_meta.pk, second_model_meta.pk]
+    form = app.get(reverse("version-create", args=[second_dataset.pk, second_version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [second_dataset_meta.pk, second_model_meta.pk]
     response = form.submit()
 
     assert response.status_code == 200
-    assert response.context['form'].errors
-    assert response.context['form'].errors['__all__'][0] == "Laukas test/dataset/TestModel1 turi nuorodą į nepublikuotą lauką kitame duomenų ištekliuje."
+    assert response.context["form"].errors
+    assert (
+        response.context["form"].errors["__all__"][0]
+        == "Laukas test/dataset/TestModel1 turi nuorodą į nepublikuotą lauką kitame duomenų ištekliuje."
+    )
 
 
 def test_publishing_property_with_published_model_ref_same_dataset(app: DjangoTestApp):
@@ -6131,13 +6174,16 @@ def test_publishing_property_with_published_model_ref_same_dataset(app: DjangoTe
         name="test/dataset/TestModel2",
         metadata_version=version,
     )
-    prop = PropertyFactory(model=second_model, metadata_version=version,)
+    prop = PropertyFactory(
+        model=second_model,
+        metadata_version=version,
+    )
     prop_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop2',
-        type='ref',
+        name="prop2",
+        type="ref",
         access=3,
         metadata_version=version,
     )
@@ -6146,10 +6192,10 @@ def test_publishing_property_with_published_model_ref_same_dataset(app: DjangoTe
     assert Property.objects.count() == 1
     assert Model.objects.filter(dataset=dataset).count() == 2
 
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [dataset_meta.pk, first_model_meta.pk]
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [dataset_meta.pk, first_model_meta.pk]
     form.submit()
     published_version = _Version.objects.filter(dataset=dataset).order_by("-created").first()
     first_published_model = Model.objects.filter(metadata_version=published_version).first()
@@ -6158,15 +6204,17 @@ def test_publishing_property_with_published_model_ref_same_dataset(app: DjangoTe
     assert Property.objects.count() == 1
     assert Model.objects.filter(dataset=dataset).count() == 3
 
-    property_form = app.get(reverse('property-update', args=[dataset.pk, version.pk, "TestModel2", "prop2"])).forms['property-form']
-    property_form['ref'].force_value(str(first_published_model.pk))
+    property_form = app.get(reverse("property-update", args=[dataset.pk, version.pk, "TestModel2", "prop2"])).forms[
+        "property-form"
+    ]
+    property_form["ref"].force_value(str(first_published_model.pk))
     property_form.submit()
     prop.refresh_from_db()
 
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [dataset_meta.pk, second_model_meta.pk, prop_meta.pk]
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [dataset_meta.pk, second_model_meta.pk, prop_meta.pk]
     form.submit()
 
     published_version = _Version.objects.filter(dataset=dataset).order_by("-created").first()
@@ -6204,13 +6252,16 @@ def test_publishing_property_with_published_model_ref_different_dataset(app: Dja
         name="test/dataset/TestModel2",
         metadata_version=second_version,
     )
-    prop = PropertyFactory(model=second_model, metadata_version=second_version,)
+    prop = PropertyFactory(
+        model=second_model,
+        metadata_version=second_version,
+    )
     prop_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=second_dataset,
-        name='prop2',
-        type='ref',
+        name="prop2",
+        type="ref",
         access=3,
         metadata_version=second_version,
     )
@@ -6219,10 +6270,10 @@ def test_publishing_property_with_published_model_ref_different_dataset(app: Dja
     assert Property.objects.count() == 1
     assert Model.objects.filter(dataset__in=[first_dataset, second_dataset]).count() == 2
 
-    form = app.get(reverse('version-create', args=[first_dataset.pk, first_version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [first_dataset_meta.pk, first_model_meta.pk]
+    form = app.get(reverse("version-create", args=[first_dataset.pk, first_version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [first_dataset_meta.pk, first_model_meta.pk]
     form.submit()
     published_version = _Version.objects.filter(dataset=first_dataset).order_by("-created").first()
     first_published_model = Model.objects.filter(metadata_version=published_version).first()
@@ -6231,16 +6282,17 @@ def test_publishing_property_with_published_model_ref_different_dataset(app: Dja
     assert Property.objects.count() == 1
     assert Model.objects.filter(dataset__in=[first_dataset, second_dataset]).count() == 3
 
-    property_form = app.get(reverse('property-update', args=[second_dataset.pk, second_version.pk, "TestModel2", "prop2"])).forms['property-form']
-    property_form['ref'].force_value(str(first_published_model.pk))
+    property_form = app.get(
+        reverse("property-update", args=[second_dataset.pk, second_version.pk, "TestModel2", "prop2"])
+    ).forms["property-form"]
+    property_form["ref"].force_value(str(first_published_model.pk))
     property_form.submit()
     prop.refresh_from_db()
 
-
-    form = app.get(reverse('version-create', args=[second_dataset.pk, second_version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [second_dataset_meta.pk, second_model_meta.pk, prop_meta.pk]
+    form = app.get(reverse("version-create", args=[second_dataset.pk, second_version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [second_dataset_meta.pk, second_model_meta.pk, prop_meta.pk]
     form.submit()
 
     published_version = _Version.objects.filter(dataset=second_dataset).order_by("-created").first()
@@ -6275,13 +6327,16 @@ def test_publishing_property_with_draft_model_ref_same_dataset(app: DjangoTestAp
         name="test/dataset/TestModel2",
         metadata_version=version,
     )
-    prop = PropertyFactory(model=second_model, metadata_version=version,)
+    prop = PropertyFactory(
+        model=second_model,
+        metadata_version=version,
+    )
     prop_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop2',
-        type='ref',
+        name="prop2",
+        type="ref",
         access=3,
         metadata_version=version,
     )
@@ -6290,21 +6345,25 @@ def test_publishing_property_with_draft_model_ref_same_dataset(app: DjangoTestAp
     assert Property.objects.count() == 1
     assert Model.objects.filter(dataset=dataset).count() == 2
 
-    property_form = app.get(reverse('property-update', args=[dataset.pk, version.pk, "TestModel2", "prop2"])).forms['property-form']
-    property_form['ref'].force_value(str(first_model.pk))
+    property_form = app.get(reverse("property-update", args=[dataset.pk, version.pk, "TestModel2", "prop2"])).forms[
+        "property-form"
+    ]
+    property_form["ref"].force_value(str(first_model.pk))
     property_form.submit()
     prop.refresh_from_db()
 
-
-    form = app.get(reverse('version-create', args=[dataset.pk, version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [dataset_meta.pk, second_model_meta.pk, prop_meta.pk]
+    form = app.get(reverse("version-create", args=[dataset.pk, version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [dataset_meta.pk, second_model_meta.pk, prop_meta.pk]
     response = form.submit()
 
     assert response.status_code == 200
-    assert response.context['form'].errors
-    assert response.context['form'].errors['__all__'][0] == "Laukas TestModel1 privalo būti publikuojamas, nes laukas prop2 turi nuorodą į jį."
+    assert response.context["form"].errors
+    assert (
+        response.context["form"].errors["__all__"][0]
+        == "Laukas TestModel1 privalo būti publikuojamas, nes laukas prop2 turi nuorodą į jį."
+    )
 
 
 def test_publishing_property_with_draft_model_ref_different_dataset(app: DjangoTestApp):
@@ -6333,13 +6392,16 @@ def test_publishing_property_with_draft_model_ref_different_dataset(app: DjangoT
         name="test/dataset/TestModel2",
         metadata_version=second_version,
     )
-    prop = PropertyFactory(model=second_model, metadata_version=second_version, )
+    prop = PropertyFactory(
+        model=second_model,
+        metadata_version=second_version,
+    )
     prop_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=second_dataset,
-        name='prop2',
-        type='ref',
+        name="prop2",
+        type="ref",
         access=3,
         metadata_version=second_version,
     )
@@ -6348,20 +6410,26 @@ def test_publishing_property_with_draft_model_ref_different_dataset(app: DjangoT
     assert Property.objects.count() == 1
     assert Model.objects.filter(dataset__in=[first_dataset, second_dataset]).count() == 2
 
-    property_form = app.get(reverse('property-update', args=[second_dataset.pk, second_version.pk, "TestModel2", "prop2"])).forms['property-form']
-    property_form['ref'].force_value(str(first_model.pk))
+    property_form = app.get(
+        reverse("property-update", args=[second_dataset.pk, second_version.pk, "TestModel2", "prop2"])
+    ).forms["property-form"]
+    property_form["ref"].force_value(str(first_model.pk))
     property_form.submit()
     prop.refresh_from_db()
 
-    form = app.get(reverse('version-create', args=[second_dataset.pk, second_version.pk])).forms['version-form']
-    form['released'] = datetime.date.today() + datetime.timedelta(days=15)
-    form['version_type'] = "MAJOR"
-    form['metadata'] = [second_dataset_meta.pk, second_model_meta.pk, prop_meta.pk]
+    form = app.get(reverse("version-create", args=[second_dataset.pk, second_version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = [second_dataset_meta.pk, second_model_meta.pk, prop_meta.pk]
     response = form.submit()
 
     assert response.status_code == 200
-    assert response.context['form'].errors
-    assert response.context['form'].errors['__all__'][0] == "Laukas prop2 turi nuorodą į nepublikuotą lauką kitame duomenų ištekliuje."
+    assert response.context["form"].errors
+    assert (
+        response.context["form"].errors["__all__"][0]
+        == "Laukas prop2 turi nuorodą į nepublikuotą lauką kitame duomenų ištekliuje."
+    )
+
 
 @pytest.mark.django_db
 class TestModelDelete:
@@ -6376,10 +6444,10 @@ class TestModelDelete:
             content_type=ContentType.objects.get_for_model(Model),
             object_id=model.pk,
             name=f"{dataset}/{model.pk}/TestModel",
-            metadata_version=metadata_version
+            metadata_version=metadata_version,
         )
 
-        resp = app.post(reverse('model-delete', args=[dataset.pk, metadata_version.pk, 'TestModel']))
+        resp = app.post(reverse("model-delete", args=[dataset.pk, metadata_version.pk, "TestModel"]))
         assert resp.json == {"success": True}
         assert not Model.objects.filter(pk=model.pk).exists()
 
@@ -6394,10 +6462,12 @@ class TestModelDelete:
             content_type=ContentType.objects.get_for_model(Model),
             object_id=model.pk,
             name=f"{dataset}/{model.pk}/TestModel",
-            metadata_version=metadata_version
+            metadata_version=metadata_version,
         )
 
-        resp = app.post(reverse('model-delete', args=[dataset.pk, metadata_version.pk, 'TestModel']), expect_errors=True)
+        resp = app.post(
+            reverse("model-delete", args=[dataset.pk, metadata_version.pk, "TestModel"]), expect_errors=True
+        )
         assert resp.status_code == 403
         assert resp.json == {"error": "Permission denied"}
         assert Model.objects.filter(pk=model.pk).exists()
@@ -6415,10 +6485,12 @@ class TestModelDelete:
             content_type=ContentType.objects.get_for_model(Model),
             object_id=model.pk,
             name=f"{dataset}/{model.pk}/TestModel",
-            metadata_version=metadata_version
+            metadata_version=metadata_version,
         )
 
-        resp = app.post(reverse('model-delete', args=[dataset.pk, metadata_version.pk, 'TestModel']), expect_errors=True)
+        resp = app.post(
+            reverse("model-delete", args=[dataset.pk, metadata_version.pk, "TestModel"]), expect_errors=True
+        )
         assert resp.status_code == 403
         assert resp.json == {"error": "Permission denied"}
         assert Model.objects.filter(pk=model.pk).exists()
@@ -6428,7 +6500,9 @@ class TestModelDelete:
         app.set_user(user)
         dataset = DatasetFactory()
         metadata_version = dataset.metadata.first().metadata_version
-        resp = app.post(reverse('model-delete', args=[dataset.pk, metadata_version.pk, 'NonExistent']), expect_errors=True)
+        resp = app.post(
+            reverse("model-delete", args=[dataset.pk, metadata_version.pk, "NonExistent"]), expect_errors=True
+        )
         assert resp.status_code == 404
 
     def test_requires_login(self, app: DjangoTestApp):
@@ -6440,13 +6514,12 @@ class TestModelDelete:
             content_type=ContentType.objects.get_for_model(Model),
             object_id=model.pk,
             name=f"{dataset}/{model.pk}/TestModel",
-            metadata_version=metadata_version
+            metadata_version=metadata_version,
         )
 
-        resp = app.post(reverse('model-delete', args=[dataset.pk, metadata_version.pk, 'TestModel']))
+        resp = app.post(reverse("model-delete", args=[dataset.pk, metadata_version.pk, "TestModel"]))
         assert resp.status_code == 302  # redirect to login
         assert Model.objects.filter(pk=model.pk).exists()
-
 
     def test_deletes_related_metadata(self, app: DjangoTestApp):
         user = UserFactory(is_staff=True)
@@ -6459,10 +6532,10 @@ class TestModelDelete:
             content_type=ContentType.objects.get_for_model(Model),
             object_id=model.pk,
             name=f"{dataset}/{model.pk}/TestModel",
-            metadata_version=metadata_version
+            metadata_version=metadata_version,
         )
 
-        app.post(reverse('model-delete', args=[dataset.pk, metadata_version.pk, 'TestModel']))
+        app.post(reverse("model-delete", args=[dataset.pk, metadata_version.pk, "TestModel"]))
 
         assert not Model.objects.filter(pk=model.pk).exists()
         assert not Metadata.objects.filter(pk=metadata.pk).exists()
@@ -6478,8 +6551,8 @@ class TestModelDelete:
             content_type=ContentType.objects.get_for_model(Model),
             object_id=model.pk,
             name=f"{dataset}/{model.pk}/TestModel",
-            metadata_version=metadata_version
+            metadata_version=metadata_version,
         )
 
-        resp = app.get(reverse('model-delete', args=[dataset.pk, metadata_version.pk, 'TestModel']), expect_errors=True)
+        resp = app.get(reverse("model-delete", args=[dataset.pk, metadata_version.pk, "TestModel"]), expect_errors=True)
         assert resp.status_code == 405

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -15,7 +15,6 @@ from pygments.lexers.data import JsonLexer
 from pygments.lexers.special import TextLexer
 from pygments.styles import get_style_by_name
 from reversion.models import Version
-from webtest import AppError
 
 from vitrina.classifiers.models import Status
 from vitrina.cms.factories import FilerFileFactory
@@ -29,7 +28,7 @@ from vitrina.settings import SPINTA_SERVER_URL
 from vitrina.structure import VersionStatus
 from vitrina.structure.factories import ModelFactory, MetadataFactory, PropertyFactory, EnumFactory, EnumItemFactory, \
     PrefixFactory, ParamItemFactory, ParamFactory, BaseFactory, VersionFactory
-from vitrina.structure.models import Metadata, Enum, EnumItem, Param, VersionType, Model, Property, Base
+from vitrina.structure.models import Metadata, Enum, EnumItem, VersionType, Model, Property, Base
 from vitrina.structure.services import create_structure_objects
 from vitrina.users.factories import UserFactory
 from vitrina.structure.models import Version as _Version
@@ -2549,16 +2548,16 @@ def test_new_version_with_updated_structure__model_base(app: DjangoTestApp):
     first_published_version = _Version.objects.filter(dataset=dataset).order_by('-created').first()
     first_version_metadata = Metadata.objects.filter(dataset=dataset, metadata_version=first_published_version).all()
 
-    base_model = ModelFactory(dataset=dataset, metadata_version=version,)
-    base_model_meta = MetadataFactory(
+    base_model = ModelFactory(dataset=dataset, metadata_version=version)
+    MetadataFactory(
         content_type=ContentType.objects.get_for_model(base_model),
         object_id=base_model.pk,
         dataset=dataset,
         name="test/dataset/BaseModel",
         metadata_version=version,
     )
-    base = BaseFactory(model=base_model, metadata_version=version,)
-    base_meta = MetadataFactory(
+    base = BaseFactory(model=base_model, metadata_version=version)
+    base_model_meta = MetadataFactory(
         content_type=ContentType.objects.get_for_model(base),
         object_id=base.pk,
         dataset=dataset,
@@ -2646,7 +2645,7 @@ def test_new_version_with_updated_structure__model_ref(app: DjangoTestApp):
     assert dataset.dataset_version.count() == 3
     assert first_version_metadata.filter(
         content_type=ContentType.objects.get_for_model(model),
-    ).first().ref is ""
+    ).first().ref == ""
 
     assert second_version_metadata.count() == 2
     assert second_version_metadata.first().object.pk != model.pk
@@ -3163,7 +3162,7 @@ def test_version_list_with_non_public_dataset_without_access(app: DjangoTestApp)
     )
 def test_version_list_with_non_public_dataset_with_access(app: DjangoTestApp, role: str):
     dataset = DatasetFactory(is_public=False)
-    version = VersionFactory(dataset=dataset)
+    VersionFactory(dataset=dataset)
     user = UserFactory()
     RepresentativeFactory(
         content_type=ContentType.objects.get_for_model(dataset),
@@ -5465,7 +5464,6 @@ def test_publishing_model_without_resource_error(app: DjangoTestApp):
         name="test/dataset/TestModel",
         metadata_version=version
     )
-    distribution_meta = distribution.metadata.first()
 
     original_metadata_count = 3
     original_model_count = 1
@@ -5543,7 +5541,7 @@ def test_publishing_property_without_model_error(app: DjangoTestApp):
     version = dataset.metadata.first().metadata_version
     dataset_meta = dataset.metadata.first()
     model = ModelFactory(dataset=dataset, metadata_version=version)
-    model_meta = MetadataFactory(
+    MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
@@ -5654,7 +5652,7 @@ def test_publishing_enum_without_property_error(app: DjangoTestApp):
     version = dataset.metadata.first().metadata_version
     dataset_meta = dataset.metadata.first()
     model = ModelFactory(dataset=dataset, metadata_version=version)
-    model_meta = MetadataFactory(
+    MetadataFactory(
         content_type=ContentType.objects.get_for_model(model),
         object_id=model.pk,
         dataset=dataset,
@@ -5662,7 +5660,7 @@ def test_publishing_enum_without_property_error(app: DjangoTestApp):
         metadata_version=version,
     )
     prop = PropertyFactory(model=model, metadata_version=version,)
-    prop_meta = MetadataFactory(
+    MetadataFactory(
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
@@ -5740,7 +5738,7 @@ def test_publishing_model_with_base_duplicates_model_and_base(app: DjangoTestApp
         metadata_version=version,
     )
     base = BaseFactory(model=base_model, metadata_version=version,)
-    base_meta = MetadataFactory(
+    MetadataFactory(
         content_type=ContentType.objects.get_for_model(base),
         object_id=base.pk,
         dataset=dataset,
@@ -5790,7 +5788,7 @@ def test_publishing_model_with_without_base_error(app: DjangoTestApp):
         metadata_version=version
     )
     base_model = ModelFactory(dataset=dataset, metadata_version=version)
-    base_model_meta = MetadataFactory(
+    MetadataFactory(
         content_type=ContentType.objects.get_for_model(base_model),
         object_id=base_model.pk,
         dataset=dataset,
@@ -5798,7 +5796,7 @@ def test_publishing_model_with_without_base_error(app: DjangoTestApp):
         metadata_version=version,
     )
     base = BaseFactory(model=base_model, metadata_version=version,)
-    base_meta = MetadataFactory(
+    MetadataFactory(
         content_type=ContentType.objects.get_for_model(base),
         object_id=base.pk,
         dataset=dataset,
@@ -6063,9 +6061,9 @@ def test_publishing_model_with_base_from_draft_version_different_dataset(app: Dj
     app.set_user(user)
     first_dataset = DatasetFactory()
     first_version = first_dataset.metadata.first().metadata_version
-    first_dataset_meta = first_dataset.metadata.first()
+    first_dataset.metadata.first()
     first_model = ModelFactory(dataset=first_dataset, metadata_version=first_version)
-    first_model_meta = MetadataFactory(
+    MetadataFactory(
         content_type=ContentType.objects.get_for_model(first_model),
         object_id=first_model.pk,
         dataset=first_dataset,
@@ -6261,7 +6259,7 @@ def test_publishing_property_with_draft_model_ref_same_dataset(app: DjangoTestAp
     version = dataset.metadata.first().metadata_version
     dataset_meta = dataset.metadata.first()
     first_model = ModelFactory(dataset=dataset, metadata_version=version)
-    first_model_meta = MetadataFactory(
+    MetadataFactory(
         content_type=ContentType.objects.get_for_model(first_model),
         object_id=first_model.pk,
         dataset=dataset,
@@ -6314,9 +6312,9 @@ def test_publishing_property_with_draft_model_ref_different_dataset(app: DjangoT
     app.set_user(user)
     first_dataset = DatasetFactory()
     first_version = first_dataset.metadata.first().metadata_version
-    first_dataset_meta = first_dataset.metadata.first()
+    first_dataset.metadata.first()
     first_model = ModelFactory(dataset=first_dataset, metadata_version=first_version)
-    first_model_meta = MetadataFactory(
+    MetadataFactory(
         content_type=ContentType.objects.get_for_model(first_model),
         object_id=first_model.pk,
         dataset=first_dataset,
@@ -6464,7 +6462,7 @@ class TestModelDelete:
             metadata_version=metadata_version
         )
 
-        resp = app.post(reverse('model-delete', args=[dataset.pk, metadata_version.pk, 'TestModel']))
+        app.post(reverse('model-delete', args=[dataset.pk, metadata_version.pk, 'TestModel']))
 
         assert not Model.objects.filter(pk=model.pk).exists()
         assert not Metadata.objects.filter(pk=metadata.pk).exists()

--- a/tests/tasks/test_services.py
+++ b/tests/tasks/test_services.py
@@ -15,9 +15,7 @@ def test_get_active_tasks():
     organization = OrganizationFactory()
     user = UserFactory(organization=organization)
     RepresentativeFactory(
-        content_type=ContentType.objects.get_for_model(organization),
-        object_id=organization.pk,
-        user=user
+        content_type=ContentType.objects.get_for_model(organization), object_id=organization.pk, user=user
     )
 
     task_for_user = TaskFactory(user=user)
@@ -33,12 +31,12 @@ def test_get_active_tasks():
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-        "role",
-        [
-            Representative.OPEN_DATA_COORDINATOR,
-            Representative.RESOURCE_COORDINATOR,
-        ],
-    )
+    "role",
+    [
+        Representative.OPEN_DATA_COORDINATOR,
+        Representative.RESOURCE_COORDINATOR,
+    ],
+)
 def test_get_active_tasks_with_task_organization_supervisor_after_5_days(role: str):
     parent_organization = OrganizationFactory()
     child_organization = parent_organization.add_child(instance=OrganizationFactory.build())
@@ -56,36 +54,30 @@ def test_get_active_tasks_with_task_organization_supervisor_after_5_days(role: s
         content_type=ContentType.objects.get_for_model(parent_organization),
         object_id=parent_organization.pk,
         role=role,
-        user=parent_organization_user
+        user=parent_organization_user,
     )
     RepresentativeFactory(
         content_type=ContentType.objects.get_for_model(child_organization),
         object_id=child_organization.pk,
         role=role,
-        user=child_organization_user
+        user=child_organization_user,
     )
 
-    active_tasks = get_active_tasks(
-        parent_organization_user,
-        now=timezone.datetime(2022, 11, 23).date()
-    )
+    active_tasks = get_active_tasks(parent_organization_user, now=timezone.datetime(2022, 11, 23).date())
     assert list(active_tasks) == [task_for_parent_organization]
 
-    active_tasks = get_active_tasks(
-        child_organization_user,
-        now=timezone.datetime(2022, 11, 23).date()
-    )
+    active_tasks = get_active_tasks(child_organization_user, now=timezone.datetime(2022, 11, 23).date())
     assert list(active_tasks) == [task_for_child_organization]
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-        "role",
-        [
-            Representative.OPEN_DATA_COORDINATOR,
-            Representative.RESOURCE_COORDINATOR,
-        ],
-    )
+    "role",
+    [
+        Representative.OPEN_DATA_COORDINATOR,
+        Representative.RESOURCE_COORDINATOR,
+    ],
+)
 def test_get_active_tasks_with_task_organization_supervisor_after_5_work_days(role: str):
     parent_organization = OrganizationFactory()
     child_organization = parent_organization.add_child(instance=OrganizationFactory.build())
@@ -103,39 +95,33 @@ def test_get_active_tasks_with_task_organization_supervisor_after_5_work_days(ro
         content_type=ContentType.objects.get_for_model(parent_organization),
         object_id=parent_organization.pk,
         role=role,
-        user=parent_organization_user
+        user=parent_organization_user,
     )
     RepresentativeFactory(
         content_type=ContentType.objects.get_for_model(child_organization),
         object_id=child_organization.pk,
         role=role,
-        user=child_organization_user
+        user=child_organization_user,
     )
 
-    active_tasks = get_active_tasks(
-        parent_organization_user,
-        now=timezone.datetime(2022, 11, 25).date()
-    )
+    active_tasks = get_active_tasks(parent_organization_user, now=timezone.datetime(2022, 11, 25).date())
     assert set(active_tasks) == {
         task_for_parent_organization,
         task_for_child_organization,
     }
 
-    active_tasks = get_active_tasks(
-        child_organization_user,
-        now=timezone.datetime(2022, 11, 25).date()
-    )
+    active_tasks = get_active_tasks(child_organization_user, now=timezone.datetime(2022, 11, 25).date())
     assert set(active_tasks) == {task_for_child_organization}
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-        "role",
-        [
-            Representative.OPEN_DATA_COORDINATOR,
-            Representative.RESOURCE_COORDINATOR,
-        ],
-    )
+    "role",
+    [
+        Representative.OPEN_DATA_COORDINATOR,
+        Representative.RESOURCE_COORDINATOR,
+    ],
+)
 def test_get_active_tasks_with_staff_after_10_days(role: str):
     parent_organization = OrganizationFactory()
     child_organization1 = parent_organization.add_child(instance=OrganizationFactory.build())
@@ -149,13 +135,13 @@ def test_get_active_tasks_with_staff_after_10_days(role: str):
         content_type=ContentType.objects.get_for_model(parent_organization),
         object_id=parent_organization.pk,
         role=role,
-        user=parent_organization_user
+        user=parent_organization_user,
     )
     RepresentativeFactory(
         content_type=ContentType.objects.get_for_model(child_organization1),
         object_id=child_organization1.pk,
         role=role,
-        user=child_organization_user
+        user=child_organization_user,
     )
 
     task_for_parent_organization = TaskFactory(organization=parent_organization)
@@ -165,40 +151,28 @@ def test_get_active_tasks_with_staff_after_10_days(role: str):
         task.created = timezone.datetime(2022, 11, 18)
         task.save()
 
-    active_tasks = get_active_tasks(
-        parent_organization_user,
-        now=timezone.datetime(2022, 11, 28).date()
-    )
+    active_tasks = get_active_tasks(parent_organization_user, now=timezone.datetime(2022, 11, 28).date())
     assert set(active_tasks) == {
         task_for_parent_organization,
         task_for_child_organization1,
-        task_for_child_organization2
+        task_for_child_organization2,
     }
 
-    active_tasks = get_active_tasks(
-        child_organization_user,
-        now=timezone.datetime(2022, 11, 28).date()
-    )
-    assert set(active_tasks) == {
-        task_for_child_organization1,
-        task_for_child_organization2
-    }
+    active_tasks = get_active_tasks(child_organization_user, now=timezone.datetime(2022, 11, 28).date())
+    assert set(active_tasks) == {task_for_child_organization1, task_for_child_organization2}
 
-    active_tasks = get_active_tasks(
-        staff,
-        now=timezone.datetime(2022, 11, 28).date()
-    )
+    active_tasks = get_active_tasks(staff, now=timezone.datetime(2022, 11, 28).date())
     assert list(active_tasks) == []
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-        "role",
-        [
-            Representative.OPEN_DATA_COORDINATOR,
-            Representative.RESOURCE_COORDINATOR,
-        ],
-    )
+    "role",
+    [
+        Representative.OPEN_DATA_COORDINATOR,
+        Representative.RESOURCE_COORDINATOR,
+    ],
+)
 def test_get_active_tasks_with_staff_after_10_work_days(role: str):
     parent_organization = OrganizationFactory()
     child_organization1 = parent_organization.add_child(instance=OrganizationFactory.build())
@@ -212,13 +186,13 @@ def test_get_active_tasks_with_staff_after_10_work_days(role: str):
         content_type=ContentType.objects.get_for_model(parent_organization),
         object_id=parent_organization.pk,
         role=role,
-        user=parent_organization_user
+        user=parent_organization_user,
     )
     RepresentativeFactory(
         content_type=ContentType.objects.get_for_model(child_organization1),
         object_id=child_organization1.pk,
         role=role,
-        user=child_organization_user
+        user=child_organization_user,
     )
 
     task_for_parent_organization = TaskFactory(organization=parent_organization)
@@ -228,31 +202,19 @@ def test_get_active_tasks_with_staff_after_10_work_days(role: str):
         task.created = timezone.datetime(2022, 11, 18)
         task.save()
 
-    active_tasks = get_active_tasks(
-        parent_organization_user,
-        now=timezone.datetime(2022, 12, 2).date()
-    )
+    active_tasks = get_active_tasks(parent_organization_user, now=timezone.datetime(2022, 12, 2).date())
     assert set(active_tasks) == {
         task_for_parent_organization,
         task_for_child_organization1,
-        task_for_child_organization2
+        task_for_child_organization2,
     }
 
-    active_tasks = get_active_tasks(
-        child_organization_user,
-        now=timezone.datetime(2022, 12, 2).date()
-    )
-    assert set(active_tasks) == {
-        task_for_child_organization1,
-        task_for_child_organization2
-    }
+    active_tasks = get_active_tasks(child_organization_user, now=timezone.datetime(2022, 12, 2).date())
+    assert set(active_tasks) == {task_for_child_organization1, task_for_child_organization2}
 
-    active_tasks = get_active_tasks(
-        staff,
-        now=timezone.datetime(2022, 12, 2).date()
-    )
+    active_tasks = get_active_tasks(staff, now=timezone.datetime(2022, 12, 2).date())
     assert set(active_tasks) == {
         task_for_parent_organization,
         task_for_child_organization1,
-        task_for_child_organization2
+        task_for_child_organization2,
     }

--- a/tests/tasks/test_services.py
+++ b/tests/tasks/test_services.py
@@ -22,7 +22,7 @@ def test_get_active_tasks():
 
     task_for_user = TaskFactory(user=user)
     task_for_organization1 = TaskFactory(organization=organization)
-    task_for_organization2 = TaskFactory(organization=OrganizationFactory())
+    TaskFactory(organization=OrganizationFactory())
 
     active_tasks = get_active_tasks(user)
     assert list(active_tasks) == [

--- a/tests/tasks/test_views.py
+++ b/tests/tasks/test_views.py
@@ -161,7 +161,7 @@ def test_task_assign_with_user_with_no_access(app: DjangoTestApp):
 
 
 @pytest.mark.django_db
-def test_task_close_with_user_with_already_closed_task(app: DjangoTestApp):
+def test_task_assign_with_user_with_already_closed_task(app: DjangoTestApp):
     user = UserFactory()
     task = TaskFactory(user=user, status=Task.COMPLETED)
     app.set_user(user)

--- a/tests/tasks/test_views.py
+++ b/tests/tasks/test_views.py
@@ -21,44 +21,34 @@ timezone = pytz.timezone(settings.TIME_ZONE)
 def set_up_data():
     organization = OrganizationFactory()
     content_type = ContentType.objects.get_for_model(organization)
-    user = User.objects.create_user(
-        email="user1@test.com",
-        password="test123"
-    )
-    user_with_organization = User.objects.create(
-        email="user3@test.com",
-        password="test123",
-        organization=organization
-    )
-    RepresentativeFactory(
-        user=user_with_organization,
-        content_type=content_type,
-        object_id=organization.pk
-    )
+    user = User.objects.create_user(email="user1@test.com", password="test123")
+    user_with_organization = User.objects.create(email="user3@test.com", password="test123", organization=organization)
+    RepresentativeFactory(user=user_with_organization, content_type=content_type, object_id=organization.pk)
     task_for_user = TaskFactory(user=user)
-    task_for_organization = TaskFactory(organization=organization,
-                                        created=timezone.localize(datetime(2022, 8, 23, 11, 30)))
+    task_for_organization = TaskFactory(
+        organization=organization, created=timezone.localize(datetime(2022, 8, 23, 11, 30))
+    )
     return {
-        'organization': organization,
-        'user': user,
-        'user_with_organization': user_with_organization,
-        'task_for_user': task_for_user,
-        'task_for_organization': task_for_organization
+        "organization": organization,
+        "user": user,
+        "user_with_organization": user_with_organization,
+        "task_for_user": task_for_user,
+        "task_for_organization": task_for_organization,
     }
 
 
 @pytest.mark.haystack
 def test_task_list_with_user(app: DjangoTestApp, set_up_data):
-    app.set_user(set_up_data['user'])
-    resp = app.get('%s?owner=user' % reverse("user-task-list", kwargs={'pk': set_up_data['user'].pk}))
-    assert list([int(task.pk) for task in resp.context["object_list"]]) == [set_up_data['task_for_user'].pk]
+    app.set_user(set_up_data["user"])
+    resp = app.get("%s?owner=user" % reverse("user-task-list", kwargs={"pk": set_up_data["user"].pk}))
+    assert list([int(task.pk) for task in resp.context["object_list"]]) == [set_up_data["task_for_user"].pk]
 
 
 @pytest.mark.haystack
 def test_task_list_with_organization(app: DjangoTestApp, set_up_data):
-    app.set_user(set_up_data['user_with_organization'])
-    resp = app.get('%s?owner=all' % reverse("user-task-list", kwargs={'pk': set_up_data['user_with_organization'].pk}))
-    assert list([int(task.pk) for task in resp.context["object_list"]]) == [set_up_data['task_for_organization'].pk]
+    app.set_user(set_up_data["user_with_organization"])
+    resp = app.get("%s?owner=all" % reverse("user-task-list", kwargs={"pk": set_up_data["user_with_organization"].pk}))
+    assert list([int(task.pk) for task in resp.context["object_list"]]) == [set_up_data["task_for_organization"].pk]
 
 
 @pytest.mark.django_db
@@ -69,7 +59,7 @@ def test_task_detail_with_no_user(app: DjangoTestApp):
     url = reverse("user-task-detail", args=[user.pk, task.pk])
     resp = app.get(url)
     assert resp.status_code == 302
-    assert resp.url == "%s?next=%s" % (reverse('login'), url)
+    assert resp.url == "%s?next=%s" % (reverse("login"), url)
 
 
 @pytest.mark.django_db
@@ -90,7 +80,7 @@ def test_task_detail_with_user_with_access(app: DjangoTestApp):
     app.set_user(user)
     url = reverse("user-task-detail", args=[user.pk, task.pk])
     resp = app.get(url)
-    assert resp.context['object'].pk == task.pk
+    assert resp.context["object"].pk == task.pk
 
 
 @pytest.mark.django_db
@@ -101,7 +91,7 @@ def test_task_close_with_no_user(app: DjangoTestApp):
     url = reverse("user-task-close", args=[user.pk, task.pk])
     resp = app.get(url)
     assert resp.status_code == 302
-    assert resp.url == "%s?next=%s" % (reverse('login'), url)
+    assert resp.url == "%s?next=%s" % (reverse("login"), url)
 
 
 @pytest.mark.django_db
@@ -132,7 +122,7 @@ def test_task_close_with_user_with_access(app: DjangoTestApp):
     app.set_user(user)
     url = reverse("user-task-close", args=[user.pk, task.pk])
     resp = app.get(url)
-    form = resp.forms['close-form']
+    form = resp.forms["close-form"]
     form.submit()
     task.refresh_from_db()
     assert task.status == Task.COMPLETED
@@ -146,7 +136,7 @@ def test_task_assign_with_no_user(app: DjangoTestApp):
     url = reverse("user-task-assign", args=[user.pk, task.pk])
     resp = app.get(url)
     assert resp.status_code == 302
-    assert resp.url == "%s?next=%s" % (reverse('login'), url)
+    assert resp.url == "%s?next=%s" % (reverse("login"), url)
 
 
 @pytest.mark.django_db
@@ -177,7 +167,7 @@ def test_task_assign_with_user_with_access(app: DjangoTestApp):
     app.set_user(user)
     url = reverse("user-task-assign", args=[user.pk, task.pk])
     resp = app.get(url)
-    form = resp.forms['assign-form']
+    form = resp.forms["assign-form"]
     form.submit()
     task.refresh_from_db()
     assert task.status == Task.ASSIGNED
@@ -190,10 +180,8 @@ def test_task_search_with_title(app: DjangoTestApp):
     task2 = TaskFactory(user=user, title="Test: task 2")
     TaskFactory(user=user, title="Something else")
     app.set_user(user)
-    resp = app.get('%s?q=Test:' % reverse("user-task-list", kwargs={'pk': user.pk}))
-    assert sorted(list([int(task.pk) for task in resp.context["object_list"]])) == sorted([
-        task1.pk, task2.pk
-    ])
+    resp = app.get("%s?q=Test:" % reverse("user-task-list", kwargs={"pk": user.pk}))
+    assert sorted(list([int(task.pk) for task in resp.context["object_list"]])) == sorted([task1.pk, task2.pk])
 
 
 @pytest.mark.haystack
@@ -203,10 +191,8 @@ def test_task_search_with_description(app: DjangoTestApp):
     task2 = TaskFactory(user=user, description="Test description 2")
     TaskFactory(user=user, description="Something else")
     app.set_user(user)
-    resp = app.get('%s?q=description' % reverse("user-task-list", kwargs={'pk': user.pk}))
-    assert sorted(list([int(task.pk) for task in resp.context["object_list"]])) == sorted([
-        task1.pk, task2.pk
-    ])
+    resp = app.get("%s?q=description" % reverse("user-task-list", kwargs={"pk": user.pk}))
+    assert sorted(list([int(task.pk) for task in resp.context["object_list"]])) == sorted([task1.pk, task2.pk])
 
 
 @pytest.mark.haystack
@@ -216,10 +202,8 @@ def test_task_search_with_user_name(app: DjangoTestApp):
     task2 = TaskFactory(user=user)
     TaskFactory()
     app.set_user(user)
-    resp = app.get('%s?q=Test+User' % reverse("user-task-list", kwargs={'pk': user.pk}))
-    assert sorted(list([int(task.pk) for task in resp.context["object_list"]])) == sorted([
-        task1.pk, task2.pk
-    ])
+    resp = app.get("%s?q=Test+User" % reverse("user-task-list", kwargs={"pk": user.pk}))
+    assert sorted(list([int(task.pk) for task in resp.context["object_list"]])) == sorted([task1.pk, task2.pk])
 
 
 @pytest.mark.haystack
@@ -227,18 +211,14 @@ def test_task_search_with_organization_name(app: DjangoTestApp):
     organization = OrganizationFactory(title="Organization")
     user = UserFactory(organization=organization)
     RepresentativeFactory(
-        user=user,
-        content_type=ContentType.objects.get_for_model(organization),
-        object_id=organization.pk
+        user=user, content_type=ContentType.objects.get_for_model(organization), object_id=organization.pk
     )
     task1 = TaskFactory(organization=organization)
     task2 = TaskFactory(organization=organization)
     TaskFactory()
     app.set_user(user)
-    resp = app.get('%s?q=Organization' % reverse("user-task-list", kwargs={'pk': user.pk}))
-    assert sorted(list([int(task.pk) for task in resp.context["object_list"]])) == sorted([
-        task1.pk, task2.pk
-    ])
+    resp = app.get("%s?q=Organization" % reverse("user-task-list", kwargs={"pk": user.pk}))
+    assert sorted(list([int(task.pk) for task in resp.context["object_list"]])) == sorted([task1.pk, task2.pk])
 
 
 @pytest.mark.haystack
@@ -248,8 +228,7 @@ def test_task_search_with_filter(app: DjangoTestApp):
     TaskFactory(user=user, title="Test: task 2", status=Task.COMPLETED)
     TaskFactory(user=user, title="Something else", status=Task.CREATED)
     app.set_user(user)
-    resp = app.get('%s?q=Test:&status=created' %
-                   reverse("user-task-list", kwargs={'pk': user.pk}))
+    resp = app.get("%s?q=Test:&status=created" % reverse("user-task-list", kwargs={"pk": user.pk}))
     assert sorted(list([int(task.pk) for task in resp.context["object_list"]])) == sorted([task1.pk])
 
 
@@ -258,15 +237,13 @@ def test_task_list_with_owner_filter__user(app: DjangoTestApp):
     organization = OrganizationFactory(title="Organization")
     user = UserFactory(organization=organization)
     RepresentativeFactory(
-        user=user,
-        content_type=ContentType.objects.get_for_model(organization),
-        object_id=organization.pk
+        user=user, content_type=ContentType.objects.get_for_model(organization), object_id=organization.pk
     )
     task1 = TaskFactory(user=user)
     task2 = TaskFactory(user=user)
     TaskFactory(organization=organization)
     app.set_user(user)
-    resp = app.get('%s?owner=user' % reverse("user-task-list", kwargs={'pk': user.pk}))
+    resp = app.get("%s?owner=user" % reverse("user-task-list", kwargs={"pk": user.pk}))
     assert sorted(list([int(task.pk) for task in resp.context["object_list"]])) == sorted([task1.pk, task2.pk])
 
 
@@ -275,17 +252,16 @@ def test_task_list_with_owner_filter__all(app: DjangoTestApp):
     organization = OrganizationFactory(title="Organization")
     user = UserFactory(organization=organization)
     RepresentativeFactory(
-        user=user,
-        content_type=ContentType.objects.get_for_model(organization),
-        object_id=organization.pk
+        user=user, content_type=ContentType.objects.get_for_model(organization), object_id=organization.pk
     )
     task1 = TaskFactory(user=user)
     task2 = TaskFactory(user=user)
     task3 = TaskFactory(organization=organization)
     app.set_user(user)
-    resp = app.get('%s?owner=all' % reverse("user-task-list", kwargs={'pk': user.pk}))
-    assert sorted(list([int(task.pk) for task in resp.context["object_list"]])) == \
-           sorted([task1.pk, task2.pk, task3.pk])
+    resp = app.get("%s?owner=all" % reverse("user-task-list", kwargs={"pk": user.pk}))
+    assert sorted(list([int(task.pk) for task in resp.context["object_list"]])) == sorted(
+        [task1.pk, task2.pk, task3.pk]
+    )
 
 
 @pytest.mark.django_db
@@ -295,7 +271,7 @@ def test_task_list_regular_user_cannot_access_other_users_tasks(app: DjangoTestA
     TaskFactory(user=user2)
 
     app.set_user(user1)
-    url = reverse("user-task-list", kwargs={'pk': user2.pk})
+    url = reverse("user-task-list", kwargs={"pk": user2.pk})
     resp = app.get(url, expect_errors=True)
     assert resp.status_code == 403
 
@@ -307,7 +283,7 @@ def test_task_list_staff_can_access_other_users_tasks(app: DjangoTestApp):
     task = TaskFactory(user=regular_user)
 
     app.set_user(staff_user)
-    url = reverse("user-task-list", kwargs={'pk': regular_user.pk})
+    url = reverse("user-task-list", kwargs={"pk": regular_user.pk})
     resp = app.get(url)
     assert resp.status_code == 200
     assert task.pk in [t.pk for t in resp.context["object_list"]]
@@ -320,7 +296,7 @@ def test_task_list_superuser_can_access_other_users_tasks(app: DjangoTestApp):
     task = TaskFactory(user=regular_user)
 
     app.set_user(superuser)
-    url = reverse("user-task-list", kwargs={'pk': regular_user.pk})
+    url = reverse("user-task-list", kwargs={"pk": regular_user.pk})
     resp = app.get(url)
     assert resp.status_code == 200
     assert task.pk in [t.pk for t in resp.context["object_list"]]
@@ -336,7 +312,7 @@ def test_task_detail_staff_can_access_other_users_tasks(app: DjangoTestApp):
     url = reverse("user-task-detail", args=[regular_user.pk, task.pk])
     resp = app.get(url)
     assert resp.status_code == 200
-    assert resp.context['object'].pk == task.pk
+    assert resp.context["object"].pk == task.pk
 
 
 @pytest.mark.django_db
@@ -349,7 +325,7 @@ def test_task_detail_superuser_can_access_other_users_tasks(app: DjangoTestApp):
     url = reverse("user-task-detail", args=[regular_user.pk, task.pk])
     resp = app.get(url)
     assert resp.status_code == 200
-    assert resp.context['object'].pk == task.pk
+    assert resp.context["object"].pk == task.pk
 
 
 @pytest.mark.haystack
@@ -362,13 +338,13 @@ def test_task_list_status_filter(app: DjangoTestApp):
     app.set_user(user)
 
     # Test CREATED filter
-    resp = app.get(f'{reverse("user-task-list", kwargs={"pk": user.pk})}?status={Task.CREATED}')
+    resp = app.get(f"{reverse('user-task-list', kwargs={'pk': user.pk})}?status={Task.CREATED}")
     result_pks = [t.pk for t in resp.context["object_list"]]
     assert task_created.pk in result_pks
     assert task_assigned.pk not in result_pks
 
     # Test ASSIGNED filter
-    resp = app.get(f'{reverse("user-task-list", kwargs={"pk": user.pk})}?status={Task.ASSIGNED}')
+    resp = app.get(f"{reverse('user-task-list', kwargs={'pk': user.pk})}?status={Task.ASSIGNED}")
     result_pks = [t.pk for t in resp.context["object_list"]]
     assert task_assigned.pk in result_pks
     assert task_created.pk not in result_pks
@@ -384,13 +360,13 @@ def test_task_list_type_filter(app: DjangoTestApp):
     app.set_user(user)
 
     # Test REQUEST filter
-    resp = app.get(f'{reverse("user-task-list", kwargs={"pk": user.pk})}?type={Task.REQUEST}')
+    resp = app.get(f"{reverse('user-task-list', kwargs={'pk': user.pk})}?type={Task.REQUEST}")
     result_pks = [t.pk for t in resp.context["object_list"]]
     assert task_request.pk in result_pks
     assert task_error.pk not in result_pks
 
     # Test ERROR filter
-    resp = app.get(f'{reverse("user-task-list", kwargs={"pk": user.pk})}?type={Task.ERROR}')
+    resp = app.get(f"{reverse('user-task-list', kwargs={'pk': user.pk})}?type={Task.ERROR}")
     result_pks = [t.pk for t in resp.context["object_list"]]
     assert task_error.pk in result_pks
     assert task_request.pk not in result_pks
@@ -406,10 +382,7 @@ def test_task_list_combined_filters(app: DjangoTestApp):
     TaskFactory(user=user, status=Task.CREATED, type=Task.ERROR)
 
     app.set_user(user)
-    resp = app.get(
-        f'{reverse("user-task-list", kwargs={"pk": user.pk})}'
-        f'?status={Task.CREATED}&type={Task.REQUEST}'
-    )
+    resp = app.get(f"{reverse('user-task-list', kwargs={'pk': user.pk})}?status={Task.CREATED}&type={Task.REQUEST}")
     result_pks = [t.pk for t in resp.context["object_list"]]
     assert result_pks == [task_match.pk]
 
@@ -423,20 +396,22 @@ def test_task_list_filter_counts_are_accurate(app: DjangoTestApp):
     TaskFactory(user=user, status=Task.COMPLETED)
 
     app.set_user(user)
-    resp = app.get(reverse("user-task-list", kwargs={'pk': user.pk}))
+    resp = app.get(reverse("user-task-list", kwargs={"pk": user.pk}))
 
-    status_filter = next(f for f in resp.context['filters'] if f['title'] == 'Būsena')
+    status_filter = next(f for f in resp.context["filters"] if f["title"] == "Būsena")
 
-    created_item = next(item for item in status_filter['items'] if item['title'] == Task.FILTER_STATUSES[Task.CREATED])
-    assert created_item['count'] == 2
+    created_item = next(item for item in status_filter["items"] if item["title"] == Task.FILTER_STATUSES[Task.CREATED])
+    assert created_item["count"] == 2
 
     assigned_item = next(
-        item for item in status_filter['items'] if item['title'] == Task.FILTER_STATUSES[Task.ASSIGNED])
-    assert assigned_item['count'] == 1
+        item for item in status_filter["items"] if item["title"] == Task.FILTER_STATUSES[Task.ASSIGNED]
+    )
+    assert assigned_item["count"] == 1
 
     completed_item = next(
-        item for item in status_filter['items'] if item['title'] == Task.FILTER_STATUSES[Task.COMPLETED])
-    assert completed_item['count'] == 1
+        item for item in status_filter["items"] if item["title"] == Task.FILTER_STATUSES[Task.COMPLETED]
+    )
+    assert completed_item["count"] == 1
 
 
 @pytest.mark.haystack
@@ -444,9 +419,7 @@ def test_task_list_owner_filter_counts_with_organization(app: DjangoTestApp):
     organization = OrganizationFactory()
     user = UserFactory(organization=organization)
     RepresentativeFactory(
-        user=user,
-        content_type=ContentType.objects.get_for_model(organization),
-        object_id=organization.pk
+        user=user, content_type=ContentType.objects.get_for_model(organization), object_id=organization.pk
     )
 
     # 2 tasks assigned to user
@@ -458,12 +431,12 @@ def test_task_list_owner_filter_counts_with_organization(app: DjangoTestApp):
     TaskFactory(organization=organization)
 
     app.set_user(user)
-    resp = app.get(reverse("user-task-list", kwargs={'pk': user.pk}))
+    resp = app.get(reverse("user-task-list", kwargs={"pk": user.pk}))
 
-    owner_filter = next(f for f in resp.context['filters'] if f['title'] == 'Vykdytojas')
+    owner_filter = next(f for f in resp.context["filters"] if f["title"] == "Vykdytojas")
 
-    user_tasks = next(item for item in owner_filter['items'] if 'Mano užduotys' in item['title'])
-    all_tasks = next(item for item in owner_filter['items'] if 'Visos užduotys' in item['title'])
+    user_tasks = next(item for item in owner_filter["items"] if "Mano užduotys" in item["title"])
+    all_tasks = next(item for item in owner_filter["items"] if "Visos užduotys" in item["title"])
 
-    assert user_tasks['count'] == 2
-    assert all_tasks['count'] == 5  # 2 user tasks + 3 org tasks
+    assert user_tasks["count"] == 2
+    assert all_tasks["count"] == 5  # 2 user tasks + 3 org tasks

--- a/tests/test_apps.py
+++ b/tests/test_apps.py
@@ -12,18 +12,15 @@ import reversion
 
 @pytest.mark.parametrize(
     "model, should_be_registered",
-    [
-        (model, is_model_versioned(model))
-        for model in get_all_models()
-    ],
+    [(model, is_model_versioned(model)) for model in get_all_models()],
 )
 def test_reversion_model_registration(model: type[models.Model], should_be_registered: bool):
     path = f"{model.__module__}.{model.__name__}"
 
     if should_be_registered:
-        assert reversion.is_registered(model), (f"Model '{path}' should be registered with reversion.")
+        assert reversion.is_registered(model), f"Model '{path}' should be registered with reversion."
     else:
-        assert not reversion.is_registered(model), (f"Model '{path}' should not be registered with reversion.")
+        assert not reversion.is_registered(model), f"Model '{path}' should not be registered with reversion."
 
 
 @override_settings(NOT_VERSIONED_MODELS=["notExistingModel"], DEBUG=True)
@@ -36,10 +33,7 @@ def test_not_existing_model_in_not_versioned_models():
         api_config.ready()
 
 
-@pytest.mark.parametrize(
-        'versioned_model',
-        [model for model in get_all_models() if is_model_versioned(model)]
-)
+@pytest.mark.parametrize("versioned_model", [model for model in get_all_models() if is_model_versioned(model)])
 @pytest.mark.django_db
 def test_versioned_models_inherit_revision_comment_admin_class(versioned_model: type[models.Model]):
     if model_admin_instance := admin.site._registry.get(versioned_model):

--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -1,5 +1,4 @@
 import pytest
-from django_webtest import DjangoTestApp
 from django.test import override_settings
 from vitrina.structure.models import ManifestValidationEntry
 from vitrina.users.factories import UserFactory

--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -13,10 +13,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
     CELERY_TASK_EAGER_PROPAGATES=True,
 )
 @pytest.mark.django_db(transaction=True)
-@pytest.mark.parametrize(
-    "include_user",
-    [True,False]
-)
+@pytest.mark.parametrize("include_user", [True, False])
 def test_celery_tasks_create_versions_with_or_without_user(include_user: bool):
     user = UserFactory() if include_user else None
     dummy_csv = SimpleUploadedFile(
@@ -30,7 +27,7 @@ def test_celery_tasks_create_versions_with_or_without_user(include_user: bool):
         source=RevisionSource.TASK,
         action="vitrina.structure.tasks.validate_manifest_task",
         args=[manifest_validation_entry.pk],
-        kwargs={}
+        kwargs={},
     )
     if user:
         validate_manifest_task.delay(manifest_validation_entry.pk, _reversion_user_id=user.id)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -12,57 +12,57 @@ from vitrina.orgs.factories import OrganizationFactory
 
 @pytest.mark.django_db
 def test_get_selected_value():
-    facet_form = Mock(selected_facets=['key_exact:value'])
-    selected_value = get_selected_value(facet_form, 'key', is_int=False)
-    assert selected_value == 'value'
+    facet_form = Mock(selected_facets=["key_exact:value"])
+    selected_value = get_selected_value(facet_form, "key", is_int=False)
+    assert selected_value == "value"
 
 
 @pytest.mark.django_db
 def test_get_selected_value_multiple():
-    facet_form = Mock(selected_facets=['key_exact:value1', 'key_exact:value2'])
-    selected_value = get_selected_value(facet_form, 'key', multiple=True, is_int=False)
-    assert selected_value == ['value1', 'value2']
+    facet_form = Mock(selected_facets=["key_exact:value1", "key_exact:value2"])
+    selected_value = get_selected_value(facet_form, "key", multiple=True, is_int=False)
+    assert selected_value == ["value1", "value2"]
 
 
 @pytest.mark.django_db
 def test_get_selected_value_int():
-    facet_form = Mock(selected_facets=['key_exact:1'])
-    selected_value = get_selected_value(facet_form, 'key')
+    facet_form = Mock(selected_facets=["key_exact:1"])
+    selected_value = get_selected_value(facet_form, "key")
     assert selected_value == 1
 
 
 @pytest.mark.django_db
 def test_get_selected_value_multiple_int():
-    facet_form = Mock(selected_facets=['key_exact:1', 'key_exact:2'])
-    selected_value = get_selected_value(facet_form, 'key', multiple=True)
+    facet_form = Mock(selected_facets=["key_exact:1", "key_exact:2"])
+    selected_value = get_selected_value(facet_form, "key", multiple=True)
     assert selected_value == [1, 2]
 
 
 @pytest.mark.django_db
 def test_get_selected_value_int_value_error(rf: RequestFactory):
-    facet_form = Mock(selected_facets=['key_exact:?'])
-    selected_value = get_selected_value(facet_form, 'key')
+    facet_form = Mock(selected_facets=["key_exact:?"])
+    selected_value = get_selected_value(facet_form, "key")
     assert selected_value is None
 
 
 @pytest.mark.django_db
 def test_get_filter_url(rf: RequestFactory):
-    request = rf.get('/')
-    filter_url = get_filter_url(request, 'key', 'value')
+    request = rf.get("/")
+    filter_url = get_filter_url(request, "key", "value")
     assert filter_url == "?selected_facets=key_exact%3Avalue"
 
 
 @pytest.mark.django_db
 def test_get_filter_url_with_existing_key(rf: RequestFactory):
-    request = rf.get('/', {"selected_facets": "key1_exact:value1"})
-    filter_url = get_filter_url(request, 'key2', 'value2')
+    request = rf.get("/", {"selected_facets": "key1_exact:value1"})
+    filter_url = get_filter_url(request, "key2", "value2")
     assert filter_url == "?selected_facets=key1_exact%3Avalue1&selected_facets=key2_exact%3Avalue2"
 
 
 @pytest.mark.django_db
 def test_get_filter_url_with_page(rf: RequestFactory):
-    request = rf.get('/', {"page": "1"})
-    filter_url = get_filter_url(request, 'key', 'value')
+    request = rf.get("/", {"page": "1"})
+    filter_url = get_filter_url(request, "key", "value")
     assert filter_url == "?selected_facets=key_exact%3Avalue"
 
 
@@ -70,10 +70,7 @@ def test_get_filter_url_with_page(rf: RequestFactory):
 def test_organization_only():
     organization = OrganizationFactory(title="Test Organization")
     result = build_page_title_context(organization=organization)
-    expected = {
-            "title": "Test Organization",
-            "object_type": str(_("Organizacija"))
-        }
+    expected = {"title": "Test Organization", "object_type": str(_("Organizacija"))}
     assert result == expected
 
 
@@ -81,12 +78,9 @@ def test_organization_only():
 def test_dataset_only():
     parent_org = OrganizationFactory(title="Parent Organization")
 
-    dataset = DatasetFactory(
-        title="Test Dataset",
-        organization=parent_org
-    )
+    dataset = DatasetFactory(title="Test Dataset", organization=parent_org)
     result = build_page_title_context(dataset=dataset, language_code="en")
-    
+
     assert result["title"] == "Test Dataset"
     assert result["root_label"] == str(_("Organizacija"))
     assert result["root_name"] == "Parent Organization"
@@ -102,7 +96,7 @@ def test_dataset_only():
         ("test.tar.gz", "gz"),
         ("test", ""),
         ("", ""),
-    ]
+    ],
 )
 def test_get_file_extension(file_name: str, result: str):
     assert get_file_extension(file_name) == result

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -5,7 +5,7 @@ from django.test import RequestFactory
 from django.utils.translation import gettext as _
 
 from vitrina.helpers import get_selected_value, get_filter_url, get_file_extension
-from vitrina.helpers import prepare_email_by_identifier, build_page_title_context
+from vitrina.helpers import build_page_title_context
 from vitrina.datasets.factories import DatasetFactory
 from vitrina.orgs.factories import OrganizationFactory
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -7,11 +7,10 @@ from vitrina.utils import RevisionComment, RevisionSource
 
 
 def test_noop_when_reversion_not_active(rf: RequestFactory):
-
     middleware = AutoRevisionCommentMiddleware(get_response=lambda r: None)
     with (
-        patch("vitrina.middleware.reversion.is_active", return_value=False), 
-        patch("vitrina.middleware.reversion.set_comment") as set_comment_mock
+        patch("vitrina.middleware.reversion.is_active", return_value=False),
+        patch("vitrina.middleware.reversion.set_comment") as set_comment_mock,
     ):
         middleware.process_view(rf.post(""), view_func=lambda r: None, view_args=[], view_kwargs={})
 
@@ -19,12 +18,11 @@ def test_noop_when_reversion_not_active(rf: RequestFactory):
 
 
 def test_noop_when_comment_already_set(rf: RequestFactory):
-
     middleware = AutoRevisionCommentMiddleware(get_response=lambda r: None)
     with (
         patch("vitrina.middleware.reversion.is_active", return_value=True),
         patch("vitrina.middleware.reversion.get_comment", return_value="test"),
-        patch("vitrina.middleware.reversion.set_comment") as set_comment_mock
+        patch("vitrina.middleware.reversion.set_comment") as set_comment_mock,
     ):
         middleware.process_view(rf.post(""), view_func=lambda r: None, view_args=[], view_kwargs={})
 
@@ -32,7 +30,6 @@ def test_noop_when_comment_already_set(rf: RequestFactory):
 
 
 def test_noop_for_admin_view(rf: RequestFactory):
-
     def admin_view(request):
         return None
 
@@ -42,7 +39,7 @@ def test_noop_for_admin_view(rf: RequestFactory):
     with (
         patch("vitrina.middleware.reversion.is_active", return_value=True),
         patch("vitrina.middleware.reversion.get_comment", return_value=None),
-        patch("vitrina.middleware.reversion.set_comment") as set_comment_mock
+        patch("vitrina.middleware.reversion.set_comment") as set_comment_mock,
     ):
         middleware.process_view(rf.post(""), view_func=admin_view, view_args=[], view_kwargs={})
 
@@ -68,7 +65,7 @@ def test_sets_comment(rf: RequestFactory):
     with (
         patch("vitrina.middleware.reversion.is_active", return_value=True),
         patch("vitrina.middleware.reversion.get_comment", return_value=None),
-        patch("vitrina.middleware.reversion.set_comment") as set_comment_mock
+        patch("vitrina.middleware.reversion.set_comment") as set_comment_mock,
     ):
         middleware.process_view(request, view_func=lambda r: None, view_args=view_args, view_kwargs=view_kwargs)
 

--- a/tests/test_reversion_utils.py
+++ b/tests/test_reversion_utils.py
@@ -5,16 +5,15 @@ from vitrina.smart_contracts.models import Agreement, AgreementFile
 from vitrina.reversion_utils import get_version_ids, VersionRelationSpec
 
 
-
 def test_get_version_ids():
     with reversion.create_revision():
         agreement_file = AgreementPDFFileFactory()
- 
+
     agreement_file_version_ids = Version.objects.get_for_object(agreement_file).values_list("id", flat=True)
     agreement_version_ids = Version.objects.get_for_object(agreement_file.agreement).values_list("id", flat=True)
     project_version_ids = Version.objects.get_for_object(agreement_file.agreement.project).values_list("id", flat=True)
 
-    version_ids =  list(agreement_file_version_ids) + list(agreement_version_ids) + list(project_version_ids)
+    version_ids = list(agreement_file_version_ids) + list(agreement_version_ids) + list(project_version_ids)
 
     agreement_children = [
         VersionRelationSpec(target_model=AgreementFile, parent_fk=AgreementFile.agreement),

--- a/tests/test_view_count.py
+++ b/tests/test_view_count.py
@@ -15,24 +15,24 @@ def test_view_count_dataset(app: DjangoTestApp):
     dataset = DatasetFactory()
     hit_count = HitCount.objects.create(content_object=dataset)
 
-    user1 = User.objects.create_user(email='user1@test.com', password='12345')
-    user2 = User.objects.create_user(email='user2@test.com', password='12345')
+    user1 = User.objects.create_user(email="user1@test.com", password="12345")
+    user2 = User.objects.create_user(email="user2@test.com", password="12345")
 
     app.set_user(user1)
 
     # visit with one user
-    resp = app.post(reverse('hitcount:hit_ajax'), {'hitcountPK': hit_count.pk}, xhr=True)
+    resp = app.post(reverse("hitcount:hit_ajax"), {"hitcountPK": hit_count.pk}, xhr=True)
     assert resp.content == b'{"hit_counted": true, "hit_message": "Hit counted: user authentication"}'
     assert HitCount.objects.get(pk=hit_count.pk).hits == 1
 
     # visit with the same user
-    resp = app.post(reverse('hitcount:hit_ajax'), {'hitcountPK': hit_count.pk}, xhr=True)
+    resp = app.post(reverse("hitcount:hit_ajax"), {"hitcountPK": hit_count.pk}, xhr=True)
     assert resp.content == b'{"hit_counted": false, "hit_message": "Not counted: authenticated user has active hit"}'
     assert HitCount.objects.get(pk=hit_count.pk).hits == 1
 
     # visit with another user
     app.set_user(user2)
-    resp = app.post(reverse('hitcount:hit_ajax'), {'hitcountPK': hit_count.pk}, xhr=True)
+    resp = app.post(reverse("hitcount:hit_ajax"), {"hitcountPK": hit_count.pk}, xhr=True)
     assert resp.content == b'{"hit_counted": true, "hit_message": "Hit counted: user authentication"}'
     assert HitCount.objects.get(pk=hit_count.pk).hits == 2
 
@@ -42,24 +42,24 @@ def test_view_count_request(app: DjangoTestApp):
     request = RequestFactory()
     hit_count = HitCount.objects.create(content_object=request)
 
-    user1 = User.objects.create_user(email='user1@test.com', password='12345')
-    user2 = User.objects.create_user(email='user2@test.com', password='12345')
+    user1 = User.objects.create_user(email="user1@test.com", password="12345")
+    user2 = User.objects.create_user(email="user2@test.com", password="12345")
 
     app.set_user(user1)
 
     # visit with one user
-    resp = app.post(reverse('hitcount:hit_ajax'), {'hitcountPK': hit_count.pk}, xhr=True)
+    resp = app.post(reverse("hitcount:hit_ajax"), {"hitcountPK": hit_count.pk}, xhr=True)
     assert resp.content == b'{"hit_counted": true, "hit_message": "Hit counted: user authentication"}'
     assert HitCount.objects.get(pk=hit_count.pk).hits == 1
 
     # visit with the same user
-    resp = app.post(reverse('hitcount:hit_ajax'), {'hitcountPK': hit_count.pk}, xhr=True)
+    resp = app.post(reverse("hitcount:hit_ajax"), {"hitcountPK": hit_count.pk}, xhr=True)
     assert resp.content == b'{"hit_counted": false, "hit_message": "Not counted: authenticated user has active hit"}'
     assert HitCount.objects.get(pk=hit_count.pk).hits == 1
 
     # visit with another user
     app.set_user(user2)
-    resp = app.post(reverse('hitcount:hit_ajax'), {'hitcountPK': hit_count.pk}, xhr=True)
+    resp = app.post(reverse("hitcount:hit_ajax"), {"hitcountPK": hit_count.pk}, xhr=True)
     assert resp.content == b'{"hit_counted": true, "hit_message": "Hit counted: user authentication"}'
     assert HitCount.objects.get(pk=hit_count.pk).hits == 2
 
@@ -69,23 +69,23 @@ def test_view_count_project(app: DjangoTestApp):
     project = ProjectFactory()
     hit_count = HitCount.objects.create(content_object=project)
 
-    user1 = User.objects.create_user(email='user1@test.com', password='12345')
-    user2 = User.objects.create_user(email='user2@test.com', password='12345')
+    user1 = User.objects.create_user(email="user1@test.com", password="12345")
+    user2 = User.objects.create_user(email="user2@test.com", password="12345")
 
     app.set_user(user1)
 
     # visit with one user
-    resp = app.post(reverse('hitcount:hit_ajax'), {'hitcountPK': hit_count.pk}, xhr=True)
+    resp = app.post(reverse("hitcount:hit_ajax"), {"hitcountPK": hit_count.pk}, xhr=True)
     assert resp.content == b'{"hit_counted": true, "hit_message": "Hit counted: user authentication"}'
     assert HitCount.objects.get(pk=hit_count.pk).hits == 1
 
     # visit with the same user
-    resp = app.post(reverse('hitcount:hit_ajax'), {'hitcountPK': hit_count.pk}, xhr=True)
+    resp = app.post(reverse("hitcount:hit_ajax"), {"hitcountPK": hit_count.pk}, xhr=True)
     assert resp.content == b'{"hit_counted": false, "hit_message": "Not counted: authenticated user has active hit"}'
     assert HitCount.objects.get(pk=hit_count.pk).hits == 1
 
     # visit with another user
     app.set_user(user2)
-    resp = app.post(reverse('hitcount:hit_ajax'), {'hitcountPK': hit_count.pk}, xhr=True)
+    resp = app.post(reverse("hitcount:hit_ajax"), {"hitcountPK": hit_count.pk}, xhr=True)
     assert resp.content == b'{"hit_counted": true, "hit_message": "Hit counted: user authentication"}'
     assert HitCount.objects.get(pk=hit_count.pk).hits == 2

--- a/tests/test_vitrina.py
+++ b/tests/test_vitrina.py
@@ -8,25 +8,22 @@ from vitrina.users.factories import UserFactory
 
 @pytest.mark.django_db
 def test_home(app: DjangoTestApp):
-    resp = app.get('/')
+    resp = app.get("/")
 
-    assert resp.status == '200 OK'
-    assert resp.context['counts'] == {
-        'dataset': 1,
-        'organization': 1,
-        'project': 0,
-        'coordinators': 0,
-        'managers': 0,
-        'users': 1
+    assert resp.status == "200 OK"
+    assert resp.context["counts"] == {
+        "dataset": 1,
+        "organization": 1,
+        "project": 0,
+        "coordinators": 0,
+        "managers": 0,
+        "users": 1,
     }
 
-    assert [
-        list(elem.stripped_strings)
-        for elem in resp.html.select('a.stats')
-    ] == [
-        ['1', 'Organizacijos'],
-        ['1', 'Duomenų ištekliai'],
-        ['0', 'Panaudojimo atvejai'],
+    assert [list(elem.stripped_strings) for elem in resp.html.select("a.stats")] == [
+        ["1", "Organizacijos"],
+        ["1", "Duomenų ištekliai"],
+        ["0", "Panaudojimo atvejai"],
         # ['0', 'Koordinatoriai'],
         # ['0', 'Tvarkytojai'],
         # ['0', 'Naudotojai'],
@@ -37,7 +34,6 @@ def test_home(app: DjangoTestApp):
 def test_request_create_link(app: DjangoTestApp):
     user = UserFactory()
     app.set_user(user)
-    resp = app.get('/')
+    resp = app.get("/")
     resp = resp.click(linkid="request-create")
-    assert resp.request.path == reverse('request-create')
-
+    assert resp.request.path == reverse("request-create")

--- a/tests/test_vitrina.py
+++ b/tests/test_vitrina.py
@@ -3,11 +3,6 @@ from django.urls import reverse
 
 from django_webtest import DjangoTestApp
 
-from vitrina.datasets.factories import DatasetFactory
-from vitrina.datasets.models import Dataset
-from vitrina.orgs.factories import OrganizationFactory
-from vitrina.plans.models import Project
-from vitrina.projects.factories import ProjectFactory
 from vitrina.users.factories import UserFactory
 
 

--- a/tests/uapi/agent/test_forms.py
+++ b/tests/uapi/agent/test_forms.py
@@ -56,7 +56,7 @@ class TestAgentForm:
         assert not form.is_valid()
         assert form.errors == {
             "open_data_publish_url": [
-                "Šis laukas yra privalomas, jei nustatytas požymis \"Atviri duomenys publikuojami Saugykloje\"."
+                'Šis laukas yra privalomas, jei nustatytas požymis "Atviri duomenys publikuojami Saugykloje".'
             ]
         }
 

--- a/tests/uapi/agent/test_template_views.py
+++ b/tests/uapi/agent/test_template_views.py
@@ -5,11 +5,9 @@ from unittest.mock import patch
 import pytest
 from django.urls import reverse
 from django_webtest import DjangoTestApp
-from django.contrib.contenttypes.models import ContentType
 from vitrina.api.models import ApiKey
 from vitrina.datasets.factories import DatasetFactory, AgentFactory
 from vitrina.datasets.models import Dataset, DCATResourceSubclass
-from vitrina.structure.factories import MetadataFactory
 from vitrina.uapi import AgentType, Environment
 from vitrina.orgs.factories import OrganizationFactory
 from vitrina.orgs.models import Organization

--- a/tests/uapi/agreement/test_views.py
+++ b/tests/uapi/agreement/test_views.py
@@ -25,10 +25,7 @@ timezone = pytz.timezone(settings.TIME_ZONE)
 class TestSyncDone:
     def test_update_404_when_agreement_does_not_exist(self, app: DjangoTestApp, valid_token: str) -> None:
         response = app.put(
-            reverse(
-                "uapi-agent-sync-done",
-                kwargs={"agreement_id": str(uuid4())}
-            ),
+            reverse("uapi-agent-sync-done", kwargs={"agreement_id": str(uuid4())}),
             extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
             expect_errors=True,
         )
@@ -41,7 +38,6 @@ class TestSyncDone:
             "message": "No Agreement matches the given query.",
             "additionalProperties": None,
         }
-
 
     def test_update_404_when_different_organization_in_token(
         self,
@@ -51,15 +47,10 @@ class TestSyncDone:
         valid_token: str,
     ) -> None:
         different_organization = OrganizationFactory()
-        agreement = AgreementFactory(
-            project=project, assigner=organization, assignee=different_organization
-        )
+        agreement = AgreementFactory(project=project, assigner=organization, assignee=different_organization)
 
         response = app.put(
-            reverse(
-                "uapi-agent-sync-done",
-                kwargs={"agreement_id": agreement.pk}
-            ),
+            reverse("uapi-agent-sync-done", kwargs={"agreement_id": agreement.pk}),
             extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
             expect_errors=True,
         )
@@ -72,7 +63,6 @@ class TestSyncDone:
             "message": "No Agreement matches the given query.",
             "additionalProperties": None,
         }
-
 
     def test_update_404_when_agreement_sync_disabled(
         self,
@@ -89,10 +79,7 @@ class TestSyncDone:
         )
 
         response = app.put(
-            reverse(
-                "uapi-agent-sync-done",
-                kwargs={"agreement_id": agreement.pk}
-            ),
+            reverse("uapi-agent-sync-done", kwargs={"agreement_id": agreement.pk}),
             extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
             expect_errors=True,
         )
@@ -105,7 +92,6 @@ class TestSyncDone:
             "message": "No Agreement matches the given query.",
             "additionalProperties": None,
         }
-
 
     def test_agent_is_disabled(
         self,
@@ -122,10 +108,7 @@ class TestSyncDone:
         )
 
         response = app.put(
-            reverse(
-                "uapi-agent-sync-done",
-                kwargs={"agreement_id": agreement.pk}
-            ),
+            reverse("uapi-agent-sync-done", kwargs={"agreement_id": agreement.pk}),
             extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token_disabled_agent}"},
             expect_errors=True,
         )
@@ -138,7 +121,6 @@ class TestSyncDone:
             "message": "The agent is disabled. Enable the agent in the Data catalog to access this API.",
             "additionalProperties": None,
         }
-
 
     def test_sync_agent_is_disabled(
         self,
@@ -155,10 +137,7 @@ class TestSyncDone:
         )
 
         response = app.put(
-            reverse(
-                "uapi-agent-sync-done",
-                kwargs={"agreement_id": agreement.pk}
-            ),
+            reverse("uapi-agent-sync-done", kwargs={"agreement_id": agreement.pk}),
             extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token_disabled_agent}"},
             expect_errors=True,
         )
@@ -171,7 +150,6 @@ class TestSyncDone:
             "message": "The agent is disabled. Enable the agent in the Data catalog to access this API.",
             "additionalProperties": None,
         }
-
 
     def test_updates_last_sync_date_and_status_to_active(
         self,
@@ -188,10 +166,7 @@ class TestSyncDone:
         )
 
         response = app.put(
-            reverse(
-                "uapi-agent-sync-done",
-                kwargs={"agreement_id": agreement.pk}
-            ),
+            reverse("uapi-agent-sync-done", kwargs={"agreement_id": agreement.pk}),
             extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
         )
 
@@ -199,7 +174,6 @@ class TestSyncDone:
         agreement.refresh_from_db()
         assert agreement.last_sync_date
         assert agreement.status == AgreementStatuses.ACTIVE
-
 
     def test_does_not_update_agreement_updated_at(
         self,
@@ -224,10 +198,7 @@ class TestSyncDone:
                 scopes=["uapi:/datasets/gov/vssa/dcat/Agreement/:patch"],
             )
             response = app.put(
-                reverse(
-                    "uapi-agent-sync-done",
-                    kwargs={"agreement_id": agreement.pk}
-                ),
+                reverse("uapi-agent-sync-done", kwargs={"agreement_id": agreement.pk}),
                 extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"},
             )
 

--- a/tests/uapi/conftest.py
+++ b/tests/uapi/conftest.py
@@ -41,11 +41,7 @@ def _generate_test_token(
     agent_is_enabled: bool = True,
 ):
     if organization and not agent and create_agent:
-        agent = AgentFactory(
-            organization=organization,
-            oauth_client_id=str(uuid.uuid4()),
-            is_enabled=agent_is_enabled
-        )
+        agent = AgentFactory(organization=organization, oauth_client_id=str(uuid.uuid4()), is_enabled=agent_is_enabled)
     now = datetime.utcnow()
     claims = {
         "iss": "test-issuer",
@@ -119,7 +115,7 @@ def dataset(organization: Organization) -> Dataset:
         organization=organization,
         title="Title of the Dataset",
         description="Description of the Dataset.",
-        metadata="test/dataset/TestModel"
+        metadata="test/dataset/TestModel",
     )
     return dataset
 

--- a/tests/uapi/dataset/test_views.py
+++ b/tests/uapi/dataset/test_views.py
@@ -96,7 +96,6 @@ class TestCreate:
             "subclass": DCATResourceSubclass.SERVICE,
         }
 
-
     @pytest.mark.parametrize(
         "subclass, subclass_additional_data, is_service, is_series",
         [
@@ -180,7 +179,6 @@ class TestCreate:
         assert response.json["series"] == is_series
         assert response.json["service"] == is_service
 
-
     def test_specific_scope(
         self,
         app: DjangoTestApp,
@@ -243,7 +241,6 @@ class TestCreate:
             "subclass": DCATResourceSubclass.DATASET,
         }
 
-
     def test_agent_is_disabled(
         self,
         app: DjangoTestApp,
@@ -277,7 +274,6 @@ class TestCreate:
             "additionalProperties": None,
         }
 
-
     @pytest.mark.parametrize("invalid_scopes", [["invalid_scope"], [], [""]])
     def test_token_does_not_have_necessary_scopes(
         self,
@@ -306,7 +302,6 @@ class TestCreate:
             "additionalProperties": None,
         }
 
-
     def test_no_organization_id_inside_token_payload(
         self,
         app: DjangoTestApp,
@@ -333,7 +328,6 @@ class TestCreate:
             "additionalProperties": None,
         }
 
-
     def test_serialization_validation_error(
         self,
         app: DjangoTestApp,
@@ -357,19 +351,14 @@ class TestCreate:
             "message": str(
                 {
                     "title": [ErrorDetail(string="Šis laukas yra privalomas.", code="required")],
-                    "description": [ErrorDetail(string="Šis laukas yra privalomas.", code="required")]
+                    "description": [ErrorDetail(string="Šis laukas yra privalomas.", code="required")],
                 }
             ),
             "context": {
-                "errors": {
-                    "title": ["Šis laukas yra privalomas."],
-                    "description": ["Šis laukas yra privalomas."]
-
-                }
+                "errors": {"title": ["Šis laukas yra privalomas."], "description": ["Šis laukas yra privalomas."]}
             },
-            "additionalProperties": None
+            "additionalProperties": None,
         }
-
 
     def test_unexpected_exception_raised_and_rollback_executed(
         self,
@@ -387,9 +376,9 @@ class TestCreate:
 
         # Mocking a property at the end of the file, to also check that rollback happened, and no new objects were created.
         with patch(
-                "vitrina.uapi.views.views.UAPIDatasetSerializer.data",
-                new_callable=PropertyMock,
-                side_effect=Exception("Unexpected error")
+            "vitrina.uapi.views.views.UAPIDatasetSerializer.data",
+            new_callable=PropertyMock,
+            side_effect=Exception("Unexpected error"),
         ):
             response = app.post(
                 url_dataset,
@@ -408,7 +397,7 @@ class TestCreate:
             "type": "Exception",
             "template": "An unexpected server error occurred.",
             "message": "Unexpected error",
-            "additionalProperties": None
+            "additionalProperties": None,
         }
 
 
@@ -459,7 +448,6 @@ class TestList:
                 }
             ]
         }
-
 
     def test_specific_scope(
         self,
@@ -514,7 +502,6 @@ class TestList:
             ]
         }
 
-
     def test_agent_is_disabled(
         self,
         app: DjangoTestApp,
@@ -537,7 +524,6 @@ class TestList:
             "message": "The agent is disabled. Enable the agent in the Data catalog to access this API.",
             "additionalProperties": None,
         }
-
 
     @pytest.mark.parametrize("invalid_scopes", [["invalid_scope"], [], [""]])
     def test_token_does_not_have_necessary_scopes(
@@ -564,7 +550,6 @@ class TestList:
             "additionalProperties": None,
         }
 
-
     def test_no_organization_id_inside_token_payload(
         self,
         app: DjangoTestApp,
@@ -588,7 +573,6 @@ class TestList:
             "additionalProperties": None,
         }
 
-
     def test_call_with_name_query_parameter(
         self,
         app: DjangoTestApp,
@@ -599,9 +583,7 @@ class TestList:
         valid_token: str,
     ):
         dataset_2 = DatasetFactory(
-            organization=organization,
-            title="Title of the Dataset 2",
-            description="Description of the Dataset 2."
+            organization=organization, title="Title of the Dataset 2", description="Description of the Dataset 2."
         )
         MetadataFactory(
             content_type=ContentType.objects.get_for_model(Dataset),
@@ -652,7 +634,6 @@ class TestList:
             ]
         }
 
-
     def test_call_with_parent_id_query_parameter(
         self,
         app: DjangoTestApp,
@@ -668,8 +649,8 @@ class TestList:
         dataset_other_organization = DatasetFactory(organization=OrganizationFactory())
 
         # Attach children to the Data Service (saved instances).
-        dataset_2.move(dataset, pos='sorted-child')
-        dataset_3.move(dataset, pos='sorted-child')
+        dataset_2.move(dataset, pos="sorted-child")
+        dataset_3.move(dataset, pos="sorted-child")
 
         response = app.get(
             url_dataset,
@@ -684,7 +665,6 @@ class TestList:
         assert str(dataset_orphan.pk) not in child_dataset_ids
         assert str(dataset_other_organization.pk) not in child_dataset_ids
 
-
     def test_no_datasets_exist(
         self,
         app: DjangoTestApp,
@@ -692,7 +672,9 @@ class TestList:
         url_dataset: str,
         valid_token: str,
     ):
-        response = app.get(url_dataset, extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"}, expect_errors=True)
+        response = app.get(
+            url_dataset, extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"}, expect_errors=True
+        )
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert response.json == {
@@ -702,9 +684,8 @@ class TestList:
             "message": (
                 "No dataset matched the provided query — http://testserver/uapi/datasets/gov/vssa/ror/dcat/Dataset/."
             ),
-            "additionalProperties": None
+            "additionalProperties": None,
         }
-
 
     def test_no_unarchived_datasets_exist(
         self,
@@ -726,7 +707,9 @@ class TestList:
             name="test/dataset/TestModel",
         )
 
-        response = app.get(url_dataset, extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"}, expect_errors=True)
+        response = app.get(
+            url_dataset, extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"}, expect_errors=True
+        )
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert Dataset.objects.filter(organization=organization).count() == 1
@@ -737,9 +720,8 @@ class TestList:
             "message": (
                 "No dataset matched the provided query — http://testserver/uapi/datasets/gov/vssa/ror/dcat/Dataset/."
             ),
-            "additionalProperties": None
+            "additionalProperties": None,
         }
-
 
     def test_list_with_query_parameters_archived_dataset(
         self,
@@ -760,7 +742,7 @@ class TestList:
             url_dataset,
             params={"name": dataset.metadata.first().name},
             extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
-            expect_errors=True
+            expect_errors=True,
         )
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
@@ -773,9 +755,8 @@ class TestList:
                 f"No dataset matched the provided query — "
                 f"http://testserver/uapi/datasets/gov/vssa/ror/dcat/Dataset/?name={quote(dataset.metadata.first().name, safe='')}."
             ),
-            "additionalProperties": None
+            "additionalProperties": None,
         }
-
 
     def test_no_datasets_for_the_organization_passed_in_path_parameters(
         self,
@@ -803,7 +784,7 @@ class TestList:
                 f"http://testserver/uapi/datasets/"
                 f"gov/vssa/ror/dcat/Dataset/?name={quote('dataset/that/does/not/exist', safe='')}."
             ),
-            "additionalProperties": None
+            "additionalProperties": None,
         }
 
 
@@ -831,7 +812,6 @@ class TestActionUploadDatasetStructure:
         file = dataset.datasetstructure_set.first().file
         assert file is not None
         assert file.label == f"dataset_{dataset.id}_structure.csv"
-
 
     def test_dataset_structure_specific_scope(
         self,
@@ -862,7 +842,6 @@ class TestActionUploadDatasetStructure:
         assert file is not None
         assert file.label == f"dataset_{dataset.id}_structure.csv"
 
-
     def test_agent_is_disabled(
         self,
         app: DjangoTestApp,
@@ -889,7 +868,6 @@ class TestActionUploadDatasetStructure:
             "message": "The agent is disabled. Enable the agent in the Data catalog to access this API.",
             "additionalProperties": None,
         }
-
 
     @pytest.mark.parametrize("invalid_scopes", [["invalid_scope"], [], [""]])
     def test_token_does_not_have_necessary_scopes(
@@ -922,7 +900,6 @@ class TestActionUploadDatasetStructure:
             "additionalProperties": None,
         }
 
-
     def test_no_organization_id_inside_token_payload(
         self,
         app: DjangoTestApp,
@@ -939,7 +916,7 @@ class TestActionUploadDatasetStructure:
             dsa,
             extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"},
             content_type="text/csv",
-            expect_errors=True
+            expect_errors=True,
         )
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -951,7 +928,6 @@ class TestActionUploadDatasetStructure:
             "message": "You do not have permission to perform this action.",
             "additionalProperties": None,
         }
-
 
     def test_no_object(
         self,
@@ -981,7 +957,6 @@ class TestActionUploadDatasetStructure:
             "additionalProperties": None,
         }
 
-
     def test_empty_csv(
         self,
         app: DjangoTestApp,
@@ -1006,7 +981,6 @@ class TestActionUploadDatasetStructure:
             "message": "CSV content is missing or invalid.",
             "additionalProperties": None,
         }
-
 
     def test_file_only_contains_special_characters(
         self,
@@ -1042,7 +1016,6 @@ class TestActionUploadDatasetStructure:
         url_dataset_structure: str,
         valid_token: str,
     ):
-
         with patch("vitrina.uapi.views.views.Dataset.save", side_effect=Exception("Unexpected error")):
             response = app.post(
                 url_dataset_structure,
@@ -1077,9 +1050,7 @@ class TestActionGetDatasetStructure:
     ):
         structure = DatasetStructureFactory(
             dataset=dataset,
-            file=FilerFileFactory(
-                file=FileField(filename=f"dataset_{dataset.id}_structure.csv", data=dsa)
-            )
+            file=FilerFileFactory(file=FileField(filename=f"dataset_{dataset.id}_structure.csv", data=dsa)),
         )
         dataset.current_structure = structure
         dataset.save()
@@ -1107,19 +1078,11 @@ class TestActionGetDatasetStructure:
         expected_rows = _normalize_csv(expected_csv)
         assert actual_rows == expected_rows
 
-
     def test_no_dataset(
-        self,
-        app: DjangoTestApp,
-        organization: Organization,
-        url_dataset_structure: str,
-        valid_token: str
+        self, app: DjangoTestApp, organization: Organization, url_dataset_structure: str, valid_token: str
     ):
         response = app.get(
-            _build_reverse_uapi_url(
-                "uapi-dataset-structure",
-                pk=1_000_000
-            ),
+            _build_reverse_uapi_url("uapi-dataset-structure", pk=1_000_000),
             extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
             expect_errors=True,
         )
@@ -1133,7 +1096,6 @@ class TestActionGetDatasetStructure:
             "additionalProperties": None,
         }
 
-
     def test_agent_is_disabled(
         self,
         app: DjangoTestApp,
@@ -1145,9 +1107,7 @@ class TestActionGetDatasetStructure:
     ):
         structure = DatasetStructureFactory(
             dataset=dataset,
-            file=FilerFileFactory(
-                file=FileField(filename=f"dataset_{dataset.id}_structure.csv", data=dsa)
-            )
+            file=FilerFileFactory(file=FileField(filename=f"dataset_{dataset.id}_structure.csv", data=dsa)),
         )
         dataset.current_structure = structure
         dataset.save()
@@ -1168,21 +1128,13 @@ class TestActionGetDatasetStructure:
             "additionalProperties": None,
         }
 
-
     def test_invalid_token(
-        self,
-        app: DjangoTestApp,
-        organization: Organization,
-        url_dataset_structure: str,
-        valid_token: str
+        self, app: DjangoTestApp, organization: Organization, url_dataset_structure: str, valid_token: str
     ):
         token_parts = valid_token.split(".")
         invalid_token = f"{token_parts[0]}.{token_parts[1]}"
         response = app.get(
-            _build_reverse_uapi_url(
-                "uapi-dataset-structure",
-                pk=1_000_000
-            ),
+            _build_reverse_uapi_url("uapi-dataset-structure", pk=1_000_000),
             extra_environ={"HTTP_AUTHORIZATION": f"Bearer {invalid_token}"},
             expect_errors=True,
         )
@@ -1196,7 +1148,6 @@ class TestActionGetDatasetStructure:
             "type": "system",
         }
 
-
     def test_no_dataset_structure(
         self,
         app: DjangoTestApp,
@@ -1207,7 +1158,9 @@ class TestActionGetDatasetStructure:
         valid_token: str,
     ):
         response = app.get(
-            url_dataset_structure, extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"}, expect_errors=True,
+            url_dataset_structure,
+            extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
+            expect_errors=True,
         )
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
@@ -1235,7 +1188,6 @@ class TestActionUpdateDatasetStructure:
 
         assert response.status_code == status.HTTP_501_NOT_IMPLEMENTED
 
-
     def test_specific_scope(
         self,
         app: DjangoTestApp,
@@ -1260,7 +1212,6 @@ class TestActionUpdateDatasetStructure:
         )
 
         assert response.status_code == status.HTTP_501_NOT_IMPLEMENTED
-
 
     def test_agent_is_disabled(
         self,
@@ -1287,7 +1238,6 @@ class TestActionUpdateDatasetStructure:
             "message": "The agent is disabled. Enable the agent in the Data catalog to access this API.",
             "additionalProperties": None,
         }
-
 
     @pytest.mark.parametrize("invalid_scopes", [["invalid_scope"], [], [""]])
     def test_token_does_not_have_necessary_scopes(
@@ -1319,7 +1269,6 @@ class TestActionUpdateDatasetStructure:
             "message": "You do not have permission to perform this action.",
             "additionalProperties": None,
         }
-
 
     def test_no_organization_id_inside_token_payload(
         self,

--- a/tests/uapi/dataset/test_views.py
+++ b/tests/uapi/dataset/test_views.py
@@ -700,7 +700,7 @@ class TestList:
             "type": "DatasetNotFound",
             "template": "The requested Dataset could not be found.",
             "message": (
-                f"No dataset matched the provided query — http://testserver/uapi/datasets/gov/vssa/ror/dcat/Dataset/."
+                "No dataset matched the provided query — http://testserver/uapi/datasets/gov/vssa/ror/dcat/Dataset/."
             ),
             "additionalProperties": None
         }
@@ -735,7 +735,7 @@ class TestList:
             "type": "DatasetNotFound",
             "template": "The requested Dataset could not be found.",
             "message": (
-                f"No dataset matched the provided query — http://testserver/uapi/datasets/gov/vssa/ror/dcat/Dataset/."
+                "No dataset matched the provided query — http://testserver/uapi/datasets/gov/vssa/ror/dcat/Dataset/."
             ),
             "additionalProperties": None
         }

--- a/tests/uapi/distribution/test_views.py
+++ b/tests/uapi/distribution/test_views.py
@@ -52,7 +52,7 @@ class TestCreate:
         distribution = DatasetDistribution.objects.filter(
             metadata__name=dataset.datasetdistribution_set.first().metadata.name,
             dataset__organization__kind=organization.kind,
-            dataset__organization__name=organization.name
+            dataset__organization__name=organization.name,
         ).first()
         assert distribution
         assert response.json == {
@@ -76,7 +76,6 @@ class TestCreate:
             "version": None,
             "upload_to_storage": distribution.upload_to_storage,
         }
-
 
     def test_specific_scope(
         self,
@@ -109,7 +108,7 @@ class TestCreate:
         distribution = DatasetDistribution.objects.filter(
             metadata__name=dataset.datasetdistribution_set.first().metadata.name,
             dataset__organization__kind=organization.kind,
-            dataset__organization__name=organization.name
+            dataset__organization__name=organization.name,
         ).first()
         assert distribution
         assert response.json == {
@@ -133,7 +132,6 @@ class TestCreate:
             "version": None,
             "upload_to_storage": distribution.upload_to_storage,
         }
-
 
     def test_agent_is_disabled(
         self,
@@ -167,7 +165,6 @@ class TestCreate:
             "additionalProperties": None,
         }
 
-
     @pytest.mark.parametrize("invalid_scopes", [["invalid_scope"], [], [""]])
     def test_token_does_not_have_necessary_scopes(
         self,
@@ -196,7 +193,6 @@ class TestCreate:
             "message": "You do not have permission to perform this action.",
             "additionalProperties": None,
         }
-
 
     def test_no_organization_id_inside_token_payload(
         self,
@@ -229,7 +225,6 @@ class TestCreate:
             "additionalProperties": None,
         }
 
-
     def test_serializer_is_invalid(
         self,
         app: DjangoTestApp,
@@ -251,11 +246,10 @@ class TestCreate:
             "code": "validation_error",
             "type": "ValidationError",
             "template": "Request validation failed.",
-            "message": str({"title": [ErrorDetail(string='Šis laukas yra privalomas.', code='required')]}),
+            "message": str({"title": [ErrorDetail(string="Šis laukas yra privalomas.", code="required")]}),
             "context": {"errors": {"title": ["Šis laukas yra privalomas."]}},
             "additionalProperties": None,
         }
-
 
     def test_unexpected_exception_raised(
         self,
@@ -272,9 +266,9 @@ class TestCreate:
         }
 
         with patch(
-                "vitrina.uapi.views.views.UAPIDistributionSerializer.data",
-                new_callable=PropertyMock,
-                side_effect=Exception("Unexpected error")
+            "vitrina.uapi.views.views.UAPIDistributionSerializer.data",
+            new_callable=PropertyMock,
+            side_effect=Exception("Unexpected error"),
         ):
             response = app.post(
                 url_distribution,
@@ -337,7 +331,6 @@ class TestList:
             ]
         }
 
-
     def test_specific_scope(
         self,
         app: DjangoTestApp,
@@ -382,7 +375,6 @@ class TestList:
             ]
         }
 
-
     def test_agent_is_disabled(
         self,
         app: DjangoTestApp,
@@ -407,7 +399,6 @@ class TestList:
             "additionalProperties": None,
         }
 
-
     @pytest.mark.parametrize("invalid_scopes", [["invalid_scope"], [], [""]])
     def test_token_does_not_have_necessary_scopes(
         self,
@@ -426,9 +417,7 @@ class TestList:
             scopes=invalid_scopes,
         )
         response = app.get(
-            url_distribution,
-            extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"},
-            expect_errors=True
+            url_distribution, extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"}, expect_errors=True
         )
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -440,7 +429,6 @@ class TestList:
             "message": "You do not have permission to perform this action.",
             "additionalProperties": None,
         }
-
 
     def test_no_organization_id_inside_token_payload(
         self,
@@ -458,9 +446,7 @@ class TestList:
             scopes=settings.OAUTH_AGENT_DEFAULT_SCOPES,
         )
         response = app.get(
-            url_distribution,
-            extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"},
-            expect_errors=True
+            url_distribution, extra_environ={"HTTP_AUTHORIZATION": f"Bearer {token}"}, expect_errors=True
         )
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -473,7 +459,6 @@ class TestList:
             "additionalProperties": None,
         }
 
-
     def test_call_with_query_parameters(
         self,
         app: DjangoTestApp,
@@ -485,9 +470,7 @@ class TestList:
         valid_token: str,
     ):
         distribution_2 = DatasetDistributionFactory(
-            dataset=dataset,
-            title="Title of the Distribution 2",
-            description="Description of the Distribution 2."
+            dataset=dataset, title="Title of the Distribution 2", description="Description of the Distribution 2."
         )
         MetadataFactory(
             content_type=ContentType.objects.get_for_model(DatasetDistribution),
@@ -497,10 +480,7 @@ class TestList:
 
         response = app.get(
             url_distribution,
-            params={
-                "dataset._id": dataset.id,
-                "name": distribution.metadata.first().name
-            },
+            params={"dataset._id": dataset.id, "name": distribution.metadata.first().name},
             extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
         )  # w/ Query parameters, we should only get one.
 
@@ -532,7 +512,6 @@ class TestList:
             ]
         }
 
-
     def test_call_with_query_parameters_dataset_does_not_exist(
         self,
         app: DjangoTestApp,
@@ -542,12 +521,9 @@ class TestList:
     ):
         response = app.get(
             url_distribution,
-            params={
-                "dataset._id": 1,
-                "name": "not_existing_distribution"
-            },
+            params={"dataset._id": 1, "name": "not_existing_distribution"},
             extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
-            expect_errors=True
+            expect_errors=True,
         )
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
@@ -558,8 +534,6 @@ class TestList:
             "message": "No distributions matched the provided query.",
             "additionalProperties": None,
         }
-
-
 
     def test_call_with_query_parameters_no_given_distribution(
         self,
@@ -571,12 +545,9 @@ class TestList:
     ):
         response = app.get(
             url_distribution,
-            params={
-                "dataset._id": dataset.id,
-                "name": "not_existing_distribution"
-            },
+            params={"dataset._id": dataset.id, "name": "not_existing_distribution"},
             extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
-            expect_errors=True
+            expect_errors=True,
         )
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
@@ -587,7 +558,6 @@ class TestList:
             "message": "No distributions matched the provided query.",
             "additionalProperties": None,
         }
-
 
     def test_distributions_dataset_is_deleted(
         self,
@@ -608,7 +578,7 @@ class TestList:
                 "name": distribution.metadata.first().name,
             },
             extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
-            expect_errors=True
+            expect_errors=True,
         )
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
@@ -620,7 +590,6 @@ class TestList:
             "message": "No distributions matched the provided query.",
             "additionalProperties": None,
         }
-
 
     def test_distributions_do_not_exist(
         self,
@@ -641,7 +610,7 @@ class TestList:
                 "name": distribution.metadata.first().name,
             },
             extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
-            expect_errors=True
+            expect_errors=True,
         )
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
@@ -653,7 +622,6 @@ class TestList:
             "message": "No distributions matched the provided query.",
             "additionalProperties": None,
         }
-
 
     def test_unexpected_exception_raised(
         self,
@@ -667,7 +635,7 @@ class TestList:
         with patch(
             "vitrina.uapi.views.views.BaseObjectListSerializer.data",
             new_callable=PropertyMock,
-            side_effect=Exception("Unexpected error")
+            side_effect=Exception("Unexpected error"),
         ):
             response = app.get(
                 url_distribution,
@@ -676,7 +644,7 @@ class TestList:
                     "name": distribution.metadata.first().name,
                 },
                 extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
-                expect_errors=True
+                expect_errors=True,
             )
 
         assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR

--- a/tests/uapi/test_pagination.py
+++ b/tests/uapi/test_pagination.py
@@ -59,7 +59,7 @@ def test_pagination_disabled_when_limit_query_param_not_given(paginator: UAPIPag
                 "_txn": "",
                 "_created": ANY,
                 "_updated": ANY,
-                "@context": ""
+                "@context": "",
             },
             {
                 "name": use_case_client2.name,
@@ -74,6 +74,7 @@ def test_pagination_disabled_when_limit_query_param_not_given(paginator: UAPIPag
             },
         ],
     }
+
 
 def test_limits_results_and_return_next_page_if_limit_query_param_given(paginator: UAPIPagination):
     use_case_client1 = UseCaseClientFactory(uuid=UUID_1)
@@ -95,7 +96,7 @@ def test_limits_results_and_return_next_page_if_limit_query_param_given(paginato
                 "_txn": "",
                 "_created": ANY,
                 "_updated": ANY,
-                "@context": ""
+                "@context": "",
             },
         ],
     }
@@ -114,11 +115,12 @@ def test_returns_all_results_and_next_page_none_if_limit_is_greater_than_result_
 
 
 @pytest.mark.parametrize(
-    "limit, err_message", [
+    "limit, err_message",
+    [
         (-1, 'Query parameter "_limit" must be a positive integer.'),
         (0, 'Query parameter "_limit" must be between 0 and 1000.'),
-        (1000, 'Query parameter "_limit" must be between 0 and 1000.')
-    ]
+        (1000, 'Query parameter "_limit" must be between 0 and 1000.'),
+    ],
 )
 def test_raise_error_if_limit_is_less_than_zero_or_more_than_max(
     paginator: UAPIPagination, limit: int, err_message: str
@@ -156,7 +158,7 @@ def test_sort_by__id_asc_if_sort_not_given(paginator: UAPIPagination):
         ([(UUID_2, "A_name"), (UUID_3, "B_name"), (UUID_4, "B_name"), (UUID_1, "C_name")], "_sort=name,_id"),
         ([(UUID_2, "A_name"), (UUID_4, "B_name"), (UUID_3, "B_name"), (UUID_1, "C_name")], "_sort=name,-_id"),
         ([(UUID_1, "C_name"), (UUID_3, "B_name"), (UUID_4, "B_name"), (UUID_2, "A_name")], "_sort=-name,_id"),
-    ]
+    ],
 )
 def test_sort_asc_desc(paginator: UAPIPagination, sort_query: str, result: list[tuple[str, str]]):
     UseCaseClientFactory(uuid=UUID_4, name="B_name")
@@ -249,9 +251,10 @@ def test_page_encoding_decoding(paginator: UAPIPagination):
     data = get_use_case_client_data(paginator, query_str="?_limit=1")
     paginated_data = paginator.get_paginated_response(data).data
 
-    assert paginator._encode_uapi_urlsafe_base64(
-        paginator._decode_uapi_urlsafe_base64(paginated_data["_next"])
-    ) == paginated_data["_next"]
+    assert (
+        paginator._encode_uapi_urlsafe_base64(paginator._decode_uapi_urlsafe_base64(paginated_data["_next"]))
+        == paginated_data["_next"]
+    )
 
 
 @pytest.mark.parametrize("incorrect_page_value", ["test", "dGVzdA..", "-a-d-a-d-s"])

--- a/tests/uapi/version/test_views.py
+++ b/tests/uapi/version/test_views.py
@@ -109,7 +109,7 @@ class TestList:
     ):
         another_dataset = DatasetFactory()
         version = dataset.metadata.first().metadata_version
-        another_version = another_dataset.metadata.first().metadata_version  # Would be returned as well, if not for the specific query parameters.
+        another_dataset.metadata.first().metadata_version  # Would be returned as well, if not for the specific query parameters.
 
         response = app.get(
             url_version,

--- a/tests/uapi/version/test_views.py
+++ b/tests/uapi/version/test_views.py
@@ -169,7 +169,6 @@ class TestList:
             "additionalProperties": None,
         }
 
-
     def test_organization_id_missing_from_token(
         self,
         app: DjangoTestApp,
@@ -225,9 +224,7 @@ class TestList:
         valid_token: str,
     ):
         response = app.get(
-            url_version,
-            extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
-            expect_errors=True
+            url_version, extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"}, expect_errors=True
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -245,9 +242,7 @@ class TestList:
         VersionFactory(dataset=dataset)
 
         response = app.get(
-            url_version,
-            extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"},
-            expect_errors=True
+            url_version, extra_environ={"HTTP_AUTHORIZATION": f"Bearer {valid_token}"}, expect_errors=True
         )
 
         assert response.status_code == status.HTTP_200_OK

--- a/tests/users/test_password_validation.py
+++ b/tests/users/test_password_validation.py
@@ -20,88 +20,115 @@ def user():
 
 @pytest.mark.django_db
 def test_register_minimum_length(app: DjangoTestApp):
-    with patch('django_recaptcha.fields.client.submit') as mocked_submit:
+    with patch("django_recaptcha.fields.client.submit") as mocked_submit:
         mocked_submit.return_value = RecaptchaResponse(is_valid=True)
-        resp = app.post(reverse('register'), {
-            'first_name': "Test",
-            'last_name': "User",
-            'email': "test@test.com",
-            'password1': "Short1!",
-            'password2': "Short1!",
-            'agree_to_terms': True,
-            "g-recaptcha-response": "PASSED",
-        })
+        resp = app.post(
+            reverse("register"),
+            {
+                "first_name": "Test",
+                "last_name": "User",
+                "email": "test@test.com",
+                "password1": "Short1!",
+                "password2": "Short1!",
+                "agree_to_terms": True,
+                "g-recaptcha-response": "PASSED",
+            },
+        )
         assert resp.status_code == 200
-        assert list(resp.context['form'].errors.values()) == [['Šis slaptažodis yra per trumpas. Jį turi sudaryti bent 12 simbolių.',
-                                                               'Slaptažodis per silpnas. Bandykite naudoti daugiau simbolių, didžiųjų raidžių, skaitmenų ir specialiųjų simbolių.']]
+        assert list(resp.context["form"].errors.values()) == [
+            [
+                "Šis slaptažodis yra per trumpas. Jį turi sudaryti bent 12 simbolių.",
+                "Slaptažodis per silpnas. Bandykite naudoti daugiau simbolių, didžiųjų raidžių, skaitmenų ir specialiųjų simbolių.",
+            ]
+        ]
 
 
 @pytest.mark.django_db
 def test_register_uppercase(app: DjangoTestApp):
-    with patch('django_recaptcha.fields.client.submit') as mocked_submit:
+    with patch("django_recaptcha.fields.client.submit") as mocked_submit:
         mocked_submit.return_value = RecaptchaResponse(is_valid=True)
-        resp = app.post(reverse('register'), {
-            'first_name': "Test",
-            'last_name': "User",
-            'email': "test@test.com",
-            'password1': "lowercase123456!",
-            'password2': "lowercase123456!",
-            'agree_to_terms': True,
-            "g-recaptcha-response": "PASSED",
-        })
+        resp = app.post(
+            reverse("register"),
+            {
+                "first_name": "Test",
+                "last_name": "User",
+                "email": "test@test.com",
+                "password1": "lowercase123456!",
+                "password2": "lowercase123456!",
+                "agree_to_terms": True,
+                "g-recaptcha-response": "PASSED",
+            },
+        )
         assert resp.status_code == 200
-        assert list(resp.context['form'].errors.values()) == [["Slaptažodyje turi būti panaudota bent viena didžioji lotyniška raidė (A - Z)."]]
+        assert list(resp.context["form"].errors.values()) == [
+            ["Slaptažodyje turi būti panaudota bent viena didžioji lotyniška raidė (A - Z)."]
+        ]
 
 
 @pytest.mark.django_db
 def test_register_lowercase(app: DjangoTestApp):
-    with patch('django_recaptcha.fields.client.submit') as mocked_submit:
+    with patch("django_recaptcha.fields.client.submit") as mocked_submit:
         mocked_submit.return_value = RecaptchaResponse(is_valid=True)
-        resp = app.post(reverse('register'), {
-            'first_name': "Test",
-            'last_name': "User",
-            'email': "test@test.com",
-            'password1': "UPPERCASE123456!",
-            'password2': "UPPERCASE123456!",
-            'agree_to_terms': True,
-            "g-recaptcha-response": "PASSED",
-        })
+        resp = app.post(
+            reverse("register"),
+            {
+                "first_name": "Test",
+                "last_name": "User",
+                "email": "test@test.com",
+                "password1": "UPPERCASE123456!",
+                "password2": "UPPERCASE123456!",
+                "agree_to_terms": True,
+                "g-recaptcha-response": "PASSED",
+            },
+        )
         assert resp.status_code == 200
-        assert list(resp.context['form'].errors.values()) == [["Slaptažodyje turi būti panaudota bent viena mažoji lotyniška raidė (a - z)."]]
+        assert list(resp.context["form"].errors.values()) == [
+            ["Slaptažodyje turi būti panaudota bent viena mažoji lotyniška raidė (a - z)."]
+        ]
 
 
 @pytest.mark.django_db
 def test_register_digit(app: DjangoTestApp):
-    with (patch('django_recaptcha.fields.client.submit') as mocked_submit):
+    with patch("django_recaptcha.fields.client.submit") as mocked_submit:
         mocked_submit.return_value = RecaptchaResponse(is_valid=True)
-        resp = app.post(reverse('register'), {
-            'first_name': "Test",
-            'last_name': "User",
-            'email': "test@test.com",
-            'password1': "NoDigits!!!!!!!!!!!!!",
-            'password2': "NoDigits!!!!!!!!!!!!!",
-            'agree_to_terms': True,
-            "g-recaptcha-response": "PASSED",
-        })
+        resp = app.post(
+            reverse("register"),
+            {
+                "first_name": "Test",
+                "last_name": "User",
+                "email": "test@test.com",
+                "password1": "NoDigits!!!!!!!!!!!!!",
+                "password2": "NoDigits!!!!!!!!!!!!!",
+                "agree_to_terms": True,
+                "g-recaptcha-response": "PASSED",
+            },
+        )
         assert resp.status_code == 200
-        assert list(resp.context['form'].errors.values()) == [["Slaptažodyje turi būti panaudotas bent vienas skaitmuo (0 - 9)."]]
+        assert list(resp.context["form"].errors.values()) == [
+            ["Slaptažodyje turi būti panaudotas bent vienas skaitmuo (0 - 9)."]
+        ]
 
 
 @pytest.mark.django_db
 def test_register_special_character(app: DjangoTestApp):
-    with (patch('django_recaptcha.fields.client.submit') as mocked_submit):
+    with patch("django_recaptcha.fields.client.submit") as mocked_submit:
         mocked_submit.return_value = RecaptchaResponse(is_valid=True)
-        resp = app.post(reverse('register'), {
-            'first_name': "Test",
-            'last_name': "User",
-            'email': "test@test.com",
-            'password1': "NoSpecialChar1",
-            'password2': "NoSpecialChar1",
-            'agree_to_terms': True,
-            "g-recaptcha-response": "PASSED",
-        })
+        resp = app.post(
+            reverse("register"),
+            {
+                "first_name": "Test",
+                "last_name": "User",
+                "email": "test@test.com",
+                "password1": "NoSpecialChar1",
+                "password2": "NoSpecialChar1",
+                "agree_to_terms": True,
+                "g-recaptcha-response": "PASSED",
+            },
+        )
         assert resp.status_code == 200
-        assert list(resp.context['form'].errors.values()) == [["Slaptažodyje turi būti panaudotas bent vienas specialusis simbolis ( !@#$%^&*()_+-=/.,\';][|}{\":?>< )."]]
+        assert list(resp.context["form"].errors.values()) == [
+            ["Slaptažodyje turi būti panaudotas bent vienas specialusis simbolis ( !@#$%^&*()_+-=/.,';][|}{\":?>< )."]
+        ]
 
 
 @pytest.mark.django_db
@@ -109,14 +136,18 @@ def test_password_change_minimum_length(app: DjangoTestApp, user: User):
     user1 = User.objects.create_user(email="testas1@testas.com", password="testas123")
     app.set_user(user1)
 
-    form = app.get(reverse('users-password-change', kwargs={'pk': user1.id})).forms['password-change-form']
-    form['old_password'] = "testas123"
-    form['new_password1'] = "Short1!"
-    form['new_password2'] = "Short1!"
+    form = app.get(reverse("users-password-change", kwargs={"pk": user1.id})).forms["password-change-form"]
+    form["old_password"] = "testas123"
+    form["new_password1"] = "Short1!"
+    form["new_password2"] = "Short1!"
     resp = form.submit()
     assert resp.status_code == 200
-    assert list(resp.context['form'].errors.values()) == [["Šis slaptažodis yra per trumpas. Jį turi sudaryti bent 12 simbolių.",
-                                                               'Slaptažodis per silpnas. Bandykite naudoti daugiau simbolių, didžiųjų raidžių, skaitmenų ir specialiųjų simbolių.']]
+    assert list(resp.context["form"].errors.values()) == [
+        [
+            "Šis slaptažodis yra per trumpas. Jį turi sudaryti bent 12 simbolių.",
+            "Slaptažodis per silpnas. Bandykite naudoti daugiau simbolių, didžiųjų raidžių, skaitmenų ir specialiųjų simbolių.",
+        ]
+    ]
 
 
 @pytest.mark.django_db
@@ -124,13 +155,15 @@ def test_password_change_uppercase(app: DjangoTestApp, user: User):
     user1 = User.objects.create_user(email="testas1@testas.com", password="testas123")
     app.set_user(user1)
 
-    form = app.get(reverse('users-password-change', kwargs={'pk': user1.id})).forms['password-change-form']
-    form['old_password'] = "testas123"
-    form['new_password1'] = "lowercase123456!"
-    form['new_password2'] = "lowercase123456!"
+    form = app.get(reverse("users-password-change", kwargs={"pk": user1.id})).forms["password-change-form"]
+    form["old_password"] = "testas123"
+    form["new_password1"] = "lowercase123456!"
+    form["new_password2"] = "lowercase123456!"
     resp = form.submit()
     assert resp.status_code == 200
-    assert list(resp.context['form'].errors.values()) == [["Slaptažodyje turi būti panaudota bent viena didžioji lotyniška raidė (A - Z)."]]
+    assert list(resp.context["form"].errors.values()) == [
+        ["Slaptažodyje turi būti panaudota bent viena didžioji lotyniška raidė (A - Z)."]
+    ]
 
 
 @pytest.mark.django_db
@@ -138,13 +171,15 @@ def test_password_change_lowercase(app: DjangoTestApp, user: User):
     user1 = User.objects.create_user(email="testas1@testas.com", password="testas123")
     app.set_user(user1)
 
-    form = app.get(reverse('users-password-change', kwargs={'pk': user1.id})).forms['password-change-form']
-    form['old_password'] = "testas123"
-    form['new_password1'] = "UPPERCASE123456!"
-    form['new_password2'] = "UPPERCASE123456!"
+    form = app.get(reverse("users-password-change", kwargs={"pk": user1.id})).forms["password-change-form"]
+    form["old_password"] = "testas123"
+    form["new_password1"] = "UPPERCASE123456!"
+    form["new_password2"] = "UPPERCASE123456!"
     resp = form.submit()
     assert resp.status_code == 200
-    assert list(resp.context['form'].errors.values()) == [["Slaptažodyje turi būti panaudota bent viena mažoji lotyniška raidė (a - z)."]]
+    assert list(resp.context["form"].errors.values()) == [
+        ["Slaptažodyje turi būti panaudota bent viena mažoji lotyniška raidė (a - z)."]
+    ]
 
 
 @pytest.mark.django_db
@@ -152,13 +187,15 @@ def test_password_change_digit(app: DjangoTestApp, user: User):
     user1 = User.objects.create_user(email="testas1@testas.com", password="testas123")
     app.set_user(user1)
 
-    form = app.get(reverse('users-password-change', kwargs={'pk': user1.id})).forms['password-change-form']
-    form['old_password'] = "testas123"
-    form['new_password1'] = "NoDigits!!!!!!!!!!!!!"
-    form['new_password2'] = "NoDigits!!!!!!!!!!!!!"
+    form = app.get(reverse("users-password-change", kwargs={"pk": user1.id})).forms["password-change-form"]
+    form["old_password"] = "testas123"
+    form["new_password1"] = "NoDigits!!!!!!!!!!!!!"
+    form["new_password2"] = "NoDigits!!!!!!!!!!!!!"
     resp = form.submit()
     assert resp.status_code == 200
-    assert list(resp.context['form'].errors.values()) == [["Slaptažodyje turi būti panaudotas bent vienas skaitmuo (0 - 9)."]]
+    assert list(resp.context["form"].errors.values()) == [
+        ["Slaptažodyje turi būti panaudotas bent vienas skaitmuo (0 - 9)."]
+    ]
 
 
 @pytest.mark.django_db
@@ -166,13 +203,15 @@ def test_password_change_special_character(app: DjangoTestApp, user: User):
     user1 = User.objects.create_user(email="testas1@testas.com", password="testas123")
     app.set_user(user1)
 
-    form = app.get(reverse('users-password-change', kwargs={'pk': user1.id})).forms['password-change-form']
-    form['old_password'] = "testas123"
-    form['new_password1'] = "NoSpecialChar1"
-    form['new_password2'] = "NoSpecialChar1"
+    form = app.get(reverse("users-password-change", kwargs={"pk": user1.id})).forms["password-change-form"]
+    form["old_password"] = "testas123"
+    form["new_password1"] = "NoSpecialChar1"
+    form["new_password2"] = "NoSpecialChar1"
     resp = form.submit()
     assert resp.status_code == 200
-    assert list(resp.context['form'].errors.values()) == [["Slaptažodyje turi būti panaudotas bent vienas specialusis simbolis ( !@#$%^&*()_+-=/.,\';][|}{\":?>< )."]]
+    assert list(resp.context["form"].errors.values()) == [
+        ["Slaptažodyje turi būti panaudotas bent vienas specialusis simbolis ( !@#$%^&*()_+-=/.,';][|}{\":?>< )."]
+    ]
 
 
 @pytest.mark.django_db
@@ -180,31 +219,33 @@ def test_password_change_not_unique(app: DjangoTestApp):
     user1 = User.objects.create_user(email="test@test.com", password="InitialPassword1!")
     app.set_user(user1)
 
-    form = app.get(reverse('users-password-change', kwargs={'pk': user1.id})).forms['password-change-form']
-    form['old_password'] = "InitialPassword1!"
-    form['new_password1'] = "AgadeBkghf91!"
-    form['new_password2'] = "AgadeBkghf91!"
+    form = app.get(reverse("users-password-change", kwargs={"pk": user1.id})).forms["password-change-form"]
+    form["old_password"] = "InitialPassword1!"
+    form["new_password1"] = "AgadeBkghf91!"
+    form["new_password2"] = "AgadeBkghf91!"
     form.submit()
     user1.refresh_from_db()
     OldPassword.objects.create(user=user1, password=user1.password, version=1)
 
     for old_password, new_password in [("AgadeBkghf91!", "AgadeBkghf92!"), ("AgadeBkghf92!", "AgadeBkghf93!")]:
-        form = app.get(reverse('users-password-change', kwargs={'pk': user1.id})).forms['password-change-form']
-        form['old_password'] = old_password
-        form['new_password1'] = new_password
-        form['new_password2'] = new_password
+        form = app.get(reverse("users-password-change", kwargs={"pk": user1.id})).forms["password-change-form"]
+        form["old_password"] = old_password
+        form["new_password1"] = new_password
+        form["new_password2"] = new_password
         form.submit()
         user1.refresh_from_db()
         OldPassword.objects.create(user=user1, password=user1.password, version=1)
 
-    form = app.get(reverse('users-password-change', kwargs={'pk': user1.id})).forms['password-change-form']
-    form['old_password'] = "AgadeBkghf93!"
-    form['new_password1'] = "AgadeBkghf92!"
-    form['new_password2'] = "AgadeBkghf92!"
+    form = app.get(reverse("users-password-change", kwargs={"pk": user1.id})).forms["password-change-form"]
+    form["old_password"] = "AgadeBkghf93!"
+    form["new_password1"] = "AgadeBkghf92!"
+    form["new_password2"] = "AgadeBkghf92!"
     resp = form.submit()
 
     assert resp.status_code == 200
-    assert list(resp.context['form'].errors.values()) == [["Slaptažotis neturi būti toks pat kaip prieš tai 3 buvusieji slaptažodžiai."]]
+    assert list(resp.context["form"].errors.values()) == [
+        ["Slaptažotis neturi būti toks pat kaip prieš tai 3 buvusieji slaptažodžiai."]
+    ]
 
 
 @pytest.mark.django_db
@@ -214,9 +255,9 @@ def test_successful_login_before_limit(app: DjangoTestApp):
     app.set_user(user1)
     # simulate 4 unsuccessful login attempts
     for index in range(4):
-        form = app.get(reverse('login')).forms['login-form']
-        form['username'] = user1.email,
-        form['password'] = "WrongPassword!"
+        form = app.get(reverse("login")).forms["login-form"]
+        form["username"] = (user1.email,)
+        form["password"] = "WrongPassword!"
         resp = form.submit()
         assert resp.status_code == 200
         user1.refresh_from_db()
@@ -226,12 +267,12 @@ def test_successful_login_before_limit(app: DjangoTestApp):
     assert user1.failed_login_attempts == 4
 
     # simulate successful login
-    form = app.get(reverse('login')).forms['login-form']
-    form['username'] = user1.email,
-    form['password'] = "InitialPassword1!"
+    form = app.get(reverse("login")).forms["login-form"]
+    form["username"] = (user1.email,)
+    form["password"] = "InitialPassword1!"
     resp = form.submit(name="otp_challenge")
-    form = resp.forms['login-form']
-    form['otp_token'] = UserEmailDevice.objects.filter(user=user1).first().token
+    form = resp.forms["login-form"]
+    form["otp_token"] = UserEmailDevice.objects.filter(user=user1).first().token
     resp = form.submit()
     assert resp.status_code == 302
 
@@ -246,9 +287,9 @@ def test_5_incorrect_attempts(app: DjangoTestApp):
     app.set_user(user1)
     # simulate 5 unsuccessful login attempts
     for _ in range(5):
-        form = app.get(reverse('login')).forms['login-form']
-        form['username'] = user1.email,
-        form['password'] = "WrongPassword!"
+        form = app.get(reverse("login")).forms["login-form"]
+        form["username"] = (user1.email,)
+        form["password"] = "WrongPassword!"
         resp = form.submit()
         assert resp.status_code == 200
 
@@ -264,9 +305,9 @@ def test_6_incorrect_attempts(app: DjangoTestApp):
 
     # simulate 6 unsuccessful login attempts
     for _ in range(6):
-        form = app.get(reverse('login')).forms['login-form']
-        form['username'] = user1.email,
-        form['password'] = "WrongPassword!"
+        form = app.get(reverse("login")).forms["login-form"]
+        form["username"] = (user1.email,)
+        form["password"] = "WrongPassword!"
         resp = form.submit()
         assert resp.status_code == 200
 
@@ -283,9 +324,9 @@ def test_password_change_after_lock(app: DjangoTestApp):
 
     # simulate 6 unsuccessful login attempts
     for _ in range(6):
-        form = app.get(reverse('login')).forms['login-form']
-        form['username'] = user1.email,
-        form['password'] = "WrongPassword!"
+        form = app.get(reverse("login")).forms["login-form"]
+        form["username"] = (user1.email,)
+        form["password"] = "WrongPassword!"
         resp = form.submit()
         assert resp.status_code == 200
 
@@ -293,10 +334,10 @@ def test_password_change_after_lock(app: DjangoTestApp):
     assert user1.failed_login_attempts == 5
     assert user1.status == User.LOCKED
 
-    form = app.get(reverse('users-password-change', kwargs={'pk': user1.id})).forms['password-change-form']
-    form['old_password'] = "InitialPassword1!"
-    form['new_password1'] = "NewPassword123456!"
-    form['new_password2'] = "NewPassword123456!"
+    form = app.get(reverse("users-password-change", kwargs={"pk": user1.id})).forms["password-change-form"]
+    form["old_password"] = "InitialPassword1!"
+    form["new_password1"] = "NewPassword123456!"
+    form["new_password2"] = "NewPassword123456!"
     resp = form.submit()
     user1.refresh_from_db()
     assert resp.status_code == 302
@@ -316,19 +357,19 @@ def test_password_older_than_90_days(app: DjangoTestApp):
 
     app.set_user(admin)
 
-    form = app.get(reverse('login')).forms['login-form']
-    form['username'] = user1.email
-    form['password'] = "InitialPassword1!"
+    form = app.get(reverse("login")).forms["login-form"]
+    form["username"] = user1.email
+    form["password"] = "InitialPassword1!"
     resp = form.submit()
     user1.refresh_from_db()
     assert resp.status_code == 200
     assert user1.status == User.LOCKED
     assert "Jūsų slaptažodžio galiojimas baigėsi" in resp.content.decode()
 
-    form = app.get(reverse('users-password-change', kwargs={'pk': user1.id})).forms['password-change-form']
-    form['old_password'] = "InitialPassword1!"
-    form['new_password1'] = "NewPassword123456!"
-    form['new_password2'] = "NewPassword123456!"
+    form = app.get(reverse("users-password-change", kwargs={"pk": user1.id})).forms["password-change-form"]
+    form["old_password"] = "InitialPassword1!"
+    form["new_password1"] = "NewPassword123456!"
+    form["new_password2"] = "NewPassword123456!"
     resp = form.submit()
     user1.refresh_from_db()
     assert resp.status_code == 302
@@ -340,10 +381,10 @@ def test_old_password_entries_on_password_change(app: DjangoTestApp):
     user1 = User.objects.create_user(email="test@test.com", password="InitialPassword1!")
     app.set_user(user1)
 
-    form = app.get(reverse('users-password-change', kwargs={'pk': user1.id})).forms['password-change-form']
-    form['old_password'] = "InitialPassword1!"
-    form['new_password1'] = "NewPassword123456!"
-    form['new_password2'] = "NewPassword123456!"
+    form = app.get(reverse("users-password-change", kwargs={"pk": user1.id})).forms["password-change-form"]
+    form["old_password"] = "InitialPassword1!"
+    form["new_password1"] = "NewPassword123456!"
+    form["new_password2"] = "NewPassword123456!"
     resp = form.submit()
     assert resp.status_code == 302
 
@@ -351,10 +392,10 @@ def test_old_password_entries_on_password_change(app: DjangoTestApp):
     # The initial password should be stored as an old password with the new password
     assert old_passwords_count == 2
 
-    form = app.get(reverse('users-password-change', kwargs={'pk': user1.id})).forms['password-change-form']
-    form['old_password'] = "NewPassword123456!"
-    form['new_password1'] = "AnotherNewPassword123!"
-    form['new_password2'] = "AnotherNewPassword123!"
+    form = app.get(reverse("users-password-change", kwargs={"pk": user1.id})).forms["password-change-form"]
+    form["old_password"] = "NewPassword123456!"
+    form["new_password1"] = "AnotherNewPassword123!"
+    form["new_password2"] = "AnotherNewPassword123!"
     resp = form.submit()
     assert resp.status_code == 302
 
@@ -369,9 +410,9 @@ def test_login_locked_user(app: DjangoTestApp):
     app.set_user(user1)
     assert user1.status == User.LOCKED
 
-    form = app.get(reverse('login')).forms['login-form']
-    form['username'] = user1.email,
-    form['password'] = "InitialPassword1!"
+    form = app.get(reverse("login")).forms["login-form"]
+    form["username"] = (user1.email,)
+    form["password"] = "InitialPassword1!"
     resp = form.submit()
     assert resp.status_code == 200
     assert "Jūsų paskyra užblokuota." in resp.content.decode()

--- a/tests/users/test_views.py
+++ b/tests/users/test_views.py
@@ -28,24 +28,24 @@ def user():
 
 @pytest.mark.django_db
 def test_login_with_wrong_credentials(app: DjangoTestApp, user: User):
-    form = app.get(reverse('login')).forms['login-form']
-    form['username'] = "test@test.com"
-    form['password'] = "wrongpassword"
+    form = app.get(reverse("login")).forms["login-form"]
+    form["username"] = "test@test.com"
+    form["password"] = "wrongpassword"
     resp = form.submit()
-    assert list(resp.context['form'].errors.values()) == [[credentials_error]]
+    assert list(resp.context["form"].errors.values()) == [[credentials_error]]
 
 
 @pytest.mark.django_db
 def test_login_with_correct_credentials(app: DjangoTestApp, user: User):
-    form = app.get(reverse('login')).forms['login-form']
-    form['username'] = "test@test.com"
-    form['password'] = "test123"
+    form = app.get(reverse("login")).forms["login-form"]
+    form["username"] = "test@test.com"
+    form["password"] = "test123"
     resp = form.submit(name="otp_challenge")
-    form = resp.forms['login-form']
-    form['otp_token'] = UserEmailDevice.objects.filter(user=user).first().token
+    form = resp.forms["login-form"]
+    form["otp_token"] = UserEmailDevice.objects.filter(user=user).first().token
     resp = form.submit()
     assert resp.status_code == 302
-    assert resp.url == reverse('home')
+    assert resp.url == reverse("home")
 
 
 @pytest.mark.django_db
@@ -53,15 +53,15 @@ def test_viisp_flag_reset_on_email_login(app: DjangoTestApp, user: User):
     user.is_viisp_login = True
     user.viisp_company_code = "123"
     user.save()
-    form = app.get(reverse('login')).forms['login-form']
-    form['username'] = "test@test.com"
-    form['password'] = "test123"
+    form = app.get(reverse("login")).forms["login-form"]
+    form["username"] = "test@test.com"
+    form["password"] = "test123"
     resp = form.submit(name="otp_challenge")
-    form = resp.forms['login-form']
-    form['otp_token'] = UserEmailDevice.objects.filter(user=user).first().token
+    form = resp.forms["login-form"]
+    form["otp_token"] = UserEmailDevice.objects.filter(user=user).first().token
     resp = form.submit()
     assert resp.status_code == 302
-    assert resp.url == reverse('home')
+    assert resp.url == reverse("home")
     user.refresh_from_db()
     assert user.is_viisp_login is False
     assert user.viisp_company_code is None
@@ -69,71 +69,83 @@ def test_viisp_flag_reset_on_email_login(app: DjangoTestApp, user: User):
 
 @pytest.mark.django_db
 def test_register_with_short_name(app: DjangoTestApp):
-    with patch('django_recaptcha.fields.client.submit') as mocked_submit:
+    with patch("django_recaptcha.fields.client.submit") as mocked_submit:
         mocked_submit.return_value = RecaptchaResponse(is_valid=True)
-        resp = app.post(reverse('register'), {
-            'first_name': "T",
-            'last_name': "User",
-            'email': "test_@test.com",
-            'password1': "TestPassword123?",
-            'password2': "TestPassword123?",
-            'agree_to_terms': True,
-            "g-recaptcha-response": "PASSED",
-        })
-        assert list(resp.context['form'].errors.values()) == [[name_error]]
-        assert User.objects.filter(email='test_@test.com').count() == 0
+        resp = app.post(
+            reverse("register"),
+            {
+                "first_name": "T",
+                "last_name": "User",
+                "email": "test_@test.com",
+                "password1": "TestPassword123?",
+                "password2": "TestPassword123?",
+                "agree_to_terms": True,
+                "g-recaptcha-response": "PASSED",
+            },
+        )
+        assert list(resp.context["form"].errors.values()) == [[name_error]]
+        assert User.objects.filter(email="test_@test.com").count() == 0
 
 
 @pytest.mark.django_db
 def test_register_with_name_with_numbers(app: DjangoTestApp):
-    with patch('django_recaptcha.fields.client.submit') as mocked_submit:
+    with patch("django_recaptcha.fields.client.submit") as mocked_submit:
         mocked_submit.return_value = RecaptchaResponse(is_valid=True)
-        resp = app.post(reverse('register'), {
-            'first_name': "T3st",
-            'last_name': "User",
-            'email': "test_@test.com",
-            'password1': "TestPassword123?",
-            'password2': "TestPassword123?",
-            'agree_to_terms': True,
-            "g-recaptcha-response": "PASSED",
-        })
-        assert list(resp.context['form'].errors.values()) == [[name_error]]
-        assert User.objects.filter(email='test_@test.com').count() == 0
+        resp = app.post(
+            reverse("register"),
+            {
+                "first_name": "T3st",
+                "last_name": "User",
+                "email": "test_@test.com",
+                "password1": "TestPassword123?",
+                "password2": "TestPassword123?",
+                "agree_to_terms": True,
+                "g-recaptcha-response": "PASSED",
+            },
+        )
+        assert list(resp.context["form"].errors.values()) == [[name_error]]
+        assert User.objects.filter(email="test_@test.com").count() == 0
 
 
 @pytest.mark.django_db
 def test_register_without_agreeing_to_terms(app: DjangoTestApp):
-    with patch('django_recaptcha.fields.client.submit') as mocked_submit:
+    with patch("django_recaptcha.fields.client.submit") as mocked_submit:
         mocked_submit.return_value = RecaptchaResponse(is_valid=True)
-        resp = app.post(reverse('register'), {
-            'first_name': "Test",
-            'last_name': "User",
-            'email': "test_@test.com",
-            'password1': "TestPassword123?",
-            'password2': "TestPassword123?",
-            'agree_to_terms': False,
-            "g-recaptcha-response": "PASSED",
-        })
-        assert list(resp.context['form'].errors.values()) == [[terms_error]]
-        assert User.objects.filter(email='test_@test.com').count() == 0
+        resp = app.post(
+            reverse("register"),
+            {
+                "first_name": "Test",
+                "last_name": "User",
+                "email": "test_@test.com",
+                "password1": "TestPassword123?",
+                "password2": "TestPassword123?",
+                "agree_to_terms": False,
+                "g-recaptcha-response": "PASSED",
+            },
+        )
+        assert list(resp.context["form"].errors.values()) == [[terms_error]]
+        assert User.objects.filter(email="test_@test.com").count() == 0
 
 
 @pytest.mark.django_db
 def test_register_with_correct_data(app: DjangoTestApp):
-    with patch('django_recaptcha.fields.client.submit') as mocked_submit:
+    with patch("django_recaptcha.fields.client.submit") as mocked_submit:
         mocked_submit.return_value = RecaptchaResponse(is_valid=True)
-        resp = app.post(reverse('register'), {
-            'first_name': "Test",
-            'last_name': "User",
-            'email': "test_@test.com",
-            'password1': "TestPassword123?",
-            'password2': "TestPassword123?",
-            'agree_to_terms': True,
-            "g-recaptcha-response": "PASSED",
-        })
+        resp = app.post(
+            reverse("register"),
+            {
+                "first_name": "Test",
+                "last_name": "User",
+                "email": "test_@test.com",
+                "password1": "TestPassword123?",
+                "password2": "TestPassword123?",
+                "agree_to_terms": True,
+                "g-recaptcha-response": "PASSED",
+            },
+        )
         assert resp.status_code == 302
-        assert resp.url == reverse('home')
-        assert User.objects.filter(email='test_@test.com').count() == 1
+        assert resp.url == reverse("home")
+        assert User.objects.filter(email="test_@test.com").count() == 1
 
 
 @pytest.mark.django_db
@@ -143,42 +155,45 @@ def test_register_with_representative(app: DjangoTestApp):
         user=None,
         email="test_@test.com",
         content_type=ContentType.objects.get_for_model(organization),
-        object_id=organization.pk
+        object_id=organization.pk,
     )
-    with patch('django_recaptcha.fields.client.submit') as mocked_submit:
+    with patch("django_recaptcha.fields.client.submit") as mocked_submit:
         mocked_submit.return_value = RecaptchaResponse(is_valid=True)
-        resp = app.post(reverse('register'), {
-            'first_name': "Test",
-            'last_name': "User",
-            'email': "test_@test.com",
-            'password1': "TestPassword123?",
-            'password2': "TestPassword123?",
-            'agree_to_terms': True,
-            "g-recaptcha-response": "PASSED",
-        })
+        resp = app.post(
+            reverse("register"),
+            {
+                "first_name": "Test",
+                "last_name": "User",
+                "email": "test_@test.com",
+                "password1": "TestPassword123?",
+                "password2": "TestPassword123?",
+                "agree_to_terms": True,
+                "g-recaptcha-response": "PASSED",
+            },
+        )
         assert resp.status_code == 302
-        assert resp.url == reverse('home')
-        assert User.objects.filter(email='test_@test.com').count() == 1
+        assert resp.url == reverse("home")
+        assert User.objects.filter(email="test_@test.com").count() == 1
         rep.refresh_from_db()
-        rep.user = User.objects.filter(email='test_@test.com').first()
+        rep.user = User.objects.filter(email="test_@test.com").first()
 
 
 @pytest.mark.django_db
 def test_reset_password_with_wrong_email(app: DjangoTestApp, user: User):
-    form = app.get(reverse('reset')).forms['password-reset-form']
-    form['email'] = "wrong.email@test.com"
+    form = app.get(reverse("reset")).forms["password-reset-form"]
+    form["email"] = "wrong.email@test.com"
     resp = form.submit()
-    assert list(resp.context['form'].errors.values()) == [[reset_error]]
+    assert list(resp.context["form"].errors.values()) == [[reset_error]]
     assert len(mail.outbox) == 0
 
 
 @pytest.mark.django_db
 def test_reset_password_with_correct_email(app: DjangoTestApp, user: User):
-    form = app.get(reverse('reset')).forms['password-reset-form']
-    form['email'] = "test@test.com"
+    form = app.get(reverse("reset")).forms["password-reset-form"]
+    form["email"] = "test@test.com"
     resp = form.submit()
     assert resp.status_code == 302
-    assert resp.url == reverse('home')
+    assert resp.url == reverse("home")
     assert len(mail.outbox) == 1
     assert mail.outbox[0].to == [user.email]
 
@@ -186,8 +201,8 @@ def test_reset_password_with_correct_email(app: DjangoTestApp, user: User):
 @pytest.mark.django_db
 def test_change_password_with_no_user(app: DjangoTestApp, user: User):
     user1 = User.objects.create_user(email="testas1@testas.com", password="testas123")
-    resp = app.get(reverse('users-password-change', kwargs={'pk': user1.id}))
-    assert resp.url == reverse('login')
+    resp = app.get(reverse("users-password-change", kwargs={"pk": user1.id}))
+    assert resp.url == reverse("login")
 
 
 @pytest.mark.django_db
@@ -196,8 +211,8 @@ def test_change_password_with_wrong_user(app: DjangoTestApp, user: User):
     user2 = User.objects.create_user(email="testas2@testas.com", password="testas123")
 
     app.set_user(user1)
-    resp = app.get(reverse('users-password-change', kwargs={'pk': user2.id}))
-    assert resp.url == reverse('user-profile', kwargs={'pk': user1.id})
+    resp = app.get(reverse("users-password-change", kwargs={"pk": user2.id}))
+    assert resp.url == reverse("user-profile", kwargs={"pk": user1.id})
 
 
 @pytest.mark.django_db
@@ -205,27 +220,27 @@ def test_change_password_with_correct_user(app: DjangoTestApp):
     user = User.objects.create_user(email="testas1@testas.com", password="testas123")
     app.set_user(user)
 
-    form = app.get(reverse('users-password-change', kwargs={'pk': user.id})).forms['password-change-form']
-    form['old_password'] = "testas123"
-    form['new_password1'] = "TestPassword123?"
-    form['new_password2'] = "TestPassword123?"
+    form = app.get(reverse("users-password-change", kwargs={"pk": user.id})).forms["password-change-form"]
+    form["old_password"] = "testas123"
+    form["new_password1"] = "TestPassword123?"
+    form["new_password2"] = "TestPassword123?"
     resp = form.submit()
-    assert resp.url == reverse('user-profile', kwargs={'pk': user.id})
+    assert resp.url == reverse("user-profile", kwargs={"pk": user.id})
 
-    form = app.get(reverse('login')).forms['login-form']
-    form['username'] = "testas1@testas.com"
-    form['password'] = "TestPassword123?"
+    form = app.get(reverse("login")).forms["login-form"]
+    form["username"] = "testas1@testas.com"
+    form["password"] = "TestPassword123?"
     resp = form.submit(name="otp_challenge")
-    form = resp.forms['login-form']
-    form['otp_token'] = UserEmailDevice.objects.filter(user=user).first().token
+    form = resp.forms["login-form"]
+    form["otp_token"] = UserEmailDevice.objects.filter(user=user).first().token
     resp = form.submit()
     assert resp.status_code == 302
-    assert resp.url == reverse('home')
+    assert resp.url == reverse("home")
 
 
 @pytest.mark.django_db
 def test_profile_view_no_login(app: DjangoTestApp, user: User):
-    resp = app.get(reverse('user-profile', kwargs={'pk': '1'}))
+    resp = app.get(reverse("user-profile", kwargs={"pk": "1"}))
     assert resp.status_code == 302
     assert resp.location == settings.LOGIN_URL
 
@@ -234,7 +249,7 @@ def test_profile_view_no_login(app: DjangoTestApp, user: User):
 def test_profile_view_wrong_login(app: DjangoTestApp, user: User):
     app.set_user(user)
     temp_user = User.objects.create_user(email="testas@testas.com", password="testas123")
-    resp = app.get(reverse('user-profile', kwargs={'pk': temp_user.pk}))
+    resp = app.get(reverse("user-profile", kwargs={"pk": temp_user.pk}))
     assert resp.status_code == 302
     assert str(user.pk) in resp.location
 
@@ -242,13 +257,13 @@ def test_profile_view_wrong_login(app: DjangoTestApp, user: User):
 @pytest.mark.django_db
 def test_profile_view_correct_login(app: DjangoTestApp, user: User):
     app.set_user(user)
-    resp = app.get(reverse('user-profile', kwargs={'pk': user.pk}))
+    resp = app.get(reverse("user-profile", kwargs={"pk": user.pk}))
     assert resp.status_code == 200
 
 
 @pytest.mark.django_db
 def test_profile_edit_form_no_login(app: DjangoTestApp, user: User):
-    resp = app.get(reverse('user-profile-change', kwargs={'pk': '1'}))
+    resp = app.get(reverse("user-profile-change", kwargs={"pk": "1"}))
     assert resp.status_code == 302
     assert resp.location == settings.LOGIN_URL
 
@@ -257,7 +272,7 @@ def test_profile_edit_form_no_login(app: DjangoTestApp, user: User):
 def test_profile_edit_form_wrong_login(app: DjangoTestApp, user: User):
     app.set_user(user)
     temp_user = User.objects.create_user(email="testas@testas.com", password="testas123")
-    resp = app.get(reverse('user-profile-change', kwargs={'pk': temp_user.pk}))
+    resp = app.get(reverse("user-profile-change", kwargs={"pk": temp_user.pk}))
     assert resp.status_code == 302
     assert str(user.pk) in resp.location
 
@@ -265,34 +280,34 @@ def test_profile_edit_form_wrong_login(app: DjangoTestApp, user: User):
 @pytest.mark.django_db
 def test_profile_edit_form_correct_login(app: DjangoTestApp):
     user = User.objects.create_user(
-        email="testas@testas.com",
-        password="testas123",
-        first_name="test",
-        last_name="user"
+        email="testas@testas.com", password="testas123", first_name="test", last_name="user"
     )
     app.set_user(user)
-    form = app.get(reverse('user-profile-change', kwargs={'pk': user.pk})).forms['user-profile-form']
-    form['phone'] = '12341234'
+    form = app.get(reverse("user-profile-change", kwargs={"pk": user.pk})).forms["user-profile-form"]
+    form["phone"] = "12341234"
     resp = form.submit()
     user.refresh_from_db()
     assert resp.status_code == 302
-    assert resp.url == reverse('user-profile', kwargs={'pk': user.pk})
-    assert user.phone == '12341234'
+    assert resp.url == reverse("user-profile", kwargs={"pk": user.pk})
+    assert user.phone == "12341234"
 
 
 @pytest.mark.django_db
 def test_email_confirmation_after_sign_up(app: DjangoTestApp):
-    with patch('django_recaptcha.fields.client.submit') as mocked_submit:
+    with patch("django_recaptcha.fields.client.submit") as mocked_submit:
         mocked_submit.return_value = RecaptchaResponse(is_valid=True)
-        app.post(reverse('register'), {
-            'first_name': "Test",
-            'last_name': "User",
-            'email': "test123@test.com",
-            'password1': "TestPassword123?",
-            'password2': "TestPassword123?",
-            'agree_to_terms': True,
-            "g-recaptcha-response": "PASSED",
-        })
+        app.post(
+            reverse("register"),
+            {
+                "first_name": "Test",
+                "last_name": "User",
+                "email": "test123@test.com",
+                "password1": "TestPassword123?",
+                "password2": "TestPassword123?",
+                "agree_to_terms": True,
+                "g-recaptcha-response": "PASSED",
+            },
+        )
 
         assert len(mail.outbox) == 1
         assert mail.outbox[0].to == ["test123@test.com"]
@@ -301,7 +316,7 @@ def test_email_confirmation_after_sign_up(app: DjangoTestApp):
 
         confirmation = EmailConfirmationHMAC(EmailConfirmation.objects.first().email_address)
         url = reverse("account_confirm_email", args=[confirmation.key])
-        form = app.get(url).forms['confirm_email_form']
+        form = app.get(url).forms["confirm_email_form"]
         form.submit()
         assert EmailConfirmation.objects.first().email_address.verified is True
 
@@ -311,38 +326,34 @@ def test_login_second_time(app: DjangoTestApp):
     user = User.objects.create_user(email="testas1@testas.com", password="testas123", status=User.ACTIVE)
     app.set_user(user)
 
-    form = app.get(reverse('login')).forms['login-form']
-    form['username'] = "testas1@testas.com"
-    form['password'] = "testas123"
+    form = app.get(reverse("login")).forms["login-form"]
+    form["username"] = "testas1@testas.com"
+    form["password"] = "testas123"
     resp = form.submit(name="otp_challenge")
-    form = resp.forms['login-form']
-    form['otp_token'] = UserEmailDevice.objects.filter(user=user).first().token
+    form = resp.forms["login-form"]
+    form["otp_token"] = UserEmailDevice.objects.filter(user=user).first().token
     resp = form.submit()
     assert resp.status_code == 302
-    assert resp.url == reverse('home')
+    assert resp.url == reverse("home")
 
-    app.get(reverse('logout'))
+    app.get(reverse("logout"))
 
-    form = app.get(reverse('login')).forms['login-form']
-    form['username'] = "testas1@testas.com"
-    form['password'] = "testas123"
+    form = app.get(reverse("login")).forms["login-form"]
+    form["username"] = "testas1@testas.com"
+    form["password"] = "testas123"
     resp = form.submit()
     assert resp.status_code == 302
-    assert resp.url == reverse('home')
+    assert resp.url == reverse("home")
 
 
 @pytest.mark.django_db
 def test_login_with_deleted_user(app: DjangoTestApp):
-    User.objects.create_user(
-        email="test@test.com",
-        password="test123",
-        status=User.DELETED
-    )
-    form = app.get(reverse('login')).forms['login-form']
-    form['username'] = "test@test.com"
-    form['password'] = "test123"
+    User.objects.create_user(email="test@test.com", password="test123", status=User.DELETED)
+    form = app.get(reverse("login")).forms["login-form"]
+    form["username"] = "test@test.com"
+    form["password"] = "test123"
     resp = form.submit()
-    assert list(resp.context['form'].errors.values()) == [[credentials_error]]
+    assert list(resp.context["form"].errors.values()) == [[credentials_error]]
 
 
 @pytest.mark.django_db
@@ -353,22 +364,18 @@ def test_login_with_suspended_user(app: DjangoTestApp):
         status=User.SUSPENDED,
         is_active=False,
     )
-    form = app.get(reverse('login')).forms['login-form']
-    form['username'] = "test@test.com"
-    form['password'] = "test123"
+    form = app.get(reverse("login")).forms["login-form"]
+    form["username"] = "test@test.com"
+    form["password"] = "test123"
     resp = form.submit()
-    assert list(resp.context['form'].errors.values()) == [[inactive_error]]
+    assert list(resp.context["form"].errors.values()) == [[inactive_error]]
 
 
 @pytest.mark.django_db
 def test_login_with_not_confirmed_user(app: DjangoTestApp):
-    User.objects.create_user(
-        email="test@test.com",
-        password="test123",
-        status=User.AWAITING_CONFIRMATION
-    )
-    form = app.get(reverse('login')).forms['login-form']
-    form['username'] = "test@test.com"
-    form['password'] = "test123"
+    User.objects.create_user(email="test@test.com", password="test123", status=User.AWAITING_CONFIRMATION)
+    form = app.get(reverse("login")).forms["login-form"]
+    form["username"] = "test@test.com"
+    form["password"] = "test123"
     resp = form.submit()
-    assert list(resp.context['form'].errors.values()) == [[awaiting_confirmation_error]]
+    assert list(resp.context["form"].errors.values()) == [[awaiting_confirmation_error]]

--- a/tests/users/test_views.py
+++ b/tests/users/test_views.py
@@ -1,4 +1,3 @@
-import re
 from unittest.mock import patch
 
 import pytest
@@ -245,15 +244,6 @@ def test_profile_view_correct_login(app: DjangoTestApp, user: User):
     app.set_user(user)
     resp = app.get(reverse('user-profile', kwargs={'pk': user.pk}))
     assert resp.status_code == 200
-
-
-@pytest.mark.django_db
-def test_profile_view_wrong_login(app: DjangoTestApp, user: User):
-    app.set_user(user)
-    temp_user = User.objects.create_user(email="testas@testas.com", password="testas123")
-    resp = app.get(reverse('user-profile', kwargs={'pk': temp_user.pk}))
-    assert resp.status_code == 302
-    assert str(user.pk) in resp.location
 
 
 @pytest.mark.django_db

--- a/tests/viisp/test_xml.py
+++ b/tests/viisp/test_xml.py
@@ -1,38 +1,47 @@
 import pytest
 from django_webtest import DjangoTestApp
-from vitrina.viisp.xml_utils import create_signed_authentication_request_xml, \
-create_signed_authentication_data_request_xml, _parse_ticket_id, _parse_user_data
+from vitrina.viisp.xml_utils import (
+    create_signed_authentication_request_xml,
+    create_signed_authentication_data_request_xml,
+    _parse_ticket_id,
+    _parse_user_data,
+)
 from base64 import b64decode
+
 
 @pytest.fixture
 def key():
-    key_content = open('tests/viisp/resources/fake_rsa_key_b64.txt', 'r').read()
-    return b64decode(key_content).decode('ascii')
+    key_content = open("tests/viisp/resources/fake_rsa_key_b64.txt", "r").read()
+    return b64decode(key_content).decode("ascii")
+
 
 def test_auth_request_xml_signing(app: DjangoTestApp, key):
-    domain = 'example.com'
+    domain = "example.com"
     xml_string = create_signed_authentication_request_xml(key, domain)
-    with open('tests/viisp/resources/signed_auth_request.xml', 'r') as xmlFile:
+    with open("tests/viisp/resources/signed_auth_request.xml", "r") as xmlFile:
         assert xml_string == xmlFile.read()
+
 
 def test_auth_data_request_xml_signing(app: DjangoTestApp, key):
-    xml_string = create_signed_authentication_data_request_xml('0961ca7d-ac07-47d2-98c7-1968db7dba8f', key)
-    with open('tests/viisp/resources/signed_auth_data_request.xml', 'r') as xmlFile:
+    xml_string = create_signed_authentication_data_request_xml("0961ca7d-ac07-47d2-98c7-1968db7dba8f", key)
+    with open("tests/viisp/resources/signed_auth_data_request.xml", "r") as xmlFile:
         assert xml_string == xmlFile.read()
 
+
 def test_ticket_id_parsing(app: DjangoTestApp):
-    with open('tests/viisp/resources/signed_auth_data_request.xml', 'r') as xmlFile:
-        assert '0961ca7d-ac07-47d2-98c7-1968db7dba8f' == _parse_ticket_id(xmlFile.read())
+    with open("tests/viisp/resources/signed_auth_data_request.xml", "r") as xmlFile:
+        assert "0961ca7d-ac07-47d2-98c7-1968db7dba8f" == _parse_ticket_id(xmlFile.read())
+
 
 def test_user_data_parsing(app: DjangoTestApp):
-    with open('tests/viisp/resources/response_with_user_data.xml', 'r') as xmlFile:
+    with open("tests/viisp/resources/response_with_user_data.xml", "r") as xmlFile:
         expected_user_data = {
-            'lt_company_code': '1234-5678',
-            'first_name': 'VARDENIS',
-            'last_name': 'PAVARDENIS',
-            'phone_number': '+37000000000',
-            'company_name': 'test company',
-            'email': 'test@test.lt',
-            'personal_code': '30000000000'
+            "lt_company_code": "1234-5678",
+            "first_name": "VARDENIS",
+            "last_name": "PAVARDENIS",
+            "phone_number": "+37000000000",
+            "company_name": "test company",
+            "email": "test@test.lt",
+            "personal_code": "30000000000",
         }
         assert expected_user_data == _parse_user_data(xmlFile.read())

--- a/tests/viisp/test_xml.py
+++ b/tests/viisp/test_xml.py
@@ -1,6 +1,4 @@
 import pytest
-from unittest.mock import patch
-from django.urls import reverse
 from django_webtest import DjangoTestApp
 from vitrina.viisp.xml_utils import create_signed_authentication_request_xml, \
 create_signed_authentication_data_request_xml, _parse_ticket_id, _parse_user_data


### PR DESCRIPTION
**Summary:**
Enable `ruff check` and `ruff format` on test files. Previously test files were not checked.

Commits:
- 6a47483e37f1de02d1de20736a3ffeac9f353756 - enables ruff for test files. Fixes `ruff check` errors. Mostly deletes unused imports and variables. Also, fix some duplicated test names.
- 008d31962e5100ded251ee12f50623975a8e8d0d - runs `ruff format`

