### PR TITLE
2324 fix enum prepare

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,20 @@
 Changes
 #######
 
+v 1.18.0 (current)
+==================
+
+Bug fixes:
+
+https://github.com/atviriduomenys/katalogas/issues/2324
+
+- Several issues related to enum item handling:
+    - When creating an enum item via the UI, the metadata version is now correctly set.
+    - Importing a manifest that contains non-string enum items without prepare values will now add an error indicating that a prepare column is required.
+    - Importing a manifest with string enum items and no prepare values will now automatically use the source column as the prepare value.
+    - Creating enum items via the UI will now return an error if a value already exists in the enum.
+
+
 v 1.17.0 (2026-03-16)
 ==================
 

--- a/tests/datasets/test_structure.py
+++ b/tests/datasets/test_structure.py
@@ -196,3 +196,96 @@ def test_update_parent_visibility_from_enum(
 
     assert model.visibility == expected_model_visibility
     assert property.visibility == expected_property_visibility
+
+
+def test_import_property_enum():
+    manifest = (
+        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,access,uri,title,description\n'
+        ',example,,,,,,,,,,,,,\n'
+        ',,,,Dataset,,,id,,,,,,,\n'
+        ',,,,,id,integer,,,,,,,,\n'
+        ',,,,,str_enum,string,,STR_ENUM,,,,,,\n'
+        ',,,,,,enum,,one,"""One""",,,,,\n'
+        ',,,,,,,,two,"""Two""",,,,,\n'
+        ',,,,,int_enum,integer,,INT_ENUM,,,,,,\n'
+        ',,,,,,enum,,1,1,,,,,\n'
+        ',,,,,,,,2,2,,,,,\n'
+    )
+    reader = csv.DictReader(io.StringIO(manifest))
+    model = "example/Dataset"
+
+    state = read(reader)
+    assert state.errors == []
+
+    str_enum_property = state.manifest.models[model].properties["str_enum"]
+    assert str_enum_property.type == "string"
+    enum_item_1 = str_enum_property.enums[""][0]
+    assert enum_item_1.source == "one"
+    assert enum_item_1.prepare == '"One"'
+    enum_item_2 = str_enum_property.enums[""][1]
+    assert enum_item_2.source == "two"
+    assert enum_item_2.prepare == '"Two"'
+
+    int_enum_property = state.manifest.models[model].properties["int_enum"]
+    assert int_enum_property.type == "integer"
+    enum_item_1 = int_enum_property.enums[""][0]
+    assert enum_item_1.source == "1"
+    assert enum_item_1.prepare == "1"
+    enum_item_2 = int_enum_property.enums[""][1]
+    assert enum_item_2.source == "2"
+    assert enum_item_2.prepare == "2"
+
+
+def test_import_property_string_enum_without_prepare_uses_source_value():
+    manifest = (
+        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,access,uri,title,description\n'
+        ',example,,,,,,,,,,,,,\n'
+        ',,,,Dataset,,,id,,,,,,,\n'
+        ',,,,,id,integer,,,,,,,,\n'
+        ',,,,,str_enum,string,,STR_ENUM,,,,,,\n'
+        ',,,,,,enum,,one,,,,,,\n'
+        ',,,,,,,,two,,,,,,\n'
+    )
+    reader = csv.DictReader(io.StringIO(manifest))
+    model = "example/Dataset"
+
+    state = read(reader)
+    assert state.errors == []
+
+    str_enum_property = state.manifest.models[model].properties["str_enum"]
+    assert str_enum_property.type == "string"
+    enum_item_1 = str_enum_property.enums[""][0]
+    assert enum_item_1.source == "one"
+    assert enum_item_1.prepare == '"one"'
+    enum_item_2 = str_enum_property.enums[""][1]
+    assert enum_item_2.source == "two"
+    assert enum_item_2.prepare == '"two"'
+
+
+def test_import_property_not_string_enum_without_prepare_results_in_error():
+    manifest = (
+        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,access,uri,title,description\n'
+        ',example,,,,,,,,,,,,,\n'
+        ',,,,Dataset,,,id,,,,,,,\n'
+        ',,,,,id,integer,,,,,,,,\n'
+        ',,,,,int_enum,integer,,INT_ENUM,,,,,,\n'
+        ',,,,,,enum,,1,,,,,,\n'
+        ',,,,,,,,2,,,,,,\n'
+    )
+    reader = csv.DictReader(io.StringIO(manifest))
+    model = "example/Dataset"
+
+    state = read(reader)
+    assert state.errors == []
+
+    int_enum_property = state.manifest.models[model].properties["int_enum"]
+    assert int_enum_property.type == "integer"
+
+    enum_item_1 = int_enum_property.enums[""][0]
+    assert enum_item_1.source == "1"
+    assert enum_item_1.prepare == ""
+    assert enum_item_1.errors
+    enum_item_2 = int_enum_property.enums[""][1]
+    assert enum_item_2.source == "2"
+    assert enum_item_2.prepare == ""
+    assert enum_item_2.errors

--- a/tests/datasets/test_structure.py
+++ b/tests/datasets/test_structure.py
@@ -200,16 +200,16 @@ def test_update_parent_visibility_from_enum(
 
 def test_import_property_enum():
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,access,uri,title,description\n'
-        ',example,,,,,,,,,,,,,\n'
-        ',,,,Dataset,,,id,,,,,,,\n'
-        ',,,,,id,integer,,,,,,,,\n'
-        ',,,,,str_enum,string,,STR_ENUM,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,access,uri,title,description\n"
+        ",example,,,,,,,,,,,,,\n"
+        ",,,,Dataset,,,id,,,,,,,\n"
+        ",,,,,id,integer,,,,,,,,\n"
+        ",,,,,str_enum,string,,STR_ENUM,,,,,,\n"
         ',,,,,,enum,,one,"""One""",,,,,\n'
         ',,,,,,,,two,"""Two""",,,,,\n'
-        ',,,,,int_enum,integer,,INT_ENUM,,,,,,\n'
-        ',,,,,,enum,,1,1,,,,,\n'
-        ',,,,,,,,2,2,,,,,\n'
+        ",,,,,int_enum,integer,,INT_ENUM,,,,,,\n"
+        ",,,,,,enum,,1,1,,,,,\n"
+        ",,,,,,,,2,2,,,,,\n"
     )
     reader = csv.DictReader(io.StringIO(manifest))
     model = "example/Dataset"
@@ -238,13 +238,13 @@ def test_import_property_enum():
 
 def test_import_property_string_enum_without_prepare_uses_source_value():
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,access,uri,title,description\n'
-        ',example,,,,,,,,,,,,,\n'
-        ',,,,Dataset,,,id,,,,,,,\n'
-        ',,,,,id,integer,,,,,,,,\n'
-        ',,,,,str_enum,string,,STR_ENUM,,,,,,\n'
-        ',,,,,,enum,,one,,,,,,\n'
-        ',,,,,,,,two,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,access,uri,title,description\n"
+        ",example,,,,,,,,,,,,,\n"
+        ",,,,Dataset,,,id,,,,,,,\n"
+        ",,,,,id,integer,,,,,,,,\n"
+        ",,,,,str_enum,string,,STR_ENUM,,,,,,\n"
+        ",,,,,,enum,,one,,,,,,\n"
+        ",,,,,,,,two,,,,,,\n"
     )
     reader = csv.DictReader(io.StringIO(manifest))
     model = "example/Dataset"
