### PR TITLE
2257 elasticsearch index

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,9 @@ https://github.com/atviriduomenys/katalogas/issues/2429
 
 - Comment button fix for reply/edit/delete buttons to work.
 
+https://github.com/atviriduomenys/katalogas/issues/2257
+
+- Index query optimization to fix N+1 problem.
 
 v 1.14.1 (2026-02-23)
 ==================

--- a/tests/datasets/test_index.py
+++ b/tests/datasets/test_index.py
@@ -1,10 +1,9 @@
 from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from haystack import connections
-
 from unittest.mock import patch
 
 import pytest
-from django.test.utils import CaptureQueriesContext
 
 from vitrina.datasets.factories import DatasetFactory
 from vitrina.datasets.models import Dataset
@@ -12,25 +11,98 @@ from vitrina.datasets.models import Dataset
 
 @pytest.mark.django_db
 class TestDatasetIndexQuery:
-    def test_dataset_index_query_count(self):
-        DatasetFactory()
-        DatasetFactory()
-        DatasetFactory()
-        DatasetFactory()
+    QUERY_COUNT_THRESHOLD = 15
+
+    def test_bulk_index_query_count(self):
+        datasets_to_create = 5
+        for _ in range(datasets_to_create):
+            DatasetFactory()
+
+        ui = connections["default"].get_unified_index()
+        index = ui.get_index(Dataset)
+
+        with CaptureQueriesContext(connection) as ctx:
+            datasets = list(index.index_queryset()[:5])
+
+            with patch("haystack.backends.elasticsearch_backend.ElasticsearchSearchBackend.update"):
+                for ds in datasets:
+                    index.full_prepare(ds)
+
+        query_count = len(ctx.captured_queries)
+
+        assert query_count <= self.QUERY_COUNT_THRESHOLD, f"Too many queries for bulk indexing: {query_count}"
+
+        # Verify batch queries use IN clauses (not individual lookups)
+        in_clause_queries = sum(1 for q in ctx.captured_queries if " IN (" in q["sql"])
+        assert in_clause_queries >= 5, "Expected batch queries with IN clauses"
+
+    def test_single_object_update_query_count(self):
+        dataset = DatasetFactory()
+
+        ui = connections["default"].get_unified_index()
+        index = ui.get_index(Dataset)
+
+        fresh_instance = Dataset.objects.get(pk=dataset.pk)
+
+        with CaptureQueriesContext(connection) as ctx:
+            with patch("haystack.backends.elasticsearch_backend.ElasticsearchSearchBackend.update"):
+                index.update_object(fresh_instance)
+
+        query_count = len(ctx.captured_queries)
+
+        assert query_count <= self.QUERY_COUNT_THRESHOLD, f"Too many queries for single object update: {query_count}"
+
+    def test_index_queryset_excludes_datasets_without_title(self):
+        dataset_with_title = DatasetFactory()
+        dataset_without_title = DatasetFactory()
+        dataset_without_title.translations.all().delete()
+
+        ui = connections["default"].get_unified_index()
+        index = ui.get_index(Dataset)
+
+        indexed_pks = list(index.index_queryset().values_list("pk", flat=True))
+
+        assert dataset_with_title.pk in indexed_pks
+        assert dataset_without_title.pk not in indexed_pks
+
+    def test_index_queryset_uses_exists_subquery(self):
         DatasetFactory()
 
         ui = connections["default"].get_unified_index()
         index = ui.get_index(Dataset)
 
-        datasets = list(index.index_queryset()[:5])
-
-        # Bulk load tags via index method
-        index._bulk_load_tags(datasets)
-
-        docs = []
         with CaptureQueriesContext(connection) as ctx:
-            with patch("haystack.backends.elasticsearch_backend.ElasticsearchSearchBackend.update", autospec=True):
-                for ds in datasets:
-                    docs.append(index.full_prepare(ds))
+            list(index.index_queryset()[:1])
 
-            assert len(ctx.captured_queries) == 0, f"Too many queries: {len(ctx.captured_queries)}"
+        main_query = ctx.captured_queries[0]["sql"]
+
+        # Should use EXISTS, not DISTINCT
+        assert "EXISTS" in main_query, "Expected EXISTS subquery for translation filter"
+        assert "DISTINCT" not in main_query or "SELECT DISTINCT" not in main_query, (
+            "Should not use DISTINCT with EXISTS subquery"
+        )
+
+    def test_query_count_scales_constantly(self):
+        for _ in range(10):
+            DatasetFactory()
+
+        ui = connections["default"].get_unified_index()
+        index = ui.get_index(Dataset)
+
+        with CaptureQueriesContext(connection) as ctx_3:
+            datasets_3 = list(index.index_queryset()[:3])
+            with patch("haystack.backends.elasticsearch_backend.ElasticsearchSearchBackend.update"):
+                for ds in datasets_3:
+                    index.full_prepare(ds)
+        count_3 = len(ctx_3.captured_queries)
+
+        with CaptureQueriesContext(connection) as ctx_10:
+            datasets_10 = list(index.index_queryset()[:10])
+            with patch("haystack.backends.elasticsearch_backend.ElasticsearchSearchBackend.update"):
+                for ds in datasets_10:
+                    index.full_prepare(ds)
+        count_10 = len(ctx_10.captured_queries)
+
+        assert count_10 <= count_3 + 5, (
+            f"Query count should scale constantly, got {count_3} for 3 datasets vs {count_10} for 10"
+        )

--- a/tests/datasets/test_index.py
+++ b/tests/datasets/test_index.py
@@ -1,0 +1,36 @@
+from django.db import connection
+from haystack import connections
+
+from unittest.mock import patch
+
+import pytest
+from django.test.utils import CaptureQueriesContext
+
+from vitrina.datasets.factories import DatasetFactory
+from vitrina.datasets.models import Dataset
+
+
+@pytest.mark.django_db
+class TestDatasetIndexQuery:
+    def test_dataset_index_query_count(self):
+        DatasetFactory()
+        DatasetFactory()
+        DatasetFactory()
+        DatasetFactory()
+        DatasetFactory()
+
+        ui = connections["default"].get_unified_index()
+        index = ui.get_index(Dataset)
+
+        datasets = list(index.index_queryset()[:5])
+
+        # Bulk load tags via index method
+        index._bulk_load_tags(datasets)
+
+        docs = []
+        with CaptureQueriesContext(connection) as ctx:
+            with patch("haystack.backends.elasticsearch_backend.ElasticsearchSearchBackend.update", autospec=True):
+                for ds in datasets:
+                    docs.append(index.full_prepare(ds))
+
+            assert len(ctx.captured_queries) == 0, f"Too many queries: {len(ctx.captured_queries)}"

--- a/tests/datasets/test_index.py
+++ b/tests/datasets/test_index.py
@@ -87,9 +87,7 @@ class TestDatasetIndexQuery:
 
         # Should use EXISTS, not DISTINCT
         assert "EXISTS" in main_query, "Expected EXISTS subquery for translation filter"
-        assert "DISTINCT" not in main_query or "SELECT DISTINCT" not in main_query, (
-            "Should not use DISTINCT with EXISTS subquery"
-        )
+        assert "SELECT DISTINCT" not in main_query, "Should not use DISTINCT with EXISTS subquery"
 
     def test_query_count_scales_constantly(self):
         for _ in range(10):

--- a/tests/datasets/test_index.py
+++ b/tests/datasets/test_index.py
@@ -7,16 +7,25 @@ import pytest
 
 from vitrina.datasets.factories import DatasetFactory
 from vitrina.datasets.models import Dataset
