### PR TITLE
[2353] Do not strip `/` prefix from `property.ref` during import/export

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,9 +4,17 @@ Changes
 v 1.15.0 (unreleased)
 ==================
 
+Bug fixes:
+
+https://github.com/atviriduomenys/katalogas/issues/2353
+
+- Do not strip `/` prefix from `property.ref` during import/export.
+
 
 v 1.14.1 (2026-02-23)
 ==================
+
+Bug fixes:
 
 https://github.com/atviriduomenys/katalogas/issues/2397
 

--- a/tests/datasets/test_views.py
+++ b/tests/datasets/test_views.py
@@ -62,6 +62,7 @@ from vitrina.resources.factories import DatasetDistributionFactory, FileFormat
 from vitrina.settings import SPINTA_SERVER_URL
 from vitrina.structure.factories import ModelFactory, MetadataFactory, VersionFactory
 from vitrina.structure import VersionStatus
+from vitrina.structure.models import Metadata
 from vitrina.testing.templates import strip_empty_lines
 from vitrina.users.factories import UserFactory, ManagerFactory
 from vitrina.users.models import User
@@ -3459,82 +3460,108 @@ def test_dataset_history_view_with_permission(app: DjangoTestApp):
     assert resp.context["history"][0]["user"] == user
 
 
-def test_dataset_structure_import_without_permission(app: DjangoTestApp):
-    user = UserFactory()
-    dataset = DatasetFactory()
-    metadata_version = VersionFactory(dataset=dataset)
-    app.set_user(user)
-    url = reverse("dataset-structure-import", args=[dataset.pk, metadata_version.pk])
-    resp = app.get(url, expect_errors=True)
+class TestDatasetStructureImport:
+    def test_dataset_structure_import_without_permission(self, app: DjangoTestApp):
+        user = UserFactory()
+        dataset = DatasetFactory()
+        metadata_version = VersionFactory(dataset=dataset)
+        app.set_user(user)
+        url = reverse("dataset-structure-import", args=[dataset.pk, metadata_version.pk])
+        resp = app.get(url, expect_errors=True)
 
-    assert resp.status_code == 403
+        assert resp.status_code == 403
 
+    @pytest.mark.parametrize("status", [s for s in VersionStatus.values if s != VersionStatus.DRAFT])
+    def test_dataset_import_in_not_draft_version(self, app: DjangoTestApp, status: str):
+        version = VersionFactory(status=status)
+        user = UserFactory(is_staff=True)
+        dataset = version.dataset
 
-@pytest.mark.parametrize("status", [s for s in VersionStatus.values if s != VersionStatus.DRAFT])
-def test_dataset_import_in_not_draft_version(app: DjangoTestApp, status: str):
-    version = VersionFactory(status=status)
-    user = UserFactory(is_staff=True)
-    dataset = version.dataset
+        app.set_user(user)
+        url = reverse("dataset-structure-import", args=[dataset.pk, version.pk])
+        response = app.get(url)
+        assert response.status_code == 302
+        assert response.location == dataset.get_absolute_url()
 
-    app.set_user(user)
-    url = reverse("dataset-structure-import", args=[dataset.pk, version.pk])
-    response = app.get(url)
-    assert response.status_code == 302
-    assert response.location == dataset.get_absolute_url()
+    def test_dataset_structure_import_not_standardized(self, app: DjangoTestApp):
+        user = UserFactory(is_staff=True)
+        dataset = DatasetFactory()
+        metadata_version = VersionFactory(dataset=dataset)
 
+        app.set_user(user)
+        resp = app.get(reverse("dataset-structure-import", args=[dataset.pk, metadata_version.pk]))
+        form = resp.forms["dataset-structure-form"]
+        form["file"] = Upload("manifest.csv", b"Column\nValue")
+        form.submit()
 
