### PR TITLE
ft/2324 fix enum prepare pt2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,10 @@ https://github.com/atviriduomenys/katalogas/issues/2324
     - Importing a manifest that contains non-string enum items without prepare values will now add an error indicating that a prepare column is required.
     - Importing a manifest with string enum items and no prepare values will now automatically use the source column as the prepare value.
     - Creating enum items via the UI will now return an error if a value already exists in the enum.
-
+    - Creating and importing enums will now check enum item value types.
+    - Enum manifest export will export enum level column correctly.
+    - Boolean type enum items can now be created/changed via UI.
+    - Enum item uniqueness is checked for source+prepare values instead of prepare only. This allows creating enums with same prepare but different source values
 
 v 1.17.0 (2026-03-16)
 ==================

--- a/tests/datasets/test_structure.py
+++ b/tests/datasets/test_structure.py
@@ -317,5 +317,38 @@ def test_import_property_not_string_enum_without_prepare_results_in_error():
     assert enum_item_2.errors == [
         'Duomenų reikšmė (source: "2") privalo turėti nurodytą "prepare" stulpelį.',
         'Reikšmė "" turi būti integer tipo.',
-        'Galima reikšmė (source: "2") "" jau egzistuoja.',
     ]
+
+
+def test_import_enum_checks_uniqueness_based_on_source_and_prepare():
+    manifest = (
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,access,uri,title,description\n"
+        ",example,,,,,,,,,,,,,\n"
+        ",,,,Dataset,,,id,,,,,,,\n"
+        ",,,,,id,integer,,,,,,,,\n"
+        ",,,,,int_enum,integer,,INT_ENUM,,,,,,\n"
+        ",,,,,,enum,,1,1,,,,,\n"
+        ",,,,,,,,2,1,,,,,\n"
+        ",,,,,,,,1,1,,,,,\n"
+    )
+    reader = csv.DictReader(io.StringIO(manifest))
+    model = "example/Dataset"
+
+    state = read(reader)
+    assert state.errors == []
+
+    int_enum_property = state.manifest.models[model].properties["int_enum"]
+    assert int_enum_property.type == "integer"
+
+    enum_item_1 = int_enum_property.enums[""][0]
+    assert enum_item_1.source == "1"
+    assert enum_item_1.prepare == "1"
+    assert enum_item_1.errors == []
+    enum_item_2 = int_enum_property.enums[""][1]
+    assert enum_item_2.source == "2"
+    assert enum_item_2.prepare == "1"
+    assert enum_item_2.errors == []
+    enum_item_3 = int_enum_property.enums[""][2]
+    assert enum_item_3.source == "1"
+    assert enum_item_3.prepare == "1"
+    assert enum_item_3.errors == ['Galima reikšmė (source: "1") "1" jau egzistuoja.']

--- a/tests/datasets/test_structure.py
+++ b/tests/datasets/test_structure.py
@@ -262,6 +262,29 @@ def test_import_property_string_enum_without_prepare_uses_source_value():
     assert enum_item_2.prepare == '"two"'
 
 
+def test_import_property_string_enum_without_quoted_prepare_adds_error():
+    manifest = (
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,access,uri,title,description\n"
+        ",example,,,,,,,,,,,,,\n"
+        ",,,,Dataset,,,id,,,,,,,\n"
+        ",,,,,id,integer,,,,,,,,\n"
+        ",,,,,str_enum,string,,STR_ENUM,,,,,,\n"
+        ",,,,,,enum,,one,one,,,,,\n"
+    )
+    reader = csv.DictReader(io.StringIO(manifest))
+    model = "example/Dataset"
+
+    state = read(reader)
+    assert state.errors == []
+
+    str_enum_property = state.manifest.models[model].properties["str_enum"]
+    assert str_enum_property.type == "string"
+    enum_item_1 = str_enum_property.enums[""][0]
+    assert enum_item_1.source == "one"
+    assert enum_item_1.prepare == "one"
+    assert enum_item_1.errors == ['Reikšmė "one" turi būti string tipo.']
+
+
 def test_import_property_not_string_enum_without_prepare_results_in_error():
     manifest = (
         "id,dataset,resource,base,model,property,type,ref,source,prepare,level,access,uri,title,description\n"
@@ -284,11 +307,15 @@ def test_import_property_not_string_enum_without_prepare_results_in_error():
     enum_item_1 = int_enum_property.enums[""][0]
     assert enum_item_1.source == "1"
     assert enum_item_1.prepare == ""
-    assert enum_item_1.errors == ['Duomenų reikšmė (source: "1") privalo turėti nurodytą "prepare" stulpelį.']
+    assert enum_item_1.errors == [
+        'Duomenų reikšmė (source: "1") privalo turėti nurodytą "prepare" stulpelį.',
+        'Reikšmė "" turi būti integer tipo.',
+    ]
     enum_item_2 = int_enum_property.enums[""][1]
     assert enum_item_2.source == "2"
     assert enum_item_2.prepare == ""
     assert enum_item_2.errors == [
         'Duomenų reikšmė (source: "2") privalo turėti nurodytą "prepare" stulpelį.',
+        'Reikšmė "" turi būti integer tipo.',
         'Galima reikšmė (source: "2") "" jau egzistuoja.',
     ]

--- a/tests/structure/test_forms.py
+++ b/tests/structure/test_forms.py
@@ -71,6 +71,44 @@ def integer_property(model: Model) -> Property:
 
 
 class TestEnumForm:
+    @pytest.mark.parametrize(
+        "given_value, saved_value",
+        [
+            ("First", '"First"'),
+            ("'First'", "'First'"),
+            ('"First"', '"First"'),
+        ],
+    )
+    def test_creating_string_enum_automatically_adds_quotes_if_not_quoted(
+        self, app: DjangoTestApp, string_property: Property, given_value: str, saved_value: str
+    ):
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        version = string_property.metadata_version
+        model = string_property.model
+        dataset = model.dataset
+
+        enum = EnumFactory(
+            content_type=ContentType.objects.get_for_model(string_property),
+            object_id=string_property.pk,
+            metadata_version=version,
+        )
+
+        form = app.get(reverse("enum-create", args=[dataset.pk, version.pk, model.name, string_property.name])).forms[
+            "enum-form"
+        ]
+        form["value"] = given_value
+        form["source"] = "TEST"
+        form["access"] = Metadata.OPEN
+        form["title"] = "Test value"
+        form["description"] = "For testing"
+        resp = form.submit()
+
+        assert resp.url == string_property.get_absolute_url()
+        enum_item_metadata = enum.enumitem_set.all().first().metadata.first()
+        assert enum_item_metadata.prepare == saved_value
+
     def test_cannot_create_enum_item_if_value_already_exists(self, app: DjangoTestApp, string_property: Property):
         user = UserFactory(is_staff=True)
         app.set_user(user)
@@ -109,7 +147,7 @@ class TestEnumForm:
 
         form = resp.context["form"]
         assert not form.is_valid()
-        assert form.errors == {"value": ['Galima reikšmė "First" jau egzistuoja.']}
+        assert form.errors == {"value": ['Galima reikšmė ""First"" jau egzistuoja.']}
 
     def test_cannot_update_enum_item_if_value_already_exists(self, app: DjangoTestApp, string_property: Property):
         user = UserFactory(is_staff=True)
@@ -157,7 +195,7 @@ class TestEnumForm:
 
         form = resp.context["form"]
         assert not form.is_valid()
-        assert form.errors == {"value": ['Galima reikšmė "First" jau egzistuoja.']}
+        assert form.errors == {"value": ['Galima reikšmė ""First"" jau egzistuoja.']}
 
     def test_enum_item_value_unique_check_excludes_current_item(self, app: DjangoTestApp, string_property: Property):
         user = UserFactory(is_staff=True)

--- a/tests/structure/test_forms.py
+++ b/tests/structure/test_forms.py
@@ -70,6 +70,21 @@ def integer_property(model: Model) -> Property:
     return prop
 
 
+@pytest.fixture
+def boolean_property(model: Model) -> Property:
+    prop = PropertyFactory(model=model, metadata_version=model.metadata_version)
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(prop),
+        object_id=prop.pk,
+        dataset=model.dataset,
+        name="prop",
+        type="boolean",
+        metadata_version=model.metadata_version,
+    )
+
+    return prop
+
+
 class TestEnumForm:
     @pytest.mark.parametrize(
         "given_value, saved_value",
@@ -147,7 +162,7 @@ class TestEnumForm:
 
         form = resp.context["form"]
         assert not form.is_valid()
-        assert form.errors == {"value": ['Galima reikšmė ""First"" jau egzistuoja.']}
+        assert form.errors == {"value": ['Galima reikšmė ""First"" su reikšme šaltinyje "TEST" jau egzistuoja.']}
 
     def test_cannot_update_enum_item_if_value_already_exists(self, app: DjangoTestApp, string_property: Property):
         user = UserFactory(is_staff=True)
@@ -190,12 +205,13 @@ class TestEnumForm:
         form = app.get(
             reverse("enum-update", args=[dataset.pk, version.pk, model.name, string_property.name, enum_item2.pk])
         ).forms["enum-form"]
-        form["value"] = "First"
+        form["source"] = "TEST"
+        form["value"] = '"First"'
         resp = form.submit()
 
         form = resp.context["form"]
         assert not form.is_valid()
-        assert form.errors == {"value": ['Galima reikšmė ""First"" jau egzistuoja.']}
+        assert form.errors == {"value": ['Galima reikšmė ""First"" su reikšme šaltinyje "TEST" jau egzistuoja.']}
 
     def test_enum_item_value_unique_check_excludes_current_item(self, app: DjangoTestApp, string_property: Property):
         user = UserFactory(is_staff=True)
@@ -231,6 +247,46 @@ class TestEnumForm:
 
         assert resp.url == string_property.get_absolute_url()
 
+    def test_enum_item_uniqueness_check_checks_both_source_and_value(
+        self, app: DjangoTestApp, string_property: Property
+    ):
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        version = string_property.metadata_version
+        model = string_property.model
+        dataset = model.dataset
+
+        enum = EnumFactory(
+            content_type=ContentType.objects.get_for_model(string_property),
+            object_id=string_property.pk,
+            metadata_version=version,
+        )
+        enum_item = EnumItemFactory(enum=enum, metadata_version=version)
+        MetadataFactory(
+            content_type=ContentType.objects.get_for_model(enum_item),
+            object_id=enum_item.pk,
+            dataset=dataset,
+            title="Test value",
+            description="For testing",
+            prepare='"First"',
+            access=Metadata.OPEN,
+            source="TEST",
+            metadata_version=version,
+        )
+
+        form = app.get(reverse("enum-create", args=[dataset.pk, version.pk, model.name, string_property.name])).forms[
+            "enum-form"
+        ]
+        form["value"] = '"First"'  # Same as existing item
+        form["source"] = "TEST2"  # Different from existing item
+        form["access"] = Metadata.OPEN
+        form["title"] = "Test value"
+        form["description"] = "For testing"
+        resp = form.submit()
+
+        assert resp.url == string_property.get_absolute_url()
+
     @pytest.mark.parametrize("non_integer_value", ["abc", '"First"', "1.33", "1.0", 1.1])
     def test_cannot_save_non_integer_item_values_for_integer_enum(
         self, app: DjangoTestApp, integer_property: Property, non_integer_value: str | float
@@ -256,3 +312,31 @@ class TestEnumForm:
         form = resp.context["form"]
         assert not form.is_valid()
         assert form.errors == {"value": [f'Reikšmė "{non_integer_value}" turi būti integer tipo.']}
+
+    @pytest.mark.parametrize("non_boolean_value", [True, False, 1, 0, "True", "False", "abc"])
+    def test_cannot_save_values_other_than_true_false_for_boolean_enum(
+        self, app: DjangoTestApp, boolean_property: Property, non_boolean_value: bool | str | int
+    ):
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        version = boolean_property.metadata_version
+        model = boolean_property.model
+        dataset = model.dataset
+
+        form = app.get(reverse("enum-create", args=[dataset.pk, version.pk, model.name, boolean_property.name])).forms[
+            "enum-form"
+        ]
+        form["value"] = non_boolean_value
+        form["source"] = "TEST"
+        form["access"] = Metadata.OPEN
+        form["title"] = "Test value"
+        form["description"] = "For testing"
+
+        resp = form.submit()
+
+        form = resp.context["form"]
+        assert not form.is_valid()
+        assert form.errors == {
+            "value": [f'Reikšmė "{non_boolean_value}" turi būti boolean tipo. Viena iš: true, false']
+        }

--- a/tests/structure/test_helpers.py
+++ b/tests/structure/test_helpers.py
@@ -1,0 +1,18 @@
+import pytest
+
+from vitrina.structure.helpers import is_quoted
+
+
+@pytest.mark.parametrize(
+    "value, result",
+    [
+        ("", False),
+        ('""', True),
+        ("''", True),
+        ("Hello", False),
+        ('"Hello"', True),
+        ("'Hello'", True),
+    ],
+)
+def test_is_quoted(value: str, result: bool):
+    assert is_quoted(value) is result

--- a/tests/structure/test_services.py
+++ b/tests/structure/test_services.py
@@ -2460,7 +2460,7 @@ def test_structure_export__visibility_row(app: DjangoTestApp):
         "3,,,,Pavadinimas,,,id,,,,,,4,develop,package,protected,,,Pavadinimas,\r\n"
         "4,,,,,id,integer,,,,,,,4,develop,package,protected,,,ID,\r\n"
         "5,,,,,class,integer,,,,,,,4,develop,package,protected,,,class,\r\n"
-        "6,,,,,,enum,,1,,1,,,,develop,package,protected,,,Class One,\r\n"
+        "6,,,,,,enum,,1,,1,,,4,develop,package,protected,,,Class One,\r\n"
         ",,,,,,,,,,,,,,,,,,,,\r\n"
     )
 
@@ -2497,7 +2497,7 @@ def test_structure_export__eli_row(app: DjangoTestApp):
         "3,,,,Pavadinimas,,,id,,,,,,4,develop,,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.1,Pavadinimas,\r\n"
         "4,,,,,id,integer,,,,,,,4,develop,,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.2,ID,\r\n"
         "5,,,,,class,integer,,,,,,,4,develop,,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.3,class,\r\n"
-        "6,,,,,,enum,,1,,1,,,,develop,,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.3.1,Class One,\r\n"
+        "6,,,,,,enum,,1,,1,,,4,develop,,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.3.1,Class One,\r\n"
         ",,,,,,,,,,,,,,,,,,,,\r\n"
     )
 
