### PR TITLE
[2339] Adjust export logic for the `resource` column

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,15 @@ https://github.com/atviriduomenys/katalogas/issues/2353
 - Do not strip `/` prefix from `property.ref` during import/export.
 
 
+https://github.com/atviriduomenys/katalogas/issues/2339
+
+- Adjust export logic for the `resource` column of manifest:
+    - More explicit filtering on distributions;
+    - Removing short-circuit which caused some resources to not be exported;
+    - Adjusting the logic for `_to_relative_model_name`;
+    - Additional improvements on `_dataset_resources_to_tabular` to avoid early exports for some rows (which caused missing some data)
+
+
 v 1.14.1 (2026-02-23)
 ==================
 

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -6841,6 +6841,47 @@ class TestStructure(BaseTestCreateManifest):
             "2,,service,,,,dask/xml,,,,eval(param(nested_xml)),,,,,,,,,service,",
         ]
 
+    def test_export__duplicated_source_exports_resources_correctly(self, app: DjangoTestApp):
+        """Ensure that resources that have an identical source column value are exported correctly."""
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        manifest = (
+            "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description\n"
+            "1,dataset,,,,,dataset,,,,,,,,,,,\n"
+            "2,,nested_read,,,,dask/xml,,,eval(param(nested_xml)),,,,,,,,\n"
+            "3,,,,,,param,nested_xml,GetData,read().response_data,,,,,,,,\n"
+            "4,,,,,,param,action_type,input/ActionType,input(),,,,,,,,\n"
+            "5,,,,Country,,,,countries/countryData,,,,,open,,,,\n"
+            "6,,,,,id,string,,id,,,,,,,,,\n"
+            ",,,,,,,,,,,,,,,,,\n"
+            "7,,nested_read_multiple,,,,dask/xml,,,eval(param(nested_xml)),,,,,,,,\n"
+            "8,,,,,,param,nested_xml,GetDataMultiple,read().response_data,,,,,,,,\n"
+            "9,,,,CountryMultiple,,,,countries/countryData,,,,,public,,,,\n"
+            "10,,,,,id,string,,id,,,,,,,,,\n"
+            ",,,,,,,,,,,,,,,,,\n"
+        )
+        dataset = self._create_manifest(manifest, "Dataset", "Dataset with ref property")
+
+        response = app.get(reverse("dataset-structure-export", args=[dataset.pk, dataset.latest_version().pk]))
+
+        assert response.text.splitlines() == [
+            "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
+            "1,dataset,,,,,,,,,,,,,,,,,,Dataset,Dataset with ref property",
+            "2,,nested_read,,,,dask/xml,,,,eval(param(nested_xml)),,,,,,,,,nested_read,",
+            "3,,,,,,param,nested_xml,GetData,,read().response_data,,,,develop,,,,,,",
+            "4,,,,,,param,action_type,input/ActionType,,input(),,,,develop,,,,,,",
+            "5,,,,Country,,,,countries/countryData,,,,,,develop,,open,,,,",
+            "6,,,,,id,string,,id,,,,,,develop,,,,,,",
+            ",,,,,,,,,,,,,,,,,,,,",
+            ",,/,,,,,,,,,,,,,,,,,,",
+            "7,,nested_read_multiple,,,,dask/xml,,,,eval(param(nested_xml)),,,,,,,,,nested_read_multiple,",
+            "8,,,,,,param,nested_xml,GetDataMultiple,,read().response_data,,,,develop,,,,,,",
+            "9,,,,CountryMultiple,,,,countries/countryData,,,,,,develop,,public,,,,",
+            "10,,,,,id,string,,id,,,,,,develop,,,,,,",
+            ",,,,,,,,,,,,,,,,,,,,",
+        ]
+
 
 class TestStructureExportDependentModels(BaseTestCreateManifest):
     @pytest.mark.django_db

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -6767,6 +6767,80 @@ class TestStructure(BaseTestCreateManifest):
             ",,,,,,,,,,,,,,,,,,,,",
         ]
 
