### PR TITLE
2334: Updating model visibility level depending on property or enum visibility

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,6 +64,12 @@ https://github.com/atviriduomenys/katalogas/issues/2434
 
 - Added metadata field for dataset when creating through post request
 
+https://github.com/atviriduomenys/katalogas/issues/2334
+
+- Propagate visibility upward from property to model
+- Added _update_model_visibility_from_property which ensures a model's visibility is automatically elevated when one of its properties has higher visibility.
+- Added _update_parent_visibility_from_enum which propagates visibility upward through the full chain — from enum to its parent property, and from property to the model — applying the same rule at each level.
+
 v 1.15.0 (2026-02-27)
 ==================
 

--- a/tests/datasets/test_structure.py
+++ b/tests/datasets/test_structure.py
@@ -182,7 +182,7 @@ def test_update_model_visibility_from_property(model_visibility, property_visibi
     ],
 )
 def test_update_parent_visibility_from_enum(
-    model_visibility, property_visibility, enum_visibility, expected_model, expected_property
+    model_visibility, property_visibility, enum_visibility, expected_model_visibility, expected_property_visibility
 ):
     model = Model(visibility=model_visibility)
     property = Property(visibility=property_visibility)
@@ -194,5 +194,5 @@ def test_update_parent_visibility_from_enum(
 
     _update_parent_visibility_from_enum(state, enum)
 
-    assert model.visibility == expected_model
-    assert property.visibility == expected_property
+    assert model.visibility == expected_model_visibility
+    assert property.visibility == expected_property_visibility

--- a/tests/datasets/test_structure.py
+++ b/tests/datasets/test_structure.py
@@ -172,7 +172,7 @@ def test_update_model_visibility_from_property(model_visibility, property_visibi
 
 
 @pytest.mark.parametrize(
-    "model_visibility, property_visibility, enum_visibility, expected_model, expected_property",
+    "model_visibility, property_visibility, enum_visibility, expected_model_visibility, expected_property_visibility",
     [
         ("private", "private", "public", "public", "public"),
         ("private", "private", "protected", "protected", "protected"),

--- a/tests/datasets/test_structure.py
+++ b/tests/datasets/test_structure.py
@@ -5,7 +5,15 @@ import pathlib
 import pytest
 
 from vitrina.datasets.factories import MANIFEST
-from vitrina.datasets.structure import detect_read_errors
+from vitrina.datasets.structure import (
+    detect_read_errors,
+    _update_model_visibility_from_property,
+    _update_parent_visibility_from_enum,
+    State,
+    Property,
+    Model,
+    Enum,
+)
 from vitrina.datasets.structure import precedes
 from vitrina.datasets.structure import read
 
@@ -141,3 +149,50 @@ id,dataset,resource,base,model,property,type,ref,source,prepare,level,access,uri
 
     assert props["id"].type == "integer"
     assert len(props["description"].comments) == 1
+
+
+@pytest.mark.parametrize(
+    "model_visibility, property_visibility, expected",
+    [
+        ("private", "public", "public"),
+        ("private", "protected", "protected"),
+        ("private", "package", "package"),
+        ("public", "private", "public"),
+        ("protected", "protected", "protected"),
+    ],
+)
+def test_update_model_visibility_from_property(model_visibility, property_visibility, expected):
+    model = Model(visibility=model_visibility)
+    property = Property(visibility=property_visibility)
+    property.model = model
+
+    _update_model_visibility_from_property(property)
+
+    assert model.visibility == expected
+
+
+@pytest.mark.parametrize(
+    "model_visibility, property_visibility, enum_visibility, expected_model, expected_property",
+    [
+        ("private", "private", "public", "public", "public"),
+        ("private", "private", "protected", "protected", "protected"),
+        ("public", "public", "private", "public", "public"),
+        ("public", "private", "protected", "public", "protected"),
+        ("private", "public", "protected", "protected", "public"),
+    ],
+)
+def test_update_parent_visibility_from_enum(
+    model_visibility, property_visibility, enum_visibility, expected_model, expected_property
+):
+    model = Model(visibility=model_visibility)
+    property = Property(visibility=property_visibility)
+    property.model = model
+    enum = Enum(visibility=enum_visibility)
+    enum.meta = property
+    state = State()
+    state.model = model
+
+    _update_parent_visibility_from_enum(state, enum)
+
+    assert model.visibility == expected_model
+    assert property.visibility == expected_property

--- a/tests/structure/test_services.py
+++ b/tests/structure/test_services.py
@@ -2607,9 +2607,12 @@ def test_structure_with_enum_level_higher_then_property(app: DjangoTestApp):
     create_structure_objects(structure)
     model = Model.objects.get(metadata__uuid="3")
     property = Property.objects.get(metadata__uuid="5")
-    property_enum = Enum.objects.filter(content_type=ContentType.objects.get_for_model(property), object_id=property.pk)
-    assert property_enum.visibility == property.visibility
-    assert property_enum.visibility == model.visibility
+    property_enum = Enum.objects.get(content_type=ContentType.objects.get_for_model(Property), object_id=property.pk)
+
+    enum_item_visibility = property_enum.enumitem_set.values_list("metadata__visibility", flat=True).first()
+
+    assert enum_item_visibility == property.visibility
+    assert enum_item_visibility == model.visibility
 
 
 @pytest.mark.django_db
@@ -2630,9 +2633,10 @@ def test_structure_with_enum_level_higher_then_model(app: DjangoTestApp):
     create_structure_objects(structure)
     model = Model.objects.get(metadata__uuid="3")
     property = Property.objects.get(metadata__uuid="5")
-    property_enum = Enum.objects.filter(content_type=ContentType.objects.get_for_model(property), object_id=property.pk)
-    assert property_enum.visibility == property.visibility
-    assert property_enum.visibility == model.visibility
+    property_enum = Enum.objects.get(content_type=ContentType.objects.get_for_model(Property), object_id=property.pk)
+
+    enum_item_visibility = property_enum.enumitem_set.values_list("metadata__visibility", flat=True).first()
+    assert enum_item_visibility == model.visibility
 
 
 @pytest.mark.django_db

--- a/tests/structure/test_services.py
+++ b/tests/structure/test_services.py
@@ -2584,15 +2584,9 @@ def test_structure_with_property_level_higher_then_model(app: DjangoTestApp):
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
-    assert list(
-        Comment.objects.filter(
-            type=Comment.STRUCTURE_ERROR,
-            content_type=ContentType.objects.get_for_model(Model),
-        ).values_list("body", flat=True)
-    ) == [
-        'Duomenų lauko "id" metaduomenų matomumo lygis "public" '
-        'negali būti aukštesnis už modelio metaduomenų matomumo lygį "package". '
-    ]
+    model = Model.objects.get(metadata__uuid="3")
+    prop = Property.objects.get(metadata__uuid="4")
+    assert prop.visibility == model.visibility
 
 
 @pytest.mark.django_db
@@ -2611,15 +2605,11 @@ def test_structure_with_enum_level_higher_then_property(app: DjangoTestApp):
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
-    assert list(
-        Comment.objects.filter(
-            type=Comment.STRUCTURE_ERROR,
-            content_type=ContentType.objects.get_for_model(Property),
-        ).values_list("body", flat=True)
-    ) == [
-        'Duomenų reikšmės "Class One" metaduomenų matomumo lygis "public" '
-        'negali būti aukštesnis už duomenų lauko metaduomenų matomumo lygį "package". '
-    ]
+    model = Model.objects.get(metadata__uuid="3")
+    property = Property.objects.get(metadata__uuid="5")
+    property_enum = Enum.objects.filter(content_type=ContentType.objects.get_for_model(property), object_id=property.pk)
+    assert property_enum.visibility == property.visibility
+    assert property_enum.visibility == model.visibility
 
 
 @pytest.mark.django_db
@@ -2638,15 +2628,11 @@ def test_structure_with_enum_level_higher_then_model(app: DjangoTestApp):
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
-    assert list(
-        Comment.objects.filter(
-            type=Comment.STRUCTURE_ERROR,
-            content_type=ContentType.objects.get_for_model(Property),
-        ).values_list("body", flat=True)
-    ) == [
-        'Duomenų reikšmės "Class One" metaduomenų matomumo lygis "public" '
-        'negali būti aukštesnis už duomenų modelio metaduomenų matomumo lygį "package". '
-    ]
+    model = Model.objects.get(metadata__uuid="3")
+    property = Property.objects.get(metadata__uuid="5")
+    property_enum = Enum.objects.filter(content_type=ContentType.objects.get_for_model(property), object_id=property.pk)
+    assert property_enum.visibility == property.visibility
+    assert property_enum.visibility == model.visibility
 
 
 @pytest.mark.django_db

--- a/vitrina/datasets/structure.py
+++ b/vitrina/datasets/structure.py
@@ -809,13 +809,6 @@ def _read_enum(
 
     enum.meta = last
 
-    # If string enum prepare is empty, use source as prepare value
-    if enum.prepare == "" and getattr(enum.meta, "type") == "string":
-        enum.prepare = f'"{enum.source}"'
-
-    if enum.prepare == "":
-        enum.errors.append(_(f'Duomenų reikšmė (source: "{enum.source}") privalo turėti nurodytą "prepare" stulpelį.'))
-
     _update_parent_visibility_from_enum(state, enum)
 
     if enum.meta.enums.get(name):

--- a/vitrina/datasets/structure.py
+++ b/vitrina/datasets/structure.py
@@ -717,14 +717,8 @@ def _read_property(
 
     if prop.model.properties.get(name):
         prop.errors.append(_(f'Savybė "{name}" jau egzistuoja.'))
-    model_visibility = _parse_visibility(prop.model.visibility)
-    prop_visibility = _parse_visibility(prop.visibility)
-    if model_visibility is not None and prop_visibility is not None and model_visibility < prop_visibility:
-        prop.errors.append(
-            _(
-                'Duomenų lauko "{0}" metaduomenų matomumo lygis "{1}" negali būti aukštesnis už modelio metaduomenų matomumo lygį "{2}". '
-            ).format(name, prop.visibility, prop.model.visibility)
-        )
+
+    _update_model_visibility_from_property(prop)
     prop.model.properties[name] = prop
 
     return prop
@@ -815,27 +809,15 @@ def _read_enum(
 
     enum.meta = last
 
-    model_visibility = None
-    property_visibility = None
+    # If string enum prepare is empty, use source as prepare value
+    if enum.prepare == "" and getattr(enum.meta, "type") == "string":
+        enum.prepare = f'"{enum.source}"'
 
-    if state.model:
-        model_visibility = _parse_visibility(state.model.visibility)
-    if enum.meta:
-        property_visibility = _parse_visibility(enum.meta.visibility)
-    enum_visibility = _parse_visibility(enum.visibility)
+    if enum.prepare == "":
+        enum.errors.append(_(f'Duomenų reikšmė (source: "{enum.source}") privalo turėti nurodytą "prepare" stulpelį.'))
 
-    if property_visibility is not None and enum_visibility is not None and property_visibility < enum_visibility:
-        enum.errors.append(
-            _(
-                'Duomenų reikšmės "{0}" metaduomenų matomumo lygis "{1}" negali būti aukštesnis už duomenų lauko metaduomenų matomumo lygį "{2}". '
-            ).format(enum.title, enum.visibility, enum.meta.visibility)
-        )
-    elif model_visibility is not None and enum_visibility is not None and model_visibility < enum_visibility:
-        enum.errors.append(
-            _(
-                'Duomenų reikšmės "{0}" metaduomenų matomumo lygis "{1}" negali būti aukštesnis už duomenų modelio metaduomenų matomumo lygį "{2}". '
-            ).format(enum.title, enum.visibility, state.model.visibility)
-        )
+    _update_parent_visibility_from_enum(state, enum)
+
     if enum.meta.enums.get(name):
         if enum.prepare in [e.prepare for e in enum.meta.enums[name]]:
             enum.errors.append(_(f'Galima reikšmė "{enum.prepare}" jau egzistuoja.'))
@@ -1038,3 +1020,22 @@ def _validate_resource_name(name: str, meta: Model):
         _validate_name(name, meta)
         if any([ch.isupper() for ch in name]):
             meta.errors.append(_(f'Kodiniame pavadinime negali būti naudojamos didžiosios raidės: "{name}".'))
+
+
+def _update_model_visibility_from_property(prop: Property) -> None:
+    model_visibility = _parse_visibility(prop.model.visibility)
+    prop_visibility = _parse_visibility(prop.visibility)
+    if model_visibility is not None and prop_visibility is not None and model_visibility < prop_visibility:
+        prop.model.visibility = prop.visibility
+
+
+def _update_parent_visibility_from_enum(state: State, enum: Enum) -> None:
+    model_visibility = _parse_visibility(state.model.visibility) if state.model else None
+    property_visibility = (
+        _parse_visibility(enum.meta.visibility) if enum.meta and isinstance(enum.meta, Property) else None
+    )
+    enum_visibility = _parse_visibility(enum.visibility)
+    if property_visibility is not None and enum_visibility is not None and property_visibility < enum_visibility:
+        enum.meta.visibility = enum.visibility
+    if model_visibility is not None and enum_visibility is not None and model_visibility < enum_visibility:
+        state.model.visibility = enum.visibility

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -1251,30 +1251,6 @@ msgstr "The organization can only be assigned the role of a data editor"
 msgid "Naudotojui išsiųstas laiškas dėl registracijos"
 msgstr "The user has been sent an email for registration"
 
-#, python-brace-format
-msgid ""
-"Duomenų lauko \"{0}\" metaduomenų matomumo lygis \"{1}\" negali būti "
-"aukštesnis už modelio metaduomenų matomumo lygį \"{2}\". "
-msgstr ""
-"Data field \"{0}\" metadata visibility level \"{1}\" must not be higher than "
-"the model metadata visibility level \"{2}\". "
-
-#, python-brace-format
-msgid ""
-"Duomenų reikšmės \"{0}\" metaduomenų matomumo lygis \"{1}\" negali būti "
-"aukštesnis už duomenų lauko metaduomenų matomumo lygį \"{2}\". "
-msgstr ""
-"Enum field \"{0}\" metadata visibility level \"{1}\" must not be higher than "
-"the property metadata visibility level \"{2}\" . "
-
-#, python-brace-format
-msgid ""
-"Duomenų reikšmės \"{0}\" metaduomenų matomumo lygis \"{1}\" negali būti "
-"aukštesnis už duomenų modelio metaduomenų matomumo lygį \"{2}\". "
-msgstr ""
-"Enum field \"{0}\" metadata visibility level \"{1}\" must not be higher than "
-"the model metadata visibility level \"{2}\" . "
-
 msgid ""
 "Modelio kodiniame pavadinime gali būti didžiosos/mažosios raidės ir "
 "skaičiai, "


### PR DESCRIPTION
Summary:

- Propagate visibility upward from property to model
- Added _update_model_visibility_from_property which ensures a model's visibility is automatically elevated when one of its properties has higher visibility. The logic is: if a property's visibility is greater than the model's, the model is updated to match the property's visibility. This prevents a situation where a model is less visible than its own properties.
- Similarly, _update_parent_visibility_from_enum propagates visibility upward through the full chain — from enum to its parent property, and from property to the model — applying the same rule at each level.

Ticket: https://github.com/atviriduomenys/katalogas/issues/2334