@@ -2534,7 +2534,7 @@ def test_structure_export__status_row(app: DjangoTestApp, setup_default_status_d
         "3,,,,Pavadinimas,,,id,,,,,,4,completed,,protected,,,Pavadinimas,\r\n"
         "4,,,,,id,integer,,,,,,,4,withdrawn,,protected,,,ID,\r\n"
         "5,,,,,class,integer,,,,,,,4,deprecated,,protected,,,class,\r\n"
-        "6,,,,,,enum,,1,,1,,,,discont,,protected,,,Class One,\r\n"
+        "6,,,,,,enum,,1,,1,,,4,discont,,protected,,,Class One,\r\n"
         ",,,,,,,,,,,,,,,,,,,,\r\n"
     )
 

--- a/tests/structure/test_services.py
+++ b/tests/structure/test_services.py
@@ -820,6 +820,34 @@ def test_structure_with_enum_and_null_value(app: DjangoTestApp):
 
 
 @pytest.mark.django_db
+def test_structure_with_two_enums_with_different_source_same_prepare_create_two_different_enum_items(
+    app: DjangoTestApp,
+):
+    manifest = (
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        "5,,,,City,,,,,,,,,,,,,,\n"
+        "6,,,,,id,integer,,,,5,,,open,,,,,\n"
+        "8,,,,,type,integer,,,,5,,,open,,,,,\n"
+        "9,,,,,,enum,,1,1,,,,,,,,,\n"
+        "10,,,,,,,,2,1,,,,,,,,,\n"
+    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure.dataset.current_structure = structure
+    structure.dataset.save()
+    create_structure_objects(structure)
+
+    prop = Property.objects.get(metadata__uuid="8")
+    prop_enum = Enum.objects.filter(content_type=ContentType.objects.get_for_model(prop), object_id=prop.pk)
+    assert prop_enum.count() == 1
+    assert prop_enum[0].name == ""
+    assert list(prop_enum[0].enumitem_set.values_list("metadata__source", "metadata__prepare")) == [
+        ("1", "1"),
+        ("2", "1"),
+    ]
+
+
+@pytest.mark.django_db
 def test_structure_with_enum_without_prepare_value_adds_comment_about_error(app: DjangoTestApp):
     manifest = (
         "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
@@ -841,6 +869,30 @@ def test_structure_with_enum_without_prepare_value_adds_comment_about_error(app:
     assert list(Comment.objects.filter(type=Comment.STRUCTURE_ERROR).values_list("body", flat=True)) == [
         'Reikšmė "" turi būti integer tipo.',
         'Duomenų reikšmė (source: "one") privalo turėti nurodytą "prepare" stulpelį.',
+    ]
+
+
+@pytest.mark.django_db
+def test_structure_with_boolean_enum_with_invalid_value_adds_comment_about_error(app: DjangoTestApp):
+    manifest = (
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,City,,,,,,,,,,,,,,\n"
+        "1,,,,,type,boolean,,,,5,,,,,,,,\n"
+        ",,,,,,enum,,taip,taip,,,,,,,,,\n"
+    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure.dataset.current_structure = structure
+    structure.dataset.save()
+    create_structure_objects(structure)
+
+    prop = Property.objects.get(metadata__uuid="1")
+    prop_enum = Enum.objects.filter(content_type=ContentType.objects.get_for_model(prop), object_id=prop.pk)
+    assert prop_enum.count() == 1
+    assert prop_enum[0].name == ""
+    assert not prop_enum[0].enumitem_set.exists()
+    assert list(Comment.objects.filter(type=Comment.STRUCTURE_ERROR).values_list("body", flat=True)) == [
+        'Reikšmė "taip" turi būti boolean tipo. Viena iš: true, false',
     ]
 
 

--- a/tests/structure/test_services.py
+++ b/tests/structure/test_services.py
@@ -775,8 +775,8 @@ def test_structure_with_enums(app: DjangoTestApp):
         "6,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
         "7,,,,,size,Size,,,,5,,,open,dct:size,,,,\n"
         "8,,,,,type,string,,,,5,,,open,dct:type,,,,\n"
-        '9,,,,,,enum,Type,,"CREATED",,,,,,,,,\n'
-        '10,,,,,,,,,"MODIFIED",,,,,,,,,\n'
+        '9,,,,,,enum,Type,,"""CREATED""",,,,,,,,,\n'
+        '10,,,,,,,,,"""MODIFIED""",,,,,,,,,\n'
     )
     structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
@@ -793,7 +793,7 @@ def test_structure_with_enums(app: DjangoTestApp):
     prop_enum = Enum.objects.filter(content_type=ContentType.objects.get_for_model(prop), object_id=prop.pk)
     assert prop_enum.count() == 1
     assert prop_enum[0].name == "Type"
-    assert list(prop_enum[0].enumitem_set.values_list("metadata__prepare", flat=True)) == ["CREATED", "MODIFIED"]
+    assert list(prop_enum[0].enumitem_set.values_list("metadata__prepare", flat=True)) == ['"CREATED"', '"MODIFIED"']
 
 
 @pytest.mark.django_db
@@ -804,8 +804,8 @@ def test_structure_with_enum_and_null_value(app: DjangoTestApp):
         ",,,,,,prefix,dct,,,,,,,http://www.purl.org/dc/terms/,,,,\n"
         ",,,,City,,,,,,,,,,,,,,\n"
         "1,,,,,type,string,,,,5,,,open,dct:type,,,,\n"
-        ',,,,,,enum,Type,,"CREATED",,,,,,,,,\n'
-        ",,,,,,,,,null,,,,,,,,,\n"
+        ',,,,,,enum,Type,,"""CREATED""",,,,,,,,,\n'
+        ',,,,,,,,,"""null""",,,,,,,,,\n'
     )
     structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
@@ -816,7 +816,7 @@ def test_structure_with_enum_and_null_value(app: DjangoTestApp):
     prop_enum = Enum.objects.filter(content_type=ContentType.objects.get_for_model(prop), object_id=prop.pk)
     assert prop_enum.count() == 1
     assert prop_enum[0].name == "Type"
-    assert list(prop_enum[0].enumitem_set.values_list("metadata__prepare", flat=True)) == ["CREATED", "null"]
+    assert list(prop_enum[0].enumitem_set.values_list("metadata__prepare", flat=True)) == ['"CREATED"', '"null"']
 
 
 @pytest.mark.django_db
@@ -839,7 +839,8 @@ def test_structure_with_enum_without_prepare_value_adds_comment_about_error(app:
     assert prop_enum[0].name == "Type"
     assert not prop_enum[0].enumitem_set.exists()
     assert list(Comment.objects.filter(type=Comment.STRUCTURE_ERROR).values_list("body", flat=True)) == [
-        'Duomenų reikšmė (source: "one") privalo turėti nurodytą "prepare" stulpelį.'
+        'Reikšmė "" turi būti integer tipo.',
+        'Duomenų reikšmė (source: "one") privalo turėti nurodytą "prepare" stulpelį.',
     ]
 
 
@@ -883,18 +884,18 @@ def test_structure_with_deleted_enums(app: DjangoTestApp):
         "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
         ",,,,,,prefix,dct,,,,,,,http://www.purl.org/dc/terms/,,,,\n"
         "2,,resource,,,,,,,,,,,,,,,,\n"
-        '3,,,,,,enum,Size,,"SMALL",,,,,,,,,\n'
-        '4,,,,,,,,,"MEDIUM",,,,,,,,,\n'
-        '5,,,,,,,,,"BIG",,,,,,,,,\n'
-        '6,,,,,,enum,Deprecated,,"SMALL",,,,,,,,,\n'
-        '7,,,,,,,,,"MEDIUM",,,,,,,,,\n'
-        '8,,,,,,,,,"BIG",,,,,,,,,\n'
+        '3,,,,,,enum,Size,,"""SMALL""",,,,,,,,,\n'
+        '4,,,,,,,,,"""MEDIUM""",,,,,,,,,\n'
+        '5,,,,,,,,,"""BIG""",,,,,,,,,\n'
+        '6,,,,,,enum,Deprecated,,"""SMALL""",,,,,,,,,\n'
+        '7,,,,,,,,,"""MEDIUM""",,,,,,,,,\n'
+        '8,,,,,,,,,"""BIG""",,,,,,,,,\n'
         "9,,,,City,,,,,,,,,,,,,,\n"
         "10,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n"
         "11,,,,,size,Size,,,,5,,,open,dct:size,,,,\n"
         "12,,,,,type,string,,,,5,,,open,dct:type,,,,\n"
-        '13,,,,,,enum,Type,,"CREATED",,,,,,,,,\n'
-        '14,,,,,,,,,"MODIFIED",,,,,,,,,\n'
+        '13,,,,,,enum,Type,,"""CREATED""",,,,,,,,,\n'
+        '14,,,,,,,,,"""MODIFIED""",,,,,,,,,\n'
     )
     structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
@@ -903,18 +904,18 @@ def test_structure_with_deleted_enums(app: DjangoTestApp):
     assert Metadata.objects.filter(dataset=structure.dataset, metadata_version=metadata_version).count() == 15
     assert list(Enum.objects.values_list("name", flat=True)) == ["Size", "Deprecated", "Type"]
     assert list(EnumItem.objects.filter(enum__name="Size").values_list("metadata__prepare", flat=True)) == [
-        "SMALL",
-        "MEDIUM",
-        "BIG",
+        '"SMALL"',
+        '"MEDIUM"',
+        '"BIG"',
     ]
     assert list(EnumItem.objects.filter(enum__name="Deprecated").values_list("metadata__prepare", flat=True)) == [
-        "SMALL",
-        "MEDIUM",
-        "BIG",
+        '"SMALL"',
+        '"MEDIUM"',
+        '"BIG"',
     ]
     assert list(EnumItem.objects.filter(enum__name="Type").values_list("metadata__prepare", flat=True)) == [
-        "CREATED",
-        "MODIFIED",
+        '"CREATED"',
+        '"MODIFIED"',
     ]
 
     new_manifest = (
@@ -922,23 +923,23 @@ def test_structure_with_deleted_enums(app: DjangoTestApp):
         "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
         ",,,,,,prefix,dct,,,,,,,http://www.purl.org/dc/terms/,,,,\n"
         "2,,resource,,,,,,,,,,,,,,,,\n"
-        '3,,,,,,enum,Size,,"SMALL",,,,,,,,,\n'
-        '5,,,,,,,,,"BIG",,,,,,,,,\n'
+        '3,,,,,,enum,Size,,"""SMALL""",,,,,,,,,\n'
+        '5,,,,,,,,,"""BIG""",,,,,,,,,\n'
         "9,,,,City,,,,,,,,,,,,,,\n"
         "10,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n"
         "11,,,,,size,Size,,,,5,,,open,dct:size,,,,\n"
         "12,,,,,type,string,,,,5,,,open,dct:type,,,,\n"
-        '13,,,,,,enum,Type,,"CREATED",,,,,,,,,\n'
+        '13,,,,,,enum,Type,,"""CREATED""",,,,,,,,,\n'
     )
     structure.file = FilerFileFactory(file=FileField(filename="file.csv", data=new_manifest))
     metadata_version = create_structure_objects(structure, metadata_version)
     assert Metadata.objects.filter(dataset=structure.dataset, metadata_version=metadata_version).count() == 10
     assert list(Enum.objects.values_list("name", flat=True)) == ["Size", "Type"]
     assert list(EnumItem.objects.filter(enum__name="Size").values_list("metadata__prepare", flat=True)) == [
-        "SMALL",
-        "BIG",
+        '"SMALL"',
+        '"BIG"',
     ]
-    assert list(EnumItem.objects.filter(enum__name="Type").values_list("metadata__prepare", flat=True)) == ["CREATED"]
+    assert list(EnumItem.objects.filter(enum__name="Type").values_list("metadata__prepare", flat=True)) == ['"CREATED"']
 
 
 @pytest.mark.django_db
@@ -2033,8 +2034,8 @@ def test_structure_export__enums(app: DjangoTestApp, use_version):
         "8,,,,,id,integer,,,,,5,,,open,dct:identifier,,Identifikatorius,\n"
         "9,,,,,size,Size,,,,,5,,,open,dct:size,,,\n"
         "10,,,,,type,string,,,,,5,,,open,dct:type,,,\n"
-        "11,,,,,,enum,Type,,CREATED,,,,,,,,,\n"
-        "12,,,,,,,,,MODIFIED,,,,,,,,,\n"
+        "11,,,,,,enum,Type,,'''CREATED''',,,,,,,,,\n"
+        "12,,,,,,,,,'''MODIFIED''',,,,,,,,,\n"
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
@@ -2057,8 +2058,8 @@ def test_structure_export__enums(app: DjangoTestApp, use_version):
         "8,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
         "9,,,,,size,Size,,,,,,,5,develop,,open,dct:size,,,\r\n"
         "10,,,,,type,string,,,,,,,5,develop,,open,dct:type,,,\r\n"
-        "11,,,,,,enum,Type,,,CREATED,,,,develop,,,,,,\r\n"
-        "12,,,,,,,,,,MODIFIED,,,,develop,,,,,,\r\n"
+        "11,,,,,,enum,Type,,,'''CREATED''',,,,develop,,,,,,\r\n"
+        "12,,,,,,,,,,'''MODIFIED''',,,,develop,,,,,,\r\n"
         ",,,,,,,,,,,,,,,,,,,,\r\n"
     )
 

--- a/tests/structure/test_utils.py
+++ b/tests/structure/test_utils.py
@@ -7,6 +7,7 @@ from vitrina.structure.utils import (
     IntegerTypeChecker,
     NotImplementedTypeChecker,
     TypeCheckerError,
+    BooleanTypeChecker,
 )
 
 
@@ -16,7 +17,7 @@ class TestTypeChecker:
         [
             ("string", StringTypeChecker),
             ("integer", IntegerTypeChecker),
-            ("boolean", NotImplementedTypeChecker),
+            ("boolean", BooleanTypeChecker),
             ("geometry", NotImplementedTypeChecker),
         ],
     )
