### PR TITLE
Bg/2296 missing menu items

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,12 @@ https://github.com/atviriduomenys/katalogas/issues/1906
 
 - Export Dataset structure for a specific version.
 
+Bug fixes:
+
+https://github.com/atviriduomenys/katalogas/issues/2296
+
+- Fixed menu-items in Organization and Dataset views.
+
 v 1.13.0 (2026-01-26)
 ==================
 

--- a/tests/datasets/test_views.py
+++ b/tests/datasets/test_views.py
@@ -3537,6 +3537,32 @@ def test_dataset_structure_import_with_version(app: DjangoTestApp):
     assert structure.file.original_filename == "file.csv"
 
 
+def test_dataset_structure_history_url(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    dataset = DatasetFactory()
+    metadata_version = VersionFactory(dataset=dataset)
+    app.set_user(user)
+    resp = app.get(reverse("dataset-structure", args=[dataset.pk, metadata_version.pk]))
+
+    view = resp.context["view"]
+    view.object = dataset
+    view.metadata_version = metadata_version
+
+    history_url = view.get_history_url()
+
+    assert history_url == reverse(
+        "dataset-structure-history",
+        kwargs={"pk": dataset.pk, "version_id": metadata_version.pk}
+    )
+
+    view.metadata_version = None
+    history_url_no_version = view.get_history_url()
+    assert history_url_no_version == reverse(
+        "dataset-structure-history-no-version",
+        kwargs={"pk": dataset.pk}
+    )
+
+
 def test_dataset_assign_new_category_without_permission(app: DjangoTestApp):
     user = UserFactory()
     app.set_user(user)

--- a/tests/datasets/test_views.py
+++ b/tests/datasets/test_views.py
@@ -3551,16 +3551,12 @@ def test_dataset_structure_history_url(app: DjangoTestApp):
     history_url = view.get_history_url()
 
     assert history_url == reverse(
-        "dataset-structure-history",
-        kwargs={"pk": dataset.pk, "version_id": metadata_version.pk}
+        "dataset-structure-history", kwargs={"pk": dataset.pk, "version_id": metadata_version.pk}
     )
 
     view.metadata_version = None
     history_url_no_version = view.get_history_url()
-    assert history_url_no_version == reverse(
-        "dataset-structure-history-no-version",
-        kwargs={"pk": dataset.pk}
-    )
+    assert history_url_no_version == reverse("dataset-structure-history-no-version", kwargs={"pk": dataset.pk})
 
 
 def test_dataset_assign_new_category_without_permission(app: DjangoTestApp):

--- a/tests/datasets/test_views.py
+++ b/tests/datasets/test_views.py
@@ -451,6 +451,31 @@ class TestDatasetListView:
         resp = app.get(reverse("dataset-list"))
         assert not resp.html.find(id="org-dataset-url")
 
+    @pytest.mark.parametrize(
+        "is_staff,can_view",
+        [
+            (True, True),
+            (False, False),
+        ],
+    )
+    def test_organization_datasets_context_flags_present(
+        self,
+        app: DjangoTestApp,
+        is_staff: bool,
+        can_view: bool,
+    ):
+        organization = OrganizationFactory()
+        user = UserFactory(is_staff=is_staff)
+
+        app.set_user(user)
+        resp = app.get(reverse("organization-datasets", args=[organization.pk]))
+
+        assert "can_view_agents" in resp.context
+        assert "can_view_keys" in resp.context
+
+        assert resp.context["can_view_agents"] is can_view
+        assert resp.context["can_view_keys"] is can_view
+
     def test_manager_dataset_url_is_hidden_for_normal_user(self, app: DjangoTestApp):
         user = User.objects.create_user(email="test@test.com", password="test123")
         app.set_user(user)

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -574,6 +574,124 @@ def test_data_tab_from_dataset_structure(app: DjangoTestApp):
     assert resp.request.path == model.get_data_url()
 
 
+@pytest.mark.parametrize("structure_view", ["dataset-structure", "dataset-structure-history"])
+@pytest.mark.django_db
+def test_history_tab_from_dataset_structure(app: DjangoTestApp, structure_view: str):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(model),
+        object_id=model.pk,
+        dataset=dataset,
+        name="test/dataset/TestModel",
+        metadata_version=version,
+    )
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(dataset),
+        object_id=dataset.pk,
+        dataset=dataset,
+        name="test/dataset",
+        metadata_version=version,
+    )
+    prop = PropertyFactory(model=model, metadata_version=version)
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(prop),
+        object_id=prop.pk,
+        dataset=dataset,
+        name='prop',
+        type='string',
+        metadata_version=version,
+    )
+
+    resp = app.get(reverse(structure_view, args=[dataset.pk, version.pk]))
+    view = resp.context["view"]
+
+    history_url = view.get_history_url()
+    resp = resp.click(linkid='history-tab')
+    assert resp.request.path == history_url
+
+
+@pytest.mark.django_db
+def test_history_tab_from_model_history(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(model),
+        object_id=model.pk,
+        dataset=dataset,
+        name="test/dataset/TestModel",
+        metadata_version=version,
+    )
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(dataset),
+        object_id=dataset.pk,
+        dataset=dataset,
+        name="test/dataset",
+        metadata_version=version,
+    )
+    prop = PropertyFactory(model=model, metadata_version=version)
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(prop),
+        object_id=prop.pk,
+        dataset=dataset,
+        name='prop',
+        type='string',
+        metadata_version=version,
+    )
+
+    resp = app.get(reverse('model-history', args=[dataset.pk, version.pk, 'TestModel']))
+    view = resp.context["view"]
+
+    history_url = view.get_history_url()
+    resp = resp.click(linkid='history-tab')
+    assert resp.request.path == history_url
+
+
+@pytest.mark.django_db
+def test_history_tab_from_property_history(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(model),
+        object_id=model.pk,
+        dataset=dataset,
+        name="test/dataset/TestModel",
+        metadata_version=version,
+    )
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(dataset),
+        object_id=dataset.pk,
+        dataset=dataset,
+        name="test/dataset",
+        metadata_version=version,
+    )
+    prop = PropertyFactory(model=model, metadata_version=version)
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(prop),
+        object_id=prop.pk,
+        dataset=dataset,
+        name='prop',
+        type='string',
+        metadata_version=version,
+    )
+
+    resp = app.get(reverse('property-history', args=[dataset.pk, version.pk, 'TestModel', 'prop']))
+    view = resp.context["view"]
+
+    history_url = view.get_history_url()
+    resp = resp.click(linkid='history-tab')
+    assert resp.request.path == history_url
+
+
 @pytest.mark.django_db
 def test_data_tab_from_model_structure(app: DjangoTestApp):
     version = VersionFactory()

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -601,8 +601,8 @@ def test_history_tab_from_dataset_structure(app: DjangoTestApp, structure_view: 
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
+        name="prop",
+        type="string",
         metadata_version=version,
     )
 