+from vitrina.projects.factories import ProjectFactory
+from vitrina.requests.factories import RequestFactory
+from vitrina.resources.factories import DatasetDistributionFactory
+from vitrina.structure.factories import ModelFactory, PropertyFactory
 
 
 @pytest.mark.django_db
 class TestDatasetIndexQuery:
-    QUERY_COUNT_THRESHOLD = 16
+    QUERY_COUNT_THRESHOLD = 23
 
     def test_bulk_index_query_count(self):
         datasets_to_create = 5
         for _ in range(datasets_to_create):
-            DatasetFactory()
+            dataset = DatasetFactory()
+            DatasetDistributionFactory(dataset=dataset)
+            model = ModelFactory(metadata_version__dataset=dataset)
+            PropertyFactory(model=model, metadata_version=model.metadata_version)
+            RequestFactory(dataset=dataset)
+            ProjectFactory(datasets=[dataset])
 
         ui = connections["default"].get_unified_index()
         index = ui.get_index(Dataset)

--- a/tests/datasets/test_index.py
+++ b/tests/datasets/test_index.py
@@ -11,7 +11,7 @@ from vitrina.datasets.models import Dataset
 
 @pytest.mark.django_db
 class TestDatasetIndexQuery:
-    QUERY_COUNT_THRESHOLD = 15
+    QUERY_COUNT_THRESHOLD = 16
 
     def test_bulk_index_query_count(self):
         datasets_to_create = 5

--- a/vitrina/datasets/models.py
+++ b/vitrina/datasets/models.py
@@ -693,12 +693,7 @@ class Dataset(Resource):
         return ""
 
     def get_resource_titles(self) -> list[str]:
-        titles = []
-        for dist in self.datasetdistribution_set.all():
-            for trans in dist.translations.all():
-                if trans.title:
-                    titles.append(trans.title)
-        return titles
+        return [dist.title for dist in self.datasetdistribution_set.all() if dist.title]
 
     def get_model_title_list(self) -> list[str]:
         return [model.title for model in self.model_set.all()]
@@ -710,20 +705,13 @@ class Dataset(Resource):
         return [prop.title for model in self.model_set.all() for prop in model.model_properties.all() if prop.title]
 
     def get_request_title_list(self) -> list[str]:
-        return [
-            trans.title for request in self.dataset_request.all() for trans in request.translations.all() if trans.title
-        ]
+        return [request.title for request in self.dataset_request.all() if request.title]
 
     def get_project_title_list(self) -> list[str]:
         return [project.title for project in self.project_set.all()]
 
     def get_resource_description(self) -> list[str]:
-        return [
-            trans.description
-            for dist in self.datasetdistribution_set.all()
-            for trans in dist.translations.all()
-            if trans.description
-        ]
+        return [dist.description for dist in self.datasetdistribution_set.all() if dist.description]
 
     def get_model_title_description(self) -> list[str]:
         return [model.description for model in self.model_set.all()]
@@ -737,12 +725,7 @@ class Dataset(Resource):
         ]
 
     def get_request_title_description(self) -> list[str]:
-        return [
-            trans.description
-            for request in self.dataset_request.all()
-            for trans in request.translations.all()
-            if trans.description
-        ]
+        return [request.description for request in self.dataset_request.all() if request.description]
 
     def get_project_title_description(self) -> list[str]:
         return [project.description for project in self.project_set.all()]
@@ -825,7 +808,7 @@ class Dataset(Resource):
     def filter_formats(self):
         formats = [obj.get_format().pk for obj in self.datasetdistribution_set.all() if obj.get_format()]
 