@@ -44,3 +45,14 @@ class TestTypeChecker:
             get_type_checker_for_type("integer").check_enum_item_value(value)
 
         assert str(exc_info.value) == f'Reikšmė "{value}" turi būti integer tipo.'
+
+    @pytest.mark.parametrize("value", ["true", "false"])
+    def test_check_enum_item_value_for_boolean_type_checker_success(self, value: str):
+        assert get_type_checker_for_type("boolean").check_enum_item_value(value) is None
+
+    @pytest.mark.parametrize("value", ["True", "False", "1", "0", "yes", "no"])
+    def test_check_enum_item_value_for_boolean_type_checker_error(self, value: str):
+        with pytest.raises(TypeCheckerError) as exc_info:
+            get_type_checker_for_type("boolean").check_enum_item_value(value)
+
+        assert str(exc_info.value) == f'Reikšmė "{value}" turi būti boolean tipo. Viena iš: true, false'

--- a/tests/structure/test_utils.py
+++ b/tests/structure/test_utils.py
@@ -23,9 +23,16 @@ class TestTypeChecker:
     def test_type_checker_types(self, type_variable: str, type_checker_class: TypeChecker):
         assert type(get_type_checker_for_type(type_variable)) is type_checker_class
 
-    @pytest.mark.parametrize("value", ["", "foo", "-1", "0", "1", "1.0", "True", "False"])
-    def test_check_enum_item_value_for_integer_type_checker(self, value: str):
+    @pytest.mark.parametrize("value", ['""', '"foo"', '"-1"', '"0"', '"1"', '"1.0"', '"True"', '"False"'])
+    def test_check_enum_item_value_for_string_type_checker_success(self, value: str):
         assert get_type_checker_for_type("string").check_enum_item_value(value) is None
+
+    @pytest.mark.parametrize("value", ["", "foo", "-1", "0", "1", "1.0", "True", "False"])
+    def test_check_enum_item_value_for_string_type_checker_error(self, value: str):
+        with pytest.raises(TypeCheckerError) as exc_info:
+            get_type_checker_for_type("string").check_enum_item_value(value)
+
+        assert str(exc_info.value) == f'Reikšmė "{value}" turi būti string tipo.'
 
     @pytest.mark.parametrize("value", ["-1", "0", "1"])
     def test_check_enum_item_value_for_integer_type_checker_success(self, value: str):

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -4684,7 +4684,7 @@ def test_updating_metadata_in_not_draft_version_not_allowed(app: DjangoTestApp, 
         ",,,,,id,integer,,,,5,discont,,open,dct:identifier,,Identifikatorius,,\n"
         ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
         ",,,,,administration,string,,,,5,,,open,dct:title,,,,\n"
-        ",,,,,,enum,small,,SMALL,,,,,,,,,\n"
+        ",,,,,,enum,small,,'''SMALL''',,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
     )
     structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
@@ -4741,9 +4741,9 @@ def test_published_metadata_gets_completed_status(app: DjangoTestApp):
         ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
         ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
         ",,,,,administration,string,,,,5,,,open,dct:title,,,,\n"
-        ",,,,,,enum,Size,,SMALL,,,,,,,,,\n"
-        ",,,,,,,,,MEDIUM,,,,,,,,,\n"
-        ",,,,,,,,,BIG,,,,,,,,,\n"
+        ",,,,,,enum,Size,,'''SMALL''',,,,,,,,,\n"
+        ",,,,,,,,,'''MEDIUM''',,,,,,,,,\n"
+        ",,,,,,,,,'''BIG''',,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
     )
     structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
@@ -4808,7 +4808,7 @@ def test_changed_metadata_keeps_status_after_publishing(app: DjangoTestApp):
         ",,,,,id,integer,,,,5,discont,,open,dct:identifier,,Identifikatorius,,\n"
         ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
         ",,,,,administration,string,,,,5,,,open,dct:title,,,,\n"
-        ",,,,,,enum,small,,SMALL,,,,,,,,,\n"
+        ",,,,,,enum,small,,'SMALL',,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
     )
     structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