@@ -610,7 +610,7 @@ def test_history_tab_from_dataset_structure(app: DjangoTestApp, structure_view: 
     view = resp.context["view"]
 
     history_url = view.get_history_url()
-    resp = resp.click(linkid='history-tab')
+    resp = resp.click(linkid="history-tab")
     assert resp.request.path == history_url
 
 
@@ -640,16 +640,16 @@ def test_history_tab_from_model_history(app: DjangoTestApp):
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
+        name="prop",
+        type="string",
         metadata_version=version,
     )
 
-    resp = app.get(reverse('model-history', args=[dataset.pk, version.pk, 'TestModel']))
+    resp = app.get(reverse("model-history", args=[dataset.pk, version.pk, "TestModel"]))
     view = resp.context["view"]
 
     history_url = view.get_history_url()
-    resp = resp.click(linkid='history-tab')
+    resp = resp.click(linkid="history-tab")
     assert resp.request.path == history_url
 
 
@@ -679,16 +679,16 @@ def test_history_tab_from_property_history(app: DjangoTestApp):
         content_type=ContentType.objects.get_for_model(prop),
         object_id=prop.pk,
         dataset=dataset,
-        name='prop',
-        type='string',
+        name="prop",
+        type="string",
         metadata_version=version,
     )
 
-    resp = app.get(reverse('property-history', args=[dataset.pk, version.pk, 'TestModel', 'prop']))
+    resp = app.get(reverse("property-history", args=[dataset.pk, version.pk, "TestModel", "prop"]))
     view = resp.context["view"]
 
     history_url = view.get_history_url()
-    resp = resp.click(linkid='history-tab')
+    resp = resp.click(linkid="history-tab")
     assert resp.request.path == history_url
 
 