+    def test_export__resource_and_param_rows_exported_with_all_columns(self, app: DjangoTestApp):
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        manifest = (
+            "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\n"
+            "1,dataset,,,,,,,,,,,,,,,,,,,\n"
+            "2,,resource_wsdl,,,,wsdl,,http://127.0.0.1:8001/api/v1/test/testing/?wsdl,,,,,,,,,,,,\n"
+            "3,,resource_soap,,,,soap,,TestTesting.TestPort.TestPort.test,,wsdl(rc_wsdl),,,,,,,,,,\n"
+            "4,,,,,,param,action_type,input/ActionType,,input(),,,,,,,,,,\n"
+            "5,,,,Soap,,,,/,,,,,,,,open,,,,\n"
+            "6,,,,,response_data,string,,ResponseData,,base64(),,,,,,,,,,\n"
+            "7,,,,,action_type,string required,,,,param(action_type),,,,,,,,,,\n"
+            ",,,,,,,,,,,,,,,,,,,,\n"
+            "8,,resource_xml,,,,dask/xml,,,,eval(param(nested_xml)),,,,,,,\n"
+            "9,,,,,,param,nested_xml,Soap,,read().response_data,,,,,,,\n"
+            "10,,,,Approver,,,,,,,,,0,,,,,,Approver,\n"
+            "11,,,,,company_name,string,,ApproverCompanyName/text(),,,,,4,,,,,,,\n"
+        )
+        dataset = self._create_manifest(manifest, "Title", "Description")
+
+        response = app.get(reverse("dataset-structure-export", args=[dataset.pk, dataset.latest_version().pk]))
+
+        assert response.text.splitlines() == [
+            "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
+            "1,dataset,,,,,,,,,,,,,,,,,,Title,Description",
+            "2,,resource_wsdl,,,,wsdl,,http://127.0.0.1:8001/api/v1/test/testing/?wsdl,,,,,,,,,,,resource_wsdl,",
+            "3,,resource_soap,,,,soap,,TestTesting.TestPort.TestPort.test,,wsdl(rc_wsdl),,,,,,,,,resource_soap,",
+            "4,,,,,,param,action_type,input/ActionType,,input(),,,,develop,,,,,,",
+            "5,,,,Soap,,,,/,,,,,,develop,,open,,,,",
+            "6,,,,,response_data,string,,ResponseData,,base64(),,,,develop,,,,,,",
+            "7,,,,,action_type,string required,,,,param(action_type),,,,develop,,,,,,",
+            ",,,,,,,,,,,,,,,,,,,,",
+            ",,/,,,,,,,,,,,,,,,,,,",
+            "8,,resource_xml,,,,dask/xml,,,,eval(param(nested_xml)),,,,,,,,,resource_xml,",
+            "9,,,,,,param,nested_xml,Soap,,read().response_data,,,,develop,,,,,,",
+            "10,,,,Approver,,,,,,,,,0,develop,,,,,Approver,",
+            "11,,,,,company_name,string,,ApproverCompanyName/text(),,,,,4,develop,,,,,,",
+            ",,,,,,,,,,,,,,,,,,,,",
+        ]
+
+    def test_export__repeat_import_correctly_updates_manifest_rows(self, app: DjangoTestApp):
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        manifest_no_prepare = (
+            "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\n"
+            "1,dataset,,,,,,,,,,,,,,,,,,,\n"
+            "2,,service,,,,dask/xml,,,,,,,,,,,,,\n"
+        )
+        dataset = self._create_manifest(manifest_no_prepare, "Title", "Description")
+        version = dataset.latest_version()
+
+        manifest_with_prepare = (
+            "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\n"
+            "1,dataset,,,,,,,,,,,,,,,,,,,\n"
+            "2,,service,,,,dask/xml,,,,eval(param(nested_xml)),,,,,,,,\n"
+        )
+
+        # Second import to test updates
+        structure = DatasetStructureFactory(
+            file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest_with_prepare)), dataset=dataset
+        )
+        dataset.current_structure = structure
+        dataset.save()
+        create_structure_objects(structure, metadata_version=version)
+
+        response = app.get(reverse("dataset-structure-export", args=[dataset.pk, version.pk]))
+        assert response.text.splitlines() == [
+            "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
+            "1,dataset,,,,,,,,,,,,,,,,,,Title,Description",
+            "2,,service,,,,dask/xml,,,,eval(param(nested_xml)),,,,,,,,,service,",
+        ]
+
 
 class TestStructureExportDependentModels(BaseTestCreateManifest):
     @pytest.mark.django_db