-def test_dataset_structure_import_not_standardized(app: DjangoTestApp):
-    user = UserFactory(is_staff=True)
-    dataset = DatasetFactory()
-    metadata_version = VersionFactory(dataset=dataset)
+        dataset.refresh_from_db()
+        structure = DatasetStructure.objects.get(dataset=dataset)
+        assert dataset.current_structure == structure
+        assert File.objects.count() == 1
+        assert structure.file.original_filename == "manifest.csv"
 
-    app.set_user(user)
-    resp = app.get(reverse("dataset-structure-import", args=[dataset.pk, metadata_version.pk]))
-    form = resp.forms["dataset-structure-form"]
-    form["file"] = Upload("manifest.csv", b"Column\nValue")
-    form.submit()
+    def test_dataset_structure_import_standardized(self, app: DjangoTestApp):
+        user = UserFactory(is_staff=True)
+        dataset = DatasetFactory()
+        metadata_version = VersionFactory(dataset=dataset)
 
-    dataset.refresh_from_db()
-    structure = DatasetStructure.objects.get(dataset=dataset)
-    assert dataset.current_structure == structure
-    assert File.objects.count() == 1
-    assert structure.file.original_filename == "manifest.csv"
+        app.set_user(user)
+        resp = app.get(reverse("dataset-structure-import", args=[dataset.pk, metadata_version.pk]))
+        form = resp.forms["dataset-structure-form"]
+        form["file"] = Upload("file.csv", MANIFEST.encode())
+        form.submit()
 
+        dataset.refresh_from_db()
+        structure = DatasetStructure.objects.get(dataset=dataset)
+        assert dataset.current_structure == structure
+        assert File.objects.count() == 1
+        assert structure.file.original_filename == "file.csv"
 
-def test_dataset_structure_import_standardized(app: DjangoTestApp):
-    user = UserFactory(is_staff=True)
-    dataset = DatasetFactory()
-    metadata_version = VersionFactory(dataset=dataset)
+    def test_dataset_structure_import_with_version(self, app: DjangoTestApp):
+        user = UserFactory(is_staff=True)
+        dataset = DatasetFactory()
+        version = VersionFactory(dataset=dataset, status=VersionStatus.DRAFT)
 
-    app.set_user(user)
-    resp = app.get(reverse("dataset-structure-import", args=[dataset.pk, metadata_version.pk]))
-    form = resp.forms["dataset-structure-form"]
-    form["file"] = Upload("file.csv", MANIFEST.encode())
-    form.submit()
+        app.set_user(user)
+        resp = app.get(reverse("dataset-structure-import", args=[dataset.pk, version.pk]))
+        form = resp.forms["dataset-structure-form"]
+        form["file"] = Upload("file.csv", MANIFEST.encode())
+        form.submit()
 
-    dataset.refresh_from_db()
-    structure = DatasetStructure.objects.get(dataset=dataset)
-    assert dataset.current_structure == structure
-    assert File.objects.count() == 1
-    assert structure.file.original_filename == "file.csv"
+        dataset.refresh_from_db()
+        structure = DatasetStructure.objects.get(dataset=dataset)
+        assert dataset.current_structure == structure
+        assert File.objects.count() == 1
+        assert structure.file.original_filename == "file.csv"
 
+    def test_dataset_structure_import_ref_property_ref_column_does_not_lose_prefixes(self, app: DjangoTestApp):
+        manifest = (
+            "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+            "1,datasets/gov/main/dataset,,,,,,,,,,,,,,,,,\n"
+            "2,,dataset,,,,,,https://get.data.gov.lt/datasets/gov/main/dataset/:ns,,,,,,,,,,,dataset,\n"
+            '3,,,,Country,,,"id,title",,,,,,,,,,,\n'
+            "4,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n"
+            "5,,,,,continent,ref,/datasets/gov/ref/dataset/Continent,,,5,,,open,dct:continent,,,,\n"
+        )
 