--- a/tests/uapi/agent/test_template_views.py
+++ b/tests/uapi/agent/test_template_views.py
@@ -45,30 +45,18 @@ class TestAgentList:
         assert archived_agent not in returned_agents
         assert different_organization_agent not in returned_agents
 
-    @pytest.mark.parametrize(
-        "is_staff,can_view",
-        [
-            (True, True),
-            (False, False),
-        ],
-    )
     def test_agent_view_exposes_can_view_agents_flag(
         self,
         app: DjangoTestApp,
-        is_staff: bool,
-        can_view: bool,
     ):
         organization = OrganizationFactory()
-        user = UserFactory(is_staff=is_staff)
+        user = UserFactory(is_staff=True)
 
         app.set_user(user)
         response = app.get(reverse("agent-list", args=[organization.pk]))
 
         assert "can_view_agents" in response.context
         assert "can_view_keys" in response.context
-
-        assert response.context["can_view_agents"] is can_view
-        assert response.context["can_view_keys"] is can_view
 
 
 class TestDetail:

--- a/tests/uapi/agent/test_template_views.py
+++ b/tests/uapi/agent/test_template_views.py
@@ -13,6 +13,7 @@ from vitrina.orgs.factories import OrganizationFactory
 from vitrina.orgs.models import Organization
 from vitrina.uapi.models import Agent, RequestHistory
 from vitrina.orgs.services import hash_api_key
+from vitrina.users.factories import UserFactory
 from vitrina.users.models import User
 
 
@@ -43,6 +44,31 @@ class TestAgentList:
         assert agent_2 in returned_agents
         assert archived_agent not in returned_agents
         assert different_organization_agent not in returned_agents
+
+    @pytest.mark.parametrize(
+        "is_staff,can_view",
+        [
+            (True, True),
+            (False, False),
+        ],
+    )
+    def test_agent_view_exposes_can_view_agents_flag(
+        self,
+        app: DjangoTestApp,
+        is_staff: bool,
+        can_view: bool,
+    ):
+        organization = OrganizationFactory()
+        user = UserFactory(is_staff=is_staff)
+
+        app.set_user(user)
+        response = app.get(reverse("agent-list", args=[organization.pk]))
+
+        assert "can_view_agents" in response.context
+        assert "can_view_keys" in response.context
+
+        assert response.context["can_view_agents"] is can_view
+        assert response.context["can_view_keys"] is can_view
 
 
 class TestDetail:

--- a/tests/uapi/agent/test_template_views.py
+++ b/tests/uapi/agent/test_template_views.py
@@ -55,8 +55,8 @@ class TestAgentList:
         app.set_user(user)
         response = app.get(reverse("agent-list", args=[organization.pk]))
 
-        assert "can_view_agents" in response.context
-        assert "can_view_keys" in response.context
+        expected_keys = {"can_view_agents", "can_view_keys"}
+        assert all(key in response.context for key in expected_keys)
 
 
 class TestDetail:

--- a/vitrina/datasets/helpers.py
+++ b/vitrina/datasets/helpers.py
@@ -9,6 +9,10 @@ from vitrina.orgs.models import Organization
 from vitrina.datasets.models import Dataset, Metadata
 
 
+def is_child_resources_list(request: HttpRequest) -> bool:
+    return request.resolver_match.url_name == "dataset-child-resources"
+
+
 def is_manager_dataset_list(request: HttpRequest):
     return request.resolver_match.url_name == "manager-dataset-list"
 

--- a/vitrina/datasets/views.py
+++ b/vitrina/datasets/views.py
@@ -1578,6 +1578,20 @@ class DatasetStructureImportView(
             )
         return reverse("dataset-structure-no-version", kwargs={"pk": self.dataset.pk})
 
