### PR TITLE
Fix bug where creating EnumItem does not assign it to version

### DIFF
--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -1571,10 +1571,16 @@ def test_property_enum_item_create__string(app: DjangoTestApp):
         EnumItem.objects.filter(
             enum__content_type=ContentType.objects.get_for_model(prop), enum__object_id=prop.pk
         ).values(
-            "metadata__prepare", "metadata__source", "metadata__access", "metadata__title", "metadata__description"
+            "metadata_version_id",
+            "metadata__prepare",
+            "metadata__source",
+            "metadata__access",
+            "metadata__title",
+            "metadata__description",
         )
     ) == [
         {
+            "metadata_version_id": version.pk,
             "metadata__prepare": '"test"',
             "metadata__source": "TEST",
             "metadata__access": Metadata.OPEN,
@@ -1630,10 +1636,16 @@ def test_property_enum_item_create__integer(app: DjangoTestApp):
         EnumItem.objects.filter(
             enum__content_type=ContentType.objects.get_for_model(prop), enum__object_id=prop.pk
         ).values(
-            "metadata__prepare", "metadata__source", "metadata__access", "metadata__title", "metadata__description"
+            "metadata_version_id",
+            "metadata__prepare",
+            "metadata__source",
+            "metadata__access",
+            "metadata__title",
+            "metadata__description",
         )
     ) == [
         {
+            "metadata_version_id": version.pk,
             "metadata__prepare": "1",
             "metadata__source": "TEST",
             "metadata__access": Metadata.OPEN,

--- a/vitrina/structure/views.py
+++ b/vitrina/structure/views.py
@@ -1884,7 +1884,7 @@ class EnumCreateView(PermissionRequiredMixin, CreateView):
 
     def form_valid(self, form):
         self.object: EnumItem = form.save(commit=False)
-        self.object.version_id = self.metadata_version.pk
+        self.object.metadata_version_id = self.metadata_version.pk
         if self.enum:
             self.object.enum = self.enum
         else:


### PR DESCRIPTION
**Summary:**
When creating `EnumItem` it assigns `version_id`. Turns out, it should be `metadata_version_id`.

Because of this bug, creating `EnumItem` does not assign it to version and it cannot be exported via DSA export