-def test_dataset_structure_import_with_version(app: DjangoTestApp):
-    user = UserFactory(is_staff=True)
-    dataset = DatasetFactory()
-    version = VersionFactory(dataset=dataset, status=VersionStatus.DRAFT)
+        user = UserFactory(is_staff=True)
+        dataset = DatasetFactory()
+        version = VersionFactory(dataset=dataset)
 
-    app.set_user(user)
-    resp = app.get(reverse("dataset-structure-import", args=[dataset.pk, version.pk]))
-    form = resp.forms["dataset-structure-form"]
-    form["file"] = Upload("file.csv", MANIFEST.encode())
-    form.submit()
+        app.set_user(user)
 
-    dataset.refresh_from_db()
-    structure = DatasetStructure.objects.get(dataset=dataset)
-    assert dataset.current_structure == structure
-    assert File.objects.count() == 1
-    assert structure.file.original_filename == "file.csv"
+        resp = app.get(reverse("dataset-structure-import", args=[dataset.pk, version.pk]))
+        form = resp.forms["dataset-structure-form"]
+        form["file"] = Upload("manifest.csv", manifest.encode())
+
+        form.submit()
+
+        dataset.refresh_from_db()
+        structure = DatasetStructure.objects.get(dataset=dataset)
+
+        assert dataset.current_structure == structure
+        assert structure.file.original_filename == "manifest.csv"
+        assert Metadata.objects.get(dataset=dataset, uuid=5).ref == "/datasets/gov/ref/dataset/Continent"
 
 
 def test_dataset_structure_history_url(app: DjangoTestApp):

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -45,6 +45,23 @@ from vitrina.structure.models import Version as _Version
 from vitrina.utils import RevisionComment, RevisionSource
 
 
+class BaseTestCreateManifest:
+    def _create_manifest(self, manifest: str, title: str, description: str):
+        dataset = DatasetFactory(
+            title=title,
+            description=description,
+            metadata=False,
+        )
+        structure = DatasetStructureFactory(
+            file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset
+        )
+        structure.dataset.current_structure = structure
+        structure.dataset.save()
+        create_structure_objects(structure)
+        dataset.refresh_from_db()
+        return dataset
+
+
 @pytest.mark.django_db
 def test_model_data(app: DjangoTestApp):
     version = VersionFactory()
@@ -6718,22 +6735,40 @@ class TestModelDelete:
         assert resp.status_code == 405
 
 
-class TestStructureExportDependentModels:
-    def _create_manifest(self, manifest: str, title: str, description: str):
-        dataset = DatasetFactory(
-            title=title,
-            description=description,
-            metadata=False,
-        )
-        structure = DatasetStructureFactory(
-            file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset
-        )
-        structure.dataset.current_structure = structure
-        structure.dataset.save()
-        create_structure_objects(structure)
-        dataset.refresh_from_db()
-        return dataset
+class TestStructure(BaseTestCreateManifest):
+    def test_import_and_export_does_not_strip_ref_property_source_prefixes(self, app: DjangoTestApp):
+        """The problem is that type `ref` property.ref removed prefixes `/`, they should not be removed.
 
+        Incorrect: `/datasets/gov/ref/dataset/Continent` -> `datasets/gov/ref/dataset/Continent`
+        Correct:   `/datasets/gov/ref/dataset/Continent` -> `/datasets/gov/ref/dataset/Continent`
+        """
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        manifest = (
+            "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+            "1,datasets/gov/main/dataset,,,,,,,,,,,,,,,,,\n"
+            "2,,dataset,,,,,,https://get.data.gov.lt/datasets/gov/main/dataset/:ns,,,,,,,,,,,dataset,\n"
+            '3,,,,Country,,,"id,title",,,,,,,,,,,\n'
+            "4,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n"
+            "5,,,,,continent,ref,/datasets/gov/ref/dataset/Continent,,,5,,,open,dct:continent,,,,\n"
+        )
+        dataset = self._create_manifest(manifest, "Dataset", "Dataset with ref property")
+
+        response = app.get(reverse("dataset-structure-export", args=[dataset.pk, dataset.latest_version().pk]))
+
+        assert response.text.splitlines() == [
+            "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
+            "1,datasets/gov/main/dataset,,,,,,,,,,,,,,,,,,Dataset,Dataset with ref property",
+            "2,,dataset,,,,,,https://get.data.gov.lt/datasets/gov/main/dataset/:ns,,,,,,,,,,,dataset,",
+            "3,,,,Country,,,id,,,,,,,develop,,,,,,",
+            "4,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,",
+            "5,,,,,continent,ref,/datasets/gov/ref/dataset/Continent,,,,,,5,develop,,open,dct:continent,,,",
+            ",,,,,,,,,,,,,,,,,,,,",
+        ]
+
+
+class TestStructureExportDependentModels(BaseTestCreateManifest):
     @pytest.mark.django_db
     def test_structure_export_dependent_models(self, app: DjangoTestApp):
         user = UserFactory(is_staff=True)
