### PR TITLE
[2349] Base reference issues when more than one file is used

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,10 @@ Security: Fix open Dependabot vulnerability alerts across pip and npm dependenci
   - Remove dead commented-out code with insecure CDN references.
 
 
+https://github.com/atviriduomenys/katalogas/issues/2349
+
+- Fix issues with Base row not being linked correctly, if model is imported with one manifest and referenced with base with another.
+
 v 1.15.0 (2026-02-27)
 ==================
 

--- a/tests/structure/test_services.py
+++ b/tests/structure/test_services.py
@@ -2669,3 +2669,150 @@ def test_structure_with_origin_source_type_headers(app: DjangoTestApp):
         "datasets/gov/ivpk/adp",
     ]
     assert Comment.objects.filter(type=Comment.STRUCTURE_ERROR).count() == 0
+
+
+class TestStructureBaseModels:
+    @pytest.mark.django_db
+    def test_structure_base_and_model_defined_in_file(self, app: DjangoTestApp):
+        """Model for Base is defined in the same file."""
+        manifest = (
+            "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description\n"
+            ",example,,,,,,,,,,,,,,,,\n"
+            ",,,,Animal,,,,,,0,completed,public,,,,,\n"
+            ",,,,,id,string,,source_animal_id,,4,completed,package,protected,,,,\n"
+            ",,,Animal,,,,,,,1,completed,public,,,,,\n"
+            ",,,,Dog,,,,,,0,completed,public,,,,,\n"
+            ",,,,,action,string,,source_dog_action,,4,completed,package,protected,,,,\n"
+            ",,,/,,,,,,,,,,,,,,\n"
+        )
+
+        structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+        structure.dataset.current_structure = structure
+        structure.dataset.save()
+        create_structure_objects(structure)
+
+        assert Base.objects.count() == 1
+        base_object = Base.objects.get(metadata__name="example/Animal")
+        assert Base.objects.first().model.name == "Animal"
+        assert Model.objects.count() == 2
+        assert Model.objects.get(metadata__name="example/Animal")
+        assert Model.objects.get(metadata__name="example/Dog").base == base_object
+
+    @pytest.mark.django_db
+    def test_structure_two_imports_first_model_secondly_reference_the_model_as_base(self, app: DjangoTestApp):
+        """Two imports: First one imports a manifest with a model. Second, uses the model as a base.
+
+        In this case, the model that was imported with the first file must have a Version status of STABLE.
+        """
+        manifest_with_model_definition = (
+            "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description\n"
+            ",example,,,,,,,,,,,,,,,,\n"
+            ",,,,Animal,,,,,,0,completed,public,,,,,\n"
+            ",,,,,id,string,,source_animal_id,,4,completed,package,protected,,,,\n"
+        )
+        structure_model = DatasetStructureFactory(
+            file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest_with_model_definition))
+        )
+        structure_model.dataset.current_structure = structure_model
+        structure_model.dataset.save()
+        version = create_structure_objects(structure_model)
+        version.status = VersionStatus.STABLE
+        version.save()
+
+        manifest_with_base_reference = (
+            "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description\n"
+            ",example2,,,,,,,,,,,,,,,,\n"
+            ",,,example/Animal,,,,,,,1,completed,public,,,,,\n"
+            ",,,,Dog,,,,,,0,completed,public,,,,,\n"
+            ",,,,,action,string,,source_dog_action,,4,completed,package,protected,,,,\n"
+            ",,,/,,,,,,,,,,,,,,\n"
+        )
+        structure_base = DatasetStructureFactory(
+            file=FilerFileFactory(file=FileField(filename="file2.csv", data=manifest_with_base_reference))
+        )
+        structure_base.dataset.current_structure = structure_base
+        structure_base.dataset.save()
+        create_structure_objects(structure_base)
+
+        assert Model.objects.count() == 2
+        animal_model = Model.objects.get(metadata__name="example/Animal")
+        dog_model = Model.objects.get(metadata__name="example2/Dog")
+
+        assert Base.objects.count() == 1
+        base_object = Base.objects.get(metadata__name="example/Animal")
+
+        assert base_object.model == animal_model
+        assert dog_model.base == base_object
+
+    @pytest.mark.django_db
+    def test_structure_two_imports_first_model_secondly_reference_the_model_as_base_model_not_released(
+        self, app: DjangoTestApp
+    ):
+        manifest_with_model_definition = (
+            "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description\n"
+            ",example,,,,,,,,,,,,,,,,\n"
+            ",,,,Animal,,,,,,0,completed,public,,,,,\n"
+            ",,,,,id,string,,source_animal_id,,4,completed,package,protected,,,,\n"
+        )
+        structure_model = DatasetStructureFactory(
+            file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest_with_model_definition))
+        )
+        structure_model.dataset.current_structure = structure_model
+        structure_model.dataset.save()
+        version = create_structure_objects(structure_model)
+        version.status = VersionStatus.DRAFT
+        version.save()
+
+        manifest_with_base_reference = (
+            "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description\n"
+            ",example2,,,,,,,,,,,,,,,,\n"
+            ",,,example/Animal,,,,,,,1,completed,public,,,,,\n"
+            ",,,,Dog,,,,,,0,completed,public,,,,,\n"
+            ",,,,,action,string,,source_dog_action,,4,completed,package,protected,,,,\n"
+            ",,,/,,,,,,,,,,,,,,\n"
+        )
+        structure_base = DatasetStructureFactory(
+            file=FilerFileFactory(file=FileField(filename="file2.csv", data=manifest_with_base_reference))
+        )
+        structure_base.dataset.current_structure = structure_base
+        structure_base.dataset.save()
+        create_structure_objects(structure_base)
+
+        assert Base.objects.count() == 0
+        assert Model.objects.count() == 2
+        assert Model.objects.get(metadata__name="example2/Dog").base is None
+
+        error_comment = Comment.objects.get(content_type=ContentType.objects.get_for_model(Model))
+        assert error_comment.type == Comment.STRUCTURE_ERROR
+        assert error_comment.body == (
+            "Nepavyko susieti bazinio modelio „example/Animal“. "
+            "Įsitikinkite, kad jis egzistuoja ir turi patvirtintą (stabilią) versiją."
+        )
+
+    @pytest.mark.django_db
+    def test_structure_base_defined_but_model_does_not_exist(self, app: DjangoTestApp):
+        """No model exists for the defined Base"""
+        manifest = (
+            "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description\n"
+            ",example,,,,,,,,,,,,,,,,\n"
+            ",,,Animal,,,,,,,1,completed,public,,,,,\n"
+            ",,,,Dog,,,,,,0,completed,public,,,,,\n"
+            ",,,,,action,string,,source_dog_action,,4,completed,package,protected,,,,\n"
+            ",,,/,,,,,,,,,,,,,,\n"
+        )
+
+        structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+        structure.dataset.current_structure = structure
+        structure.dataset.save()
+        create_structure_objects(structure)
+
+        assert Base.objects.count() == 0  # No model to link with - no base is created.
+        assert Model.objects.count() == 1
+        assert Model.objects.get(metadata__name="example/Dog").base is None
+
+        error_comment = Comment.objects.get(content_type=ContentType.objects.get_for_model(Model))
+        assert error_comment.type == Comment.STRUCTURE_ERROR
+        assert error_comment.body == (
+            "Nepavyko susieti bazinio modelio „example/Animal“. "
+            "Įsitikinkite, kad jis egzistuoja ir turi patvirtintą (stabilią) versiją."
+        )

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import uuid
+from http import HTTPStatus
 
 import pytest
 from django.contrib.contenttypes.models import ContentType
