### PR TITLE
2326 Encode TAB space in RDF export

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,10 @@ https://github.com/atviriduomenys/katalogas/issues/2296
 
 - Fixed menu-items in Organization and Dataset views.
 
+https://github.com/atviriduomenys/katalogas/issues/2326
+
+- Encode TAB spaces for RDF exports.
+
 https://github.com/atviriduomenys/katalogas/issues/2340
 
 - Card content alignment fixes in home page.

--- a/tests/api/test_views.py
+++ b/tests/api/test_views.py
@@ -33,6 +33,8 @@ from vitrina.classifiers.factories import FrequencyFactory
 from vitrina.resources.factories import FileFormat
 from vitrina.utils import RevisionComment, RevisionSource
 
+from vitrina.api.helpers import _encode_xml_control_chars
+
 
 @pytest.mark.django_db
 def test_retrieve_catalog_list_without_api_key(app: DjangoTestApp):
@@ -2217,3 +2219,64 @@ def test_edp_dcat_ap_rdf_hvd_dataset(app: DjangoTestApp):
     </dcat:Dataset>
 </rdf:RDF>"""
     )
+
+
+class EncodeXmlControlCharsTests(TestCase):
+    def test_encode_xml_control_chars_encodes_tabs(self):
+        result = _encode_xml_control_chars("Hello\tWorld")
+        self.assertEqual(result, "Hello&#x9;World")
+
+    def test_encode_xml_control_chars_encodes_multiple_tabs(self):
+        result = _encode_xml_control_chars("Col1\tCol2\tCol3")
+        self.assertEqual(result, "Col1&#x9;Col2&#x9;Col3")
+
+    def test_encode_xml_control_chars_no_tabs(self):
+        result = _encode_xml_control_chars("No tabs here")
+        self.assertEqual(result, "No tabs here")
+
+    def test_encode_xml_control_chars_empty_string(self):
+        result = _encode_xml_control_chars("")
+        self.assertEqual(result, "")
+
+
+class EdpDcatApRdfTabEncodingTests(TestCase):
+    def test_edp_dcat_ap_rdf_encodes_tabs_in_rights_statement(self):
+        organization = OrganizationFactory()
+        dataset = Dataset.objects.create(
+            title="Dataset with tabs",
+            access_rights=Dataset.PUBLIC,
+            deleted=None,
+            deleted_on=None,
+            organization_id=organization.pk,
+        )
+        DatasetDistributionFactory(
+            dataset=dataset,
+            conditions="Legal document\thttps://example.com/legal",
+        )
+
+        response = self.client.get(reverse("edp-dcat-ap-rdf"))
+
+        self.assertEqual(response.status_code, 200)
+
+        self.assertIn(b"&#x9;", response.content)
+        self.assertNotIn(b"Legal document\t", response.content)
+
+    def test_edp_dcat_ap_restricted_rdf_encodes_tabs_in_rights_statement(self):
+        organization = OrganizationFactory()
+        dataset = Dataset.objects.create(
+            title="Restricted Dataset with tabs",
+            access_rights=Dataset.RESTRICTED,
+            deleted=None,
+            deleted_on=None,
+            organization_id=organization.pk,
+        )
+        DatasetDistributionFactory(
+            dataset=dataset,
+            conditions="Document name\thttps://example.com/doc",
+        )
+
+        response = self.client.get(reverse("edp-dcat-ap-restricted-rdf"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"&#x9;", response.content)
+        self.assertNotIn(b"Document name\t", response.content)

--- a/tests/api/test_views.py
+++ b/tests/api/test_views.py
@@ -2221,62 +2221,43 @@ def test_edp_dcat_ap_rdf_hvd_dataset(app: DjangoTestApp):
     )
 
 
-class EncodeXmlControlCharsTests(TestCase):
-    def test_encode_xml_control_chars_encodes_tabs(self):
-        result = _encode_xml_control_chars("Hello\tWorld")
-        self.assertEqual(result, "Hello&#x9;World")
-
-    def test_encode_xml_control_chars_encodes_multiple_tabs(self):
-        result = _encode_xml_control_chars("Col1\tCol2\tCol3")
-        self.assertEqual(result, "Col1&#x9;Col2&#x9;Col3")
-
-    def test_encode_xml_control_chars_no_tabs(self):
-        result = _encode_xml_control_chars("No tabs here")
-        self.assertEqual(result, "No tabs here")
-
-    def test_encode_xml_control_chars_empty_string(self):
-        result = _encode_xml_control_chars("")
-        self.assertEqual(result, "")
+@pytest.mark.parametrize(
+    "input_str, expected",
+    [
+        ("Hello\tWorld", "Hello&#x9;World"),
+        ("Col1\tCol2\tCol3", "Col1&#x9;Col2&#x9;Col3"),
+        ("No tabs here", "No tabs here"),
+        ("", ""),
+    ],
+)
+def test_encode_xml_control_chars(input_str, expected):
+    assert _encode_xml_control_chars(input_str) == expected
 
 
-class EdpDcatApRdfTabEncodingTests(TestCase):
-    def test_edp_dcat_ap_rdf_encodes_tabs_in_rights_statement(self):
-        organization = OrganizationFactory()
-        dataset = Dataset.objects.create(
-            title="Dataset with tabs",
-            access_rights=Dataset.PUBLIC,
-            deleted=None,
-            deleted_on=None,
-            organization_id=organization.pk,
-        )
-        DatasetDistributionFactory(
-            dataset=dataset,
-            conditions="Legal document\thttps://example.com/legal",
-        )
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "access_rights, url_name",
+    [
+        (Dataset.PUBLIC, "edp-dcat-ap-rdf"),
+        (Dataset.RESTRICTED, "edp-dcat-ap-restricted-rdf"),
+    ],
+)
+def test_edp_dcat_ap_rdf_encodes_tabs_in_rights_statement(app: DjangoTestApp, access_rights, url_name):
+    organization = OrganizationFactory()
+    dataset = Dataset.objects.create(
+        title="Dataset with tabs",
+        access_rights=access_rights,
+        deleted=None,
+        deleted_on=None,
+        organization_id=organization.pk,
+    )
+    DatasetDistributionFactory(
+        dataset=dataset,
+        conditions="Legal document\thttps://example.com/legal",
+    )
 
-        response = self.client.get(reverse("edp-dcat-ap-rdf"))
+    response = app.get(reverse(url_name))
 
-        self.assertEqual(response.status_code, 200)
-
-        self.assertIn(b"&#x9;", response.content)
-        self.assertNotIn(b"Legal document\t", response.content)
-
-    def test_edp_dcat_ap_restricted_rdf_encodes_tabs_in_rights_statement(self):
-        organization = OrganizationFactory()
-        dataset = Dataset.objects.create(
-            title="Restricted Dataset with tabs",
-            access_rights=Dataset.RESTRICTED,
-            deleted=None,
-            deleted_on=None,
-            organization_id=organization.pk,
-        )
-        DatasetDistributionFactory(
-            dataset=dataset,
-            conditions="Document name\thttps://example.com/doc",
-        )
-
-        response = self.client.get(reverse("edp-dcat-ap-restricted-rdf"))
-
-        self.assertEqual(response.status_code, 200)
-        self.assertIn(b"&#x9;", response.content)
-        self.assertNotIn(b"Document name\t", response.content)
+    assert response.status_code == 200
+    assert b"&#x9;" in response.content
+    assert b"Legal document\t" not in response.content

--- a/vitrina/api/helpers.py
+++ b/vitrina/api/helpers.py
@@ -1,5 +1,9 @@
 from typing import Optional
 
+from django.db.models import QuerySet
+from django.http import HttpRequest, HttpResponse
+from django.template.loader import render_to_string
+
 from vitrina.datasets.models import Dataset, Relation, DatasetRelation, DatasetGroup
 from vitrina.datasets.services import DynamicResourceService
 from vitrina.resources.models import DatasetDistribution as Distribution
@@ -8,6 +12,9 @@ from vitrina.resources.models import FormatName
 from vitrina.classifiers.models import Category
 from vitrina.classifiers.models import Frequency
 from vitrina.classifiers.models import Licence
+
+
+DCAT_AP_RDF_TEMPLATE_NAME = "vitrina/api/edp/dcat_ap_rdf.html"
 
 
 def get_datasets_for_rdf(qs):
@@ -71,6 +78,20 @@ def get_datasets_for_rdf(qs):
             "subclass": dataset.subclass,
             "is_hvd": dataset.is_hvd,
         }
+
+
+def _encode_xml_control_chars(content: str) -> str:
+    return content.replace("\t", "&#x9;")
+
+
+def render_rdf_response(request: HttpRequest, datasets: QuerySet[Dataset]) -> HttpResponse:
+    content = render_to_string(
+        DCAT_AP_RDF_TEMPLATE_NAME,
+        {"datasets": get_datasets_for_rdf(datasets)},
+        request=request,
+    )
+    content = _encode_xml_control_chars(content)
+    return HttpResponse(content, content_type="application/rdf+xml")
 
 
 def _get_distribution(dataset: Dataset, dist: Distribution):

--- a/vitrina/api/views.py
+++ b/vitrina/api/views.py
@@ -2,7 +2,6 @@ from django.contrib.contenttypes.models import ContentType
 from django.db.utils import IntegrityError
 from django.http import HttpRequest
 from django.http import HttpResponse
-from django.shortcuts import render
 from django.templatetags.static import static
 from django.utils import timezone
 from django.apps import apps
@@ -26,7 +25,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet, ModelViewSet
 from reversion import set_user
 
-from vitrina.api.helpers import get_datasets_for_rdf
+from vitrina.api.helpers import render_rdf_response
 from vitrina.api.models import ApiDescription
 from vitrina.api.permissions import APIKeyPermission, HasStatsPostPermission
 from vitrina.api.serializers import (
@@ -746,26 +745,9 @@ class DatasetModelDownloadViewSet(CreateModelMixin, UpdateModelMixin, GenericVie
         return Response(serializer.data, status=status.HTTP_200_OK, headers=headers)
 
 
-DCAT_AP_RDF_TEMPLATE_NAME = "vitrina/api/edp/dcat_ap_rdf.html"
-
-
 def edp_dcat_ap_rdf(request: HttpRequest) -> HttpResponse:
-    return render(
-        request,
-        DCAT_AP_RDF_TEMPLATE_NAME,
-        {
-            "datasets": get_datasets_for_rdf(Dataset.edp_public.all()),
-        },
-        content_type="application/rdf+xml",
-    )
+    return render_rdf_response(request, Dataset.edp_public.all())
 
 
 def edp_dcat_ap_restricted_rdf(request: HttpRequest) -> HttpResponse:
-    return render(
-        request,
-        DCAT_AP_RDF_TEMPLATE_NAME,
-        {
-            "datasets": get_datasets_for_rdf(Dataset.edp_restricted.all()),
-        },
-        content_type="application/rdf+xml",
-    )
+    return render_rdf_response(request, Dataset.edp_restricted.all())

--- a/vitrina/datasets/views.py
+++ b/vitrina/datasets/views.py
@@ -48,7 +48,7 @@ from reversion import add_to_revision
 from reversion.models import Version
 
 from vitrina.structure.models import Version as _Version
-from vitrina.api.helpers import get_datasets_for_rdf
+from vitrina.api.helpers import render_rdf_response
 from vitrina.api.models import ApiKey
 from vitrina.comments.models import Comment
 from vitrina.datasets.forms import (
@@ -623,15 +623,7 @@ class DatasetRDFDownloadView(PermissionRequiredMixin, View):
         return has_perm(self.request.user, Action.VIEW, dataset)
 
     def get(self, request, **kwargs):
-        dataset = Dataset.objects.filter(pk=kwargs.get("pk"))
-        return render(
-            request,
-            "vitrina/api/edp/dcat_ap_rdf.html",
-            {
-                "datasets": get_datasets_for_rdf(dataset),
-            },
-            content_type="application/rdf+xml",
-        )
+        return render_rdf_response(request, Dataset.objects.filter(pk=kwargs.get("pk")))
 
 
 class OpenDataPortalDatasetDetailView(View):


### PR DESCRIPTION
Laiškas iš EDP:

Our technical team has been trying to launch the harvesting process. Unfortunately, they inform us that the file has an issue with a literal on line 1363, which contains TAB characters, which is not allowed in XML.
If you need to keep the TABs, they must be encoded as follows:
```
&#x9;
```

If questions, please let us know. We can also set up a brief call to solve the issue asap. If so, please provide us a couple of slots and we will confirm availability. 