-        if self.model_set.exists() and any(
+        if list(self.model_set.all()) and any(
             dist.format.extension == "UAPI" for dist in self.datasetdistribution_set.all() if dist.format
         ):
             from vitrina.resources.models import Format
@@ -894,7 +877,10 @@ class Dataset(Resource):
         resource_roles = {Representative.RESOURCE_COORDINATOR, Representative.RESOURCE_MANAGER}
         open_data_roles = {Representative.OPEN_DATA_COORDINATOR, Representative.OPEN_DATA_MANAGER}
 
-        ancestors = list(self.get_ancestors().only("pk", "organization_id"))
+        if self.depth == 1:
+            ancestors = []
+        else:
+            ancestors = list(self.get_ancestors().only("pk", "organization_id"))
 
         if not ancestors:
             all_reps = list(self.representatives.all())

--- a/vitrina/datasets/models.py
+++ b/vitrina/datasets/models.py
@@ -766,7 +766,7 @@ class Dataset(Resource):
         return list(group_pks)
 
     def get_excluded_groups(self) -> list[int]:
-        return [excluded_groups.group_id for excluded_groups in self.excluded_groups.all()]
+        return [excluded_group.group_id for excluded_group in self.excluded_groups.all()]
 
     def get_parent_organization_title(self):
         if self.organization:

--- a/vitrina/datasets/models.py
+++ b/vitrina/datasets/models.py
@@ -756,7 +756,7 @@ class Dataset(Resource):
         return DatasetGroup.objects.filter(pk__in=ids).exclude(pk__in=self.get_excluded_groups())
 
     def get_group_list(self) -> list[int]:
-        excluded_pks = {eg.group_id for eg in self.excluded_groups.all()}
+        excluded_pks = self.get_excluded_groups()
         group_pks = {
             uri.group_id
             for category in self.category.all()
@@ -766,7 +766,7 @@ class Dataset(Resource):
         return list(group_pks)
 
     def get_excluded_groups(self) -> list[int]:
-        return [eg.group_id for eg in self.excluded_groups.all()]
+        return [excluded_groups.group_id for excluded_groups in self.excluded_groups.all()]
 
     def get_parent_organization_title(self):
         if self.organization:
@@ -887,26 +887,53 @@ class Dataset(Resource):
             .distinct()
         )
 
+    def _ensure_managers_cached(self) -> None:
+        if hasattr(self, "_cached_resource_managers"):
+            return
+
+        resource_roles = {Representative.RESOURCE_COORDINATOR, Representative.RESOURCE_MANAGER}
+        open_data_roles = {Representative.OPEN_DATA_COORDINATOR, Representative.OPEN_DATA_MANAGER}
+
+        ancestors = list(self.get_ancestors().only("pk", "organization_id"))
+
+        if not ancestors:
+            all_reps = list(self.representatives.all())
+            if self.organization:
+                all_reps.extend(self.organization.representatives.all())
+        else:
+            all_roles = resource_roles | open_data_roles
+            dataset_ct = ContentType.objects.get_for_model(Dataset)
+            organization_ct = ContentType.objects.get_for_model(Organization)
+
+            dataset_ids = {self.id}
+            organization_ids = {self.organization_id}
+            for parent in ancestors:
+                dataset_ids.add(parent.pk)
+                organization_ids.add(parent.organization_id)
+
+            all_reps = list(
+                Representative.objects.filter(
+                    Q(content_type=dataset_ct, object_id__in=dataset_ids, role__in=all_roles)
+                    | Q(content_type=organization_ct, object_id__in=organization_ids, role__in=all_roles),
+                    user__isnull=False,
+                )
+            )
+
+        self._cached_resource_managers = {
+            rep.user_id for rep in all_reps if rep.role in resource_roles and rep.user_id is not None
+        }
+        self._cached_open_data_managers = {
+            rep.user_id for rep in all_reps if rep.role in open_data_roles and rep.user_id is not None
+        }
+
     @property
     def resource_managers(self) -> set[int]:
-        if not hasattr(self, "_cached_resource_managers"):
-            resource_roles = {Representative.RESOURCE_COORDINATOR, Representative.RESOURCE_MANAGER}
-            self._cached_resource_managers = {
-                rep.user_id
-                for rep in self.representatives.all()
-                if rep.role in resource_roles and rep.user_id is not None
-            }
+        self._ensure_managers_cached()
         return self._cached_resource_managers
 
     @property
     def open_data_managers(self) -> set[int]:
-        if not hasattr(self, "_cached_open_data_managers"):
-            open_data_roles = {Representative.OPEN_DATA_COORDINATOR, Representative.OPEN_DATA_MANAGER}
-            self._cached_open_data_managers = {
-                rep.user_id
-                for rep in self.representatives.all()
-                if rep.role in open_data_roles and rep.user_id is not None
-            }
+        self._ensure_managers_cached()
         return self._cached_open_data_managers
 
     @property

--- a/vitrina/datasets/models.py
+++ b/vitrina/datasets/models.py
@@ -15,6 +15,7 @@ from django.utils.safestring import mark_safe
 from django.utils.timezone import make_aware
 from django.utils.translation import gettext_lazy as _
 from filer.fields.file import FilerFileField
+from tagulous.models import TagModel
 from parler.models import TranslatedFields, TranslatableModel
 from tagulous.models import TagField
 from treebeard.mp_tree import MP_Node
@@ -669,26 +670,29 @@ class Dataset(Resource):
     def get_absolute_url(self):
         return reverse("dataset-detail", kwargs={"pk": self.pk})
 
-    def get_tag_object_list(self):
-        if not hasattr(self, "_cached_tag_object_list"):
-            self._cached_tag_object_list = list(self.tags.all().values("name", "pk"))
-        return self._cached_tag_object_list
-
-    def get_tag_list(self):
-        if not hasattr(self, "_cached_tag_list"):
+    def _get_tags_from_cache_or_db(self) -> list[TagModel]:
+        if not hasattr(self, "_cached_tags"):
             prefetched = getattr(self, "_prefetched_objects_cache", {})
             if "tags" in prefetched:
-                self._cached_tag_list = [tag.pk for tag in prefetched["tags"]]
+                self._cached_tags = list(prefetched["tags"])
             else:
-                self._cached_tag_list = [tag.pk for tag in self.tags.all()]
-        return self._cached_tag_list
+                self._cached_tags = list(self.tags.all())
+        return self._cached_tags
 
-    def get_tag_title(self, tag_id):
+    def get_tag_object_list(self) -> list[dict]:
+        tags = self._get_tags_from_cache_or_db()
+        return [{"name": tag.name, "pk": tag.pk} for tag in tags]
+
+    def get_tag_list(self) -> list[int]:
+        tags = self._get_tags_from_cache_or_db()
+        return [tag.pk for tag in tags]
+
+    def get_tag_title(self, tag_id) -> str:
         if tag := self.tags.tag_model.objects.filter(pk=tag_id).first():
             return tag.name
         return ""
 
-    def get_resource_titles(self):
+    def get_resource_titles(self) -> list[str]:
         titles = []
         for dist in self.datasetdistribution_set.all():
             for trans in dist.translations.all():
@@ -696,59 +700,51 @@ class Dataset(Resource):
                     titles.append(trans.title)
         return titles
 
-    def get_model_title_list(self):
+    def get_model_title_list(self) -> list[str]:
         return [model.title for model in self.model_set.all()]
 
-    def get_model_name_list(self):
+    def get_model_name_list(self) -> list[str]:
         return [model.full_name for model in self.model_set.all() if model.name]
 
-    def get_property_title_list(self):
-        titles = []
-        for model in self.model_set.all():
-            for prop in model.model_properties.all():
-                if prop.title:
-                    titles.append(prop.title)
-        return titles
+    def get_property_title_list(self) -> list[str]:
+        return [prop.title for model in self.model_set.all() for prop in model.model_properties.all() if prop.title]
 
-    def get_request_title_list(self):
-        titles = []
-        for request in self.dataset_request.all():
-            for trans in request.translations.all():
-                if trans.title:
-                    titles.append(trans.title)
-        return titles
+    def get_request_title_list(self) -> list[str]:
+        return [
+            trans.title for request in self.dataset_request.all() for trans in request.translations.all() if trans.title
+        ]
 
-    def get_project_title_list(self):
+    def get_project_title_list(self) -> list[str]:
         return [project.title for project in self.project_set.all()]
 
-    def get_resource_description(self):
-        descriptions = []
-        for dist in self.datasetdistribution_set.all():
-            for trans in dist.translations.all():
-                if trans.description:
-                    descriptions.append(trans.description)
-        return descriptions
+    def get_resource_description(self) -> list[str]:
+        return [
+            trans.description
+            for dist in self.datasetdistribution_set.all()
+            for trans in dist.translations.all()
+            if trans.description
+        ]
 
-    def get_model_title_description(self):
+    def get_model_title_description(self) -> list[str]:
         return [model.description for model in self.model_set.all()]
 
-    def get_property_title_description(self):
-        descriptions = []
-        for model in self.model_set.all():
-            for prop in model.model_properties.all():
-                if prop.description:
-                    descriptions.append(prop.description)
-        return descriptions
+    def get_property_title_description(self) -> list[str]:
+        return [
+            prop.description
+            for model in self.model_set.all()
+            for prop in model.model_properties.all()
+            if prop.description
+        ]
 
-    def get_request_title_description(self):
-        descriptions = []
-        for request in self.dataset_request.all():
-            for trans in request.translations.all():
-                if trans.description:
-                    descriptions.append(trans.description)
-        return descriptions
+    def get_request_title_description(self) -> list[str]:
+        return [
+            trans.description
+            for request in self.dataset_request.all()
+            for trans in request.translations.all()
+            if trans.description
+        ]
 
-    def get_project_title_description(self):
+    def get_project_title_description(self) -> list[str]:
         return [project.description for project in self.project_set.all()]
 
     def get_all_groups(self):
@@ -759,17 +755,17 @@ class Dataset(Resource):
         )
         return DatasetGroup.objects.filter(pk__in=ids).exclude(pk__in=self.get_excluded_groups())
 
-    def get_group_list(self):
+    def get_group_list(self) -> list[int]:
         excluded_pks = {eg.group_id for eg in self.excluded_groups.all()}
-
-        group_pks = set()
-        for category in self.category.all():
-            for uri in category.datasetgroupcategoryuri_set.all():
-                if uri.group_id is not None and uri.group_id not in excluded_pks:
-                    group_pks.add(uri.group_id)
+        group_pks = {
+            uri.group_id
+            for category in self.category.all()
+            for uri in category.datasetgroupcategoryuri_set.all()
+            if uri.group_id is not None and uri.group_id not in excluded_pks
+        }
         return list(group_pks)
 
-    def get_excluded_groups(self):
+    def get_excluded_groups(self) -> list[int]:
         return [eg.group_id for eg in self.excluded_groups.all()]
 
     def get_parent_organization_title(self):
@@ -969,7 +965,7 @@ class Dataset(Resource):
                 return category.icon
         return None
 
-    def _get_first_metadata(self):
+    def _get_first_metadata(self) -> Metadata | None:
         prefetched = getattr(self, "_prefetched_objects_cache", {})
         if "metadata" in prefetched:
             if not hasattr(self, "_cached_first_metadata"):
@@ -985,7 +981,7 @@ class Dataset(Resource):
             return metadata.name
         return ""
 
