### PR TITLE
[2429] Adding missing script for comment buttons to work

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,10 @@ https://github.com/atviriduomenys/katalogas/issues/2339
     - Adjusting the logic for `_to_relative_model_name`;
     - Additional improvements on `_dataset_resources_to_tabular` to avoid early exports for some rows (which caused missing some data)
 
+https://github.com/atviriduomenys/katalogas/issues/2429
+
+- Comment button fix for reply/edit/delete buttons to work.
+
 
 v 1.14.1 (2026-02-23)
 ==================

--- a/vitrina/templates/component/comments.html
+++ b/vitrina/templates/component/comments.html
@@ -77,3 +77,4 @@
         $("#div_id_increase_frequency").toggle(false);
     });
 </script>
+<script src="{% static 'vitrina/datasets/js/comments.js' %}"></script>


### PR DESCRIPTION
Button functionality script was missing from the template, implemented it, buttons work as expected.

https://github.com/user-attachments/assets/e6dc7a55-6f8c-4b97-bf4b-38c62fe43fd7