@@ -264,13 +264,13 @@ def test_import_property_string_enum_without_prepare_uses_source_value():
 
 def test_import_property_not_string_enum_without_prepare_results_in_error():
     manifest = (
-        'id,dataset,resource,base,model,property,type,ref,source,prepare,level,access,uri,title,description\n'
-        ',example,,,,,,,,,,,,,\n'
-        ',,,,Dataset,,,id,,,,,,,\n'
-        ',,,,,id,integer,,,,,,,,\n'
-        ',,,,,int_enum,integer,,INT_ENUM,,,,,,\n'
-        ',,,,,,enum,,1,,,,,,\n'
-        ',,,,,,,,2,,,,,,\n'
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,access,uri,title,description\n"
+        ",example,,,,,,,,,,,,,\n"
+        ",,,,Dataset,,,id,,,,,,,\n"
+        ",,,,,id,integer,,,,,,,,\n"
+        ",,,,,int_enum,integer,,INT_ENUM,,,,,,\n"
+        ",,,,,,enum,,1,,,,,,\n"
+        ",,,,,,,,2,,,,,,\n"
     )
     reader = csv.DictReader(io.StringIO(manifest))
     model = "example/Dataset"

--- a/tests/datasets/test_structure.py
+++ b/tests/datasets/test_structure.py
@@ -284,8 +284,11 @@ def test_import_property_not_string_enum_without_prepare_results_in_error():
     enum_item_1 = int_enum_property.enums[""][0]
     assert enum_item_1.source == "1"
     assert enum_item_1.prepare == ""
-    assert enum_item_1.errors
+    assert enum_item_1.errors == ['Duomenų reikšmė (source: "1") privalo turėti nurodytą "prepare" stulpelį.']
     enum_item_2 = int_enum_property.enums[""][1]
     assert enum_item_2.source == "2"
     assert enum_item_2.prepare == ""
-    assert enum_item_2.errors
+    assert enum_item_2.errors == [
+        'Duomenų reikšmė (source: "2") privalo turėti nurodytą "prepare" stulpelį.',
+        'Galima reikšmė (source: "2") "" jau egzistuoja.',
+    ]