-    def get_level(self):
+    def get_level(self) -> int | None:
         if metadata := self._get_first_metadata():
             return metadata.average_level
         return None
@@ -996,7 +992,7 @@ class Dataset(Resource):
             identifier.notation if (identifier := self.identifiers.filter(scheme_agency__code="risr").first()) else None
         )
 
-    def public_types(self):
+    def public_types(self) -> list[int]:
         return [t.pk for t in self.type.all() if t.show_filter]
 
     def type_order(self):

--- a/vitrina/datasets/models.py
+++ b/vitrina/datasets/models.py
@@ -670,10 +670,18 @@ class Dataset(Resource):
         return reverse("dataset-detail", kwargs={"pk": self.pk})
 
     def get_tag_object_list(self):
-        return list(self.tags.all().values("name", "pk"))
+        if not hasattr(self, "_cached_tag_object_list"):
+            self._cached_tag_object_list = list(self.tags.all().values("name", "pk"))
+        return self._cached_tag_object_list
 
     def get_tag_list(self):
-        return list(self.tags.all().values_list("pk", flat=True))
+        if not hasattr(self, "_cached_tag_list"):
+            prefetched = getattr(self, "_prefetched_objects_cache", {})
+            if "tags" in prefetched:
+                self._cached_tag_list = [tag.pk for tag in prefetched["tags"]]
+            else:
+                self._cached_tag_list = [tag.pk for tag in self.tags.all()]
+        return self._cached_tag_list
 
     def get_tag_title(self, tag_id):
         if tag := self.tags.tag_model.objects.filter(pk=tag_id).first():
@@ -681,37 +689,67 @@ class Dataset(Resource):
         return ""
 
     def get_resource_titles(self):
-        return list(self.datasetdistribution_set.all().values_list("translations__title", flat=True))
+        titles = []
+        for dist in self.datasetdistribution_set.all():
+            for trans in dist.translations.all():
+                if trans.title:
+                    titles.append(trans.title)
+        return titles
 
     def get_model_title_list(self):
-        return list(model.title for model in self.model_set.all())
+        return [model.title for model in self.model_set.all()]
 
     def get_model_name_list(self):
-        return list(model.full_name for model in self.model_set.all() if model.name)
+        return [model.full_name for model in self.model_set.all() if model.name]
 
     def get_property_title_list(self):
-        return list(item.title for item in Property.objects.filter(model__in=self.model_set.all()))
+        titles = []
+        for model in self.model_set.all():
+            for prop in model.model_properties.all():
+                if prop.title:
+                    titles.append(prop.title)
+        return titles
 
     def get_request_title_list(self):
-        return [request.title for request in self.dataset_request.prefetch_related("translations")]
+        titles = []
+        for request in self.dataset_request.all():
+            for trans in request.translations.all():
+                if trans.title:
+                    titles.append(trans.title)
+        return titles
 
     def get_project_title_list(self):
-        return list(self.project_set.all().values_list("title", flat=True))
+        return [project.title for project in self.project_set.all()]
 
     def get_resource_description(self):
-        return list(self.datasetdistribution_set.all().values_list("translations__description", flat=True))
+        descriptions = []
+        for dist in self.datasetdistribution_set.all():
+            for trans in dist.translations.all():
+                if trans.description:
+                    descriptions.append(trans.description)
+        return descriptions
 
     def get_model_title_description(self):
-        return list(model.description for model in self.model_set.all())
+        return [model.description for model in self.model_set.all()]
 
     def get_property_title_description(self):
-        return list(item.description for item in Property.objects.filter(model__in=self.model_set.all()))
+        descriptions = []
+        for model in self.model_set.all():
+            for prop in model.model_properties.all():
+                if prop.description:
+                    descriptions.append(prop.description)
+        return descriptions
 
     def get_request_title_description(self):
-        return [request.description for request in self.dataset_request.prefetch_related("translations")]
+        descriptions = []
+        for request in self.dataset_request.all():
+            for trans in request.translations.all():
+                if trans.description:
+                    descriptions.append(trans.description)
+        return descriptions
 
     def get_project_title_description(self):
-        return list(self.project_set.all().values_list("description", flat=True))
+        return [project.description for project in self.project_set.all()]
 
     def get_all_groups(self):
         ids = (
@@ -722,15 +760,17 @@ class Dataset(Resource):
         return DatasetGroup.objects.filter(pk__in=ids).exclude(pk__in=self.get_excluded_groups())
 
     def get_group_list(self):
-        return list(
-            self.category.filter(datasetgroupcategoryuri__group__isnull=False)
-            .values_list("datasetgroupcategoryuri__group__pk", flat=True)
-            .distinct()
-            .exclude(pk__in=self.get_excluded_groups())
-        )
+        excluded_pks = {eg.group_id for eg in self.excluded_groups.all()}
+
+        group_pks = set()
+        for category in self.category.all():
+            for uri in category.datasetgroupcategoryuri_set.all():
+                if uri.group_id is not None and uri.group_id not in excluded_pks:
+                    group_pks.add(uri.group_id)
+        return list(group_pks)
 
     def get_excluded_groups(self):
-        return DatasetExcludedGroups.objects.filter(dataset=self).values_list("group__pk", flat=True)
+        return [eg.group_id for eg in self.excluded_groups.all()]
 
     def get_parent_organization_title(self):
         if self.organization:
@@ -853,25 +893,25 @@ class Dataset(Resource):
 
     @property
     def resource_managers(self) -> set[int]:
-        return set(
-            self.get_managers_queryset(
-                [
-                    Representative.RESOURCE_COORDINATOR,
-                    Representative.RESOURCE_MANAGER,
-                ]
-            )
-        )
+        if not hasattr(self, "_cached_resource_managers"):
+            resource_roles = {Representative.RESOURCE_COORDINATOR, Representative.RESOURCE_MANAGER}
+            self._cached_resource_managers = {
+                rep.user_id
+                for rep in self.representatives.all()
+                if rep.role in resource_roles and rep.user_id is not None
+            }
+        return self._cached_resource_managers
 
     @property
     def open_data_managers(self) -> set[int]:
-        return set(
-            self.get_managers_queryset(
-                [
-                    Representative.OPEN_DATA_COORDINATOR,
-                    Representative.OPEN_DATA_MANAGER,
-                ]
-            )
-        )
+        if not hasattr(self, "_cached_open_data_managers"):
+            open_data_roles = {Representative.OPEN_DATA_COORDINATOR, Representative.OPEN_DATA_MANAGER}
+            self._cached_open_data_managers = {
+                rep.user_id
+                for rep in self.representatives.all()
+                if rep.role in open_data_roles and rep.user_id is not None
+            }
+        return self._cached_open_data_managers
 
     @property
     def language_array(self):
@@ -908,11 +948,6 @@ class Dataset(Resource):
                 metadata.average_level = sum(levels) / len(levels)
                 metadata.save()
 
-    def get_level(self):
-        if metadata := self.metadata.first():
-            return metadata.average_level
-        return None
-
     def published_created_sort(self):
         return self.published or self.created
 
@@ -934,11 +969,26 @@ class Dataset(Resource):
                 return category.icon
         return None
 
+    def _get_first_metadata(self):
+        prefetched = getattr(self, "_prefetched_objects_cache", {})
+        if "metadata" in prefetched:
+            if not hasattr(self, "_cached_first_metadata"):
+                metadata_list = list(self.metadata.all())
+                self._cached_first_metadata = metadata_list[0] if metadata_list else None
+            return self._cached_first_metadata
+        else:
+            return self.metadata.first()
+
     @property
     def name(self):
-        if metadata := self.metadata.first():
+        if metadata := self._get_first_metadata():
             return metadata.name
         return ""
+
+    def get_level(self):
+        if metadata := self._get_first_metadata():
+            return metadata.average_level
+        return None
 
     @property
     def identifier(self) -> str | None:
@@ -947,7 +997,7 @@ class Dataset(Resource):
         )
 
     def public_types(self):