@@ -18,6 +19,7 @@ from reversion.models import Version
 
 from vitrina.classifiers.models import Status
 from vitrina.cms.factories import FilerFileFactory
+from vitrina.comments.models import Comment
 from vitrina.datasets.factories import DatasetStructureFactory, DatasetFactory
 from vitrina.datasets.models import Dataset
 from vitrina.orgs.factories import RepresentativeFactory, OrganizationFactory
@@ -46,7 +48,7 @@ from vitrina.utils import RevisionComment, RevisionSource
 
 
 class BaseTestCreateManifest:
-    def _create_manifest(self, manifest: str, title: str, description: str):
+    def _create_manifest(self, manifest: str, title: str = "", description: str = ""):
         dataset = DatasetFactory(
             title=title,
             description=description,
@@ -6769,6 +6771,7 @@ class TestStructure(BaseTestCreateManifest):
 
         response = app.get(reverse("dataset-structure-export", args=[dataset.pk, dataset.latest_version().pk]))
 
+        assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
             "1,datasets/gov/main/dataset,,,,,,,,,,,,,,,,,,Dataset,Dataset with ref property",
@@ -6802,6 +6805,7 @@ class TestStructure(BaseTestCreateManifest):
 
         response = app.get(reverse("dataset-structure-export", args=[dataset.pk, dataset.latest_version().pk]))
 
+        assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
             "1,dataset,,,,,,,,,,,,,,,,,,Title,Description",
@@ -6847,6 +6851,8 @@ class TestStructure(BaseTestCreateManifest):
         create_structure_objects(structure, metadata_version=version)
 
         response = app.get(reverse("dataset-structure-export", args=[dataset.pk, version.pk]))
+
+        assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
             "1,dataset,,,,,,,,,,,,,,,,,,Title,Description",
@@ -6877,6 +6883,7 @@ class TestStructure(BaseTestCreateManifest):
 
         response = app.get(reverse("dataset-structure-export", args=[dataset.pk, dataset.latest_version().pk]))
 
+        assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
             "1,dataset,,,,,,,,,,,,,,,,,,Dataset,Dataset with ref property",
@@ -6893,6 +6900,148 @@ class TestStructure(BaseTestCreateManifest):
             "10,,,,,id,string,,id,,,,,,develop,,,,,,",
             ",,,,,,,,,,,,,,,,,,,,",
         ]