@@ -6780,7 +6815,7 @@ class TestStructureExportDependentModels:
             '3,,,,Country,,,"id, title",,,,,,,develop,,,,,,\r\n'
             "4,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
             "5,,,,,title,string,,,,,,,5,develop,,open,dct:title,,,\r\n"
-            "6,,,,,continent,ref,datasets/gov/ref/dataset/Continent,,,,,,5,develop,,open,dct:continent,,,\r\n"
+            "6,,,,,continent,ref,/datasets/gov/ref/dataset/Continent,,,,,,5,develop,,open,dct:continent,,,\r\n"
             ",,,,,,,,,,,,,,,,,,,,\r\n"
         )
 
@@ -6822,7 +6857,7 @@ class TestStructureExportDependentModels:
             '3,,,,Country,,,"id, title",,,,,,,develop,,,,,,\r\n'
             "4,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
             "5,,,,,title,string,,,,,,,5,develop,,open,dct:title,,,\r\n"
-            "6,,,,,continent,ref,datasets/gov/ref/dataset/Continent,,,,,,5,develop,,open,dct:continent,,,\r\n"
+            "6,,,,,continent,ref,/datasets/gov/ref/dataset/Continent,,,,,,5,develop,,open,dct:continent,,,\r\n"
             ",,,,,,,,,,,,,,,,,,,,\r\n"
         )
 
@@ -6869,13 +6904,13 @@ class TestStructureExportDependentModels:
             "7,datasets/gov/ref/dataset,,,,,,,,,,,,,,,,,,Referenced Dataset,Dependent dataset depth 1\r\n"
             '8,,,,Continent,,,"id, title",,,,,,,develop,,,,,,\r\n'
             "9,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
-            "10,,,,,title,ref,datasets/gov/other/dataset/Other,,,,,,5,develop,,open,dct:title,,,\r\n"
+            "10,,,,,title,ref,/datasets/gov/other/dataset/Other,,,,,,5,develop,,open,dct:title,,,\r\n"
             "1,datasets/gov/main/dataset,,,,,,,,,,,,,,,,,,Main Dataset,Root dataset\r\n"
             "2,,dataset,,,,,,https://get.data.gov.lt/datasets/gov/main/dataset/:ns,,,,,,,,,,,dataset,\r\n"
             '3,,,,Country,,,"id, title",,,,,,,develop,,,,,,\r\n'
             "4,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
             "5,,,,,title,string,,,,,,,5,develop,,open,dct:title,,,\r\n"
-            "6,,,,,continent,ref,datasets/gov/ref/dataset/Continent,,,,,,5,develop,,open,dct:continent,,,\r\n"
+            "6,,,,,continent,ref,/datasets/gov/ref/dataset/Continent,,,,,,5,develop,,open,dct:continent,,,\r\n"
             ",,,,,,,,,,,,,,,,,,,,\r\n"
         )
 