@@ -4892,7 +4892,7 @@ def test_draft_metadata_defaults_to_develop_after_hard_change(app: DjangoTestApp
         ",,,,,id,integer,,,,5,discont,,open,dct:identifier,,Identifikatorius,,\n"
         ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
         ",,,,,administration,string,,,,5,,,open,dct:title,,,,\n"
-        ",,,,,,enum,small,,SMALL,,,,,,,,,\n"
+        ",,,,,,enum,small,,'''SMALL''',,,,,,,,,\n"
         ",,,,,,,big,,BIG,,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
     )
@@ -4954,7 +4954,7 @@ def test_changing_multiple_fields_in_draft_structure_respects_status(app: Django
         ",,,,,id,integer,,,,5,discont,,open,dct:identifier,,Identifikatorius,,\n"
         ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
         ",,,,,administration,string,,,,5,,,open,dct:title,,,,\n"
-        ",,,,,,enum,small,,SMALL,,,,,,,,,\n"
+        ",,,,,,enum,small,,'''SMALL''',,,,,,,,,\n"
         ",,,,,,,big,,BIG,,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
     )
@@ -5022,8 +5022,8 @@ def test_draft_metadata_form_does_not_change_status_is_kept(app: DjangoTestApp):
         ",,,,,id,integer,,,,5,discont,,open,dct:identifier,,Identifikatorius,,\n"
         ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
         ",,,,,administration,string,,,,5,,,open,dct:title,,,,\n"
-        ",,,,,,enum,small,,SMALL,,,,,,,,,\n"
-        ",,,,,,,big,,BIG,,,,,,,,,\n"
+        ",,,,,,enum,small,,'SMALL',,,,,,,,,\n"
+        ",,,,,,,big,,'''BIG''',,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
     )
     structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
@@ -5439,15 +5439,15 @@ def test_publish_form_shows_all_metadata_rows_enum(app: DjangoTestApp):
         "id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n"
         "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
         "2,,,,,,prefix,dct,,,,,,,,http://purl.org/dc/terms/,,,\n"
-        "3,,,,,,enum,Size,,SMALL,,,,,,,,,,\n"
-        "4,,,,,,,,,MEDIUM,,,,,,,,,\n"
-        "5,,,,,,,,,BIG,,,,,,,,,\n"
+        "3,,,,,,enum,Size,,'''SMALL''',,,,,,,,,,\n"
+        "4,,,,,,,,,'''MEDIUM''',,,,,,,,,\n"
+        "5,,,,,,,,,'''BIG''',,,,,,,,,\n"
         "6,,,,City,,,,,,,,,,,,,,\n"
         "7,,,,,id,integer,,,,,5,,,open,dct:identifier,,Identifikatorius,\n"
         "8,,,,,size,Size,,,,,5,,,open,dct:size,,,\n"
         "9,,,,,type,string,,,,,5,,,open,dct:type,,,\n"
-        "10,,,,,,enum,Type,,CREATED,,,,,,,,,\n"
-        "11,,,,,,,,,MODIFIED,,,,,,,,,\n"
+        "10,,,,,,enum,Type,,'''CREATED''',,,,,,,,,\n"
+        "11,,,,,,,,,'''MODIFIED''',,,,,,,,,\n"
     )
     structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -4475,6 +4475,50 @@ def test_property_enum_item_create__higher_visibility_then_model_with_error(app:
     ]
 
 
+# Not all types tested. Only a few of them
+@pytest.mark.django_db
+@pytest.mark.parametrize("not_allowed_type", ["date", "geometry", "number", "object"])
+def test_property_enum_item_create__not_allowed_for_types_that_have_no_type_checker_class(
+    app: DjangoTestApp, not_allowed_type: str
+):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(model),
+        object_id=model.pk,
+        dataset=dataset,
+        name="test/dataset/TestModel",
+        visibility=Metadata.PRIVATE,
+        metadata_version=version,
+    )
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(dataset),
+        object_id=dataset.pk,
+        dataset=dataset,
+        name="test/dataset",
+        metadata_version=version,
+    )
+    prop = PropertyFactory(model=model, metadata_version=version)
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(prop),
+        object_id=prop.pk,
+        dataset=dataset,
+        name="prop",
+        type=not_allowed_type,
+        metadata_version=version,
+    )
+    response = app.get(
+        reverse("enum-create", args=[dataset.pk, version.pk, model.name, prop.name]),
+    )
+
+    assert response.status_code == 302
+    assert response.url == prop.get_absolute_url()
+
+
 @pytest.mark.django_db
 def test_manifest_export_openapi(app: DjangoTestApp):
     """Test OpenAPI manifest export returns valid spec with correct metadata, schemas, tags, and paths."""
@@ -5067,6 +5111,66 @@ def test_draft_metadata_form_does_not_change_status_is_kept(app: DjangoTestApp):
     for enum_item in prop.enums.first().enumitem_set.all():
         enum_metadata = enum_item.metadata.first()
         assert enum_metadata.status.codename == "develop"
+
+
+# Not all types tested. Only a few of them
+@pytest.mark.django_db
+@pytest.mark.parametrize("not_allowed_type", ["date", "geometry", "number", "object"])
+def test_property_enum_item_update__not_allowed_for_types_that_have_no_type_checker_class(
+    app: DjangoTestApp, not_allowed_type: str
+):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(model),
+        object_id=model.pk,
+        dataset=dataset,
+        name="test/dataset/TestModel",
+        visibility=Metadata.PRIVATE,
+        metadata_version=version,
+    )
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(dataset),
+        object_id=dataset.pk,
+        dataset=dataset,
+        name="test/dataset",
+        metadata_version=version,
+    )
+    prop = PropertyFactory(model=model, metadata_version=version)
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(prop),
+        object_id=prop.pk,
+        dataset=dataset,
+        name="prop",
+        type=not_allowed_type,
+        metadata_version=version,
+    )
+    enum = EnumFactory(
+        content_type=ContentType.objects.get_for_model(prop),
+        object_id=prop.pk,
+        metadata_version=version,
+    )
+    enum_item = EnumItemFactory(enum=enum, metadata_version=version)
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(enum_item),
+        object_id=enum_item.pk,
+        dataset=dataset,
+        title="Test value",
+        description="For testing",
+        prepare="",
+        access=Metadata.OPEN,
+        source="TEST",
+        metadata_version=version,
+    )
+
+    response = app.get(reverse("enum-update", args=[dataset.pk, version.pk, model.name, prop.name, enum_item.pk]))
+
+    assert response.status_code == 302
+    assert response.url == prop.get_absolute_url()
 
 
 @pytest.mark.django_db