--- a/tests/structure/test_forms.py
+++ b/tests/structure/test_forms.py
@@ -1,0 +1,220 @@
+import pytest
+from django.contrib.contenttypes.models import ContentType
+from django.urls import reverse
+from django_webtest import DjangoTestApp
+
+from vitrina.structure.factories import (
+    VersionFactory,
+    ModelFactory,
+    MetadataFactory,
+    PropertyFactory,
+    EnumFactory,
+    EnumItemFactory,
+)
+from vitrina.structure.models import Property, Metadata, Model
+from vitrina.users.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def model() -> Model:
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(model),
+        object_id=model.pk,
+        dataset=dataset,
+        name="test/dataset/TestModel",
+        metadata_version=version,
+    )
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(dataset),
+        object_id=dataset.pk,
+        dataset=dataset,
+        name="test/dataset",
+        metadata_version=version,
+    )
+
+    return model
+
+
+@pytest.fixture
+def string_property(model: Model) -> Property:
+    prop = PropertyFactory(model=model, metadata_version=model.metadata_version)
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(prop),
+        object_id=prop.pk,
+        dataset=model.dataset,
+        name="prop",
+        type="string",
+        metadata_version=model.metadata_version,
+    )
+
+    return prop
+
+
+@pytest.fixture
+def integer_property(model: Model) -> Property:
+    prop = PropertyFactory(model=model, metadata_version=model.metadata_version)
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(prop),
+        object_id=prop.pk,
+        dataset=model.dataset,
+        name="prop",
+        type="integer",
+        metadata_version=model.metadata_version,
+    )
+
+    return prop
+
+
+class TestEnumForm:
+    def test_cannot_create_enum_item_if_value_already_exists(self, app: DjangoTestApp, string_property: Property):
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        version = string_property.metadata_version
+        model = string_property.model
+        dataset = model.dataset
+
+        enum = EnumFactory(
+            content_type=ContentType.objects.get_for_model(string_property),
+            object_id=string_property.pk,
+            metadata_version=version,
+        )
+        enum_item = EnumItemFactory(enum=enum, metadata_version=version)
+        MetadataFactory(
+            content_type=ContentType.objects.get_for_model(enum_item),
+            object_id=enum_item.pk,
+            dataset=dataset,
+            title="Test value",
+            description="For testing",
+            prepare='"First"',
+            access=Metadata.OPEN,
+            source="TEST",
+            metadata_version=version,
+        )
+
+        form = app.get(reverse("enum-create", args=[dataset.pk, version.pk, model.name, string_property.name])).forms[
+            "enum-form"
+        ]
+        form["value"] = "First"
+        form["source"] = "TEST"
+        form["access"] = Metadata.OPEN
+        form["title"] = "Test value"
+        form["description"] = "For testing"
+        resp = form.submit()
+
+        form = resp.context["form"]
+        assert not form.is_valid()
+        assert form.errors == {"value": ['Galima reikšmė "First" jau egzistuoja.']}
+
+    def test_cannot_update_enum_item_if_value_already_exists(self, app: DjangoTestApp, string_property: Property):
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        version = string_property.metadata_version
+        model = string_property.model
+        dataset = model.dataset
+
+        enum = EnumFactory(
+            content_type=ContentType.objects.get_for_model(string_property),
+            object_id=string_property.pk,
+            metadata_version=version,
+        )
+        enum_item = EnumItemFactory(enum=enum, metadata_version=version)
+        MetadataFactory(
+            content_type=ContentType.objects.get_for_model(enum_item),
+            object_id=enum_item.pk,
+            dataset=dataset,
+            title="Test value",
+            description="For testing",
+            prepare='"First"',
+            access=Metadata.OPEN,
+            source="TEST",
+            metadata_version=version,
+        )
+        enum_item2 = EnumItemFactory(enum=enum, metadata_version=version)
+        MetadataFactory(
+            content_type=ContentType.objects.get_for_model(enum_item2),
+            object_id=enum_item.pk,
+            dataset=dataset,
+            title="Test value",
+            description="For testing",
+            prepare='"Second"',
+            access=Metadata.OPEN,
+            source="TEST2",
+            metadata_version=version,
+        )
+
+        form = app.get(
+            reverse("enum-update", args=[dataset.pk, version.pk, model.name, string_property.name, enum_item2.pk])
+        ).forms["enum-form"]
+        form["value"] = "First"
+        resp = form.submit()
+
+        form = resp.context["form"]
+        assert not form.is_valid()
+        assert form.errors == {"value": ['Galima reikšmė "First" jau egzistuoja.']}
+
+    def test_enum_item_value_unique_check_excludes_current_item(self, app: DjangoTestApp, string_property: Property):
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        version = string_property.metadata_version
+        model = string_property.model
+        dataset = model.dataset
+
+        enum = EnumFactory(
+            content_type=ContentType.objects.get_for_model(string_property),
+            object_id=string_property.pk,
+            metadata_version=version,
+        )
+        enum_item = EnumItemFactory(enum=enum, metadata_version=version)
+        MetadataFactory(
+            content_type=ContentType.objects.get_for_model(enum_item),
+            object_id=enum_item.pk,
+            dataset=dataset,
+            title="Test value",
+            description="For testing",
+            prepare='"First"',
+            access=Metadata.OPEN,
+            source="TEST",
+            metadata_version=version,
+        )
+
+        form = app.get(
+            reverse("enum-update", args=[dataset.pk, version.pk, model.name, string_property.name, enum_item.pk])
+        ).forms["enum-form"]
+        form["value"] = "First2"
+        resp = form.submit()
+
+        assert resp.url == string_property.get_absolute_url()
+
+    @pytest.mark.parametrize("non_integer_value", ["abc", '"First"', "1.33", "1.0", 1.1])
+    def test_cannot_save_non_integer_item_values_for_integer_enum(
+        self, app: DjangoTestApp, integer_property: Property, non_integer_value: str | float
+    ):
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        version = integer_property.metadata_version
+        model = integer_property.model
+        dataset = model.dataset
+
+        form = app.get(reverse("enum-create", args=[dataset.pk, version.pk, model.name, integer_property.name])).forms[
+            "enum-form"
+        ]
+        form["value"] = non_integer_value
+        form["source"] = "TEST"
+        form["access"] = Metadata.OPEN
+        form["title"] = "Test value"
+        form["description"] = "For testing"
+
+        resp = form.submit()
+
+        form = resp.context["form"]
+        assert not form.is_valid()
+        assert form.errors == {"value": [f'Reikšmė "{non_integer_value}" turi būti integer tipo.']}