+
+    def test_export__model_and_reference_as_base_in_file(self, app: DjangoTestApp):
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        manifest = (
+            "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description\n"
+            "1,example,,,,,,,,,,,,,,,,\n"
+            "2,,,,Animal,,,,,,0,completed,public,,,,,\n"
+            "3,,,,,id,string,,source_animal_id,,4,completed,package,protected,,,,\n"
+            "4,,,Animal,,,,,,,1,completed,public,,,,,\n"
+            "5,,,,Dog,,,,,,0,completed,public,,,,,\n"
+            "6,,,,,action,string,,source_dog_action,,4,completed,package,protected,,,,\n"
+            ",,,/,,,,,,,,,,,,,,\n"
+        )
+
+        dataset = self._create_manifest(manifest, "Dataset", "Dataset with ref property")
+
+        response = app.get(reverse("dataset-structure-export", args=[dataset.pk, dataset.latest_version().pk]))
+
+        assert response.status_code == HTTPStatus.OK
+        assert response.text.splitlines() == [
+            "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
+            "1,example,,,,,,,,,,,,,,,,,,Dataset,Dataset with ref property",
+            "2,,,,Animal,,,,,,,,,0,completed,public,,,,,",
+            "3,,,,,id,string,,source_animal_id,,,,,4,completed,package,protected,,,,",
+            ",,,,,,,,,,,,,,,,,,,,",
+            "4,,,Animal,,,,,,,,,,,,,,,,,",
+            "5,,,,Dog,,,,,,,,,0,completed,public,,,,,",
+            "6,,,,,action,string,,source_dog_action,,,,,4,completed,package,protected,,,,",
+            ",,,,,,,,,,,,,,,,,,,,",
+        ]
+
+    def test_export__model_and_reference_as_base_in_two_different_files(self, app: DjangoTestApp):
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        model_manifest = (
+            "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description\n"
+            "1,example,,,,,,,,,,,,,,,,\n"
+            "2,,,,Animal,,,,,,0,completed,public,,,,,\n"
+            "3,,,,,id,string,,source_animal_id,,4,completed,package,protected,,,,\n"
+        )
+        model_dataset = self._create_manifest(model_manifest, "Model Dataset", "Dataset that defines base model.")
+        model_version = model_dataset.latest_version()
+        model_version.status = VersionStatus.STABLE
+        model_version.save()
+
+        base_manifest = (
+            "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description\n"
+            "1,example2,,,,,,,,,,,,,,,,\n"
+            "2,,,example/Animal,,,,,,,1,completed,public,,,,,\n"
+            "3,,,,Dog,,,,,,0,completed,public,,,,,\n"
+            "4,,,,,action,string,,source_dog_action,,4,completed,package,protected,,,,\n"
+            ",,,/,,,,,,,,,,,,,,\n"
+        )
+        dataset = self._create_manifest(base_manifest, "Base Dataset", "Dataset that references model with base")
+
+        response = app.get(reverse("dataset-structure-export", args=[dataset.pk, dataset.latest_version().pk]))
+
+        assert response.status_code == HTTPStatus.OK
+        assert response.text.splitlines() == [
+            "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
+            "1,example2,,,,,,,,,,,,,,,,,,Base Dataset,Dataset that references model with base",
+            "2,,,example/Animal,,,,,,,,,,,,,,,,,",
+            "3,,,,Dog,,,,,,,,,0,completed,public,,,,,",
+            "4,,,,,action,string,,source_dog_action,,,,,4,completed,package,protected,,,,",
+            ",,,,,,,,,,,,,,,,,,,,",
+        ]
+
+    def test_export__model_and_reference_different_files_model_is_not_released(self, app: DjangoTestApp):
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        model_manifest = (
+            "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description\n"
+            "1,example,,,,,,,,,,,,,,,,\n"
+            "2,,,,Animal,,,,,,0,completed,public,,,,,\n"
+            "3,,,,,id,string,,source_animal_id,,4,completed,package,protected,,,,\n"
+        )
+        self._create_manifest(model_manifest, "Model Dataset", "Dataset that defines base model.")
+
+        base_manifest = (
+            "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description\n"
+            "1,example2,,,,,,,,,,,,,,,,\n"
+            "2,,,example/Animal,,,,,,,1,completed,public,,,,,\n"
+            "3,,,,Dog,,,,,,0,completed,public,,,,,\n"
+            "4,,,,,action,string,,source_dog_action,,4,completed,package,protected,,,,\n"
+            ",,,/,,,,,,,,,,,,,,\n"
+        )
+        dataset = self._create_manifest(base_manifest, "Base Dataset", "Dataset that references model with base")
+
+        response = app.get(reverse("dataset-structure-export", args=[dataset.pk, dataset.latest_version().pk]))
+
+        assert response.status_code == HTTPStatus.OK
+        assert response.text.splitlines() == [
+            "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
+            "1,example2,,,,,,,,,,,,,,,,,,Base Dataset,Dataset that references model with base",
+            "3,,,,Dog,,,,,,,,,0,completed,public,,,,,",
+            "4,,,,,action,string,,source_dog_action,,,,,4,completed,package,protected,,,,",
+            ",,,,,,,,,,,,,,,,,,,,",
+        ]
+
+        error_comment = Comment.objects.get(content_type=ContentType.objects.get_for_model(Model))
+        assert error_comment.type == Comment.STRUCTURE_ERROR
+        assert error_comment.body == (
+            "Nepavyko susieti bazinio modelio „example/Animal“. "
+            "Įsitikinkite, kad jis egzistuoja ir turi patvirtintą (stabilią) versiją."
+        )
+
+    def test_export__base_reference_without_defined_model(self, app: DjangoTestApp):
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        manifest = (
+            "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description\n"
+            "1,example,,,,,,,,,,,,,,,,\n"
+            "2,,,Animal,,,,,,,1,completed,public,,,,,\n"
+            "3,,,,Dog,,,,,,0,completed,public,,,,,\n"
+            "4,,,,,action,string,,source_dog_action,,4,completed,package,protected,,,,\n"
+            ",,,/,,,,,,,,,,,,,,\n"
+        )
+
+        dataset = self._create_manifest(manifest, "Dataset", "Dataset with ref property")
+
+        response = app.get(reverse("dataset-structure-export", args=[dataset.pk, dataset.latest_version().pk]))
+
+        assert response.status_code == HTTPStatus.OK
+        assert response.text.splitlines() == [  # Base could not be linked, so it is missing.
+            "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
+            "1,example,,,,,,,,,,,,,,,,,,Dataset,Dataset with ref property",
+            "3,,,,Dog,,,,,,,,,0,completed,public,,,,,",
+            "4,,,,,action,string,,source_dog_action,,,,,4,completed,package,protected,,,,",
+            ",,,,,,,,,,,,,,,,,,,,",
+        ]
+
+        error_comment = Comment.objects.get(content_type=ContentType.objects.get_for_model(Model))
+        assert error_comment.type == Comment.STRUCTURE_ERROR
+        assert error_comment.body == (
+            "Nepavyko susieti bazinio modelio „example/Animal“. "
+            "Įsitikinkite, kad jis egzistuoja ir turi patvirtintą (stabilią) versiją."
+        )
 
 
 class TestStructureExportDependentModels(BaseTestCreateManifest):