--- a/vitrina/datasets/structure.py
+++ b/vitrina/datasets/structure.py
@@ -831,7 +831,7 @@ def _read_enum(
 
     # Validate enum item value uniqueness
     if enum.meta.enums.get(name):
-        if enum.prepare in [e.prepare for e in enum.meta.enums[name]]:
+        if (enum.source, enum.prepare) in [(e.source, e.prepare) for e in enum.meta.enums[name]]:
             enum.errors.append(_(f'Galima reikšmė (source: "{enum.source}") "{enum.prepare}" jau egzistuoja.'))
 
         enum.meta.enums[name].append(enum)

--- a/vitrina/datasets/structure.py
+++ b/vitrina/datasets/structure.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass, field
 from typing import Any, Iterable, NamedTuple, TypedDict, Tuple, List
 from django.utils.translation import gettext_lazy as _
 
+from vitrina.structure.utils import get_type_checker_for_type, NotImplementedTypeChecker, TypeCheckerError
+
 DIMS = [
     "dataset",
     "resource",
@@ -809,8 +811,10 @@ def _read_enum(
 
     enum.meta = last
 
+    enum_type = getattr(enum.meta, "type")
+
     # If string enum prepare is empty, use source as prepare value
-    if enum.prepare == "" and getattr(enum.meta, "type") == "string":
+    if enum.prepare == "" and enum_type == "string":
         enum.prepare = f'"{enum.source}"'
 
     if enum.prepare == "":
@@ -818,6 +822,14 @@ def _read_enum(
 
     _update_parent_visibility_from_enum(state, enum)
 
+    # Validate if enum item value matches enum type
+    if (type_checker := get_type_checker_for_type(enum_type)) and type(type_checker) is not NotImplementedTypeChecker:
+        try:
+            type_checker.check_enum_item_value(enum.prepare)
+        except TypeCheckerError as e:
+            enum.errors.append(str(e))
+
+    # Validate enum item value uniqueness
     if enum.meta.enums.get(name):
         if enum.prepare in [e.prepare for e in enum.meta.enums[name]]:
             enum.errors.append(_(f'Galima reikšmė (source: "{enum.source}") "{enum.prepare}" jau egzistuoja.'))

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -4220,6 +4220,12 @@ msgstr ""
 "The visibility of the metadata '{0}' should not be greater than the "
 "visibility of the data field '{1}'."
 
+#, python-brace-format
+msgid ""
+"Galima reikšmė \"{prepare}\" su reikšme šaltinyje \"{source}\" jau "
+"egzistuoja."
+msgstr "Enum item \"{prepare}\" with source \"{source}\" already exists."
+
 msgid "Nėra per ką sieti"
 msgstr "Nothing to link to"
 
@@ -4904,6 +4910,18 @@ msgstr "Estimated changes"
 msgid "Galiojantys keitimai"
 msgstr "Deployed changes"
 
+#, python-brace-format
+msgid "Reikšmė \"{value}\" turi būti string tipo."
+msgstr "Enum item \"{value}\" must be string type."
+
+#, python-brace-format
+msgid "Reikšmė \"{value}\" turi būti integer tipo."
+msgstr "Enum item \"{value}\" must be integer type."
+
+#, python-brace-format
+msgid "Reikšmė \"{value}\" turi būti boolean tipo. Viena iš: {possible_values}"
+msgstr "Enum item \"{value}\" must be boolean type. One of: {possible_values}"
+
 msgid "Savybės reikšmės tipas nėra palaikomas."
 msgstr "Type of property value is not implemented."
 
@@ -4916,11 +4934,19 @@ msgstr "API: all records"
 msgid "Negalima kurti naujos reikšmės, kai versijos būsena nėra juodraštis."
 msgstr "Can not create a new enum, when the version status is not draft."
 
+#, python-brace-format
+msgid "Reikšmių duomenų lauko tipui \"{metadata_type}\" kurti negalima"
+msgstr "Cannot create enum items for property with type \"{metadata_type}\""
+
 msgid "Galimos reikšmės pridėjimas"
 msgstr "Add enum item"
 
 msgid "Negalima redaguoti reikšmės, kai versijos būsena nėra juodraštis."
 msgstr "Can not edit the enum, when the version status is not draft."
+
+#, python-brace-format
+msgid "Reikšmių duomenų lauko tipui \"{metadata_type}\" keisti negalima"
+msgstr "Cannot change enum items for property with type \"{metadata_type}\""
 
 msgid "Galimos reikšmės redagavimas"
 msgstr "Edit enum item"

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-06 10:42+0200\n"
+"POT-Creation-Date: 2026-03-19 12:50+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -42,6 +42,7 @@ msgstr "client id"
 msgid "Nepriskirti"
 msgstr "Unassigned"
 
+#, python-brace-format
 msgid ""
 "Baigėsi Jūsų API rakto galiojimas. Raktą galite atsinaujinti savo "
 "organizacijos tvarkytojų sąraše: {url}"
@@ -516,17 +517,19 @@ msgstr "Evaluated"
 msgid "Viešas komentaras"
 msgstr "Public comment"
 
-msgid "Struktūros importavimo metu sukurtas sisteminis komentaras.<br>"
-msgstr "Comment imported with a manifest.<br>"
-
-msgid "<b>Objektas:</b> {content_type} | {content_object}"
-msgstr "<b>Object:</b> {content_type} | {content_object}"
-
-msgid "<b>Parengimas:</b> <pre><code>{prepare}</code></pre>"
-msgstr "<b>Prepare:</b> <pre><code>{prepare}</code></pre>"
-
-msgid "<b>Nuoroda:</b> <a href='{uri}'>{uri}</a>"
-msgstr "<b>URI:</b> <a href='{uri}'>{uri}</a>"
+#, python-brace-format
+msgid ""
+"Struktūros importavimo metu sukurtas sisteminis komentaras.<br>\n"
+"                <b>Objektas:</b> {content_type} | {content_object}<br>\n"
+"                <b>Parengimas:</b> <pre><code>{prepare}</code></pre><br>\n"
+"                <b>Nuoroda:</b> <a href=\"{uri}\">{uri}</a>\n"
+"            "
+msgstr ""
+"Comment imported with a manifest.<br>\n"
+"                <b>Object:</b> {content_type} | {content_object}<br>\n"
+"                <b>Prepare:</b> <pre><code>{prepare}</code></pre><br>\n"
+"                <b>URI:</b> <a href=\"{uri}\">{uri}</a>\n"
+"            "
 
 msgid "Negalima atmesti — patvirtinti/atidaryti priskyrimai egzistuoja."
 msgstr "Cannot reject - approved/opened assignments exist"
@@ -1268,27 +1271,6 @@ msgstr "The organization can only be assigned the role of a data editor"
 
 msgid "Naudotojui išsiųstas laiškas dėl registracijos"
 msgstr "The user has been sent an email for registration"
-
-msgid ""
-"Duomenų lauko \"{0}\" metaduomenų matomumo lygis \"{1}\" negali būti "
-"aukštesnis už modelio metaduomenų matomumo lygį \"{2}\". "
-msgstr ""
-"Data field \"{0}\" metadata visibility level \"{1}\" must not be higher than "
-"the model metadata visibility level \"{2}\". "
-
-msgid ""
-"Duomenų reikšmės \"{0}\" metaduomenų matomumo lygis \"{1}\" negali būti "
-"aukštesnis už duomenų lauko metaduomenų matomumo lygį \"{2}\". "
-msgstr ""
-"Enum field \"{0}\" metadata visibility level \"{1}\" must not be higher than "
-"the property metadata visibility level \"{2}\" . "
-
-msgid ""
-"Duomenų reikšmės \"{0}\" metaduomenų matomumo lygis \"{1}\" negali būti "
-"aukštesnis už duomenų modelio metaduomenų matomumo lygį \"{2}\". "
-msgstr ""
-"Enum field \"{0}\" metadata visibility level \"{1}\" must not be higher than "
-"the model metadata visibility level \"{2}\" . "
 
 msgid ""
 "Modelio kodiniame pavadinime gali būti didžiosos/mažosios raidės ir "
@@ -2929,6 +2911,7 @@ msgstr "Contact editing"
 msgid "Šio kontakto ištrinti negalima, nes jis yra naudojamas sutartyse."
 msgstr "This contact can not be deleted, because it is used in agreements."
 
+#, python-brace-format
 msgid "Ar tikrai norite ištrinti kontaktą \"{contact}\"?"
 msgstr "Are you sure you want to delete the contact \"{contact}\"?"
 
@@ -3254,9 +3237,11 @@ msgstr "API key will be shown only one time, so you must copy it. Created key:"
 msgid "Kurti klientą"
 msgstr "Create client"
 
+#, python-brace-format
 msgid "Klientas \"{0}\" sukurtas sėkmingai."
 msgstr "Client \"{0}\" created successfully."
 
+#, python-brace-format
 msgid "Kliento raktas - {0}. Butinai išsisaugokite raktą, jis nebebus rodomas!"
 msgstr ""
 "Client key – {0}. Be sure to save this key; it will not be shown again!"
@@ -3267,12 +3252,14 @@ msgstr "Client registration"
 msgid "Kliento redagavimas"
 msgstr "Client edit"
 
+#, python-brace-format
 msgid "Klientas \"{0}\" atnaujintas sėkmingai"
 msgstr "Client \"{0}\" changed successfully"
 
 msgid "Šiam klientui aktyvių leidimų nėra"
 msgstr "There are no active scopes for this client"
 
+#, python-brace-format
 msgid "Leidimas \"{0}\" sukurtas sėkmingai"
 msgstr "Use case \"{0}\" created successfully"
 
@@ -3878,6 +3865,7 @@ msgstr "Confirm proposal"
 msgid "Dokumentas turi būti adoc formato."
 msgstr "The document must be in adoc format."
 
+#, python-brace-format
 msgid "ADOC klaida: {error}"
 msgstr "ADOC error: {error}"
 
@@ -3890,6 +3878,7 @@ msgstr "Upload document signed by data receiver"
 msgid "Veiksmas įvykdytas sėkmingai."
 msgstr "Action was executed successfully"
 
+#, python-brace-format
 msgid ""
 "Veiksmas gali būti atliekamas tik sutarčiai esant būsenoje "
 "{expected_status}.Dabartinė būsena: {current_status}."
@@ -3953,12 +3942,14 @@ msgstr "Legal basis for data provision (obligation)"
 msgid "Mokėjimo sąlygos"
 msgstr "Payment terms"
 
+#, python-brace-format
 msgid "Sutartis: {organization}"
 msgstr "Agreement: {organization}"
 
 msgid "Sutartis neturi sugeneruoto ODRL JSON failo."
 msgstr "The agreement does not have a generated ODRL JSON file."
 
+#, python-brace-format
 msgid ""
 "Nepavyko rasti 'assignee.ex:representative' sutarties '{0}' ODRL JSON faile. "
 "Klaida: {1}"
@@ -3966,6 +3957,7 @@ msgstr ""
 "Failed to find 'assignee.ex:representative' in the ODRL JSON file of "
 "agreement '{0}'. Error: {1}"
 
+#, python-brace-format
 msgid ""
 "Nepavyko rasti 'assigner.ex:representative' sutarties '{0}' ODRL JSON faile. "
 "Klaida: {1}"
@@ -4025,11 +4017,13 @@ msgstr "The uploaded agreement is not signed with the assigner's signature."
 msgid "Įkeltoje sutartyje rasti daugiau nei 2 parašai."
 msgstr "More than two signatures were found in the uploaded agreement."
 
+#, python-brace-format
 msgid ""
 "Pasirašyti galima tik sutartis su būsenomis `{formed}` arba `{initiated}`."
 msgstr ""
 "Only agreements with the statuses `{formed}` or `{initiated}` can be signed."
 
+#, python-brace-format
 msgid ""
 "Nesutampa pasirašiusių asmenų vardai ir pavardės. Reikalingi parašai: "
 "{expected}, ADOC rasti parašai: {found}."
@@ -4040,6 +4034,7 @@ msgstr ""
 msgid "Nerastas PDF failas."
 msgstr "PDF file not found."
 
+#, python-brace-format
 msgid "Blogas ADOC failas: {error}"
 msgstr "Invalid ADOC file: {error}"
 
@@ -4206,6 +4201,7 @@ msgstr "Dataset or namespace description."
 msgid "Aprašymas neatitinka Markdown formato."
 msgstr "Description doesn't match Markdown format."
 
+#, python-brace-format
 msgid ""
 "Metaduomenų matomumas '{0}' negali būti didesnis nei duomenų modelio "
 "matomumas '{1}'."
@@ -4213,6 +4209,7 @@ msgstr ""
 "Metadata visibility '{0}' should not be higher than data model visibility "
 "'{1}'."
 
+#, python-brace-format
 msgid ""
 "Metaduomenų matomumas '{0}' negali būti didesnis nei duomenų lauko matomumas "
 "'{1}'."
@@ -4995,21 +4992,25 @@ msgstr "Published version can not be published again"
 msgid "Privalote publikuoti duomenų rinkinį."
 msgstr "You must publish the dataset"
 
+#, python-brace-format
 msgid ""
 "Laukas {0} turi nuorodą į nepublikuojamą lauką tame pačiame duomenų "
 "ištekliuje."
 msgstr "Field {0} has a reference to an unpublished field in the same dataset."
 
+#, python-brace-format
 msgid ""
 "Laukas {0} turi nuorodą į nepublikuotą lauką {1} tame pačiame duomenų "
 "ištekliuje."
 msgstr ""
 "Field {0} has a reference to an unpublished field {1} in the same dataset."
 
+#, python-brace-format
 msgid ""
 "Laukas {0} privalo būti publikuojamas, nes laukas {1} turi nuorodą į jį."
 msgstr "Field {0} must be published, because field {1} has a reference to it."
 
+#, python-brace-format
 msgid "Laukas {0} turi nuorodą į nepublikuotą lauką kitame duomenų ištekliuje."
 msgstr ""
 "Field {0} has a reference to an unpublished field in a different dataset."
@@ -5758,18 +5759,22 @@ msgstr "No errors"
 msgid "Pridėti Agentą"
 msgstr "Add an Agent"
 
+#, python-brace-format
 msgid "Agentas '{0}' sukurtas sėkmingai!"
 msgstr "Agent \"{0}\" created successfully."
 
 msgid "Redaguoti Agentą"
 msgstr "Edit agent"
 
+#, python-brace-format
 msgid "Agentas '{0}' atnaujintas sėkmingai!"
 msgstr "Agent \"{0}\" updated successfully"
 
+#, python-brace-format
 msgid "Agentas '{0}' pašalintas sėkmingai!"
 msgstr "Agent \"{0}\" deleted successfully"
 
+#, python-brace-format
 msgid "Aplinka '{0}' sukurta sėkmingai!"
 msgstr "Environment \"{0}\" created successfully."
 
@@ -5800,12 +5805,15 @@ msgstr ""
 msgid "Redaguoti aplinką"
 msgstr "Edit environment"
 
+#, python-brace-format
 msgid "'{0}' aplinka atnaujinta sėkmingai!"
 msgstr "\"{0}\" environment updated successfully"
 
+#, python-brace-format
 msgid "Ar tikrai norite ištrinti aplinką: {0}?"
 msgstr "Are you sure you want to delete environment: {0}?"
 
+#, python-brace-format
 msgid "'{0}' aplinka pašalinta sėkmingai!"
 msgstr "'{0}' environment deleted successfully!"
 

--- a/vitrina/structure/forms.py
+++ b/vitrina/structure/forms.py
@@ -204,7 +204,7 @@ class EnumForm(forms.ModelForm):
         else:
             self.initial["visibility"] = "None"
 
-    def _is_value_unique(self, value: tuple[str, str], exclude_enum_item_id: int | None = None) -> bool:
+    def _is_value_not_unique(self, value: tuple[str, str], exclude_enum_item_id: int | None = None) -> bool:
         enum_items = self.enum.enumitem_set.all().prefetch_related("metadata")
         if exclude_enum_item_id:
             enum_items = enum_items.exclude(id=exclude_enum_item_id)
@@ -287,7 +287,7 @@ class EnumForm(forms.ModelForm):
 
         # If enum does not exist yet, there is no point checking for uniqueness of its items
         exclude_id = self.instance.id if self.instance and self.instance.pk else None
-        if self.enum and self._is_value_unique((source, prepare), exclude_enum_item_id=exclude_id):
+        if self.enum and self._is_value_not_unique((source, prepare), exclude_enum_item_id=exclude_id):
             error_msg = _(
                 'Galima reikšmė "{prepare}" su reikšme šaltinyje "{source}" jau egzistuoja.'.format(
                     prepare=prepare, source=source

--- a/vitrina/structure/forms.py
+++ b/vitrina/structure/forms.py
@@ -276,7 +276,7 @@ class EnumForm(forms.ModelForm):
 
         return visibility
 
-    def clean(self):
+    def clean(self) -> dict:
         cleaned_data = super().clean()
 
         if self.errors:
@@ -294,6 +294,8 @@ class EnumForm(forms.ModelForm):
                 )
             )
             self.add_error("value", error_msg)
+
+        return cleaned_data
 
 
 MODEL_LEVEL_CHOICES = (

--- a/vitrina/structure/forms.py
+++ b/vitrina/structure/forms.py
@@ -288,7 +288,12 @@ class EnumForm(forms.ModelForm):
         # If enum does not exist yet, there is no point checking for uniqueness of its items
         exclude_id = self.instance.id if self.instance and self.instance.pk else None
         if self.enum and self._is_value_unique((source, prepare), exclude_enum_item_id=exclude_id):
-            self.add_error("value", _(f'Galima reikšmė "{prepare}" su reikšme šaltinyje "{source}" jau egzistuoja.'))
+            error_msg = _(
+                'Galima reikšmė "{prepare}" su reikšme šaltinyje "{source}" jau egzistuoja.'.format(
+                    prepare=prepare, source=source
+                )
+            )
+            self.add_error("value", error_msg)
 
 
 MODEL_LEVEL_CHOICES = (

--- a/vitrina/structure/forms.py
+++ b/vitrina/structure/forms.py
@@ -204,14 +204,14 @@ class EnumForm(forms.ModelForm):
         else:
             self.initial["visibility"] = "None"
 
-    def _is_value_unique(self, value: str, exclude_enum_item_id: int | None = None) -> bool:
+    def _is_value_unique(self, value: tuple[str, str], exclude_enum_item_id: int | None = None) -> bool:
         enum_items = self.enum.enumitem_set.all().prefetch_related("metadata")
         if exclude_enum_item_id:
             enum_items = enum_items.exclude(id=exclude_enum_item_id)
         for enum_item in enum_items:
             if not (metadata := enum_item.metadata.first()):
                 continue
-            if metadata.prepare == value:
+            if (metadata.source, metadata.prepare) == value:
                 return True
 
         return False
@@ -234,11 +234,6 @@ class EnumForm(forms.ModelForm):
             spyna.parse(value)
         except ParseError as e:
             raise ValidationError(e)
-
-        # If enum does not exist yet, there is no point checking for uniqueness of its items
-        exclude_id = self.instance.id if self.instance and self.instance.pk else None
-        if self.enum and self._is_value_unique(value, exclude_enum_item_id=exclude_id):
-            raise ValidationError(_(f'Galima reikšmė "{value}" jau egzistuoja.'))
 
         return value
 
@@ -280,6 +275,20 @@ class EnumForm(forms.ModelForm):
                     )
 
         return visibility
+
+    def clean(self):
+        cleaned_data = super().clean()
+
+        if self.errors:
+            return cleaned_data
+
+        source = cleaned_data.get("source")
+        prepare = cleaned_data.get("value")
+
+        # If enum does not exist yet, there is no point checking for uniqueness of its items
+        exclude_id = self.instance.id if self.instance and self.instance.pk else None
+        if self.enum and self._is_value_unique((source, prepare), exclude_enum_item_id=exclude_id):
+            self.add_error("value", _(f'Galima reikšmė "{prepare}" su reikšme šaltinyje "{source}" jau egzistuoja.'))
 
 
 MODEL_LEVEL_CHOICES = (

--- a/vitrina/structure/forms.py
+++ b/vitrina/structure/forms.py
@@ -18,7 +18,7 @@ from lark import ParseError
 from vitrina.classifiers.models import Status
 from vitrina.resources.models import DatasetDistribution
 from vitrina.structure import spyna, AccessType
-from vitrina.structure.helpers import is_time_unit, is_si_unit
+from vitrina.structure.helpers import is_time_unit, is_si_unit, is_quoted
 from vitrina.structure.models import (
     EnumItem,
     Metadata,
@@ -221,6 +221,9 @@ class EnumForm(forms.ModelForm):
             return value
 
         if metadata := self.prop.metadata.first():
+            if metadata.type == "string" and not is_quoted(value):
+                value = f'"{value}"'
+
             checker = metadata.get_type_checker()
             try:
                 checker.check_enum_item_value(value)
@@ -233,9 +236,8 @@ class EnumForm(forms.ModelForm):
             raise ValidationError(e)
 
         # If enum does not exist yet, there is no point checking for uniqueness of its items
-        compare_value = f'"{value}"' if metadata.type == "string" else value
         exclude_id = self.instance.id if self.instance and self.instance.pk else None
-        if self.enum and self._is_value_unique(compare_value, exclude_enum_item_id=exclude_id):
+        if self.enum and self._is_value_unique(value, exclude_enum_item_id=exclude_id):
             raise ValidationError(_(f'Galima reikšmė "{value}" jau egzistuoja.'))
 
         return value

--- a/vitrina/structure/helpers.py
+++ b/vitrina/structure/helpers.py
@@ -156,3 +156,7 @@ def get_type_repr(meta):
     if meta.type_args:
         args = f"({meta.type_args})"
     return f"{type}{args}{unique}{required}"
+
+
+def is_quoted(value: str) -> bool:
+    return len(value) > 1 and value[0] == value[-1] and value[0] in ('"', "'")

--- a/vitrina/structure/services.py
+++ b/vitrina/structure/services.py
@@ -1417,6 +1417,7 @@ def _enums_to_tabular(obj: models.Model, separator: bool = False, version: Versi
                         "ref": enum.name if first else "",
                         "source": meta.source,
                         "prepare": meta.prepare,
+                        "level": meta.level_given,
                         "access": _get_access(meta.access),
                         "title": meta.title,
                         "description": meta.description,

--- a/vitrina/structure/services.py
+++ b/vitrina/structure/services.py
@@ -259,6 +259,7 @@ def _load_enums(
                 if en := existing_enum_items.filter(
                     metadata__content_type=enum_ct,
                     metadata__name=meta.name,
+                    metadata__source=meta.source,
                     metadata__prepare=meta.prepare,
                     metadata__dataset=dataset,
                 ).first():

--- a/vitrina/structure/templates/vitrina/structure/property_structure.html
+++ b/vitrina/structure/templates/vitrina/structure/property_structure.html
@@ -199,170 +199,166 @@
             </div>
         {% endif %}
 
-        {% if metadata.type == 'string' or metadata.type == 'integer' %}
-        <div>
-            <h4 class="custom-title is-size-4-mobile no-margin-bottom">{% translate "Reikšmių sąrašas" %}</h4>
-            {% if prop.filtered_enums %}
+        {% if metadata.type in allowed_enum_types %}
+            <div>
+                <h4 class="custom-title is-size-4-mobile no-margin-bottom">{% translate "Reikšmių sąrašas" %}</h4>
                 {% for enum in prop.filtered_enums %}
                     {% for enum_item in enum.filtered_items %}
-                    {% define enum_item.metadata.first as enum_meta %}
-                    <div class="columns no-margin-bottom">
-                        <div class="column is-6">
-                            {% if enum_meta.visibility is not None %}
-                                {% if enum_meta.visibility == 0 %}
-                                    <span class="mr-1 tag is-light is-rounded">
-                                        <span class="icon is-small has-tooltip-right has-text-grey"
-                                              data-tooltip="{% translate 'Metaduomenys nepublikuojami' %}">
-                                            <i class="fas fa-eye-slash"></i>
+                        {% define enum_item.metadata.first as enum_meta %}
+                        <div class="columns no-margin-bottom">
+                            <div class="column is-6">
+                                {% if enum_meta.visibility is not None %}
+                                    {% if enum_meta.visibility == 0 %}
+                                        <span class="mr-1 tag is-light is-rounded">
+                                            <span class="icon is-small has-tooltip-right has-text-grey"
+                                                  data-tooltip="{% translate 'Metaduomenys nepublikuojami' %}">
+                                                <i class="fas fa-eye-slash"></i>
+                                            </span>
                                         </span>
-                                    </span>
-                                {% elif enum_meta.visibility == 1 %}
-                                    <span class="mr-1 tag is-warning is-light is-rounded">
-                                        <span class="icon is-small has-tooltip-right"
-                                              data-tooltip="{% translate 'Naudojamas informacinės sistemos (IS) lygmeniu' %}">
-                                            <strong class="has-text-warning-dark">IS</strong>
+                                    {% elif enum_meta.visibility == 1 %}
+                                        <span class="mr-1 tag is-warning is-light is-rounded">
+                                            <span class="icon is-small has-tooltip-right"
+                                                  data-tooltip="{% translate 'Naudojamas informacinės sistemos (IS) lygmeniu' %}">
+                                                <strong class="has-text-warning-dark">IS</strong>
+                                            </span>
                                         </span>
-                                    </span>
-                                {% elif enum_meta.visibility == 2 %}
-                                    <span class="mr-1 tag is-success is-light is-rounded">
-                                        <span class="icon is-small has-tooltip-right"
-                                              data-tooltip="{% translate 'Naudojamas LT lygmeniu' %}">
-                                            <strong class="has-text-success-dark">LT</strong>
+                                    {% elif enum_meta.visibility == 2 %}
+                                        <span class="mr-1 tag is-success is-light is-rounded">
+                                            <span class="icon is-small has-tooltip-right"
+                                                  data-tooltip="{% translate 'Naudojamas LT lygmeniu' %}">
+                                                <strong class="has-text-success-dark">LT</strong>
+                                            </span>
                                         </span>
-                                    </span>
-                                {% elif enum_meta.visibility == 3 %}
-                                    <span class="mr-1 tag is-info is-light is-rounded">
-                                        <span class="icon is-small has-tooltip-right is-info"
-                                              data-tooltip="{% translate 'Naudojamas EU lygmeniu' %}">
-                                            <strong class="has-text-info-dark">EU</strong>
+                                    {% elif enum_meta.visibility == 3 %}
+                                        <span class="mr-1 tag is-info is-light is-rounded">
+                                            <span class="icon is-small has-tooltip-right is-info"
+                                                  data-tooltip="{% translate 'Naudojamas EU lygmeniu' %}">
+                                                <strong class="has-text-info-dark">EU</strong>
+                                            </span>
                                         </span>
-                                    </span>
+                                    {% endif %}
                                 {% endif %}
-                            {% endif %}
-                            {% if enum_meta.prepare %}
-                                <span class="pr-5 has-text-weight-semibold">{{ enum_meta.prepare }}</span>
-                            {% endif %}
-                            {% if enum_meta.title %}
-                                <span class="has-text-weight-semibold">{{ enum_meta.title }}</span>
-                            {% endif %}
-                            <div class="ml-4">
-                                {% if enum_meta.source %}
-                                    <span>source: </span>
-                                    <span class="has-text-weight-semibold">{{ enum_meta.source }}</span>
+                                {% if enum_meta.prepare %}
+                                    <span class="pr-5 has-text-weight-semibold">{{ enum_meta.prepare }}</span>
+                                {% endif %}
+                                {% if enum_meta.title %}
+                                    <span class="has-text-weight-semibold">{{ enum_meta.title }}</span>
+                                {% endif %}
+                                <div class="ml-4">
+                                    {% if enum_meta.source %}
+                                        <span>source: </span>
+                                        <span class="has-text-weight-semibold">{{ enum_meta.source }}</span>
+                                    {% endif %}
+                                </div>
+                                {% if enum_meta.description %}
+                                    <div class="ml-4"><p>{{ enum_meta.description | markdown | safe }}</p></div>
                                 {% endif %}
                             </div>
-                            {% if enum_meta.description %}
-                                <div class="ml-4"><p>{{ enum_meta.description | markdown | safe }}</p></div>
-                            {% endif %}
-                        </div>
-                        <div class="column is-2">
-                            {% if enum_meta.status.codename %}
-                                {% if enum_meta.status.codename == "develop" %}
-                                    <span class="tag has-tooltip"
-                                          data-tooltip="{% translate 'Būsena' %}" style="background-color: #eaedfa; color: #304cd3;">
-                                        {{ enum_meta.status.name }}
-                                    </span>
-                                {% elif enum_meta.status.codename == "completed" %}
-                                    <span class="tag has-tooltip is-success is-light"
-                                          data-tooltip="{% translate 'Būsena' %}">
-                                        {{ enum_meta.status.name }}
-                                    </span>
-                                {% elif enum_meta.status.codename == "discont" %}
-                                    <span class="tag has-tooltip"
-                                          data-tooltip="{% translate 'Būsena' %}" style="background-color: #fff5e5; color: #ffa525;">
-                                        {{ enum_meta.status.name }}
-                                    </span>
-                                {% elif enum_meta.status.codename == "deprecated" %}
-                                    <span class="tag has-tooltip is-warning is-light"
-                                          data-tooltip="{% translate 'Būsena' %}">
-                                        {{ enum_meta.status.name }}
-                                    </span>
-                                {% elif enum_meta.status.codename == "withdrawn" %}
-                                    <span class="tag has-tooltip is-danger is-light"
-                                          data-tooltip="{% translate 'Būsena' %}">
-                                        {{ enum_meta.status.name }}
-                                    </span>
+                            <div class="column is-2">
+                                {% if enum_meta.status.codename %}
+                                    {% if enum_meta.status.codename == "develop" %}
+                                        <span class="tag has-tooltip"
+                                              data-tooltip="{% translate 'Būsena' %}" style="background-color: #eaedfa; color: #304cd3;">
+                                            {{ enum_meta.status.name }}
+                                        </span>
+                                    {% elif enum_meta.status.codename == "completed" %}
+                                        <span class="tag has-tooltip is-success is-light"
+                                              data-tooltip="{% translate 'Būsena' %}">
+                                            {{ enum_meta.status.name }}
+                                        </span>
+                                    {% elif enum_meta.status.codename == "discont" %}
+                                        <span class="tag has-tooltip"
+                                              data-tooltip="{% translate 'Būsena' %}" style="background-color: #fff5e5; color: #ffa525;">
+                                            {{ enum_meta.status.name }}
+                                        </span>
+                                    {% elif enum_meta.status.codename == "deprecated" %}
+                                        <span class="tag has-tooltip is-warning is-light"
+                                              data-tooltip="{% translate 'Būsena' %}">
+                                            {{ enum_meta.status.name }}
+                                        </span>
+                                    {% elif enum_meta.status.codename == "withdrawn" %}
+                                        <span class="tag has-tooltip is-danger is-light"
+                                              data-tooltip="{% translate 'Būsena' %}">
+                                            {{ enum_meta.status.name }}
+                                        </span>
+                                    {% endif %}
                                 {% endif %}
-                            {% endif %}
-                        </div>
-                        <div class="column is-1">
-                            {% if enum_meta.eli %}
-                                <a href="{{ enum_meta.eli }}"
-                                   class="tag is-white has-tooltip"
-                                   data-tooltip="{% translate 'ELI nuoroda' %}"
-                                   target="_blank" rel="noopener noreferrer">
-                                    <span class="ml-3 icon is-small has-text-grey">
-                                        <i class="fas fa-link mr-1"></i>
-                                        <span>ELI</span>
-                                    </span>
-                                </a>
-                            {% endif %}
-                        </div>
-                        <div class="column is-1">
-                        {% if enum_meta.metadata_version %}
-                            {% if enum_meta.metadata_version.status == "DRAFT" %}
-                                <span class="tag is-danger is-light">({% translate "rengiama" %})</span>
-                            {% elif enum_meta.draft and enum_meta.metadata_version.status != "DRAFT"%}
-                                <span class="tag is-danger is-light">{{ enum_meta.metadata_version.external_version}} ({% translate "rengiama" %})</span>
-                            {% elif enum_meta.metadata_version.external_version and not enum_meta.draft %}
-                                <span class="tag is-success is-light">{{ enum_meta.metadata_version.external_version }}</span>
-                            {% endif %}
-                        {% endif %}
-                        </div>
-                        <div class="column is-2">
-                            {% if enum_meta.prepare or enum_meta.title %}
-                                {% if prop.name and model.name and can_manage_structure %}
-                                {% if not is_disabled %}
-                                    <a href="{% url 'enum-update' dataset.pk version_id.pk model.name prop.name enum_item.pk %}"
-                                       class="button is-primary is-small">
-                                        {% translate "Keisti" %}
-                                    </a>
-                                    <a href="{% url 'enum-delete' dataset.pk version_id.pk model.name prop.name enum_item.pk %}"
-                                       onclick="return confirm({% translate 'Ar jūs tikrai norite ištrinti?' %})"
-                                       class="button is-link is-small"
-                                       id="delete_enum">
-                                        {% translate "Ištrinti" %}
-                                    </a>
-                                {% else %}
-                                    <a class="button is-primary is-small is-disabled"
-                                       style="pointer-events: none; opacity: 0.5;"
-                                       aria-disabled="true">
-                                        {% translate "Keisti" %}
-                                    </a>
-                                    <a class="button is-link is-small is-disabled"
-                                       style="pointer-events: none; opacity: 0.5;"
-                                       aria-disabled="true">
-                                        {% translate "Ištrinti" %}
+                            </div>
+                            <div class="column is-1">
+                                {% if enum_meta.eli %}
+                                    <a href="{{ enum_meta.eli }}"
+                                       class="tag is-white has-tooltip"
+                                       data-tooltip="{% translate 'ELI nuoroda' %}"
+                                       target="_blank" rel="noopener noreferrer">
+                                        <span class="ml-3 icon is-small has-text-grey">
+                                            <i class="fas fa-link mr-1"></i>
+                                            <span>ELI</span>
+                                        </span>
                                     </a>
                                 {% endif %}
+                            </div>
+                            <div class="column is-1">
+                            {% if enum_meta.metadata_version %}
+                                {% if enum_meta.metadata_version.status == "DRAFT" %}
+                                    <span class="tag is-danger is-light">({% translate "rengiama" %})</span>
+                                {% elif enum_meta.draft and enum_meta.metadata_version.status != "DRAFT"%}
+                                    <span class="tag is-danger is-light">{{ enum_meta.metadata_version.external_version}} ({% translate "rengiama" %})</span>
+                                {% elif enum_meta.metadata_version.external_version and not enum_meta.draft %}
+                                    <span class="tag is-success is-light">{{ enum_meta.metadata_version.external_version }}</span>
                                 {% endif %}
                             {% endif %}
+                            </div>
+                            <div class="column is-2">
+                                {% if enum_meta.prepare or enum_meta.title %}
+                                    {% if prop.name and model.name and can_manage_structure %}
+                                    {% if not is_disabled %}
+                                        <a href="{% url 'enum-update' dataset.pk version_id.pk model.name prop.name enum_item.pk %}"
+                                           class="button is-primary is-small">
+                                            {% translate "Keisti" %}
+                                        </a>
+                                        <a href="{% url 'enum-delete' dataset.pk version_id.pk model.name prop.name enum_item.pk %}"
+                                           onclick="return confirm({% translate 'Ar jūs tikrai norite ištrinti?' %})"
+                                           class="button is-link is-small"
+                                           id="delete_enum">
+                                            {% translate "Ištrinti" %}
+                                        </a>
+                                    {% else %}
+                                        <a class="button is-primary is-small is-disabled"
+                                           style="pointer-events: none; opacity: 0.5;"
+                                           aria-disabled="true">
+                                            {% translate "Keisti" %}
+                                        </a>
+                                        <a class="button is-link is-small is-disabled"
+                                           style="pointer-events: none; opacity: 0.5;"
+                                           aria-disabled="true">
+                                            {% translate "Ištrinti" %}
+                                        </a>
+                                    {% endif %}
+                                    {% endif %}
+                                {% endif %}
+                            </div>
                         </div>
-                    </div>
+                    {% endfor %}
+                {% empty %}
+                    <p>{% translate "Galimos reikšmės neapibrėžtos." %}</p>
                 {% endfor %}
-            {% endfor %}
-            {% else %}
-                <p>
-                    {% translate "Galimos reikšmės neapibrėžtos." %}
-                </p>
-            {% endif %}
-            {% if model.name and prop.name and can_manage_structure %}
-                <div class="buttons is-right mt-5">
-                    {% if not is_disabled %}
-                        <a href="{% url 'enum-create' dataset.pk version_id.pk model.name prop.name %}"
-                           class="button is-primary">
-                            {% translate "Nauja reikšmė" %}
-                        </a>
-                    {% else %}
-                        <a class="button is-primary is-disabled"
-                           style="pointer-events: none; opacity: 0.5;"
-                           aria-disabled="true">
-                            {% translate "Nauja reikšmė" %}
-                        </a>
-                    {% endif %}
-                </div>
-            {% endif %}
-        </div>
+                {% if model.name and prop.name and can_manage_structure %}
+                    <div class="buttons is-right mt-5">
+                        {% if not is_disabled %}
+                            <a href="{% url 'enum-create' dataset.pk version_id.pk model.name prop.name %}"
+                               class="button is-primary">
+                                {% translate "Nauja reikšmė" %}
+                            </a>
+                        {% else %}
+                            <a class="button is-primary is-disabled"
+                               style="pointer-events: none; opacity: 0.5;"
+                               aria-disabled="true">
+                                {% translate "Nauja reikšmė" %}
+                            </a>
+                        {% endif %}
+                    </div>
+                {% endif %}
+            </div>
         {% endif %}
 
         {% if metadata.description %}

--- a/vitrina/structure/utils.py
+++ b/vitrina/structure/utils.py
@@ -22,7 +22,8 @@ class TypeChecker(ABC, Generic[T]):
 class StringTypeChecker(TypeChecker[str]):
     def check_enum_item_value(self, value: str) -> None:
         if not is_quoted(value):
-            raise TypeCheckerError(_(f'Reikšmė "{value}" turi būti string tipo.'))
+            error_msg = _('Reikšmė "{value}" turi būti string tipo.').format(value=value)
+            raise TypeCheckerError(error_msg)
 
 
 class IntegerTypeChecker(TypeChecker[int]):
@@ -30,14 +31,18 @@ class IntegerTypeChecker(TypeChecker[int]):
         try:
             int(value)
         except (TypeError, ValueError):
-            raise TypeCheckerError(_(f'Reikšmė "{value}" turi būti integer tipo.'))
+            error_msg = _('Reikšmė "{value}" turi būti integer tipo.').format(value=value)
+            raise TypeCheckerError(error_msg)
 
 
 class BooleanTypeChecker(TypeChecker[bool]):
     def check_enum_item_value(self, value: str) -> None:
         if value not in VALID_BOOLEAN_PREPARE_VALUES:
             possible_values = ", ".join(VALID_BOOLEAN_PREPARE_VALUES)
-            raise TypeCheckerError(_(f'Reikšmė "{value}" turi būti boolean tipo. Viena iš: {possible_values}'))
+            error_msg = _('Reikšmė "{value}" turi būti boolean tipo. Viena iš: {possible_values}').format(
+                value=value, possible_values=possible_values
+            )
+            raise TypeCheckerError(error_msg)
 
 
 class NotImplementedTypeChecker(TypeChecker[Any]):

--- a/vitrina/structure/utils.py
+++ b/vitrina/structure/utils.py
@@ -3,6 +3,8 @@ from typing import TypeVar, Generic, Any
 
 from django.utils.translation import gettext_lazy as _
 
+from vitrina.structure.helpers import is_quoted
+
 T = TypeVar("T")
 
 
@@ -15,7 +17,9 @@ class TypeChecker(ABC, Generic[T]):
 
 
 class StringTypeChecker(TypeChecker[str]):
-    pass
+    def check_enum_item_value(self, value: str) -> None:
+        if not is_quoted(value):
+            raise TypeCheckerError(_(f'Reikšmė "{value}" turi būti string tipo.'))
 
 
 class IntegerTypeChecker(TypeChecker[int]):

--- a/vitrina/structure/utils.py
+++ b/vitrina/structure/utils.py
@@ -8,6 +8,9 @@ from vitrina.structure.helpers import is_quoted
 T = TypeVar("T")
 
 
+VALID_BOOLEAN_PREPARE_VALUES = ("true", "false")
+
+
 class TypeCheckerError(Exception):
     pass
 
@@ -30,6 +33,13 @@ class IntegerTypeChecker(TypeChecker[int]):
             raise TypeCheckerError(_(f'Reikšmė "{value}" turi būti integer tipo.'))
 
 
+class BooleanTypeChecker(TypeChecker[bool]):
+    def check_enum_item_value(self, value: str) -> None:
+        if value not in VALID_BOOLEAN_PREPARE_VALUES:
+            possible_values = ", ".join(VALID_BOOLEAN_PREPARE_VALUES)
+            raise TypeCheckerError(_(f'Reikšmė "{value}" turi būti boolean tipo. Viena iš: {possible_values}'))
+
+
 class NotImplementedTypeChecker(TypeChecker[Any]):
     def check_enum_item_value(self, value: str) -> None:
         raise TypeCheckerError(_("Savybės reikšmės tipas nėra palaikomas."))
@@ -38,6 +48,7 @@ class NotImplementedTypeChecker(TypeChecker[Any]):
 TYPE_CHECKER_MAP = {
     "string": StringTypeChecker(),
     "integer": IntegerTypeChecker(),
+    "boolean": BooleanTypeChecker(),
 }
 
 

--- a/vitrina/structure/views.py
+++ b/vitrina/structure/views.py
@@ -1872,7 +1872,10 @@ class EnumCreateView(PermissionRequiredMixin, CreateView):
             return redirect(self.property.get_absolute_url())
 
         if (metadata := self.property.metadata.first()) and metadata.type not in TYPE_CHECKER_MAP:
-            messages.error(request, _(f'Reikšmių duomenų lauko tipui "{metadata.type}" kurti negalima'))
+            error_msg = _('Reikšmių duomenų lauko tipui "{metadata_type}" kurti negalima').format(
+                metadata_type=metadata.type
+            )
+            messages.error(request, error_msg)
             return redirect(self.property.get_absolute_url())
 
         self.enum = self.property.enums.first()
@@ -2009,7 +2012,10 @@ class EnumUpdateView(PermissionRequiredMixin, UpdateView):
             return redirect(self.property.get_absolute_url())
 
         if (metadata := self.property.metadata.first()) and metadata.type not in TYPE_CHECKER_MAP:
-            messages.error(request, _(f'Reikšmių duomenų lauko tipui "{metadata.type}" keisti negalima'))
+            error_msg = _('Reikšmių duomenų lauko tipui "{metadata_type}" keisti negalima').format(
+                metadata_type=metadata.type
+            )
+            messages.error(request, error_msg)
             return redirect(self.property.get_absolute_url())
 
         return super().dispatch(request, *args, **kwargs)

--- a/vitrina/structure/views.py
+++ b/vitrina/structure/views.py
@@ -1921,8 +1921,6 @@ class EnumCreateView(PermissionRequiredMixin, CreateView):
         visibility = form.cleaned_data.get("visibility")
         status = form.cleaned_data.get("status") or Status.objects.filter(is_default=True).first()
         eli = form.cleaned_data.get("eli")
-        if (metadata := self.property.metadata.first()) and metadata.type == "string":
-            value = f'"{value}"'
 
         Metadata.objects.create(
             uuid=str(uuid.uuid4()),
@@ -1935,7 +1933,7 @@ class EnumCreateView(PermissionRequiredMixin, CreateView):
             visibility=visibility,
             status=status,
             eli=eli,
-            prepare_ast=spyna.parse(form.cleaned_data.get("value")),
+            prepare_ast=spyna.parse(value),
             source=form.cleaned_data.get("source"),
             access=form.cleaned_data.get("access") or None,
             title=form.cleaned_data.get("title"),
@@ -2046,14 +2044,11 @@ class EnumUpdateView(PermissionRequiredMixin, UpdateView):
     def form_valid(self, form):
         self.object: EnumItem = form.save()
         value = form.cleaned_data.get("value")
-        if (metadata := self.property.metadata.first()) and metadata.type == "string":
-            value = f'"{value}"'
-
         old_metadata = self.get_object().metadata.first()
 
         if metadata := self.object.metadata.first():
             metadata.prepare = value
-            metadata.prepare_ast = spyna.parse(form.cleaned_data.get("value"))
+            metadata.prepare_ast = spyna.parse(value)
             metadata.source = form.cleaned_data.get("source")
             metadata.access = form.cleaned_data.get("access") or None
             metadata.title = form.cleaned_data.get("title")

--- a/vitrina/structure/views.py
+++ b/vitrina/structure/views.py
@@ -84,6 +84,7 @@ from vitrina.structure.services import (
     get_allowed_visibilities,
 )
 from vitrina.datasets.structure import read as read_structure
+from vitrina.structure.utils import TYPE_CHECKER_MAP
 from vitrina.tasks.models import Task
 from spinta.manifests.open_api.helpers import create_openapi_manifest
 from spinta.manifests.components import ManifestPath
@@ -762,6 +763,7 @@ class PropertyStructureView(
         )
         context["can_manage_structure"] = self.can_manage_structure
         context["is_disabled"] = self.metadata_version is not None and not self.metadata_version.is_draft()
+        context["allowed_enum_types"] = TYPE_CHECKER_MAP.keys()
 
         allowed_enum_visibilities = get_allowed_visibilities(
             self.request.user, self.object, Action.VIEW, model_class=Enum
@@ -1868,6 +1870,11 @@ class EnumCreateView(PermissionRequiredMixin, CreateView):
         if self.metadata_version and not self.metadata_version.is_draft():
             messages.error(request, _("Negalima kurti naujos reikšmės, kai versijos būsena nėra juodraštis."))
             return redirect(self.property.get_absolute_url())
+
+        if (metadata := self.property.metadata.first()) and metadata.type not in TYPE_CHECKER_MAP:
+            messages.error(request, _(f'Reikšmių duomenų lauko tipui "{metadata.type}" kurti negalima'))
+            return redirect(self.property.get_absolute_url())
+
         self.enum = self.property.enums.first()
         return super().dispatch(request, *args, **kwargs)
 
@@ -2000,6 +2007,11 @@ class EnumUpdateView(PermissionRequiredMixin, UpdateView):
         if self.metadata_version and not self.metadata_version.is_draft():
             messages.error(request, _("Negalima redaguoti reikšmės, kai versijos būsena nėra juodraštis."))
             return redirect(self.property.get_absolute_url())
+
+        if (metadata := self.property.metadata.first()) and metadata.type not in TYPE_CHECKER_MAP:
+            messages.error(request, _(f'Reikšmių duomenų lauko tipui "{metadata.type}" keisti negalima'))
+            return redirect(self.property.get_absolute_url())
+
         return super().dispatch(request, *args, **kwargs)
 
     def has_permission(self):


### PR DESCRIPTION
**Summary:**
Fix some more enum related bugs:
- Add check if enum item matches property type in manifest import and UI. 
  - Always save string enum items with quotes, because Spinta doesn't support unquoted prepare values (a.k.a binds)
- Show/Change/Create enum items for booleans via UI.
- Allow creating enum items only for types that has `TypeChecker` class. Currently: `string`, `integer`, `boolean`.
- Allow creating enum items with identical prepare values, as long as source is different

**Ticket:**
https://github.com/atviriduomenys/katalogas/issues/2324