-        return list(self.type.filter(show_filter=True).values_list("pk", flat=True))
+        return [t.pk for t in self.type.all() if t.show_filter]
 
     def type_order(self):
         order = 0

--- a/vitrina/datasets/search_indexes.py
+++ b/vitrina/datasets/search_indexes.py
@@ -1,4 +1,7 @@
 from django.contrib.contenttypes.models import ContentType
+from django.db.models import Prefetch
+from vitrina.resources.models import DatasetDistribution
+from vitrina.structure.models import Model
 from haystack.fields import (
     CharField,
     IntegerField,
@@ -80,6 +83,36 @@ class DatasetIndex(SearchIndex, Indexable):
                 organization_id__isnull=False,
                 translations__title__isnull=False,
             )
+            .select_related(
+                "organization",
+                "organization__jurisdiction",
+                "frequency",
+                "subclass",
+            )
+            .prefetch_related(
+                "tags",
+                "translations",
+                "subclass__translations",
+                "category",
+                "category__datasetgroupcategoryuri_set",
+                "excluded_groups",
+                "type",
+                "part_of",
+                "related_datasets",
+                "metadata",
+                "representatives",
+                "project_set",
+                Prefetch(
+                    "datasetdistribution_set", queryset=DatasetDistribution.objects.prefetch_related("translations")
+                ),
+                Prefetch(
+                    "model_set",
+                    queryset=Model.objects.prefetch_related(
+                        "model_properties",
+                    ),
+                ),
+                Prefetch("dataset_request", queryset=Request.objects.prefetch_related("translations")),
+            )
             .distinct()
         )
 
@@ -89,6 +122,42 @@ class DatasetIndex(SearchIndex, Indexable):
             categories.extend([cat.pk for cat in category.get_ancestors() if cat.dataset_set.exists()])
             categories.append(category.pk)
         return categories
+
+    def prepare_tags(self, obj):
+        if hasattr(obj, "_cached_tag_list"):
+            return obj._cached_tag_list
+        return [t.pk for t in obj.tags.all()]
+
+    def prepare(self, obj):
+        if not hasattr(obj, "_cached_tag_list"):
+            self._bulk_load_tags([obj])
+        return super().prepare(obj)
+
+    def update_object(self, instance, using=None, **kwargs):
+        self._bulk_load_tags([instance])
+        super().update_object(instance, using, **kwargs)
+
+    def update(self, using=None):
+        backend = self.get_backend(using)
+        if backend is not None:
+            batch_size = 100
+            qs = self.index_queryset(using=using)
+            total = qs.count()
+
+            for start in range(0, total, batch_size):
+                batch = list(qs[start : start + batch_size])
+                self._bulk_load_tags(batch)
+                backend.update(self, batch)
+
+    def _bulk_load_tags(self, datasets):
+        if not datasets:
+            return
+
+        for ds in datasets:
+            tags = list(ds.tags.all())
+
+            ds._cached_tag_list = [t.pk for t in tags]
+            ds._cached_tag_object_list = [{"pk": t.pk, "name": t.name} for t in tags]
 
 
 class CustomSignalProcessor(signals.BaseSignalProcessor):

--- a/vitrina/datasets/search_indexes.py
+++ b/vitrina/datasets/search_indexes.py
@@ -39,7 +39,7 @@ class DatasetIndex(SearchIndex, Indexable):
     project_title = MultiValueField(model_attr="get_project_title_list", boost=0.9)
     category = MultiValueField(model_attr="category__pk", faceted=True, boost=0.8)
     organization = MultiValueField(model_attr="organization__pk", faceted=True, null=True, boost=0.8)
-    resource_description = MultiValueField(model_attr="get_resource_titles", boost=0.7)
+    resource_description = MultiValueField(model_attr="get_resource_description", boost=0.7)
     model_description = MultiValueField(model_attr="get_model_title_description", boost=0.7)
     property_description = MultiValueField(model_attr="get_property_title_description", boost=0.7)
     request_description = MultiValueField(model_attr="get_request_title_description", boost=0.7)

--- a/vitrina/datasets/search_indexes.py
+++ b/vitrina/datasets/search_indexes.py
@@ -1,7 +1,7 @@
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Prefetch, Exists, OuterRef
 from vitrina.resources.models import DatasetDistribution