--- a/vitrina/datasets/structure.py
+++ b/vitrina/datasets/structure.py
@@ -596,7 +596,7 @@ def _read_base(
     if name == "/":
         base = state.base = None
     else:
-        name = get_relative_model_name(state.dataset, name)
+        name = get_relative_model_name_for_base(state.dataset, name)
         base = state.base = Base(
             id=row["id"],
             name=name,
@@ -918,6 +918,15 @@ def _parse_visibility(value: str) -> int:
         "public": StructureMetadata.VISIBILITY_PUBLIC,
     }
     return visibility_mapper.get(value)
+
+
+def get_relative_model_name_for_base(dataset: Dataset, name: str) -> str:
+    if name.startswith("/"):
+        return name[1:]
+    elif "/" in name or dataset is None:
+        return name
+    else:
+        return f"{dataset.name}/{name}"
 
 
 def get_relative_model_name(dataset: Dataset, name: str) -> str:

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -3155,7 +3155,7 @@ msgstr "Delete scope"
 msgid "Organizacijų sujungimas"
 msgstr "Organization merge"
 
-msgid "Organiacijų sujungimas"
+msgid "Organizacijų sujungimas"
 msgstr "Organization merge"
 
 msgid "Ryšiai su duomenų ištekliais"

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-03 09:42+0200\n"
+"POT-Creation-Date: 2026-03-04 09:29+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,9 +17,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-
-msgid "Organizacija"
-msgstr "Organization"
 
 msgid "Versijos duomenys"
 msgstr "Version data"
@@ -56,6 +53,9 @@ msgstr "API key"
 msgid "Taikymo sritis"
 msgstr "Application area"
 
+msgid "Organizacija"
+msgstr "Organization"
+
 msgid "Duomenų išteklius"
 msgstr "Resource"
 
@@ -83,10 +83,6 @@ msgstr "Home"
 
 msgid "Duomenų ištekliai"
 msgstr "Resources"
-
-#, python-brace-format
-msgid "{self.models[0].name}"
-msgstr ""
 
 msgid "kategoriją"
 msgstr "Category"
@@ -521,16 +517,6 @@ msgstr "Evaluated"
 msgid "Viešas komentaras"
 msgstr "Public comment"
 
-#, python-brace-format
-msgid ""
-"Pateiktas naujas prašymas: **[{self.rel_content_object.title}]({url})**."
-msgstr ""
-
-msgid ""
-"Šis duomenų rinkinys įtrauktas į {self.rel_content_object.get_title()} "
-"projektą."
-msgstr ""
-
 msgid "Negalima atmesti — patvirtinti/atidaryti priskyrimai egzistuoja."
 msgstr "Cannot reject - approved/opened assignments exist"
 
@@ -578,22 +564,6 @@ msgstr "Data updated</br>in the repository"
 
 msgid "Metaduomenys atnaujinti</br>kataloge"
 msgstr "Metadata updated</br>in the catalog"
-
-#, python-brace-format
-msgid "Vėluoja {late_for.days} dieną"
-msgstr ""
-
-#, python-brace-format
-msgid "Vėluoja {late_for.days} dienas"
-msgstr ""
-
-#, python-brace-format
-msgid "Vėluoja {hours} valandą"
-msgstr ""
-
-#, python-brace-format
-msgid "Vėluoja {hours} valandas"
-msgstr ""
 
 msgid "Duomenų rinkinio pavadinimas"
 msgstr "Dataset title"
@@ -645,13 +615,13 @@ msgstr "Documentation"
 
 msgid "Ši savybė nurodo dokumentą apie šį duomenų rinkinį. Atitinka foaf:page."
 msgstr ""
-"This property refers to the document about this dataset. Corresponds to foaf:"
-"page."
+"This property refers to the document about this dataset. Corresponds to "
+"foaf:page."
 
 msgid "Ši savybė nurodo puslapį apie šį duomenų rinkinį. Atitinka foaf:page."
 msgstr ""
-"This property refers to the page about this dataset. Corresponds to foaf:"
-"page."
+"This property refers to the page about this dataset. Corresponds to "
+"foaf:page."
 
 msgid "Duomenų ištekliaus identifikatorius. Atitinka dct:identifier."
 msgstr "The main identifier for the resource. Corresponds to dct:identifier."
@@ -702,8 +672,8 @@ msgstr ""
 "<br>To specify a particular location in the legal document, append \"#\" "
 "followed by the exact reference, e.g., \"#17.2\".<br>In cases where there "
 "are multiple documents with annexes: \"#annex1/17.2\", \"17.2/17.2.5\", "
-"where \"annex1\" is the document file name.<br>Corresponds to eli:"
-"LegalResource."
+"where \"annex1\" is the document file name.<br>Corresponds to "
+"eli:LegalResource."
 
 msgid "Tėvinis išteklius"
 msgstr "Parent resource"
@@ -755,8 +725,8 @@ msgid "API adresas"
 msgstr "API address"
 
 msgid ""
-"Laisvu tekstu pateikiamas duomenų paslaugos galinio taško URL. Atitinka dcat:"
-"endpointURL."
+"Laisvu tekstu pateikiamas duomenų paslaugos galinio taško URL. Atitinka "
+"dcat:endpointURL."
 msgstr ""
 "The root location or primary endpoint of the service (an URL). Corresponds "
 "to dcat:endpointURL."
@@ -766,8 +736,8 @@ msgstr "API specification"
 
 msgid ""
 "Šioje savybėje pateikiamas paslaugų, prieinamų per galinius taškus, "
-"aprašymas. Įskaitant jų operacijas, parametrus ir t. t. Atitinka dcat:"
-"endpointDescription."
+"aprašymas. Įskaitant jų operacijas, parametrus ir t. t. Atitinka "
+"dcat:endpointDescription."
 msgstr ""
 "A description of the services available via the end-points. Including their "
 "operations, parameters etc. Corresponds to dcat:endpointDescription."
@@ -873,14 +843,6 @@ msgstr "Both \"Organization\" and \"Agent\" fields cannot be assigned."
 msgid "Privaloma užpildyti \"Organizacija\" arba \"Agentas\" lauką."
 msgstr "\"Organization\" or \"Agent\" field must be assigned."
 
-#, python-brace-format
-msgid "Ryšys \"{attribution}\" su šia organizacija jau egzistuoja."
-msgstr "Relation \"{attribution}\" with this organization already exists."
-
-#, python-brace-format
-msgid "Ryšys \"{attribution}\" su šiuo agentu jau egzistuoja."
-msgstr "Relation \"{attribution}\" with this agent already exists."
-
 msgid "Pridėti"
 msgstr "Add"
 
@@ -906,6 +868,9 @@ msgstr "Groups"
 msgid "Kategorija"
 msgstr "Category"
 
+msgid "Rodyti pasirinktas kategorijas"
+msgstr "Display selected categories."
+
 msgid "Išsaugoti"
 msgstr "Save"
 
@@ -914,15 +879,6 @@ msgstr "Relation type"
 
 msgid "Neteisinga ryšio tipo reikšmė."
 msgstr "Relation type is incorrect."
-
-#, python-brace-format
-msgid ""
-"\"{relation.inversive_title}\" ryšys su šiuo duomenų rinkiniu jau egzistuoja."
-msgstr ""
-
-#, python-brace-format
-msgid "\"{relation.title}\" ryšys su šiuo duomenų rinkiniu jau egzistuoja."
-msgstr "\"{relation.title}\" relation with this dataset already exists."
 
 msgid "Terminas"
 msgstr "Deadline"
@@ -1021,8 +977,8 @@ msgid "Teisės - Aprašymas"
 msgstr "Rights - Description"
 
 msgid ""
-"Laisvu tekstu pateikiamas teisių deklaracijos aprašymas. Atitinka dct:"
-"rights / dct:description."
+"Laisvu tekstu pateikiamas teisių deklaracijos aprašymas. Atitinka "
+"dct:rights / dct:description."
 msgstr ""
 "The description of the declaration of rights. Corresponds to dct:rights  / "
 "dct:description."
@@ -1031,8 +987,8 @@ msgid "Katalogas"
 msgstr "Directory"
 
 msgid ""
-"Katalogas, kurio turinys domina šio katalogo kontekste. Atitinka dcat:"
-"Catalog."
+"Katalogas, kurio turinys domina šio katalogo kontekste. Atitinka "
+"dcat:Catalog."
 msgstr ""
 "A catalogue whose contents are of interest in the context of this catalogue. "
 "Corresponds to dcat:catalog."
@@ -1055,19 +1011,19 @@ msgstr "Access rights"
 
 msgid ""
 "Informacija ar duomenų rinkinys yra atviri duomenys, ar jam taikomi prieigos "
-"apribojimai, ar jis nėra viešas, ar jis konfidencialus. Atitinka dct:"
-"accessRights."
+"apribojimai, ar jis nėra viešas, ar jis konfidencialus. Atitinka "
+"dct:accessRights."
 msgstr ""
 "Describe level of access rights according to the list of values (i.e., "
-"Public, non public, confidential and restricted). Corresponds to dct:"
-"accessRights."
+"Public, non public, confidential and restricted). Corresponds to "
+"dct:accessRights."
 
 msgid "Žymės"
 msgstr "Tags"
 
 msgid ""
-"Duomenų išteklių apibūdinantys raktažodžiai arba žymos. Atitinka dcat:"
-"keyword."
+"Duomenų išteklių apibūdinantys raktažodžiai arba žymos. Atitinka "
+"dcat:keyword."
 msgstr "Keywords or tags describing the resource. Corresponds to dcat:keyword."
 
 msgid "Geoportalo id"
@@ -1141,8 +1097,8 @@ msgid "Laikotarpio pradžios data"
 msgstr "Period start date"
 
 msgid ""
-"Ši savybė nurodo pradžios datą, kurią apima duomenų rinkinys. Atitinka dct:"
-"temporal."
+"Ši savybė nurodo pradžios datą, kurią apima duomenų rinkinys. Atitinka "
+"dct:temporal."
 msgstr ""
 "This property indicates the start date covered by the dataset. Corresponds "
 "to dct:temporal."
@@ -1151,8 +1107,8 @@ msgid "Laikotarpio pabaigos data"
 msgstr "Period end date"
 
 msgid ""
-"Ši savybė nurodo pabaigos datą, kurią apima duomenų rinkinys. Atitinka dct:"
-"temporal."
+"Ši savybė nurodo pabaigos datą, kurią apima duomenų rinkinys. Atitinka "
+"dct:temporal."
 msgstr ""
 "This property indicates the end date covered by the dataset. Corresponds to "
 "dct:temporal."
@@ -1176,16 +1132,16 @@ msgstr "Spatial resolution (in meters)"
 msgid ""
 "Erdvės skiriamoji geba metrais. Atitinka dcat:spatialResolutionInMeters."
 msgstr ""
-"Spatial resolution (in meters). Corresponds to dcat:"
-"spatialResolutionInMeters."
+"Spatial resolution (in meters). Corresponds to "
+"dcat:spatialResolutionInMeters."
 
 msgid "Teisės - Susijęs dokumentas"
 msgstr "Rights - Related document"
 
 msgid "Teisių deklaracijos nuoroda. Atitinka dct:rights / dct:relation."
 msgstr ""
-"Reference to the declaration of rights. Corresponds to dct:rights / dct:"
-"relation."
+"Reference to the declaration of rights. Corresponds to dct:rights / "
+"dct:relation."
 
 msgid "Paslaugos tipas. Atitinka dct:type"
 msgstr "Service type. Corresponds to dct:type"
@@ -1198,6 +1154,9 @@ msgstr "Addition to dataset"
 
 msgid "Duomenų atvėrimas"
 msgstr "Data opening"
+
+msgid "Jau įtraukta į versiją"
+msgstr "Already added to the version"
 
 msgid "Duomenų rinkinių atnaujinimo ataskaita"
 msgstr "Dataset update report"
@@ -1293,24 +1252,12 @@ msgid "Naudotojui išsiųstas laiškas dėl registracijos"
 msgstr "The user has been sent an email for registration"
 
 #, python-brace-format
-msgid "Modelis \"{model.name}\" jau egzistuoja."
-msgstr "Model \"{model.name}\" already exists."
-
-#, python-brace-format
-msgid "Savybė \"{name}\" jau egzistuoja."
-msgstr ""
-
-#, python-brace-format
 msgid ""
 "Duomenų lauko \"{0}\" metaduomenų matomumo lygis \"{1}\" negali būti "
 "aukštesnis už modelio metaduomenų matomumo lygį \"{2}\". "
 msgstr ""
 "Data field \"{0}\" metadata visibility level \"{1}\" must not be higher than "
 "the model metadata visibility level \"{2}\". "
-
-#, python-brace-format
-msgid "Prefiksas \"{name}\" jau egzistuoja."
-msgstr "Prefix \"{name}\" already exists."
 
 #, python-brace-format
 msgid ""
@@ -1328,41 +1275,17 @@ msgstr ""
 "Enum field \"{0}\" metadata visibility level \"{1}\" must not be higher than "
 "the model metadata visibility level \"{2}\" . "
 
-#, python-brace-format
-msgid "Galima reikšmė \"{enum.prepare}\" jau egzistuoja."
-msgstr ""
-
-#, python-brace-format
-msgid "Parametras \"{param.prepare}\" jau egzistuoja."
-msgstr ""
-
-#, python-brace-format
-msgid ""
-"\"{name}\" kodiniame pavadinime gali būti naudojamos tik lotyniškos raidės."
-msgstr "Code name \"{name}\" can only include latin characters."
-
-#, python-brace-format
-msgid ""
-"Pirmas modelio kodinio pavadinimo simbolis turi būti didžioji raidė: "
-"\"{name}\"."
-msgstr "First symbol of model code name must be a capital letter: \"{name}\"."
-
 msgid ""
 "Modelio kodiniame pavadinime gali būti didžiosos/mažosios raidės ir "
 "skaičiai, "
 msgstr "Model code name can contain uppercase/lowercase letters and numbers. "
 
-#, python-brace-format
-msgid "Pirmas kodinio pavadinimo simbolis turi būti mažoji raidė: \"{name}\"."
-msgstr "First symbol of code name must be a lowercase letter: \"{name}\"."
-
-#, python-brace-format
 msgid ""
-"Kodiniame pavadinime negali būti naudojamos didžiosios raidės: \"{name}\"."
-msgstr "Code name can not include upper case letters: \"{name}\"."
-
-msgid "Pavadinime gali būti mažosios raidės ir skaičiai, "
-msgstr "Name can only contain lowercase letters and numbers, "
+"Pavadinime gali būti mažosios raidės ir skaičiai, žodžiai gali būti atskirti "
+"_ simboliu, arba . simboliu, "
+msgstr ""
+"Code name can include lowercase letters and numbers, and words can be "
+"separated by the _ symbol. No other symbols are allowed."
 
 msgid "Duomenų rinkinių atvėrimo progresas"
 msgstr "Progress of opening datasets"
@@ -1497,8 +1420,8 @@ msgid "API dokumentacijos formatas (pvz., JSON, YAML)"
 msgstr "API documentation format (e.g., JSON, YAML)"
 
 msgid ""
-"Ši savybė nurodo laikotarpį, kurį apima duomenų rinkinys. Atitinka dct:"
-"temporal."
+"Ši savybė nurodo laikotarpį, kurį apima duomenų rinkinys. Atitinka "
+"dct:temporal."
 msgstr ""
 "This property indicates the period covered by the dataset. Corresponds to "
 "dct:temporal."
@@ -1913,14 +1836,6 @@ msgstr "Add manager"
 msgid "Tvarkytojo redagavimas"
 msgstr "Edit user"
 
-#, python-brace-format
-msgid "Ar tikrai norite pašalinti \"{obj.organization.title}\" iš {role}?"
-msgstr "Are you sure you want to remove \"{obj.organization.title}\" from {role}?"
-
-#, python-brace-format
-msgid "Ar tikrai norite ištrinti \"{obj}\" {role}?"
-msgstr "Are you sure you want to delete \"{obj}\" {role}?"
-
 msgid "Poreikių pridėjimas"
 msgstr "Add requests"
 
@@ -1972,116 +1887,26 @@ msgstr "Time"
 msgid "Duomenų rinkinių būsenos"
 msgstr "Dataset statuses"
 
-msgid ""
-"{self.get_title_for_indicator(indicator)} pagal rinkinio būseną rinkinio "
-"įkėlimo datai"
-msgstr ""
-
-msgid "{self.get_title_for_indicator(indicator)} pagal rinkinio būseną laike"
-msgstr ""
-
-msgid ""
-"{self.get_title_for_indicator(indicator)} pagal rinkinio valdymo sritį "
-"rinkinio įkėlimo datai"
-msgstr ""
-
-msgid ""
-"{self.get_title_for_indicator(indicator)} pagal rinkinio valdymo sritį laike"
-msgstr ""
-
 msgid "Duomenų rinkinių brandos lygiai"
 msgstr "Dataset maturity levels"
-
-msgid ""
-"{self.get_title_for_indicator(indicator)} pagal rinkinio brandos lygį "
-"rinkinio įkėlimo datai"
-msgstr ""
-
-msgid "{Y_TITLES.get(indicator, '')} pagal rinkinio brandos lygį laike"
-msgstr ""
-
-msgid ""
-"{self.get_title_for_indicator(indicator)} pagal rinkinio organizaciją "
-"rinkinio įkėlimo datai"
-msgstr ""
-
-msgid ""
-"{self.get_title_for_indicator(indicator)} pagal rinkinio organizaciją laike"
-msgstr ""
 
 msgid "Duomenų rinkinių žymės"
 msgstr "Dataset tags"
 
-msgid ""
-"{self.get_title_for_indicator(indicator)} pagal rinkinio žymes rinkinio "
-"įkėlimo datai"
-msgstr ""
-
-msgid "{self.get_title_for_indicator(indicator)} pagal rinkinio žymes laike"
-msgstr ""
-
 msgid "Duomenų rinkinių formatai"
 msgstr "Dataset formats"
-
-msgid ""
-"{self.get_title_for_indicator(indicator)} pagal rinkinio formatą rinkinio "
-"įkėlimo datai"
-msgstr ""
-
-msgid "{self.get_title_for_indicator(indicator)} pagal rinkinio formatą laike"
-msgstr ""
 
 msgid "Duomenų rinkinių atnaujinimo dažnumas"
 msgstr "Dataset update frequency"
 
-msgid ""
-"{self.get_title_for_indicator(indicator)} pagal rinkinio atnaujinimą "
-"rinkinio įkėlimo datai"
-msgstr ""
-
-msgid ""
-"{self.get_title_for_indicator(indicator)} pagal rinkinio atnaujinimą laike"
-msgstr ""
-
 msgid "Duomenų rinkinių grupės"
 msgstr "Dataset groups"
-
-msgid ""
-"{self.get_title_for_indicator(indicator)} pagal rinkinio grupes rinkinio "
-"įkėlimo datai"
-msgstr ""
-
-msgid "{self.get_title_for_indicator(indicator)} pagal rinkinio grupes laike"
-msgstr ""
 
 msgid "Duomenų rinkinių prieigos teisės"
 msgstr "Dataset count by years"
 
-msgid ""
-"{self.get_title_for_indicator(indicator)} pagal rinkinio prieigos teises "
-"rinkinio įkėlimo datai"
-msgstr ""
-
-msgid ""
-"{self.get_title_for_indicator(indicator)} pagal rinkinio prieigos teises "
-"laike"
-msgstr ""
-
-msgid ""
-"{self.get_title_for_indicator(indicator)} pagal rinkinio kategoriją rinkinio "
-"įkėlimo datai"
-msgstr ""
-
-msgid ""
-"{self.get_title_for_indicator(indicator)} pagal rinkinio kategoriją laike"
-msgstr ""
-
 msgid "Duomenų rinkinių kiekis metuose"
 msgstr "Dataset count by years"
-
-msgid ""
-"{self.get_title_for_indicator(indicator)} pagal rinkinio įkėlimo datą laike"
-msgstr ""
 
 msgid "Termino pašalinimas"
 msgstr "Delete term"
@@ -2492,10 +2317,6 @@ msgstr "Reject"
 
 msgid "Veiksmai"
 msgstr "Action"
-
-#, python-brace-format
-msgid "\"{obj_display}\" prašymas pašalintas sėkmingai."
-msgstr ""
 
 msgid "Duomenų teikėjo \""
 msgstr "Data providers"
@@ -3018,8 +2839,8 @@ msgid "Dėmesio:"
 msgstr "Attention:"
 
 msgid ""
-"Prieš pradedant registraciją įsikinkite, kad jūsų data.gov profilio el."
-"paštas sutampa su viisp sistemoje esančio profilio el.paštu. Jį galima "
+"Prieš pradedant registraciją įsikinkite, kad jūsų data.gov profilio "
+"el.paštas sutampa su viisp sistemoje esančio profilio el.paštu. Jį galima "
 "koreguoti."
 msgstr ""
 "Before you begin registration, make sure that the e-mail address of your "
@@ -3151,9 +2972,6 @@ msgstr "Edit scope"
 
 msgid "Šalinti taikymo sritį"
 msgstr "Delete scope"
-
-msgid "Organizacijų sujungimas"
-msgstr "Organization merge"
 
 msgid "Organizacijų sujungimas"
 msgstr "Organization merge"
@@ -3298,6 +3116,9 @@ msgstr ""
 "Check this box if you want the use case to be publicly visible to everyone. "
 "Otherwise, it will only be visible to the assignee's and assigner's "
 "organizations."
+
+msgid "Fizinis asmuo"
+msgstr "Individual person"
 
 msgid "Kliento pavadinimas"
 msgstr "Client name"
@@ -3720,30 +3541,17 @@ msgstr "Creation date"
 msgid "Poreikio pateikimo data"
 msgstr "Request creation date"
 
-msgid "{self.get_title_for_indicator(indicator)} pagal poreikio būseną laike"
-msgstr ""
-
 msgid "Duomenų rinkinių būsena"
 msgstr "Dataset status"
 
-msgid ""
-"{self.get_title_for_indicator(indicator)} pagal duomenų rinkinio būseną laike"
-msgstr ""
-
 msgid "Poreikių organizacijos"
 msgstr "Request organizations"
-
-msgid "{self.get_title_for_indicator(indicator)} pagal organizaciją laike"
-msgstr ""
 
 msgid "Poreikių valdymo sritys"
 msgstr "Request management areas"
 
 msgid "Poreikių kiekis metuose"
 msgstr "Request count by years"
-
-msgid "{self.get_title_for_indicator(indicator)} pagal pateikimo datą"
-msgstr ""
 
 msgid "Poreikio registravimas"
 msgstr "Request creation"
@@ -4024,7 +3832,8 @@ msgstr "Agreement document is signed by data receiver."
 
 msgid ""
 "Duomenų gavėjo pasiūlymas duomenims gauti yra patvirtintas duomenų teikėjo."
-msgstr "Data receiver's request for data has been approved by the data provider."
+msgstr ""
+"Data receiver's request for data has been approved by the data provider."
 
 msgid "Sutarties dokumentas sukurtas, bet nepasirašytas."
 msgstr "Agreement document is created, but not signed yet."
@@ -4074,8 +3883,8 @@ msgstr "Action was executed successfully"
 
 #, python-brace-format
 msgid ""
-"Veiksmas gali būti atliekamas tik sutarčiai esant būsenoje {expected_status}."
-"Dabartinė būsena: {current_status}."
+"Veiksmas gali būti atliekamas tik sutarčiai esant būsenoje "
+"{expected_status}.Dabartinė būsena: {current_status}."
 msgstr ""
 "The action can only be executed when the agreement has the status "
 "{expected_status}. Current status: {current_status}"
@@ -4467,10 +4276,6 @@ msgstr ""
 "Linking a model to its base is not only done by using a trusted identifier, "
 "but while providing data the integrity of identifiers is also ensured."
 
-#, python-brace-format
-msgid "Duomenų filtre nurodytas modelyje neegzistuojantis laukas: \"{ast}\"."
-msgstr ""
-
 msgid "Savybė nurodanti duomenų lauko pavadinimą, modelio atributas."
 msgstr "Property indicating the data field name, a model attribute."
 
@@ -4598,14 +4403,6 @@ msgstr ""
 
 msgid "Modelis su tokiu kodiniu pavadinimu jau egzistuoja."
 msgstr "Model with this code name already exists."
-
-#, python-brace-format
-msgid "Nevalidus uri \"{uri}\" formatas."
-msgstr ""
-
-#, python-brace-format
-msgid "Neatpažintas \"{prefix}\" prefiksas."
-msgstr ""
 
 msgid ""
 "Stulpelis 'Klasė' turi būti užpildytas pasirenkant šį metaduomenų matomumo "
@@ -4963,34 +4760,6 @@ msgid ""
 "Įsitikinkite, kad jis egzistuoja ir turi patvirtintą (stabilią) versiją."
 msgstr "Ensure, that it exists and has a confirmed (stable) version."
 
-#, python-brace-format
-msgid "Duomenų išteklius \"{meta.name}\" jau egzistuoja."
-msgstr "Data resource \"{meta.name}\" already exists."
-
-#, python-brace-format
-msgid ""
-"\"{meta.name}\" kodiniame pavadinime gali būti naudojamos tik lotyniškos "
-"raidės."
-msgstr "Code name \"{meta.name}\" can only include latin characters."
-
-#, python-brace-format
-msgid ""
-"\"{meta.name}\" kodiniame pavadinime gali būti naudojamos tik mažosios "
-"raidės."
-msgstr "Code name \"{meta.name}\" can only include lowercase letters."
-
-#, python-brace-format
-msgid "Klaida skaitant formulę \"{prepare}\"\": {e}"
-msgstr ""
-
-#, python-brace-format
-msgid "Neteisingas uri \"{uri}\" formatas."
-msgstr "Invalid URI \"{uri}\" format."
-
-#, python-brace-format
-msgid "Prefiksas \"{prefix}\" duomenų ištekliuje neegzistuoja."
-msgstr ""
-
 msgid "Nepavyko gauti duomenų iš Saugyklos per nustatytą laiką"
 msgstr "Failed to retrieve data from Storage within the allotted time"
 
@@ -5184,16 +4953,6 @@ msgstr "Can not edit the property, when the version status is not draft."
 
 msgid "Duomenų lauko redagavimas"
 msgstr "Edit property"
-
-#, python-brace-format
-msgid ""
-"Pridėtas \"{model.name}\" modelio bazinis duomenų laukas \"{prop.name}\"."
-msgstr ""
-
-#, python-brace-format
-msgid ""
-"Pašalintas \"{model.name}\" modelio bazinis duomenų laukas \"{prop_name}\"."
-msgstr ""
 
 msgid "Parametro pridėjimas"
 msgstr "Add parameter"
@@ -5432,9 +5191,6 @@ msgstr "Logout"
 
 msgid "Prisijungti"
 msgstr "Login"
-
-msgid "Fizinis asmuo"
-msgstr "Individual person"
 
 msgid "Duomenų paieška"
 msgstr "Data search"
@@ -5961,16 +5717,12 @@ msgid ""
 "Nurodoma su Agentu susieta duomenų paslauga. Atitinka DCAT:DataService. Jei "
 "nenurodyta, duomenų paslauga bus sukurta automatiškai."
 msgstr ""
-"The data service associated with the Agent is specified. Corresponds to DCAT:"
-"DataService. If not specified, the data service will be created "
+"The data service associated with the Agent is specified. Corresponds to "
+"DCAT:DataService. If not specified, the data service will be created "
 "automatically."
 
 msgid "Duomenų paslauga automatiškai sukurta kuriant agentą."
 msgstr "Data service automatically created with the agent."
-
-#, python-brace-format
-msgid "Agentas {self.object.title} sukurtas sėkmingai!"
-msgstr "Agent {self.object.title} created successfully!"
 
 msgid ""
 "Išsisaugokite slaptą raktą rodomą puslapio pabaigoje, jis bus rodomas tik šį "
@@ -5998,20 +5750,8 @@ msgstr ""
 msgid "Redaguoti Agentą"
 msgstr "Edit agent"
 
-#, python-brace-format
-msgid "Agentas {self.object.title} atnaujintas sėkmingai!"
-msgstr "Agent {self.object.title} updated successfully!"
-
 msgid "Pašalinti Agentą"
 msgstr "Delete agent"
-
-#, python-brace-format
-msgid "Ar tikrai norite ištrinti Agentą: {self.object}?"
-msgstr "Are you sure you want to delete agent: {self.object}?"
-
-#, python-brace-format
-msgid "Agentas {self.object.title} pašalintas sėkmingai!"
-msgstr "Agent {self.object.title} deleted successfully!"
 
 msgid "Asmeninė informacija"
 msgstr "Personal information"
@@ -6036,15 +5776,6 @@ msgstr "Edit user"
 
 msgid "Naudotojas \""
 msgstr "User"
-
-msgid ""
-"Organizacijos \"{rep.content_object}\" {rep.get_role_display().lower()}: "
-msgstr ""
-
-msgid ""
-"Duomenų ištekliaus \"{rep.content_object}\" {rep.get_role_display()."
-"lower()}: "
-msgstr ""
 
 msgid "Vienkartinis prisijungimo kodas"
 msgstr "Single use login code"
@@ -6525,19 +6256,3 @@ msgid ""
 "Prisijunkite su šiuo elektroniniu paštu ir bandykite viisp autentifikaciją "
 "iš naujo"
 msgstr "Log in with this e-mail address and try viisp authentication again"
-
-#~ msgid "Rodyti pasirinktas kategorijas"
-#~ msgstr "Display selected categories."
-
-#~ msgid "Jau įtraukta į versiją"
-#~ msgstr "Already added to the version"
-
-#~ msgid ""
-#~ "Pavadinime gali būti mažosios raidės ir skaičiai, žodžiai gali būti "
-#~ "atskirti _ simboliu, arba . simboliu, "
-#~ msgstr ""
-#~ "Code name can include lowercase letters and numbers, and words can be "
-#~ "separated by the _ symbol. No other symbols are allowed."
-
-#~ msgid "Organizacijos sutartys"
-#~ msgstr "Organization agreements"

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -4959,6 +4959,10 @@ msgstr ""
 msgid "Invalid"
 msgstr ""
 
+msgid ""
+"Įsitikinkite, kad jis egzistuoja ir turi patvirtintą (stabilią) versiją."
+msgstr "Ensure, that it exists and has a confirmed (stable) version."
+
 #, python-brace-format
 msgid "Duomenų išteklius \"{meta.name}\" jau egzistuoja."
 msgstr "Data resource \"{meta.name}\" already exists."

--- a/vitrina/orgs/views.py
+++ b/vitrina/orgs/views.py
@@ -2814,7 +2814,7 @@ class OrganizationMergeView(PermissionRequiredMixin, OrganizationBaseViewMixin, 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["current_title"] = _("Organizacijų sujungimas")
-        context["parent_links"].update({None: _("Organiacijų sujungimas")})
+        context["parent_links"].update({None: _("Organizacijų sujungimas")})
         context["form"] = OrganizationMergeForm()
         return context
 

--- a/vitrina/structure/services.py
+++ b/vitrina/structure/services.py
@@ -745,30 +745,46 @@ def _link_models(dataset: Dataset, dataset_meta: struct.Dataset, metadata_versio
             model.update_level()
 
 
+def resolve_base_model(base_metadata: struct.Base, metadata_version: Version) -> Model | None:
+    """Retrieves a base model based on metadata, prioritizing specific version or stable status.
+
+    This function attempts to find a Model object associated with a given base_metadata.
+    It handles two scenarios for model import:
+        1.  Model and Base in the same file: In this case, the function expects to find the model
+            with the same `metadata_version` as provided.
+        2.  Model imported before Base: If the model is defined in a separate file and then referenced
+            as a base, their `metadata_version`s might differ. In this scenario,
+            the function falls back to searching for the newest `STABLE` version of the model.
+    """
+    model_content_type = ContentType.objects.get_for_model(Model)
+    base_filter = Q(metadata__content_type=model_content_type, metadata__name=base_metadata.name)
+
+    queryset = Model.objects.filter(base_filter).order_by("-created")
+    return (
+        queryset.filter(metadata_version=metadata_version).first()
+        or queryset.filter(metadata_version__status=VersionStatus.STABLE).first()
+    )
+
+
 def _link_base(
     dataset: Dataset,
     meta: struct.Base,
     model: Model,
     metadata_version: Version,
 ):
-    base_ct = ContentType.objects.get_for_model(Base)
-    model_ct = ContentType.objects.get_for_model(Model)
-
     if meta:
         if meta.errors:
             _create_errors(meta.errors, model)
         else:
-            if base_model := Model.objects.filter(
-                metadata__content_type=model_ct, metadata__name=meta.name, metadata_version=metadata_version
-            ).first():
-                if base := Base.objects.filter(
-                    metadata__content_type=base_ct,
+            if base_model := resolve_base_model(meta, metadata_version):
+                if base_object := Base.objects.filter(
+                    metadata__content_type=ContentType.objects.get_for_model(Base),
                     metadata__name=meta.name,
                     model=base_model,
                     metadata_version=metadata_version,
                 ).first():
                     if not meta.id:
-                        meta.id = base.metadata.first().uuid
+                        meta.id = base_object.metadata.first().uuid
 
                 base = Base(model=base_model, metadata_version=metadata_version)
                 base, metadata = _create_or_update_metadata(dataset, meta, base, metadata_version=metadata_version)
@@ -777,6 +793,14 @@ def _link_base(
                 model.base = base
                 model.save()
                 _create_errors(meta.errors, base)
+            else:
+                meta.errors.append(
+                    _(
+                        f"Nepavyko susieti bazinio modelio „{meta.name}“. "
+                        f"Įsitikinkite, kad jis egzistuoja ir turi patvirtintą (stabilią) versiją."
+                    )
+                )
+                _create_errors(meta.errors, model)
 
     elif model.base:
         base = model.base

--- a/vitrina/structure/services.py
+++ b/vitrina/structure/services.py
@@ -752,8 +752,8 @@ def resolve_base_model(base_metadata: struct.Base, metadata_version: Version) ->
     It handles two scenarios for model import:
         1.  Model and Base in the same file: In this case, the function expects to find the model
             with the same `metadata_version` as provided.
-        2.  Model imported before Base: If the model is defined in a separate file and then referenced
-            as a base, their `metadata_version`s might differ. In this scenario,
+        2.  Model imported after being referenced as Base: If the model is defined in a separate file and then
+            referenced as a base, their `metadata_version`s might differ. In this scenario,
             the function falls back to searching for the newest `STABLE` version of the model.
     """
     model_content_type = ContentType.objects.get_for_model(Model)


### PR DESCRIPTION
It was assumed that the base and its model (the referenced one with `Base`) will be imported via a single file. The assumption is wrong since there might be a need to reference an old imported model (with Base).

#### Solution:

- If both the model is imported and it is later used as Base in the same file - the solution should keep the model intact and not destroy the already implemented logic, the base should be exported as it was - successfully.
- If Model is imported first and only later the Base is imported to a different Dataset (object in Catalog), we should try to link them up
    - We use the latest released (`STABLE`) version of the model that is referenced via the row where `Base` is defined.
    - Error is thrown in case there are no models found that could be referenced.

#### Notes:
- Covered extensively with test cases.