+    def get_history_url(self):
+        if self.metadata_version:
+            return reverse(
+                "dataset-structure-history",
+                kwargs={"pk": self.dataset.pk, "version_id": self.metadata_version.pk},
+            )
+        else:
+            return reverse(
+                "dataset-structure-history-no-version",
+                kwargs={
+                    "pk": self.dataset.pk,
+                },
+            )
+
 
 class DatasetMembersView(
     LoginRequiredMixin,
@@ -1942,7 +1956,7 @@ class DatasetProjectsView(DatasetStructureMixin, PermissionRequiredMixin, Histor
     context_object_name = "projects"
     paginate_by = 20
 
-    # HistroyMixin
+    # HistoryMixin
     object: Dataset
     detail_url_name = "dataset-detail"
     history_url_name = "dataset-history"
@@ -3487,7 +3501,7 @@ class DatasetDeletePlanDetailView(DatasetDeletePlanView):
 class DatasetPlansHistoryView(DatasetStructureMixin, PlanMixin, HistoryView):
     model = Dataset
     detail_url_name = "dataset-detail"
-    history_url_name = "dataset-history"
+    history_url_name = "dataset-plans-history"
     plan_url_name = "dataset-plans"
     tabs_template_name = "vitrina/datasets/tabs.html"
 

--- a/vitrina/datasets/views.py
+++ b/vitrina/datasets/views.py
@@ -1578,7 +1578,7 @@ class DatasetStructureImportView(
             )
         return reverse("dataset-structure-no-version", kwargs={"pk": self.dataset.pk})
 
-    def get_history_url(self):
+    def get_history_url(self) -> str:
         if self.metadata_version:
             return reverse(
                 "dataset-structure-history",

--- a/vitrina/datasets/views.py
+++ b/vitrina/datasets/views.py
@@ -70,7 +70,7 @@ from vitrina.datasets.forms import (
     DatasetResourceForm,
     CatalogResourceForm,
 )
-from vitrina.datasets.helpers import is_manager_dataset_list, generate_unique_dataset_name
+from vitrina.datasets.helpers import is_manager_dataset_list, generate_unique_dataset_name, is_child_resources_list
 from vitrina.structure import VersionStatus
 from vitrina.structure.views import DatasetStructureMixin
 
@@ -442,11 +442,12 @@ class DatasetListView(PermissionRequiredMixin, PlanMixin, FacetedSearchView):
         context["sort"] = sorting
         return context
 
-    def get_plan_url(self):
+    def get_plan_url(self) -> str | None:
         if is_org_dataset_list(self.request):
             return reverse("organization-plans", args=[self.organization.pk])
-        else:
-            return None
+        if is_child_resources_list(self.request):
+            return reverse("dataset-plans", args=[self.dataset.pk])
+        return None
 
 
 class DatasetRedirectView(View):
@@ -1640,6 +1641,7 @@ class CreateMemberView(
     HistoryMixin,
     LoginRequiredMixin,
     PermissionRequiredMixin,
+    PlanMixin,
     CreateView,
 ):
     model = Representative
@@ -1648,6 +1650,7 @@ class CreateMemberView(
 
     detail_url_name = "dataset-detail"
     history_url_name = "dataset-history"
+    plan_url_name = "dataset-plans"
 
     def has_permission(self):
         subclass = self.dataset.subclass
@@ -1689,6 +1692,9 @@ class CreateMemberView(
         return self.dataset
 
     def get_history_object(self):
+        return self.dataset
+
+    def get_plan_object(self) -> Dataset:
         return self.dataset
 
     def form_valid(self, form):
@@ -1755,6 +1761,7 @@ class UpdateMemberView(
     HistoryMixin,
     LoginRequiredMixin,
     PermissionRequiredMixin,
+    PlanMixin,
     UpdateView,
 ):
     model = Representative
@@ -1764,6 +1771,7 @@ class UpdateMemberView(
 
     detail_url_name = "dataset-detail"
     history_url_name = "dataset-history"
+    plan_url_name = "dataset-plans"
 
     def has_permission(self):
         subclass = self.dataset.subclass
@@ -1808,6 +1816,9 @@ class UpdateMemberView(
         return self.dataset
 
     def get_history_object(self):
+        return self.dataset
+
+    def get_plan_object(self) -> Dataset:
         return self.dataset
 
     def form_valid(self, form):
@@ -3729,7 +3740,11 @@ class DatasetRepresentativeApiKeyView(PermissionRequiredMixin, TemplateView):
 
 
 class DatasetChildResourceListView(
-    DatasetBreadcrumbsMixin, LanguageChoiceMixin, HistoryMixin, DatasetStructureMixin, DatasetListView
+    DatasetBreadcrumbsMixin,
+    LanguageChoiceMixin,
+    HistoryMixin,
+    DatasetStructureMixin,
+    DatasetListView,
 ):
     model = Dataset
     detail_url_name = DatasetDetailView.detail_url_name
@@ -3766,6 +3781,12 @@ class DatasetChildResourceListView(
                 self.request.user,
                 action,
                 Dataset,
+                self.object,
+            ),
+            "can_view_members": has_perm(
+                self.request.user,
+                Action.VIEW,
+                Representative,
                 self.object,
             ),
             "parent_dataset_id": self.parent_dataset_id,

--- a/vitrina/datasets/views.py
+++ b/vitrina/datasets/views.py
@@ -75,6 +75,7 @@ from vitrina.structure import VersionStatus
 from vitrina.structure.views import DatasetStructureMixin
 
 from vitrina.tasks.models import Task
+from vitrina.uapi.models import Agent
 from vitrina.views import HistoryView, HistoryMixin, PlanMixin
 from vitrina.datasets.mixins import DatasetBreadcrumbsMixin, Crumb
 from vitrina.datasets.services import (
@@ -390,6 +391,10 @@ class DatasetListView(PermissionRequiredMixin, PlanMixin, FacetedSearchView):
                 Action.CREATE,
                 Dataset,
                 self.organization,
+            )
+            extra_context["can_view_agents"] = has_perm(self.request.user, Action.VIEW, Agent, self.organization)
+            extra_context["can_view_keys"] = has_perm(
+                self.request.user, Action.MANAGE_KEYS, Organization, self.organization
             )
             context["organization_id"] = self.organization.pk
             if not form.selected_facets:

--- a/vitrina/orgs/templates/vitrina/orgs/tabs.html
+++ b/vitrina/orgs/templates/vitrina/orgs/tabs.html
@@ -14,7 +14,7 @@
         </li>
         {% endif %}
         {% if can_view_contacts %}
-        <li class="{%if request.resolver_match.url_name == 'organization-contacts' or request.resolver_match.url_name == 'contacts-create' or request.resolver_match.url_name == 'contacts-update' %} is-active {% endif %}">
+        <li class="{%if request.resolver_match.url_name == 'organization-contacts' or request.resolver_match.url_name == 'contact-create' or request.resolver_match.url_name == 'contact-update' %} is-active {% endif %}">
             <a href="{% url 'organization-contacts' organization.id %}">
                 {% translate "Kontaktai" %}
             </a>
@@ -43,7 +43,7 @@
             </li>
         {% endif %}
         {% if can_view_agents %}
-            <li class="{% if request.resolver_match.url_name == 'agent-list' %} is-active {% endif %}">
+            <li class="{% if request.resolver_match.url_name == 'agent-list' or request.resolver_match.url_name == 'agent-create' or request.resolver_match.url_name == 'agent-update' %} is-active {% endif %}">
                 <a href="{% url 'agent-list' organization.id %}">
                     {% translate "Agentai" %}
                 </a>

--- a/vitrina/orgs/views.py
+++ b/vitrina/orgs/views.py
@@ -123,6 +123,8 @@ logger = logging.getLogger()
 
 
 class OrganizationBaseViewMixin:
+    plan_url_name = "organization-plans"
+
     def setup(self, request, *args, **kwargs):
         self.organization = get_object_or_404(Organization, pk=kwargs.get("pk"))
         return super().setup(request, *args, **kwargs)
@@ -138,6 +140,9 @@ class OrganizationBaseViewMixin:
         context_data["can_view_keys"] = has_perm(self.request.user, Action.MANAGE_KEYS, Organization, self.organization)
         context_data["organization"] = self.organization
         return context_data
+
+    def get_plan_object(self) -> Organization:
+        return self.organization
 
 
 class RepresentativeRequestApproveView(PermissionRequiredMixin, TemplateView):
@@ -504,6 +509,7 @@ class OrganizationMembersView(
     LoginRequiredMixin,
     PermissionRequiredMixin,
     OrganizationBaseViewMixin,
+    PlanMixin,
     ListView,
 ):
     template_name = "vitrina/orgs/members.html"
@@ -542,6 +548,7 @@ class OrganizationContactsView(
     LoginRequiredMixin,
     PermissionRequiredMixin,
     OrganizationBaseViewMixin,
+    PlanMixin,
     ListView,
 ):
     template_name = "vitrina/orgs/contacts.html"
@@ -577,6 +584,7 @@ class ContactCreateView(
     LoginRequiredMixin,
     PermissionRequiredMixin,
     OrganizationBaseViewMixin,
+    PlanMixin,
     CreateView,
 ):
     model = Contact
@@ -628,7 +636,7 @@ class ContactCreateView(
         return HttpResponseRedirect(self.get_success_url())
 
 
-class ContactUpdateView(LoginRequiredMixin, PermissionRequiredMixin, OrganizationBaseViewMixin, UpdateView):
+class ContactUpdateView(LoginRequiredMixin, PermissionRequiredMixin, OrganizationBaseViewMixin, PlanMixin, UpdateView):
     model = Contact
     form_class = ContactUpdateForm
     template_name = "base_form.html"
@@ -714,6 +722,7 @@ class OrganizationProjectsView(
     LoginRequiredMixin,
     PermissionRequiredMixin,
     OrganizationBaseViewMixin,
+    PlanMixin,
     ListView,
 ):
     template_name = "vitrina/orgs/projects_list.html"
@@ -742,7 +751,7 @@ class OrganizationProjectsView(
         return context_data
 
 
-class OrganizationBasedAgreementListView(OrganizationBaseViewMixin, BaseAgreementListView):
+class OrganizationBasedAgreementListView(OrganizationBaseViewMixin, PlanMixin, BaseAgreementListView):
     template_name = "vitrina/orgs/organization_agreements.html"
     parent_type = "organization"
 
@@ -1052,6 +1061,7 @@ class RepresentativeCreateView(
     LoginRequiredMixin,
     PermissionRequiredMixin,
     OrganizationBaseViewMixin,
+    PlanMixin,
     CreateView,
 ):
     model = Representative
@@ -1168,7 +1178,9 @@ class RepresentativeCreateView(
         return HttpResponseRedirect(self.get_success_url())
 
 
-class RepresentativeUpdateView(LoginRequiredMixin, PermissionRequiredMixin, OrganizationBaseViewMixin, UpdateView):
+class RepresentativeUpdateView(
+    LoginRequiredMixin, PermissionRequiredMixin, OrganizationBaseViewMixin, PlanMixin, UpdateView
+):
     model = Representative
     form_class = RepresentativeUpdateForm
     template_name = "base_form.html"
@@ -1529,7 +1541,9 @@ class OrganizationPlanCreateView(PermissionRequiredMixin, OrganizationBaseViewMi
         return redirect(reverse("organization-plans", args=[self.organization.pk]))
 
 
-class OrganizationApiKeysView(LoginRequiredMixin, PermissionRequiredMixin, OrganizationBaseViewMixin, TemplateView):
+class OrganizationApiKeysView(
+    LoginRequiredMixin, PermissionRequiredMixin, OrganizationBaseViewMixin, PlanMixin, TemplateView
+):
     template_name = "vitrina/orgs/apikeys.html"
 
     organization: Organization
@@ -1623,7 +1637,7 @@ class OrganizationApiKeysView(LoginRequiredMixin, PermissionRequiredMixin, Organ
 
 
 class OrganizationApiKeysDetailView(
-    LoginRequiredMixin, PermissionRequiredMixin, OrganizationBaseViewMixin, TemplateView
+    LoginRequiredMixin, PermissionRequiredMixin, OrganizationBaseViewMixin, PlanMixin, TemplateView
 ):
     template_name = "vitrina/orgs/apikeys_detail.html"
     pk_url_kwarg = "apikey_id"

--- a/vitrina/plans/views.py
+++ b/vitrina/plans/views.py
@@ -12,6 +12,7 @@ from vitrina.orgs.services import has_perm, Action
 from vitrina.orgs.views import OrganizationBaseViewMixin
 from vitrina.plans.models import Plan
 from vitrina.plans.services import has_plan_close_permission
+from vitrina.uapi.models import Agent
 from vitrina.views import PlanMixin, HistoryView
 
 
@@ -46,6 +47,8 @@ class PlanDetailView(PlanMixin, DetailView):
         context["plan_datasets"] = self.object.plandataset_set.all()
         context["history_url"] = reverse("plan-history", args=[self.organization.pk, self.object.pk])
         context["history_url_name"] = "plan-hisotry"
+        context["can_view_agents"] = has_perm(self.request.user, Action.VIEW, Agent, self.organization)
+        context["can_view_keys"] = has_perm(self.request.user, Action.MANAGE_KEYS, Organization, self.organization)
         return context
 
 

--- a/vitrina/structure/views.py
+++ b/vitrina/structure/views.py
@@ -313,6 +313,20 @@ class DatasetStructureView(
     def get_api_url(self):
         return self.models[0].get_api_url() if self.models else None
 
+    def get_history_url(self) -> str:
+        if self.metadata_version:
+            return reverse(
+                "dataset-structure-history",
+                kwargs={"pk": self.object.pk, "version_id": self.metadata_version.pk},
+            )
+        else:
+            return reverse(
+                "dataset-structure-history-no-version",
+                kwargs={
+                    "pk": self.object.pk,
+                },
+            )
+
 
 class ModelStructureView(
     DatasetBreadcrumbsMixin, HistoryMixin, StructureMixin, PlanMixin, PermissionRequiredMixin, TemplateView
@@ -3030,7 +3044,7 @@ class ParamDeleteView(PermissionRequiredMixin, DeleteView):
 class DatasetStructureHistoryView(StructureMixin, PlanMixin, HistoryView):
     model = Dataset
     detail_url_name = "dataset-detail"
-    history_url_name = "dataset-history"
+    history_url_name = "dataset-structure-history"
     plan_url_name = "dataset-plans"
     tabs_template_name = "vitrina/datasets/tabs.html"
 
@@ -3135,6 +3149,15 @@ class DatasetStructureHistoryView(StructureMixin, PlanMixin, HistoryView):
     def get_api_url(self):
         return self.models[0].get_api_url() if self.models else None
 
+    def get_history_url(self) -> str:
+        if self.metadata_version:
+            return reverse(
+                "dataset-structure-history",
+                kwargs={"pk": self.kwargs.get("pk"), "version_id": self.metadata_version.pk},
+            )
+        else:
+            return reverse("dataset-structure-history-no-version", kwargs={"pk": self.kwargs.get("pk")})
+
     def get_history_objects(self):
         model_ids = self.models.values_list("pk", flat=True)
         allowed_visibilities = get_allowed_visibilities(
@@ -3167,7 +3190,7 @@ class DatasetStructureHistoryView(StructureMixin, PlanMixin, HistoryView):
 class ModelHistoryView(StructureMixin, PlanMixin, HistoryView):
     model = Dataset
     detail_url_name = "dataset-detail"
-    history_url_name = "dataset-history"
+    history_url_name = "model-history"
     plan_url_name = "dataset-plans"
     tabs_template_name = "vitrina/datasets/tabs.html"
 
@@ -3309,11 +3332,23 @@ class ModelHistoryView(StructureMixin, PlanMixin, HistoryView):
         history_objects = property_history_objects | model_history_objects
         return history_objects.order_by("-revision__date_created")
 
+    def get_history_url(self) -> str | None:
+        if self.model_obj.name:
+            return reverse(
+                self.history_url_name,
+                kwargs={
+                    "pk": self.kwargs.get("pk"),
+                    "version_id": self.metadata_version.pk,
+                    "model": self.model_obj.name,
+                },
+            )
+        return None
+
 
 class PropertyHistoryView(StructureMixin, PlanMixin, HistoryView):
     model = Dataset
     detail_url_name = "dataset-detail"
-    history_url_name = "dataset-history"
+    history_url_name = "property-history"
     plan_url_name = "dataset-plans"
     tabs_template_name = "vitrina/datasets/tabs.html"
 
@@ -3458,6 +3493,19 @@ class PropertyHistoryView(StructureMixin, PlanMixin, HistoryView):
 
     def get_api_url(self):
         return self.model_obj.get_api_url()
+
+    def get_history_url(self) -> str | None:
+        if self.model.name and self.property.name:
+            return reverse(
+                self.history_url_name,
+                kwargs={
+                    "pk": self.kwargs.get("pk"),
+                    "version_id": self.metadata_version.pk,
+                    "model": self.model_obj.name,
+                    "prop": self.property.name,
+                },
+            )
+        return None
 
     def get_history_objects(self):
         return Version.objects.get_for_object(self.property).order_by("-revision__date_created")

--- a/vitrina/structure/views.py
+++ b/vitrina/structure/views.py
@@ -3333,16 +3333,16 @@ class ModelHistoryView(StructureMixin, PlanMixin, HistoryView):
         return history_objects.order_by("-revision__date_created")
 
     def get_history_url(self) -> str | None:
-        if self.model_obj.name:
-            return reverse(
-                self.history_url_name,
-                kwargs={
-                    "pk": self.kwargs.get("pk"),
-                    "version_id": self.metadata_version.pk,
-                    "model": self.model_obj.name,
-                },
-            )
-        return None
+        if not self.model_obj.name:
+            return None
+        return reverse(
+            self.history_url_name,
+            kwargs={
+                "pk": self.kwargs.get("pk"),
+                "version_id": self.metadata_version.pk,
+                "model": self.model_obj.name,
+            },
+        )
 
 
 class PropertyHistoryView(StructureMixin, PlanMixin, HistoryView):

--- a/vitrina/uapi/views/template_views.py
+++ b/vitrina/uapi/views/template_views.py
@@ -64,6 +64,8 @@ class BaseAgentView(LoginRequiredMixin, PermissionRequiredMixin, TemplateView):
                     self.request.user, Action.UPDATE, Representative, self.organization
                 ),
                 "can_manage_keys": has_perm(self.request.user, Action.MANAGE_KEYS, self.organization),
+                "can_view_agents": has_perm(self.request.user, Action.VIEW, Agent, self.organization),
+                "can_view_keys": has_perm(self.request.user, Action.MANAGE_KEYS, Organization, self.organization),
             }
         )
 

--- a/vitrina/uapi/views/template_views.py
+++ b/vitrina/uapi/views/template_views.py
@@ -35,13 +35,15 @@ from vitrina.uapi.models import RequestHistory
 from vitrina.resources.models import Format
 from vitrina.uapi.forms import AgentForm
 from vitrina.uapi.models import Agent
+from vitrina.views import PlanMixin
 
 logger = logging.getLogger(__name__)
 
 
-class BaseAgentView(LoginRequiredMixin, PermissionRequiredMixin, TemplateView):
+class BaseAgentView(LoginRequiredMixin, PermissionRequiredMixin, PlanMixin, TemplateView):
     organization_url_kwarg = "organization_id"
     template_name = "base_form.html"
+    plan_url_name = "organization-plans"
 
     def setup(self, request, *args, **kwargs) -> None:
         super().setup(request, *args, **kwargs)
@@ -70,6 +72,9 @@ class BaseAgentView(LoginRequiredMixin, PermissionRequiredMixin, TemplateView):
         )
 
         return context
+
+    def get_plan_object(self) -> Organization:
+        return self.organization
 
 
 class AgentListView(BaseAgentView):

--- a/vitrina/views.py
+++ b/vitrina/views.py
@@ -264,8 +264,7 @@ class HistoryMixin:
 
     def get_history_url(self) -> str:
         obj = self.get_history_object()
-        url_name = self.get_history_url_name()
-        return reverse(url_name, args=[obj.pk])
+        return reverse(self.get_history_url_name(), args=[obj.pk])
 
     def get_history_object(self):
         return self.object

--- a/vitrina/views.py
+++ b/vitrina/views.py
@@ -264,18 +264,8 @@ class HistoryMixin:
 
     def get_history_url(self):
         obj = self.get_history_object()
-        if hasattr(self, "metadata_version") and self.metadata_version:
-            return reverse(
-                "dataset-structure-history",
-                kwargs={"pk": obj.pk, "version_id": self.metadata_version.pk},
-            )
-        else:
-            return reverse(
-                "dataset-structure-history-no-version",
-                kwargs={
-                    "pk": obj.pk,
-                },
-            )
+        url_name = self.get_history_url_name()
+        return reverse(url_name, args=[obj.pk])
 
     def get_history_object(self):
         return self.object

--- a/vitrina/views.py
+++ b/vitrina/views.py
@@ -262,7 +262,7 @@ class HistoryMixin:
         obj = self.get_detail_object()
         return reverse("dataset-child-resources", args=[obj.pk])
 
-    def get_history_url(self):
+    def get_history_url(self) -> str:
         obj = self.get_history_object()
         url_name = self.get_history_url_name()
         return reverse(url_name, args=[obj.pk])


### PR DESCRIPTION
Summary:

- Added missing menu items "Agents" and "Keys" to all Organization views
- Fixed child_resources view in Dataset to view missing menu items "Representatives" and "Plans"
- Added "Plans" menu item to all Organization views
- Overriden get_history_url in history pages to not reroute to previous history tab

Ticket:

https://github.com/atviriduomenys/katalogas/issues/2296