-from vitrina.structure.models import Model
+from vitrina.structure.models import Model, Property
 from haystack.fields import (
     CharField,
     IntegerField,
@@ -105,12 +105,17 @@ class DatasetIndex(SearchIndex, Indexable):
                 "organization__representatives",
                 "project_set",
                 Prefetch(
-                    "datasetdistribution_set", queryset=DatasetDistribution.objects.prefetch_related("translations")
+                    "datasetdistribution_set",
+                    queryset=DatasetDistribution.objects.select_related("format").prefetch_related("translations"),
                 ),
                 Prefetch(
                     "model_set",
                     queryset=Model.objects.prefetch_related(
-                        "model_properties",
+                        "metadata",
+                        Prefetch(
+                            "model_properties",
+                            queryset=Property.objects.prefetch_related("metadata"),
+                        ),
                     ),
                 ),
                 Prefetch("dataset_request", queryset=Request.objects.prefetch_related("translations")),

--- a/vitrina/datasets/search_indexes.py
+++ b/vitrina/datasets/search_indexes.py
@@ -102,6 +102,7 @@ class DatasetIndex(SearchIndex, Indexable):
                 "related_datasets",
                 "metadata",
                 "representatives",
+                "organization__representatives",
                 "project_set",
                 Prefetch(
                     "datasetdistribution_set", queryset=DatasetDistribution.objects.prefetch_related("translations")

--- a/vitrina/datasets/search_indexes.py
+++ b/vitrina/datasets/search_indexes.py
@@ -1,5 +1,5 @@
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import Prefetch
+from django.db.models import Prefetch, Exists, OuterRef
 from vitrina.resources.models import DatasetDistribution
 from vitrina.structure.models import Model
 from haystack.fields import (
@@ -74,6 +74,7 @@ class DatasetIndex(SearchIndex, Indexable):
         return Dataset
 
     def index_queryset(self, using=None):
+        DatasetTranslation = Dataset._parler_meta.root_model
         return (
             self.get_model()
             .objects.all()
@@ -81,8 +82,8 @@ class DatasetIndex(SearchIndex, Indexable):
                 deleted__isnull=True,
                 deleted_on__isnull=True,
                 organization_id__isnull=False,
-                translations__title__isnull=False,
             )
+            .filter(Exists(DatasetTranslation.objects.filter(master_id=OuterRef("pk"), title__isnull=False)))
             .select_related(
                 "organization",
                 "organization__jurisdiction",
@@ -113,7 +114,6 @@ class DatasetIndex(SearchIndex, Indexable):
                 ),
                 Prefetch("dataset_request", queryset=Request.objects.prefetch_related("translations")),
             )
-            .distinct()
         )
 
     def prepare_category(self, obj):
@@ -122,42 +122,6 @@ class DatasetIndex(SearchIndex, Indexable):
             categories.extend([cat.pk for cat in category.get_ancestors() if cat.dataset_set.exists()])
             categories.append(category.pk)
         return categories
-
-    def prepare_tags(self, obj):
-        if hasattr(obj, "_cached_tag_list"):
-            return obj._cached_tag_list
-        return [t.pk for t in obj.tags.all()]
-
-    def prepare(self, obj):
-        if not hasattr(obj, "_cached_tag_list"):
-            self._bulk_load_tags([obj])
-        return super().prepare(obj)
-
-    def update_object(self, instance, using=None, **kwargs):
-        self._bulk_load_tags([instance])
-        super().update_object(instance, using, **kwargs)
-
-    def update(self, using=None):
-        backend = self.get_backend(using)
-        if backend is not None:
-            batch_size = 100
-            qs = self.index_queryset(using=using)
-            total = qs.count()
-
-            for start in range(0, total, batch_size):
-                batch = list(qs[start : start + batch_size])
-                self._bulk_load_tags(batch)
-                backend.update(self, batch)
-
-    def _bulk_load_tags(self, datasets):
-        if not datasets:
-            return
-
-        for ds in datasets:
-            tags = list(ds.tags.all())
-
-            ds._cached_tag_list = [t.pk for t in tags]
-            ds._cached_tag_object_list = [{"pk": t.pk, "name": t.name} for t in tags]
 
 
 class CustomSignalProcessor(signals.BaseSignalProcessor):

--- a/vitrina/structure/models.py
+++ b/vitrina/structure/models.py
@@ -192,38 +192,45 @@ class Model(models.Model):
         db_table = "model"
         verbose_name = _("Modelis")
 
+    def _get_first_metadata(self) -> Metadata | None:
+        prefetched = getattr(self, "_prefetched_objects_cache", {})
+        if "metadata" in prefetched:
+            metadata_list = list(self.metadata.all())
+            return metadata_list[0] if metadata_list else None
+        return self.metadata.first()
+
     def __str__(self) -> str:
-        if metadata := self.metadata.first():
+        if metadata := self._get_first_metadata():
             return metadata.name
         return ""
 
     @property
     def name(self) -> str:
-        if metadata := self.metadata.first():
+        if metadata := self._get_first_metadata():
             return metadata.name.split("/")[-1]
         return ""
 
     @property
     def full_name(self) -> str:
-        if metadata := self.metadata.first():
+        if metadata := self._get_first_metadata():
             return metadata.name
         return ""
 
     @property
     def title(self) -> str:
-        if metadata := self.metadata.first():
+        if metadata := self._get_first_metadata():
             return metadata.title
         return ""
 
     @property
     def description(self) -> str:
-        if metadata := self.metadata.first():
+        if metadata := self._get_first_metadata():
             return metadata.description
         return ""
 
     @property
     def visibility(self) -> int | None:
-        if metadata := self.metadata.first():
+        if metadata := self._get_first_metadata():
             return metadata.visibility
         return None
 
@@ -374,8 +381,15 @@ class Property(models.Model):
         db_table = "property"
         verbose_name = _("Savybė")
 
+    def _get_first_metadata(self) -> Metadata | None:
+        prefetched = getattr(self, "_prefetched_objects_cache", {})
+        if "metadata" in prefetched:
+            metadata_list = list(self.metadata.all())
+            return metadata_list[0] if metadata_list else None
+        return self.metadata.first()
+
     def __str__(self):
-        if metadata := self.metadata.first():
+        if metadata := self._get_first_metadata():
             return metadata.name
         return ""
 
@@ -394,25 +408,25 @@ class Property(models.Model):
 
     @builtins.property
     def name(self):
-        if metadata := self.metadata.first():
+        if metadata := self._get_first_metadata():
             return metadata.name
         return ""
 
     @builtins.property
     def title(self):
-        if metadata := self.metadata.first():
+        if metadata := self._get_first_metadata():
             return metadata.title
         return ""
 
     @builtins.property
     def description(self):
-        if metadata := self.metadata.first():
+        if metadata := self._get_first_metadata():
             return metadata.description
         return ""
 
     @builtins.property
     def visibility(self) -> int | None:
-        if metadata := self.metadata.first():
+        if metadata := self._get_first_metadata():
             return metadata.visibility
         return None
 

--- a/vitrina/structure/models.py
+++ b/vitrina/structure/models.py
@@ -195,8 +195,10 @@ class Model(models.Model):
     def _get_first_metadata(self) -> Metadata | None:
         prefetched = getattr(self, "_prefetched_objects_cache", {})
         if "metadata" in prefetched:
-            metadata_list = list(self.metadata.all())
-            return metadata_list[0] if metadata_list else None
+            if not hasattr(self, "_cached_first_metadata"):
+                metadata_list = list(self.metadata.all())
+                self._cached_first_metadata = metadata_list[0] if metadata_list else None
+            return self._cached_first_metadata
         return self.metadata.first()
 
     def __str__(self) -> str:
@@ -384,8 +386,10 @@ class Property(models.Model):
     def _get_first_metadata(self) -> Metadata | None:
         prefetched = getattr(self, "_prefetched_objects_cache", {})
         if "metadata" in prefetched:
-            metadata_list = list(self.metadata.all())
-            return metadata_list[0] if metadata_list else None
+            if not hasattr(self, "_cached_first_metadata"):
+                metadata_list = list(self.metadata.all())
+                self._cached_first_metadata = metadata_list[0] if metadata_list else None
+            return self._cached_first_metadata
         return self.metadata.first()
 
     def __str__(self):


### PR DESCRIPTION
from 245 queries to 23.

`rebuild_index` time before and after:
```
Before:
poetry run python manage.py rebuild_index --noinput  248,44s

After:
poetry run python manage.py rebuild_index --noinput  41,67s
```

```
--- Query 1/23 ---
SELECT "dataset"."id", "dataset"."path", "dataset"."numchild", "dataset"."depth", "dataset"."created", "dataset"."modified", "dataset"."deleted", "dataset"."deleted_on", "dataset"."soft_deleted", "dataset"."version", "dataset"."slug", "dataset"."uuid", "dataset"."internal_id", "dataset"."theme", "dataset"."category_old", "dataset"."catalog", "dataset"."origin", "dataset"."organization_id", "dataset"."status", "dataset"."published", "dataset"."is_public", "dataset"."language", "dataset"."spatial_coverage", "dataset"."temporal_coverage", "dataset"."update_frequency", "dataset"."frequency_id", "dataset"."last_update", "dataset"."access_rights", "dataset"."notes", "dataset"."geoportal_id", "dataset"."creator_text", "dataset"."publisher_id", "dataset"."landing_page", "dataset"."is_hvd", "dataset"."subclass_id", "dataset"."endpoint_url", "dataset"."endpoint_type_id", "dataset"."endpoint_description", "dataset"."endpoint_description_type_id", "dataset"."service", "dataset"."series", "dataset"."information_system_type_id", "dataset"."information_system_importance_id", "dataset"."temporal_start", "dataset"."temporal_end", "dataset"."information_system_publisher_id", "dataset"."information_system_creator_id", "dataset"."temporal_resolution", "dataset"."spatial_resolution", "dataset"."rights_relation", "dataset"."contact_id", "dataset"."meta", "dataset"."priority_score", "dataset"."structure_data", "dataset"."structure_filename", "dataset"."current_structure_id", "dataset"."financed", "dataset"."financing_plan_id", "dataset"."financing_priorities", "dataset"."financing_received", "dataset"."financing_required", "dataset"."will_be_financed", "organization"."id", "organization"."path", "organization"."depth", "organization"."numchild", "organization"."created", "organization"."modified", "organization"."version", "organization"."description", "organization"."municipality", "organization"."region", "organization"."slug", "organization"."title", "organization"."uuid", "organization"."deleted", "organization"."deleted_on", "organization"."address", "organization"."company_code", "organization"."email", "organization"."is_public", "organization"."phone", "organization"."jurisdiction_id", "organization"."website", "organization"."kind", "organization"."role", "organization"."image_id", "organization"."publisher", "organization"."name", "organization"."alternative_titles", "organization"."imageuuid", "area_of_management"."id", "area_of_management"."name_lt", "area_of_management"."name_en", "frequency"."id", "frequency"."created", "frequency"."modified", "frequency"."version", "frequency"."deleted", "frequency"."deleted_on", "frequency"."title", "frequency"."title_en", "frequency"."uri", "frequency"."is_default", "frequency"."hours", "frequency"."code", "vitrina_datasets_dcatresourcesubclass"."uuid", "vitrina_datasets_dcatresourcesubclass"."created_at", "vitrina_datasets_dcatresourcesubclass"."updated_at", "vitrina_datasets_dcatresourcesubclass"."name", "vitrina_datasets_dcatresourcesubclass"."uri" FROM "dataset" INNER JOIN "organization" ON ("dataset"."organization_id" = "organization"."id") INNER JOIN "area_of_management" ON ("organization"."jurisdiction_id" = "area_of_management"."id") LEFT OUTER JOIN "frequency" ON ("dataset"."frequency_id" = "frequency"."id") INNER JOIN "vitrina_datasets_dcatresourcesubclass" ON ("dataset"."subclass_id" = "vitrina_datasets_dcatresourcesubclass"."uuid") WHERE ("dataset"."deleted" IS NULL AND "dataset"."deleted_on" IS NULL AND "dataset"."organization_id" IS NOT NULL AND EXISTS(SELECT 1 AS "a" FROM "dataset_translation" U0 WHERE (U0."master_id" = ("dataset"."id") AND U0."title" IS NOT NULL) LIMIT 1)) ORDER BY "dataset"."path" ASC LIMIT 5

--- Query 2/23 ---
SELECT ("dataset_tags"."dataset_id") AS "_prefetch_related_val_dataset_id", "vitrina_datasets_tagulous_dataset_tags"."id", "vitrina_datasets_tagulous_dataset_tags"."name", "vitrina_datasets_tagulous_dataset_tags"."slug", "vitrina_datasets_tagulous_dataset_tags"."count", "vitrina_datasets_tagulous_dataset_tags"."protected" FROM "vitrina_datasets_tagulous_dataset_tags" INNER JOIN "dataset_tags" ON ("vitrina_datasets_tagulous_dataset_tags"."id" = "dataset_tags"."tagulous_dataset_tags_id") WHERE "dataset_tags"."dataset_id" IN (1, 2, 3, 4, 5) ORDER BY "vitrina_datasets_tagulous_dataset_tags"."name" ASC

--- Query 3/23 ---
SELECT "dataset_translation"."id", "dataset_translation"."language_code", "dataset_translation"."title", "dataset_translation"."description", "dataset_translation"."conditions", "dataset_translation"."master_id" FROM "dataset_translation" WHERE "dataset_translation"."master_id" IN (1, 2, 3, 4, 5)

--- Query 4/23 ---
SELECT "vitrina_datasets_dcatresourcesubclass_translation"."id", "vitrina_datasets_dcatresourcesubclass_translation"."language_code", "vitrina_datasets_dcatresourcesubclass_translation"."title", "vitrina_datasets_dcatresourcesubclass_translation"."description", "vitrina_datasets_dcatresourcesubclass_translation"."master_id" FROM "vitrina_datasets_dcatresourcesubclass_translation" WHERE "vitrina_datasets_dcatresourcesubclass_translation"."master_id" IN ('b15f1cc7-060d-4aff-8081-10786298575a'::uuid)

--- Query 5/23 ---
SELECT ("dataset_category"."dataset_id") AS "_prefetch_related_val_dataset_id", "category"."id", "category"."path", "category"."depth", "category"."numchild", "category"."created", "category"."modified", "category"."version", "category"."deleted", "category"."deleted_on", "category"."uri", "category"."title", "category"."title_en", "category"."edp_title", "category"."description", "category"."parent_id", "category"."featured", "category"."icon" FROM "category" INNER JOIN "dataset_category" ON ("category"."id" = "dataset_category"."category_id") WHERE "dataset_category"."dataset_id" IN (1, 2, 3, 4, 5) ORDER BY "category"."path" ASC

--- Query 6/23 ---
SELECT "dataset_excluded_groups"."id", "dataset_excluded_groups"."dataset_id", "dataset_excluded_groups"."group_id" FROM "dataset_excluded_groups" WHERE "dataset_excluded_groups"."dataset_id" IN (1, 2, 3, 4, 5)

--- Query 7/23 ---
SELECT ("dataset_type"."dataset_id") AS "_prefetch_related_val_dataset_id", "type"."id", "type"."name", "type"."uri", "type"."description", "type"."show_filter" FROM "type" INNER JOIN "dataset_type" ON ("type"."id" = "dataset_type"."type_id") WHERE "dataset_type"."dataset_id" IN (1, 2, 3, 4, 5)

--- Query 8/23 ---
SELECT ("dataset_part_of"."dataset_id") AS "_prefetch_related_val_dataset_id", "dataset_relation"."id", "dataset_relation"."relation_id", "dataset_relation"."dataset_id", "dataset_relation"."part_of_id" FROM "dataset_relation" INNER JOIN "dataset_part_of" ON ("dataset_relation"."id" = "dataset_part_of"."datasetrelation_id") WHERE "dataset_part_of"."dataset_id" IN (1, 2, 3, 4, 5)

--- Query 9/23 ---
SELECT "dataset_relation"."id", "dataset_relation"."relation_id", "dataset_relation"."dataset_id", "dataset_relation"."part_of_id" FROM "dataset_relation" WHERE "dataset_relation"."part_of_id" IN (1, 2, 3, 4, 5)

--- Query 10/23 ---
SELECT "metadata"."id", "metadata"."uuid", "metadata"."name", "metadata"."type", "metadata"."ref", "metadata"."source", "metadata"."prepare", "metadata"."prepare_ast", "metadata"."level", "metadata"."level_given", "metadata"."average_level", "metadata"."access", "metadata"."visibility", "metadata"."eli", "metadata"."status_id", "metadata"."count", "metadata"."prefix_id", "metadata"."uri", "metadata"."version", "metadata"."title", "metadata"."description", "metadata"."order", "metadata"."content_type_id", "metadata"."object_id", "metadata"."dataset_id", "metadata"."required", "metadata"."unique", "metadata"."type_args", "metadata"."metadata_version_id", "metadata"."draft" FROM "metadata" WHERE ("metadata"."content_type_id" = 112 AND "metadata"."object_id" IN (1, 2, 3, 4, 5))

--- Query 11/23 ---
SELECT "representative"."id", "representative"."created", "representative"."modified", "representative"."version", "representative"."email", "representative"."first_name", "representative"."last_name", "representative"."phone", "representative"."deleted", "representative"."deleted_on", "representative"."role", "representative"."user_id", "representative"."organization_id", "representative"."has_api_access", "representative"."content_type_id", "representative"."object_id", "representative"."can_make_agreements" FROM "representative" WHERE ("representative"."content_type_id" = 112 AND "representative"."object_id" IN (1, 2, 3, 4, 5))

--- Query 12/23 ---
SELECT "representative"."id", "representative"."created", "representative"."modified", "representative"."version", "representative"."email", "representative"."first_name", "representative"."last_name", "representative"."phone", "representative"."deleted", "representative"."deleted_on", "representative"."role", "representative"."user_id", "representative"."organization_id", "representative"."has_api_access", "representative"."content_type_id", "representative"."object_id", "representative"."can_make_agreements" FROM "representative" WHERE ("representative"."content_type_id" = 86 AND "representative"."object_id" IN (1, 2, 3, 4, 5))

--- Query 13/23 ---
SELECT ("usecase_datasets"."dataset_id") AS "_prefetch_related_val_dataset_id", "usecase"."id", "usecase"."created", "usecase"."modified", "usecase"."version", "usecase"."beneficiary_group", "usecase"."benefit", "usecase"."description", "usecase"."extra_information", "usecase"."slug", "usecase"."status", "usecase"."url", "usecase"."uuid", "usecase"."user_id", "usecase"."deleted", "usecase"."deleted_on", "usecase"."comment", "usecase"."title", "usecase"."image_id", "usecase"."organization_id", "usecase"."is_public", "usecase"."other_assignee_legislations", "usecase"."imageuuid" FROM "usecase" INNER JOIN "usecase_datasets" ON ("usecase"."id" = "usecase_datasets"."project_id") WHERE "usecase_datasets"."dataset_id" IN (1, 2, 3, 4, 5)

--- Query 14/23 ---
SELECT "dataset_distribution"."id", "dataset_distribution"."created", "dataset_distribution"."modified", "dataset_distribution"."version", "dataset_distribution"."deleted", "dataset_distribution"."deleted_on", "dataset_distribution"."dataset_id", "dataset_distribution"."access_url", "dataset_distribution"."format_id", "dataset_distribution"."compression_format_id", "dataset_distribution"."packaging_format_id", "dataset_distribution"."download_url", "dataset_distribution"."file_id", "dataset_distribution"."geo_location", "dataset_distribution"."distribution_version", "dataset_distribution"."issued", "dataset_distribution"."comment", "dataset_distribution"."data_service_id", "dataset_distribution"."is_parameterized", "dataset_distribution"."upload_to_storage", "dataset_distribution"."imported", "dataset_distribution"."licence_id", "dataset_distribution"."temporal_resolution", "dataset_distribution"."spatial_resolution", "dataset_distribution"."status_id", "dataset_distribution"."rights_relation", "dataset_distribution"."is_hvd", "dataset_distribution"."period_start", "dataset_distribution"."period_end", "dataset_distribution"."type", "dataset_distribution"."mime_type", "dataset_distribution"."identifier", "dataset_distribution"."size", "dataset_distribution"."filename", "dataset_distribution"."metadata_version_id", "dataset_distribution"."access", "dataset_distribution"."name", "dataset_distribution"."level", "format"."id", "format"."created", "format"."modified", "format"."version", "format"."extension", "format"."deleted", "format"."deleted_on", "format"."mimetype", "format"."rating", "format"."title", "format"."uri", "format"."media_type_uri" FROM "dataset_distribution" LEFT OUTER JOIN "format" ON ("dataset_distribution"."format_id" = "format"."id") WHERE "dataset_distribution"."dataset_id" IN (1, 2, 3, 4, 5)

--- Query 15/23 ---
SELECT "dataset_distribution_translation"."id", "dataset_distribution_translation"."language_code", "dataset_distribution_translation"."title", "dataset_distribution_translation"."description", "dataset_distribution_translation"."conditions", "dataset_distribution_translation"."master_id" FROM "dataset_distribution_translation" WHERE "dataset_distribution_translation"."master_id" IN (1, 2, 3, 4, 5)

--- Query 16/23 ---
SELECT "model"."id", "model"."created", "model"."dataset_id", "model"."distribution_id", "model"."base_id", "model"."is_parameterized", "model"."metadata_version_id" FROM "model" WHERE "model"."dataset_id" IN (1, 2, 3, 4, 5)

--- Query 17/23 ---
SELECT "django_content_type"."id", "django_content_type"."app_label", "django_content_type"."model" FROM "django_content_type" WHERE ("django_content_type"."app_label" = 'vitrina_structure' AND "django_content_type"."model" = 'model') LIMIT 21

--- Query 18/23 ---
SELECT "metadata"."id", "metadata"."uuid", "metadata"."name", "metadata"."type", "metadata"."ref", "metadata"."source", "metadata"."prepare", "metadata"."prepare_ast", "metadata"."level", "metadata"."level_given", "metadata"."average_level", "metadata"."access", "metadata"."visibility", "metadata"."eli", "metadata"."status_id", "metadata"."count", "metadata"."prefix_id", "metadata"."uri", "metadata"."version", "metadata"."title", "metadata"."description", "metadata"."order", "metadata"."content_type_id", "metadata"."object_id", "metadata"."dataset_id", "metadata"."required", "metadata"."unique", "metadata"."type_args", "metadata"."metadata_version_id", "metadata"."draft" FROM "metadata" WHERE ("metadata"."content_type_id" = 151 AND "metadata"."object_id" IN (1, 2, 3, 4, 5))

--- Query 19/23 ---
SELECT "property"."id", "property"."created", "property"."model_id", "property"."ref_model_id", "property"."property_id", "property"."given", "property"."metadata_version_id" FROM "property" WHERE "property"."model_id" IN (1, 2, 3, 4, 5)

--- Query 20/23 ---
SELECT "django_content_type"."id", "django_content_type"."app_label", "django_content_type"."model" FROM "django_content_type" WHERE ("django_content_type"."app_label" = 'vitrina_structure' AND "django_content_type"."model" = 'property') LIMIT 21

--- Query 21/23 ---
SELECT "metadata"."id", "metadata"."uuid", "metadata"."name", "metadata"."type", "metadata"."ref", "metadata"."source", "metadata"."prepare", "metadata"."prepare_ast", "metadata"."level", "metadata"."level_given", "metadata"."average_level", "metadata"."access", "metadata"."visibility", "metadata"."eli", "metadata"."status_id", "metadata"."count", "metadata"."prefix_id", "metadata"."uri", "metadata"."version", "metadata"."title", "metadata"."description", "metadata"."order", "metadata"."content_type_id", "metadata"."object_id", "metadata"."dataset_id", "metadata"."required", "metadata"."unique", "metadata"."type_args", "metadata"."metadata_version_id", "metadata"."draft" FROM "metadata" WHERE ("metadata"."content_type_id" = 152 AND "metadata"."object_id" IN (1, 2, 3, 4, 5))

--- Query 22/23 ---
SELECT "request"."id", "request"."created", "request"."modified", "request"."version", "request"."deleted", "request"."deleted_on", "request"."comment", "request"."dataset_id", "request"."format", "request"."is_existing", "request"."notes", "request"."periodicity", "request"."planned_opening_date", "request"."purpose", "request"."slug", "request"."status", "request"."uuid", "request"."user_id", "request"."changes", "request"."is_public", "request"."structure_data", "request"."structure_filename" FROM "request" WHERE "request"."dataset_id" IN (1, 2, 3, 4, 5)

--- Query 23/23 ---
SELECT "request_translation"."id", "request_translation"."language_code", "request_translation"."title", "request_translation"."description", "request_translation"."master_id" FROM "request_translation" WHERE "request_translation"."master_id" IN (1, 2, 3, 4, 5)
```