--- a/vitrina/structure/services.py
+++ b/vitrina/structure/services.py
@@ -600,14 +600,22 @@ def _link_distributions(dataset_meta: struct.Dataset, dataset: Dataset, metadata
 
 def _link_resource_distributions(dataset_meta: struct.Dataset, dataset: Dataset, metadata_version: Version):
     """Link each resource as a separate distribution."""
+    distribution_content_type = ContentType.objects.get_for_model(DatasetDistribution)
     for i, resource_meta in enumerate(dataset_meta.resources.values()):
         title = resource_meta.title or dataset_meta.title or resource_meta.name
 
-        distribution = DatasetDistribution.objects.filter(
-            dataset=dataset,
-            download_url=resource_meta.source,
-            metadata_version=metadata_version,
-        ).first()
+        distribution = (
+            DatasetDistribution.objects.filter(
+                dataset=dataset,
+                download_url=resource_meta.source,
+                metadata_version=metadata_version,
+            )
+            .filter(
+                Q(metadata__name=resource_meta.name, metadata__content_type=distribution_content_type)
+                | Q(metadata__isnull=True)
+            )
+            .first()
+        )
 
         if not distribution:
             distribution = _create_distribution_with_status_update(
@@ -1705,11 +1713,13 @@ def _properties_to_tabular(model: Model, version: Version | None = None) -> Gene
 
 
 def _to_relative_model_name(name: str, dataset: Dataset) -> str:
-    if dataset.name and name.startswith(dataset.name):
-        prefix = dataset.name
-        return name[len(prefix) + 1 :]
-    else:
-        return name
+    if dataset.name:
+        if name == dataset.name:
+            return name
+        prefix = dataset.name + "/"
+        if name.startswith(prefix):
+            return name[len(prefix) :]
+    return name
 
 
 def _get_access(acess: int) -> str:

--- a/vitrina/structure/services.py
+++ b/vitrina/structure/services.py
@@ -468,22 +468,9 @@ def _create_or_update_metadata(
     obj_meta: struct.Metadata,
     obj: models.Model,
     order: int = None,
-    use_existing_meta: bool = False,
     metadata_version: Version = None,
 ) -> Tuple[models.Model, struct.Metadata]:
     ct = ContentType.objects.get_for_model(obj)
-
-    if (
-        use_existing_meta
-        and obj.pk
-        and Metadata.objects.filter(
-            object_id=obj.pk, content_type=ct, dataset=dataset, metadata_version=metadata_version
-        ).exists()
-    ):
-        metadata = Metadata.objects.filter(
-            object_id=obj.pk, content_type=ct, dataset=dataset, metadata_version=metadata_version
-        ).first()
-        return metadata.object, metadata
 
     if (
         obj_meta.id
@@ -643,11 +630,8 @@ def _link_resource_distributions(dataset_meta: struct.Dataset, dataset: Dataset,
             resource_meta,
             distribution,
             i,
-            use_existing_meta=True,
             metadata_version=metadata_version,
         )
-        metadata.name = resource_meta.name
-        metadata.save()
 
         _load_params(dataset, resource_meta.params, distribution, metadata_version)
         _clean_errors(distribution)
@@ -1344,25 +1328,27 @@ def _dataset_to_tabular(dataset: Dataset, separator: bool = False, version: Vers
     yield from _prefixes_to_tabular(dataset, separator=separator, version=version)
     yield from _enums_to_tabular(dataset, separator=separator, version=version)
     yield from _params_to_tabular(dataset, separator=separator, version=version)
-    yield from _dataset_resources_to_tabular(dataset, separator=separator, version=version)
+    yield from _dataset_resources_to_tabular(dataset, version=version)
     yield from _models_to_tabular(dataset, separator=separator, version=version)
 
 
-def _dataset_resources_to_tabular(
-    dataset: Dataset, separator: bool = False, version: Version | None = None
-) -> Generator:
+def _dataset_resources_to_tabular(dataset: Dataset, version: Version | None = None) -> Generator:
     distribution_filter = {"dataset": dataset, "model__isnull": True}
+    model_filter = {"dataset": dataset, "distribution__isnull": False}
     metadata_queryset = Metadata.objects.all()
     if version is not None:
         distribution_filter["metadata_version"] = version
+        model_filter["metadata__metadata_version"] = version
         metadata_queryset = metadata_queryset.filter(metadata_version=version)
     distributions = (
         DatasetDistribution.objects.filter(**distribution_filter)
         .prefetch_related(Prefetch("metadata", queryset=metadata_queryset.order_by("order")))
         .order_by("metadata__order")
     )
+    distributions_with_models = set(Model.objects.filter(**model_filter).values_list("distribution_id", flat=True))
     for distribution in distributions:
-        yield from _resource_to_tabular(distribution, version=version)
+        if distribution.pk not in distributions_with_models:
+            yield from _resource_to_tabular(distribution, version=version)
 
 
 def _enums_to_tabular(obj: models.Model, separator: bool = False, version: Version | None = None) -> Generator:
@@ -1496,12 +1482,12 @@ def _models_to_tabular(dataset: Dataset, separator: bool = False, version: Versi
     resource = None
     base = None
     for model in dataset_models:
-        if model.distribution and not resource:
-            yield from _resource_to_tabular(model.distribution, version=version)
+        if model.distribution != resource:
+            if resource:
+                yield from _end_marker("resource")
+            if model.distribution:
+                yield from _resource_to_tabular(model.distribution, version=version)
             resource = model.distribution
-        elif not model.distribution and resource:
-            yield from _end_marker("resource")
-            resource = None
 
         if model.base and not base:
             yield from _base_to_tabular(model.base, version=version)


### PR DESCRIPTION
### Summary

This PR resolves an issue where resource-level metadata was being lost during both initial imports and subsequent updates. The system was short-circuiting the metadata populations process, leading to empty columns in exported manifests even when the imported CSV contained valid data.

### Changes

#### `vitrina/structure/services.py`
   - In `_link_resource_distributions`, the call to `_create_or_update_metadata` previously used the flag `use_existing_metadata=True`. Because resources often have "skeleton" metadata records created automatically, this flag caused the importer to stop as soon as it found the record, failing to apply the actual data (e.g. `eval()` functions) from the manifest. Removing this flag ensures manifest data is always applied to the metadata record.
       - Removed `use_existing_meta` parameter from `_create_or_update_metadata`. It is a deprecated—bug-causing implementation that should not be used for structure export. Additionally, the only occurrence of its usage has been removed, so no need for the flag anymore.
   - In `_dataset_resources_to_tabular` we ensure that a resource isn't printed twice if it has a model attached. The logic change guarantees that even if the `model__isnull` filter misses something, the export won't double-count resources.
   - In `_link_resource_distributions` the distribution lookup has been updated, to not associate rows with resources, that have an identical `source` but different content (e.g. resource name). 
       - Fix introduced following a comment from testing:
           - https://github.com/atviriduomenys/katalogas/issues/2339#issuecomment-3943554965

### Tests

- No previous tests failed, so the change is not expected to break anything that is already covered by tests.
- Added new tests ensuring that the change works as expected and the `resource`/`param` columns are exported correctly.