--- a/tests/structure/test_services.py
+++ b/tests/structure/test_services.py
@@ -820,6 +820,30 @@ def test_structure_with_enum_and_null_value(app: DjangoTestApp):
 
 
 @pytest.mark.django_db
+def test_structure_with_enum_without_prepare_value_adds_comment_about_error(app: DjangoTestApp):
+    manifest = (
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,City,,,,,,,,,,,,,,\n"
+        "1,,,,,type,integer,,,,5,,,,,,,,\n"
+        ",,,,,,enum,Type,one,,,,,,,,,,\n"
+    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure.dataset.current_structure = structure
+    structure.dataset.save()
+    create_structure_objects(structure)
+
+    prop = Property.objects.get(metadata__uuid="1")
+    prop_enum = Enum.objects.filter(content_type=ContentType.objects.get_for_model(prop), object_id=prop.pk)
+    assert prop_enum.count() == 1
+    assert prop_enum[0].name == "Type"
+    assert not prop_enum[0].enumitem_set.exists()
+    assert list(Comment.objects.filter(type=Comment.STRUCTURE_ERROR).values_list("body", flat=True)) == [
+        'Duomenų reikšmė (source: "one") privalo turėti nurodytą "prepare" stulpelį.'
+    ]
+
+
+@pytest.mark.django_db
 def test_structure_with_params(app: DjangoTestApp):
     manifest = (
         "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"

--- a/tests/structure/test_services.py
+++ b/tests/structure/test_services.py
@@ -1165,7 +1165,7 @@ def test_structure_with_existing_enums(app: DjangoTestApp):
             type=Comment.STRUCTURE_ERROR,
             content_type=ContentType.objects.get_for_model(structure),
         ).values_list("body", flat=True)
-    ) == ['Galima reikšmė "SMALL" jau egzistuoja.']
+    ) == ['Galima reikšmė (source: "") "SMALL" jau egzistuoja.']
 
 
 @pytest.mark.django_db
@@ -2416,7 +2416,7 @@ def test_structure_export__visibility_row(app: DjangoTestApp):
         "3,,,,Pavadinimas,,,id,,,,4,,package,protected,,,Pavadinimas,\n"
         "4,,,,,id,integer,,,,,4,,package,protected,,,ID,\n"
         "5,,,,,class,integer,,,,,4,,package,protected,,,class,\n"
-        "6,,,,,,enum,,1,,,4,,package,protected,,,Class One,\n"
+        "6,,,,,,enum,,1,1,,4,,package,protected,,,Class One,\n"
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
@@ -2435,7 +2435,7 @@ def test_structure_export__visibility_row(app: DjangoTestApp):
         "3,,,,Pavadinimas,,,id,,,,,,4,develop,package,protected,,,Pavadinimas,\r\n"
         "4,,,,,id,integer,,,,,,,4,develop,package,protected,,,ID,\r\n"
         "5,,,,,class,integer,,,,,,,4,develop,package,protected,,,class,\r\n"
-        "6,,,,,,enum,,1,,,,,,develop,package,protected,,,Class One,\r\n"
+        "6,,,,,,enum,,1,,1,,,,develop,package,protected,,,Class One,\r\n"
         ",,,,,,,,,,,,,,,,,,,,\r\n"
     )
 
@@ -2453,7 +2453,7 @@ def test_structure_export__eli_row(app: DjangoTestApp):
         "3,,,,Pavadinimas,,,id,,,,4,,,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.1,Pavadinimas,\n"
         "4,,,,,id,integer,,,,,4,,,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.2,ID,\n"
         "5,,,,,class,integer,,,,,4,,,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.3,class,\n"
-        "6,,,,,,enum,,1,,,4,,,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.3.1,Class One,\n"
+        "6,,,,,,enum,,1,1,,4,,,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.3.1,Class One,\n"
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
@@ -2472,7 +2472,7 @@ def test_structure_export__eli_row(app: DjangoTestApp):
         "3,,,,Pavadinimas,,,id,,,,,,4,develop,,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.1,Pavadinimas,\r\n"
         "4,,,,,id,integer,,,,,,,4,develop,,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.2,ID,\r\n"
         "5,,,,,class,integer,,,,,,,4,develop,,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.3,class,\r\n"