@@ -6903,7 +6938,7 @@ class TestStructureExportDependentModels:
             '3,,,,Country,,,"id, title",,,,,,,develop,,,,,,\r\n'
             "4,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
             "5,,,,,title,string,,,,,,,5,develop,,open,dct:title,,,\r\n"
-            "6,,,,,continent,ref,datasets/gov/ref/dataset/Continent,,,,,,5,develop,,open,dct:continent,,,\r\n"
+            "6,,,,,continent,ref,/datasets/gov/ref/dataset/Continent,,,,,,5,develop,,open,dct:continent,,,\r\n"
             ",,,,,,,,,,,,,,,,,,,,\r\n"
         )
 
@@ -6955,8 +6990,8 @@ class TestStructureExportDependentModels:
             '3,,,,MainModel,,,"id, prop1",,,,,,,develop,,,,,,\r\n'
             "4,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
             "5,,,,,prop1,string,,,,,,,5,develop,,open,dct:prop1,,,\r\n"
-            "6,,,,,prop2,ref,datasets/gov/ref/d1/D1Model1,,,,,,5,develop,,open,dct:prop2,,,\r\n"
-            "7,,,,,prop3,ref,datasets/gov/ref/d1/D1Model2,,,,,,5,develop,,open,dct:prop3,,,\r\n"
+            "6,,,,,prop2,ref,/datasets/gov/ref/d1/D1Model1,,,,,,5,develop,,open,dct:prop2,,,\r\n"
+            "7,,,,,prop3,ref,/datasets/gov/ref/d1/D1Model2,,,,,,5,develop,,open,dct:prop3,,,\r\n"
             ",,,,,,,,,,,,,,,,,,,,\r\n"
         )
 

--- a/vitrina/datasets/structure.py
+++ b/vitrina/datasets/structure.py
@@ -710,7 +710,7 @@ def _read_property(
 
     if prop.ref and prop.type in ("ref", "backref", "generic"):
         ref_model, ref_props = _parse_property_ref(prop.ref)
-        prop.ref = get_relative_model_name(state.dataset, ref_model)
+        prop.ref = get_relative_model_name_for_ref(state.dataset, ref_model)
         prop.ref_props = ref_props
 
     prop.model = state.model
@@ -926,12 +926,14 @@ def get_relative_model_name(dataset: Dataset, name: str) -> str:
     elif dataset is None:
         return name
     else:
-        return "/".join(
-            [
-                dataset.name,
-                name,
-            ]
-        )
+        return f"{dataset.name}/{name}"
+
+
+def get_relative_model_name_for_ref(dataset: Dataset, name: str) -> str:
+    if name.startswith("/") or dataset is None:
+        return name
+    else:
+        return f"{dataset.name}/{name}"
 
 
 def _get_level(row: Row) -> str:

--- a/vitrina/structure/services.py
+++ b/vitrina/structure/services.py
@@ -815,9 +815,10 @@ def _link_properties(
                 PropertyList.objects.filter(
                     content_type=ct, object_id=prop.pk, metadata_version=metadata_version
                 ).delete()
-
+                # Stripping `property.ref` is needed during linking to find the related model, if it exists.
+                property_meta_ref = prop_meta.ref.lstrip("/")
                 if ref_model := Model.objects.filter(
-                    metadata__name=prop_meta.ref,
+                    metadata__name=property_meta_ref,
                     metadata__content_type=model_ct,
                 ).first():
                     prop.ref_model = ref_model


### PR DESCRIPTION
During the import of structure, `/` prefix is stripped from `property.ref` column, values starting with `/` or without it have different meanings in the DSA, due to that, this value should be left unstripped.

During export, it should work the same way - export the way it was imported.

Imported & Exported via Catalog, the prefix is still in place, untouched:
<img width="1458" height="415" alt="image" src="https://github.com/user-attachments/assets/7d25a64e-54c8-4f02-b0ff-2a7c2ca9a7ca" />


#### Notes:

- Old tests adjusted, new tests written.