-        "6,,,,,,enum,,1,,,,,,develop,,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.3.1,Class One,\r\n"
+        "6,,,,,,enum,,1,,1,,,,develop,,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.3.1,Class One,\r\n"
         ",,,,,,,,,,,,,,,,,,,,\r\n"
     )
 
@@ -2490,7 +2490,7 @@ def test_structure_export__status_row(app: DjangoTestApp, setup_default_status_d
         "3,,,,Pavadinimas,,,id,,,,4,completed,,protected,,,Pavadinimas,\n"
         "4,,,,,id,integer,,,,,4,withdrawn,,protected,,,ID,\n"
         "5,,,,,class,integer,,,,,4,deprecated,,protected,,,class,\n"
-        "6,,,,,,enum,,1,,,4,discont,,protected,,,Class One,\n"
+        "6,,,,,,enum,,1,1,,4,discont,,protected,,,Class One,\n"
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
@@ -2509,7 +2509,7 @@ def test_structure_export__status_row(app: DjangoTestApp, setup_default_status_d
         "3,,,,Pavadinimas,,,id,,,,,,4,completed,,protected,,,Pavadinimas,\r\n"
         "4,,,,,id,integer,,,,,,,4,withdrawn,,protected,,,ID,\r\n"
         "5,,,,,class,integer,,,,,,,4,deprecated,,protected,,,class,\r\n"
-        "6,,,,,,enum,,1,,,,,,discont,,protected,,,Class One,\r\n"
+        "6,,,,,,enum,,1,,1,,,,discont,,protected,,,Class One,\r\n"
         ",,,,,,,,,,,,,,,,,,,,\r\n"
     )
 
@@ -2524,7 +2524,7 @@ def test_structure_models_props_and_enums_with_visibility_status_eli(app: Django
         "3,,,,Pavadinimas,,,id,,,4,completed,package,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.1,Pavadinimas,,\n"
         "4,,,,,id,integer,,,,4,completed,package,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.2,ID,,\n"
         "5,,,,,class,integer,,,,4,discont,protected,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.3,class,,\n"
-        "6,,,,,,enum,,1,,4,deprecated,protected,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.3.1,Class One,,\n"
+        "6,,,,,,enum,,1,1,4,deprecated,protected,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.3.1,Class One,,\n"
     )
     structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
 
@@ -2599,7 +2599,7 @@ def test_structure_with_enum_level_higher_then_property(app: DjangoTestApp):
         "3,,,,Pavadinimas,,,id,,,4,,package,protected,,,Pavadinimas,,\n"
         "4,,,,,id,integer,,,,4,,package,protected,,,ID,,\n"
         "5,,,,,class,integer,,,,4,,package,protected,,,class,,\n"
-        "6,,,,,,enum,,1,,4,,public,protected,,,Class One,,\n"
+        "6,,,,,,enum,,1,1,4,,public,protected,,,Class One,,\n"
     )
     structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
@@ -2625,7 +2625,7 @@ def test_structure_with_enum_level_higher_then_model(app: DjangoTestApp):
         "3,,,,Pavadinimas,,,id,,,4,,package,protected,,,Pavadinimas,,\n"
         "4,,,,,id,integer,,,,4,,package,protected,,,ID,,\n"
         "5,,,,,class,integer,,,,4,,,protected,,,class,,\n"
-        "6,,,,,,enum,,1,,4,,public,protected,,,Class One,,\n"
+        "6,,,,,,enum,,1,1,4,,public,protected,,,Class One,,\n"
     )
     structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure

--- a/tests/structure/test_utils.py
+++ b/tests/structure/test_utils.py
@@ -1,0 +1,39 @@
+import pytest
+
+from vitrina.structure.utils import (
+    get_type_checker_for_type,
+    TypeChecker,
+    StringTypeChecker,
+    IntegerTypeChecker,
+    NotImplementedTypeChecker,
+    TypeCheckerError,
+)
+
+
+class TestTypeChecker:
+    @pytest.mark.parametrize(
+        "type_variable, type_checker_class",
+        [
+            ("string", StringTypeChecker),
+            ("integer", IntegerTypeChecker),
+            ("boolean", NotImplementedTypeChecker),
+            ("geometry", NotImplementedTypeChecker),
+        ],
+    )
+    def test_type_checker_types(self, type_variable: str, type_checker_class: TypeChecker):
+        assert type(get_type_checker_for_type(type_variable)) is type_checker_class
+
+    @pytest.mark.parametrize("value", ["", "foo", "-1", "0", "1", "1.0", "True", "False"])
+    def test_check_enum_item_value_for_integer_type_checker(self, value: str):
+        assert get_type_checker_for_type("string").check_enum_item_value(value) is None
+
+    @pytest.mark.parametrize("value", ["-1", "0", "1"])
+    def test_check_enum_item_value_for_integer_type_checker_success(self, value: str):
+        assert get_type_checker_for_type("integer").check_enum_item_value(value) is None
+
+    @pytest.mark.parametrize("value", ["", "foo", "1.0", "True", "False"])
+    def test_check_enum_item_value_for_integer_type_checker_error(self, value: str):
+        with pytest.raises(TypeCheckerError) as exc_info:
+            get_type_checker_for_type("integer").check_enum_item_value(value)
+
+        assert str(exc_info.value) == f'Reikšmė "{value}" turi būti integer tipo.'

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -1601,7 +1601,8 @@ def test_property_enum_item_create__string(app: DjangoTestApp):
 
 
 @pytest.mark.django_db
-def test_property_enum_item_create__integer(app: DjangoTestApp):
+@pytest.mark.parametrize("integer_value", [-1, 0, 1])
+def test_property_enum_item_create__integer(app: DjangoTestApp, integer_value: int):
     user = UserFactory(is_staff=True)
     app.set_user(user)
 
@@ -1633,7 +1634,7 @@ def test_property_enum_item_create__integer(app: DjangoTestApp):
     )
 
     form = app.get(reverse("enum-create", args=[dataset.pk, version.pk, model.name, prop.name])).forms["enum-form"]
-    form["value"] = 1
+    form["value"] = integer_value
     form["source"] = "TEST"
     form["access"] = Metadata.OPEN
     form["title"] = "Test value"
@@ -1656,7 +1657,7 @@ def test_property_enum_item_create__integer(app: DjangoTestApp):
     ) == [
         {
             "metadata_version_id": version.pk,
-            "metadata__prepare": "1",
+            "metadata__prepare": str(integer_value),
             "metadata__source": "TEST",
             "metadata__access": Metadata.OPEN,
             "metadata__title": "Test value",
@@ -1665,48 +1666,6 @@ def test_property_enum_item_create__integer(app: DjangoTestApp):
     ]
     assert Version.objects.get_for_object(prop).count() == 1
     assert Version.objects.get_for_object(prop).first().revision.user == user
-
-
-@pytest.mark.django_db
-def test_property_enum_item_create__integer_with_error(app: DjangoTestApp):
-    user = UserFactory(is_staff=True)
-    app.set_user(user)
-
-    version = VersionFactory()
-    model = ModelFactory(dataset=version.dataset, metadata_version=version)
-    dataset = version.dataset
-    MetadataFactory(
-        content_type=ContentType.objects.get_for_model(model),
-        object_id=model.pk,
-        dataset=dataset,
-        name="test/dataset/TestModel",
-        metadata_version=version,
-    )
-    MetadataFactory(
-        content_type=ContentType.objects.get_for_model(dataset),
-        object_id=dataset.pk,
-        dataset=dataset,
-        name="test/dataset",
-        metadata_version=version,
-    )
-    prop = PropertyFactory(model=model, metadata_version=version)
-    MetadataFactory(
-        content_type=ContentType.objects.get_for_model(prop),
-        object_id=prop.pk,
-        dataset=dataset,
-        name="prop",
-        type="integer",
-        metadata_version=version,
-    )
-
-    form = app.get(reverse("enum-create", args=[dataset.pk, version.pk, model.name, prop.name])).forms["enum-form"]
-    form["value"] = "invalid"
-    form["source"] = "TEST"
-    form["access"] = Metadata.OPEN
-    form["title"] = "Test value"
-    form["description"] = "For testing"
-    resp = form.submit()
-    assert list(resp.context["form"].errors.values()) == [["Reikšmė turi būti integer tipo."]]
 
 
 @pytest.mark.django_db

--- a/vitrina/datasets/structure.py
+++ b/vitrina/datasets/structure.py
@@ -809,11 +809,18 @@ def _read_enum(
 
     enum.meta = last
 
+    # If string enum prepare is empty, use source as prepare value
+    if enum.prepare == "" and getattr(enum.meta, "type") == "string":
+        enum.prepare = f'"{enum.source}"'
+
+    if enum.prepare == "":
+        enum.errors.append(_(f'Duomenų reikšmė (source: "{enum.source}") privalo turėti nurodytą "prepare" stulpelį.'))
+
     _update_parent_visibility_from_enum(state, enum)
 
     if enum.meta.enums.get(name):
         if enum.prepare in [e.prepare for e in enum.meta.enums[name]]:
-            enum.errors.append(_(f'Galima reikšmė "{enum.prepare}" jau egzistuoja.'))
+            enum.errors.append(_(f'Galima reikšmė (source: "{enum.source}") "{enum.prepare}" jau egzistuoja.'))
 
         enum.meta.enums[name].append(enum)
     else:

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -1269,14 +1269,6 @@ msgstr "The organization can only be assigned the role of a data editor"
 msgid "Naudotojui išsiųstas laiškas dėl registracijos"
 msgstr "The user has been sent an email for registration"
 
-#, python-brace-format
-msgid ""
-"Duomenų lauko \"{0}\" metaduomenų matomumo lygis \"{1}\" negali būti "
-"aukštesnis už modelio metaduomenų matomumo lygį \"{2}\". "
-msgstr ""
-"Data field \"{0}\" metadata visibility level \"{1}\" must not be higher than "
-"the model metadata visibility level \"{2}\". "
-
 msgid ""
 "Duomenų lauko \"{0}\" metaduomenų matomumo lygis \"{1}\" negali būti "
 "aukštesnis už modelio metaduomenų matomumo lygį \"{2}\". "

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -1269,6 +1269,14 @@ msgstr "The organization can only be assigned the role of a data editor"
 msgid "Naudotojui išsiųstas laiškas dėl registracijos"
 msgstr "The user has been sent an email for registration"
 
+#, python-brace-format
+msgid ""
+"Duomenų lauko \"{0}\" metaduomenų matomumo lygis \"{1}\" negali būti "
+"aukštesnis už modelio metaduomenų matomumo lygį \"{2}\". "
+msgstr ""
+"Data field \"{0}\" metadata visibility level \"{1}\" must not be higher than "
+"the model metadata visibility level \"{2}\". "
+
 msgid ""
 "Duomenų lauko \"{0}\" metaduomenų matomumo lygis \"{1}\" negali būti "
 "aukštesnis už modelio metaduomenų matomumo lygį \"{2}\". "
@@ -4203,9 +4211,6 @@ msgstr "Dataset title"
 msgid "Duomenų rinkinio ar vardų erdvės aprašymas."
 msgstr "Dataset or namespace description."
 
-msgid "Reikšmė turi būti integer tipo."
-msgstr "Value must be integer."
-
 msgid "Aprašymas neatitinka Markdown formato."
 msgstr "Description doesn't match Markdown format."
 
@@ -4748,13 +4753,13 @@ msgid "Metaduomenų versija"
 msgstr "Metadata version"
 
 msgid "Pending"
-msgstr ""
+msgstr "Pending"
 
 msgid "Valid"
-msgstr ""
+msgstr "Valid"
 
 msgid "Invalid"
-msgstr ""
+msgstr "Invalid"
 
 msgid ""
 "Įsitikinkite, kad jis egzistuoja ir turi patvirtintą (stabilią) versiją."
@@ -4906,6 +4911,9 @@ msgstr "Estimated changes"
 
 msgid "Galiojantys keitimai"
 msgstr "Deployed changes"
+
+msgid "Savybės reikšmės tipas nėra palaikomas."
+msgstr "Type of property value is not implemented."
 
 msgid "Kiekis"
 msgstr "Amount"

--- a/vitrina/structure/forms.py
+++ b/vitrina/structure/forms.py
@@ -28,7 +28,9 @@ from vitrina.structure.models import (
     Version,
     VersionStatus,
     VersionType,
+    Enum,
 )
+from vitrina.structure.utils import TypeCheckerError
 
 
 class ModelChoiceTypeField(forms.ModelChoiceField):
@@ -161,10 +163,11 @@ class EnumForm(forms.ModelForm):
             "description",
         )
 
-    def __init__(self, prop=None, *args, **kwargs):
+    def __init__(self, prop: Property, enum: Enum, *args, **kwargs):
         super().__init__(*args, **kwargs)
         instance = self.instance if self.instance and self.instance.pk else None
         self.prop = prop
+        self.enum = enum
         self.helper = FormHelper()
         self.helper.attrs["novalidate"] = ""
         self.helper.form_id = "enum-form"
@@ -201,19 +204,40 @@ class EnumForm(forms.ModelForm):
         else:
             self.initial["visibility"] = "None"
 
+    def _is_value_unique(self, value: str, exclude_enum_item_id: int | None = None) -> bool:
+        enum_items = self.enum.enumitem_set.all().prefetch_related("metadata")
+        if exclude_enum_item_id:
+            enum_items = enum_items.exclude(id=exclude_enum_item_id)
+        for enum_item in enum_items:
+            if not (metadata := enum_item.metadata.first()):
+                continue
+            if metadata.prepare == value:
+                return True
+
+        return False
+
     def clean_value(self):
-        value = self.cleaned_data.get("value")
-        if value:
-            if metadata := self.prop.metadata.first():
-                if metadata.type == "integer":
-                    try:
-                        int(value)
-                    except ValueError:
-                        raise ValidationError(_("Reikšmė turi būti integer tipo."))
+        if not (value := self.cleaned_data.get("value")):
+            return value
+
+        if metadata := self.prop.metadata.first():
+            checker = metadata.get_type_checker()
             try:
-                spyna.parse(value)
-            except ParseError as e:
+                checker.check_enum_item_value(value)
+            except TypeCheckerError as e:
                 raise ValidationError(e)
+
+        try:
+            spyna.parse(value)
+        except ParseError as e:
+            raise ValidationError(e)
+
+        # If enum does not exist yet, there is no point checking for uniqueness of its items
+        compare_value = f'"{value}"' if metadata.type == "string" else value
+        exclude_id = self.instance.id if self.instance and self.instance.pk else None
+        if self.enum and self._is_value_unique(compare_value, exclude_enum_item_id=exclude_id):
+            raise ValidationError(_(f'Galima reikšmė "{value}" jau egzistuoja.'))
+
         return value
 
     def clean_description(self):

--- a/vitrina/structure/models.py
+++ b/vitrina/structure/models.py
@@ -17,6 +17,8 @@ from vitrina.structure import VersionStatus, VersionType, AccessType
 from vitrina.structure.helpers import get_type_repr
 from enum import Enum
 
+from vitrina.structure.utils import TypeChecker, get_type_checker_for_type
+
 
 class StatusCode(str, Enum):
     DEVELOP = "develop"
@@ -136,6 +138,9 @@ class Metadata(models.Model):
         if self.type:
             return get_type_repr(self)
         return ""
+
+    def get_type_checker(self) -> TypeChecker:
+        return get_type_checker_for_type(self.type)
 
 
 class Base(models.Model):

--- a/vitrina/structure/utils.py
+++ b/vitrina/structure/utils.py
@@ -15,8 +15,7 @@ class TypeChecker(ABC, Generic[T]):
 
 
 class StringTypeChecker(TypeChecker[str]):
-    def check_enum_item_value(self, value: str) -> None:
-        pass
+    pass
 
 
 class IntegerTypeChecker(TypeChecker[int]):

--- a/vitrina/structure/utils.py
+++ b/vitrina/structure/utils.py
@@ -1,0 +1,42 @@
+from abc import ABC
+from typing import TypeVar, Generic, Any
+
+from django.utils.translation import gettext_lazy as _
+
+T = TypeVar("T")
+
+
+class TypeCheckerError(Exception):
+    pass
+
+
+class TypeChecker(ABC, Generic[T]):
+    def check_enum_item_value(self, value: str) -> None: ...
+
+
+class StringTypeChecker(TypeChecker[str]):
+    def check_enum_item_value(self, value: str) -> None:
+        pass
+
+
+class IntegerTypeChecker(TypeChecker[int]):
+    def check_enum_item_value(self, value: str) -> None:
+        try:
+            int(value)
+        except (TypeError, ValueError):
+            raise TypeCheckerError(_(f'Reikšmė "{value}" turi būti integer tipo.'))
+
+
+class NotImplementedTypeChecker(TypeChecker[Any]):
+    def check_enum_item_value(self, value: str) -> None:
+        raise TypeCheckerError(_("Savybės reikšmės tipas nėra palaikomas."))
+
+
+TYPE_CHECKER_MAP = {
+    "string": StringTypeChecker(),
+    "integer": IntegerTypeChecker(),
+}
+
+
+def get_type_checker_for_type(type_str: str) -> TypeChecker:
+    return TYPE_CHECKER_MAP.get(type_str, NotImplementedTypeChecker())

--- a/vitrina/structure/views.py
+++ b/vitrina/structure/views.py
@@ -1877,6 +1877,7 @@ class EnumCreateView(PermissionRequiredMixin, CreateView):
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
         kwargs["prop"] = self.property
+        kwargs["enum"] = self.enum
         return kwargs
 
     def get_context_data(self, **kwargs):
@@ -1920,9 +1921,9 @@ class EnumCreateView(PermissionRequiredMixin, CreateView):
         visibility = form.cleaned_data.get("visibility")
         status = form.cleaned_data.get("status") or Status.objects.filter(is_default=True).first()
         eli = form.cleaned_data.get("eli")
-        if metadata := self.property.metadata.first():
-            if metadata.type == "string":
-                value = f'"{value}"'
+        if (metadata := self.property.metadata.first()) and metadata.type == "string":
+            value = f'"{value}"'
+
         Metadata.objects.create(
             uuid=str(uuid.uuid4()),
             dataset=self.dataset,
@@ -2016,6 +2017,7 @@ class EnumUpdateView(PermissionRequiredMixin, UpdateView):
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
         kwargs["prop"] = self.property
+        kwargs["enum"] = self.get_object().enum
         return kwargs
 
     def get_context_data(self, **kwargs):
@@ -2044,9 +2046,8 @@ class EnumUpdateView(PermissionRequiredMixin, UpdateView):
     def form_valid(self, form):
         self.object: EnumItem = form.save()
         value = form.cleaned_data.get("value")
-        if metadata := self.property.metadata.first():
-            if metadata.type == "string":
-                value = f'"{value}"'
+        if (metadata := self.property.metadata.first()) and metadata.type == "string":
+            value = f'"{value}"'
 
         old_metadata = self.get_object().metadata.first()
 


### PR DESCRIPTION
**Summary:**
Fixes few bugs with enum items:
- Importing manifest with non-string enum items and without `prepare` values will now show error that `prepare` column is required.
- Importing manifest with string enum items and without `prepare` values will now get `prepare` value from `source` column.
- Creating enum items via UI will now return error if value already exist in enum
- Introduced `TypeChecker` class used with enum items. Currently, it is used for validating enum value type in `EnumForm`. I am planning to also use it in manifest import and maybe introduce methods for value casting.
- Few small refactorings

**Ticket:**
https://github.com/atviriduomenys/katalogas/issues/2324