### PR TITLE
2298 elasticsearch issue

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -179,6 +179,12 @@ https://github.com/atviriduomenys/katalogas/issues/2467
 
 - Comments for `Base` manifest rows are now imported & displayed correctly in Catalog & after export.
 
+https://github.com/atviriduomenys/katalogas/issues/2298
+
+- Fix orphaned Elasticsearch documents caused by transaction rollbacks in signal processor.
+- Add template guard to prevent 500 errors from orphaned Elasticsearch documents.
+
+
 v 1.15.0 (2026-02-27)
 ==================
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,6 +59,23 @@ def _haystack_marker(request):
 
         call_command("clear_index", interactive=False, using=["default"])
 
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _immediate_es_indexing(request):
+    django_db_marker = request.node.get_closest_marker("django_db")
+    uses_real_transactions = django_db_marker and django_db_marker.kwargs.get("transaction", False)
+
+    if uses_real_transactions:
+        yield
+    else:
+        with patch(
+            "vitrina.datasets.search_indexes.CustomSignalProcessor._on_commit",
+            staticmethod(lambda func: func()),
+        ):
+            yield
+
 
 @pytest.fixture(scope="session", autouse=True)
 def set_test_settings(tmp_path_factory):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,7 +63,7 @@ def _haystack_marker(request):
 
 
 @pytest.fixture(autouse=True)
-def _immediate_es_indexing(request):
+def _immediate_elastic_search_indexing(request):
     django_db_marker = request.node.get_closest_marker("django_db")
     uses_real_transactions = django_db_marker and django_db_marker.kwargs.get("transaction", False)
 

--- a/tests/datasets/test_index.py
+++ b/tests/datasets/test_index.py
@@ -122,19 +122,19 @@ class TestSignalProcessorTransactionSafety:
     def test_no_orphan_on_transaction_rollback(self):
         backend = connections["default"].get_backend()
 
-        try:
+        pk = None
+        with pytest.raises(Exception, match="Force rollback"):
             with transaction.atomic():
                 dataset = DatasetFactory()
                 pk = dataset.pk
                 raise Exception("Force rollback")
-        except Exception:
-            pass
 
+        assert pk is not None
         assert not Dataset.objects.filter(pk=pk).exists(), "DB record should not exist after rollback"
 
+        doc_id = f"vitrina_datasets.dataset.{pk}"
         try:
             backend.conn.indices.refresh(index=backend.index_name)
-            doc_id = f"vitrina_datasets.dataset.{pk}"
             result = backend.conn.exists(index=backend.index_name, id=doc_id)
         except NotFoundError:
             result = False

--- a/tests/datasets/test_index.py
+++ b/tests/datasets/test_index.py
@@ -1,5 +1,6 @@
-from django.db import connection
+from django.db import connection, transaction
 from django.test.utils import CaptureQueriesContext
+from elasticsearch.exceptions import NotFoundError
 from haystack import connections
 from unittest.mock import patch
 
@@ -113,3 +114,43 @@ class TestDatasetIndexQuery:
         assert count_10 <= count_3 + 7, (
             f"Query count should scale constantly, got {count_3} for 3 datasets vs {count_10} for 10"
         )
+
+
+@pytest.mark.django_db(transaction=True)
+class TestSignalProcessorTransactionSafety:
+    @pytest.mark.haystack
+    def test_no_orphan_on_transaction_rollback(self):
+        backend = connections["default"].get_backend()
+
+        try:
+            with transaction.atomic():
+                dataset = DatasetFactory()
+                pk = dataset.pk
+                raise Exception("Force rollback")
+        except Exception:
+            pass
+
+        assert not Dataset.objects.filter(pk=pk).exists(), "DB record should not exist after rollback"
+
+        try:
+            backend.conn.indices.refresh(index=backend.index_name)
+            doc_id = f"vitrina_datasets.dataset.{pk}"
+            result = backend.conn.exists(index=backend.index_name, id=doc_id)
+        except NotFoundError:
+            result = False
+
+        assert result is False, (
+            f"Orphaned ES document found for pk={pk}. "
+            "The signal processor indexed the document inside a transaction that was rolled back."
+        )
+
+    @pytest.mark.haystack
+    def test_indexes_after_transaction_commit(self):
+        backend = connections["default"].get_backend()
+
+        dataset = DatasetFactory()
+
+        backend.conn.indices.refresh(index=backend.index_name)
+        doc_id = f"vitrina_datasets.dataset.{dataset.pk}"
+        result = backend.conn.exists(index=backend.index_name, id=doc_id)
+        assert result is True, "ES document should exist after a committed save"

--- a/vitrina/datasets/search_indexes.py
+++ b/vitrina/datasets/search_indexes.py
@@ -1,4 +1,8 @@
+import logging
+
 from django.contrib.contenttypes.models import ContentType
+from django.db import models, transaction
+
 from django.db.models import Prefetch, Exists, OuterRef
 from vitrina.resources.models import DatasetDistribution
 from vitrina.structure.models import Model, Property
@@ -10,7 +14,6 @@ from haystack.fields import (
     EdgeNgramField,
     BooleanField,
 )
-from django.db import models
 
 from haystack import signals
 from haystack.exceptions import NotHandled
@@ -18,6 +21,8 @@ from haystack.indexes import SearchIndex, Indexable
 
 from vitrina.datasets.models import Dataset
 from vitrina.requests.models import RequestObject, Request
+
+logger = logging.getLogger(__name__)
 
 
 class DatasetIndex(SearchIndex, Indexable):
@@ -131,6 +136,8 @@ class DatasetIndex(SearchIndex, Indexable):
 
 
 class CustomSignalProcessor(signals.BaseSignalProcessor):
+    _on_commit = staticmethod(transaction.on_commit)
+
     def setup(self):
         models.signals.post_save.connect(self.handle_save)
         models.signals.post_delete.connect(self.handle_delete)
@@ -144,20 +151,48 @@ class CustomSignalProcessor(signals.BaseSignalProcessor):
 
         for using in using_backends:
             try:
-                index = self.connections[using].get_unified_index().get_index(sender)
-
-                if index.index_queryset().filter(pk=instance.pk):
-                    index.update_object(instance, using=using)
-                    if isinstance(instance, Dataset):
-                        req_index = self.connections[using].get_unified_index().get_index(Request)
-                        reqs = RequestObject.objects.filter(
-                            content_type=ContentType.objects.get_for_model(instance),
-                            object_id=instance.pk,
-                        )
-                        for req in reqs:
-                            req_index.update_object(req.request, using=using)
-                else:
-                    index.remove_object(instance, using=using)
-
+                self.connections[using].get_unified_index().get_index(sender)
             except NotHandled:
-                pass
+                continue
+
+            self._on_commit(lambda s=sender, inst=instance, u=using: self._index_instance(s, inst, u))
+
+    def handle_delete(self, sender, instance, **kwargs):
+        using_backends = self.connection_router.for_write(instance=instance)
+
+        for using in using_backends:
+            try:
+                index = self.connections[using].get_unified_index().get_index(sender)
+            except NotHandled:
+                continue
+
+            self._on_commit(lambda i=index, inst=instance, u=using: i.remove_object(inst, using=u))
+
+    def _index_instance(self, sender, instance, using):
+        try:
+            index = self.connections[using].get_unified_index().get_index(sender)
+        except NotHandled:
+            return
+
+        if not sender.objects.filter(pk=instance.pk).exists():
+            return
+
+        try:
+            if not index.index_queryset().filter(pk=instance.pk).exists():
+                index.remove_object(instance, using=using)
+                return
+
+            index.update_object(instance, using=using)
+            if isinstance(instance, Dataset):
+                self._reindex_related_requests(instance, using)
+        except Exception:
+            logger.warning("Failed to index %s pk=%s", sender.__name__, instance.pk, exc_info=True)
+
+    def _reindex_related_requests(self, dataset, using):
+        req_index = self.connections[using].get_unified_index().get_index(Request)
+        reqs = RequestObject.objects.filter(
+            content_type=ContentType.objects.get_for_model(dataset),
+            object_id=dataset.pk,
+        )
+        for req in reqs:
+            req_index.update_object(req.request, using=using)

--- a/vitrina/datasets/search_indexes.py
+++ b/vitrina/datasets/search_indexes.py
@@ -146,7 +146,7 @@ class CustomSignalProcessor(signals.BaseSignalProcessor):
         models.signals.post_save.disconnect(self.handle_save)
         models.signals.post_delete.disconnect(self.handle_delete)
 
-    def handle_save(self, sender, instance, **kwargs):
+    def handle_save(self, sender: type[models.Model], instance: models.Model, **kwargs) -> None:
         using_backends = self.connection_router.for_write(instance=instance)
 
         for using in using_backends:
@@ -157,7 +157,7 @@ class CustomSignalProcessor(signals.BaseSignalProcessor):
 
             self._on_commit(lambda s=sender, inst=instance, u=using: self._index_instance(s, inst, u))
 
-    def handle_delete(self, sender, instance, **kwargs):
+    def handle_delete(self, sender: type[models.Model], instance: models.Model, **kwargs) -> None:
         using_backends = self.connection_router.for_write(instance=instance)
 
         for using in using_backends:
@@ -168,18 +168,20 @@ class CustomSignalProcessor(signals.BaseSignalProcessor):
 
             self._on_commit(lambda i=index, inst=instance, u=using: i.remove_object(inst, using=u))
 
-    def _index_instance(self, sender, instance, using):
+    def _index_instance(self, sender: type[models.Model], instance: models.Model, using: str) -> None:
         try:
             index = self.connections[using].get_unified_index().get_index(sender)
         except NotHandled:
             return
 
         if not sender.objects.filter(pk=instance.pk).exists():
+            logger.debug("Skipping indexing for %s pk=%s: object no longer exists", sender.__name__, instance.pk)
             return
 
         try:
             if not index.index_queryset().filter(pk=instance.pk).exists():
                 index.remove_object(instance, using=using)
+                logger.debug("Removed %s pk=%s from index: not in index_queryset", sender.__name__, instance.pk)
                 return
 
             index.update_object(instance, using=using)
@@ -188,7 +190,7 @@ class CustomSignalProcessor(signals.BaseSignalProcessor):
         except Exception:
             logger.warning("Failed to index %s pk=%s", sender.__name__, instance.pk, exc_info=True)
 
-    def _reindex_related_requests(self, dataset, using):
+    def _reindex_related_requests(self, dataset: Dataset, using: str) -> None:
         req_index = self.connections[using].get_unified_index().get_index(Request)
         reqs = RequestObject.objects.filter(
             content_type=ContentType.objects.get_for_model(dataset),

--- a/vitrina/datasets/templates/vitrina/datasets/list.html
+++ b/vitrina/datasets/templates/vitrina/datasets/list.html
@@ -4,10 +4,12 @@
 {% load hitcount_tags %}
 {% load util_tags %}
 {% load markdown_tags %}
-
-{% block pageTitle %} | {% translate "Duomenų ištekliai" %}{% endblock %}
-{% block pageOgTitle %} | {% translate "Duomenų ištekliai" %}{% endblock %}
-
+{% block pageTitle %}
+    | {% translate "Duomenų ištekliai" %}
+{% endblock %}
+{% block pageOgTitle %}
+    | {% translate "Duomenų ištekliai" %}
+{% endblock %}
 {% block head %}
     <style>
         .autocomplete {
@@ -47,185 +49,182 @@
             color: #ffffff;
         }
         .divider-right {
-          border-right: 1px solid #dcdcdc;
-          height: 100%;
+            border-right: 1px solid #dcdcdc;
+            height: 100%;
         }
         .dataset-list-description {
-        word-break: break-all;
-        overflow-wrap: break-word;
+            word-break: break-all;
+            overflow-wrap: break-word;
+        }
+        .dataset-list-group-tag {
+            background-color: Gainsboro;
+            color: black;
         }
     </style>
 {% endblock %}
-
 {% block parent_links %}
     {% include "component/breadcrumbs.html" %}
 {% endblock %}
-
 {% block current_title %}
-{% if request.resolver_match.url_name == 'organization-datasets' %}
-    {{ organization }}
-{% else %}
-    {{ page_title }}
-{% endif %}
+    {% if request.resolver_match.url_name == 'organization-datasets' %}
+        {{ organization }}
+    {% else %}
+        {{ page_title }}
+    {% endif %}
 {% endblock %}
-
 {% block content %}
     {% if request.resolver_match.url_name == 'organization-datasets' %}
         {% include 'vitrina/orgs/tabs.html' %}
     {% elif request.resolver_match.url_name == 'dataset-child-resources' %}
         {% include 'vitrina/datasets/tabs.html' %}
     {% endif %}
-
     <div class="card mb-5">
-      <div class="card-content">
-        <form id="dataset-filter" class="field has-addons is-fullwidth"
-        action="{{ search_url }}"
-        method="get">
-            <div class="control is-expanded">
-                <label class="visually-hidden" for="search-input">{% translate 'Duomenų rinkinio paieška' %}</label>
-                <input class="input" id="search-input" type="text" name="q"
-                       placeholder="{% translate 'Ieškoti duomenų rinkinių' %}"
-                       value="{{ q | escape }}" title="{% translate 'Paieška' %}"/>
-                {% for k, values in search_query.items %}
-                    {% for v in values %}
-                        {% if k != 'q' and k != 'page' %}
-                            <input type="hidden" name="{{ k }}" value="{{ v | escape }}"/>
-                        {% endif %}
+        <div class="card-content">
+            <form id="dataset-filter"
+                  class="field has-addons is-fullwidth"
+                  action="{{ search_url }}"
+                  method="get">
+                <div class="control is-expanded">
+                    <label class="visually-hidden" for="search-input">{% translate 'Duomenų rinkinio paieška' %}</label>
+                    <input class="input"
+                           id="search-input"
+                           type="text"
+                           name="q"
+                           placeholder="{% translate 'Ieškoti duomenų rinkinių' %}"
+                           value="{{ q | escape }}"
+                           title="{% translate 'Paieška' %}" />
+                    {% for k, values in search_query.items %}
+                        {% for v in values %}
+                            {% if k != 'q' and k != 'page' %}<input type="hidden" name="{{ k }}" value="{{ v | escape }}" />{% endif %}
+                        {% endfor %}
                     {% endfor %}
-                {% endfor %}
-            </div>
-            <p class="control">
-                <button class="button is-primary" type="submit" title="{% translate 'Ieškoti' %}" aria-label="{% translate 'Ieškoti' %}">
-                    <span class="icon is-large">
-                        <i class="fa fa-search"></i>
-                    </span>
-                </button>
-            </p>
-        </form>
-
-        <div class="buttons is-right">
-
-          {% if request.resolver_match.url_name == 'organization-datasets' and can_create_dataset %}
-          <a href="{%url 'resource-subclass-add' pk=view.kwargs.pk %}" id="add_dataset" class="button is-primary is-normal m-t-md is-size-6-mobile">
-              {% translate "Pridėti duomenų išteklių" %}
-          </a>
-          {% elif request.resolver_match.url_name == 'dataset-child-resources' and can_create_dataset %}
-          <a href="{%url 'child-resource-subclass-add' pk=organization_id parent_id=parent_dataset_id %}" id="add_dataset" class="button is-primary is-normal m-t-md is-size-6-mobile">
-              {% translate "Pridėti vaikinį duomenų išteklių" %}
-          </a>
-          {% endif %}
-
-          <div class="dropdown is-hoverable is-block is-right">
-            <div class="dropdown-trigger">
-              <button class="button" aria-haspopup="true" aria-controls="dropdown-menu4">
-                  {% if sort %}
-                      {% for sort_option in sort_options %}
-                        {% if sort == sort_option.key %}
-                            <span class="icon is-small">
-                              <i class="{{ sort_option.icon }}"></i>
-                            </span>
-                            <span>{{ sort_option.title }}</span>
-                        {% endif %}
-                      {% endfor %}
-                  {% else %}
-                    <span class="icon is-slikuotamall">
-                      <i class="{{ sort_options.0.icon }}"></i>
-                    </span>
-                    <span>{{ sort_options.0.title }}</span>
-                  {% endif %}
-                <span class="icon is-small">
-                  <i class="fas fa-angle-down" aria-hidden="true"></i>
-                </span>
-              </button>
-            </div>
-            <div class="dropdown-menu" id="dropdown-menu4" role="menu">
-              <div class="dropdown-content">
-                  {% for sort_option in sort_options %}
-                    <a class="dropdown-item" href="{{ sort_option.url }}" role="menuitem">
-                      <span class="icon is-small">
-                        <i class="{{ sort_option.icon }}"></i>
-                      </span>
-                      <span>{{ sort_option.title }}</span>
+                </div>
+                <p class="control">
+                    <button class="button is-primary"
+                            type="submit"
+                            title="{% translate 'Ieškoti' %}"
+                            aria-label="{% translate 'Ieškoti' %}">
+                        <span class="icon is-large">
+                            <i class="fa fa-search"></i>
+                        </span>
+                    </button>
+                </p>
+            </form>
+            <div class="buttons is-right">
+                {% if request.resolver_match.url_name == 'organization-datasets' and can_create_dataset %}
+                    <a href="{% url 'resource-subclass-add' pk=view.kwargs.pk %}"
+                       id="add_dataset"
+                       class="button is-primary is-normal m-t-md is-size-6-mobile">
+                        {% translate "Pridėti duomenų išteklių" %}
                     </a>
-                  {% endfor %}
-              </div>
+                {% elif request.resolver_match.url_name == 'dataset-child-resources' and can_create_dataset %}
+                    <a href="{% url 'child-resource-subclass-add' pk=organization_id parent_id=parent_dataset_id %}"
+                       id="add_dataset"
+                       class="button is-primary is-normal m-t-md is-size-6-mobile">
+                        {% translate "Pridėti vaikinį duomenų išteklių" %}
+                    </a>
+                {% endif %}
+                <div class="dropdown is-hoverable is-block is-right">
+                    <div class="dropdown-trigger">
+                        <button class="button" aria-haspopup="true" aria-controls="dropdown-menu4">
+                            {% if sort %}
+                                {% for sort_option in sort_options %}
+                                    {% if sort == sort_option.key %}
+                                        <span class="icon is-small">
+                                            <i class="{{ sort_option.icon }}"></i>
+                                        </span>
+                                        <span>{{ sort_option.title }}</span>
+                                    {% endif %}
+                                {% endfor %}
+                            {% else %}
+                                <span class="icon is-slikuotamall">
+                                    <i class="{{ sort_options.0.icon }}"></i>
+                                </span>
+                                <span>{{ sort_options.0.title }}</span>
+                            {% endif %}
+                            <span class="icon is-small">
+                                <i class="fas fa-angle-down" aria-hidden="true"></i>
+                            </span>
+                        </button>
+                    </div>
+                    <div class="dropdown-menu" id="dropdown-menu4" role="menu">
+                        <div class="dropdown-content">
+                            {% for sort_option in sort_options %}
+                                <a class="dropdown-item" href="{{ sort_option.url }}" role="menuitem">
+                                    <span class="icon is-small">
+                                        <i class="{{ sort_option.icon }}"></i>
+                                    </span>
+                                    <span>{{ sort_option.title }}</span>
+                                </a>
+                            {% endfor %}
+                        </div>
+                    </div>
+                </div>
             </div>
-          </div>
-
         </div>
-      </div>
     </div>
-
     <div class="columns">
         <div class="column is-6 is-5-desktop is-4-widescreen is-hidden-mobile">
             <div class="card">
-                <div class="card-content">
-                  {% include "vitrina/datasets/filters.html" %}
-                </div>
+                <div class="card-content">{% include "vitrina/datasets/filters.html" %}</div>
             </div>
         </div>
-
         <div class="column">
-
             <div class="buttons">
-              <div class="control">
-                <div class="tags">
-                  <span class="tag is-white is-medium has-text-dark">{% translate "Rasta duomenų išteklių" %}:</span>
-                  <span class="tag is-medium">{{ paginator.count }}</span>
+                <div class="control">
+                    <div class="tags">
+                        <span class="tag is-white is-medium has-text-dark">{% translate "Rasta duomenų išteklių" %}:</span>
+                        <span class="tag is-medium">{{ paginator.count }}</span>
+                    </div>
                 </div>
-              </div>
             </div>
-
             {% for i in page_obj %}
-            {% get_current_language as LANGUAGE_CODE %}
+                {% get_current_language as LANGUAGE_CODE %}
                 {% if i.object %}
-                <article class="media adp-media is-block">
-                    <div class="columns">
-                        {% define i.object.get_icon as icon %}
-                        {% if icon %}
-                            <div class="column is-2 is-align-self-center">
-                                <div class="category-icon has-text-centered">
-                                    <i class="fa-solid fa-{{ icon }} fa-2x"></i>
+                    <article class="media adp-media is-block">
+                        <div class="columns">
+                            {% define i.object.get_icon as icon %}
+                            {% if icon %}
+                                <div class="column is-2 is-align-self-center">
+                                    <div class="category-icon has-text-centered">
+                                        <i class="fa-solid fa-{{ icon }} fa-2x"></i>
+                                    </div>
                                 </div>
-                            </div>
-
-                            <div class="column is-8">
-                        {% else %}
-                            <div class="column is-10">
-                        {% endif %}
-                            <div class="media-content divider-right pr-1">
-                                <div class="content">
-                                    <div>
-                                        <strong>
-                                            <a href="{{ i.object.get_absolute_url }}"class="dataset-list-title">
-                                                {% objectlanguage i.object LANGUAGE_CODE %}
+                            {% endif %}
+                            <div class="column {% if icon %}is-8{% else %}is-10{% endif %}">
+                                <div class="media-content divider-right pr-1">
+                                    <div class="content">
+                                        <div>
+                                            <strong>
+                                                <a href="{{ i.object.get_absolute_url }}"class="dataset-list-title">
+                                                    {% objectlanguage i.object LANGUAGE_CODE %}
                                                     {{ i.object.title }}
                                                 {% endobjectlanguage %}
                                             </a>
                                         </strong>
                                     </div>
                                     <div class="tags mt-2 mb-1">
-                                      <span class="tag is-white has-text-dark">
-                                          {% if i.object.published %}
-                                              {% translate "Publikuota" %}:
-                                              {{ i.object.published|date:"SHORT_DATE_FORMAT" }}
-                                          {% else %}
-                                              {% translate "Sukurta" %}:
-                                              {{ i.object.created|date:"SHORT_DATE_FORMAT" }}
-                                          {% endif %}
-                                      </span>
-                                      {% if i.object.modified and i.object.modified > i.object.published %}
-                                      <span class="tag is-white has-text-dark">
-                                          {% translate "Atnaujinta" %}:
-                                          {{ i.object.modified|date:"SHORT_DATE_FORMAT" }}
-                                      </span>
-                                      {% endif %}
-
-                                      {% if i.object.organization.title %}
-                                      <a href="{{ i.object.organization.get_absolute_url }}" class="tag is-white has-text-dark dataset-list-organization">
-                                        {{ i.object.organization.title }}
-                                      </a>
-                                      {% endif %}
+                                        <span class="tag is-white has-text-dark">
+                                            {% if i.object.published %}
+                                                {% translate "Publikuota" %}:
+                                                {{ i.object.published|date:"SHORT_DATE_FORMAT" }}
+                                            {% else %}
+                                                {% translate "Sukurta" %}:
+                                                {{ i.object.created|date:"SHORT_DATE_FORMAT" }}
+                                            {% endif %}
+                                        </span>
+                                        {% if i.object.modified and i.object.modified > i.object.published %}
+                                            <span class="tag is-white has-text-dark">
+                                                {% translate "Atnaujinta" %}:
+                                                {{ i.object.modified|date:"SHORT_DATE_FORMAT" }}
+                                            </span>
+                                        {% endif %}
+                                        {% if i.object.organization.title %}
+                                            <a href="{{ i.object.organization.get_absolute_url }}"
+                                               class="tag is-white has-text-dark dataset-list-organization">
+                                                {{ i.object.organization.title }}
+                                            </a>
+                                        {% endif %}
                                     </div>
                                     <div class="is-flex is-justify-content-space-between is-align-items-center mb-2">
                                         <span class="tag is-white has-text-dark">
@@ -236,79 +235,70 @@
                                                 {% translate "Ne" %}
                                             {% endif %}
                                         </span>
-
-                                    <span class="tag is-white has-text-dark">
-                                        {% translate "Brandos lygis" %}:
-                                        {% with level=i.object.get_level|add:"0" %}
-                                            <span style="margin-left: 0.5em;" class="{% if level and level > 0 %}has-text-warning{% endif %}">
-                                                {% for i in "12345" %}
-                                                    {% if level > 0 and forloop.counter <= level %}
-                                                        <i class="fas fa-star"></i>
-                                                    {% else %}
-                                                        <i class="far fa-star has-text-grey-light"></i>
-                                                    {% endif %}
-                                                {% endfor %}
-                                            </span>
-                                        {% endwith %}
-                                    </span>
+                                        <span class="tag is-white has-text-dark">
+                                            {% translate "Brandos lygis" %}:
+                                            {% with level=i.object.get_level|add:"0" %}
+                                                <span style="margin-left: 0.5em"
+                                                      class="{% if level and level > 0 %}has-text-warning{% endif %}">
+                                                    {% for i in "12345" %}
+                                                        {% if level > 0 and forloop.counter <= level %}
+                                                            <i class="fas fa-star"></i>
+                                                        {% else %}
+                                                            <i class="far fa-star has-text-grey-light"></i>
+                                                        {% endif %}
+                                                    {% endfor %}
+                                                </span>
+                                            {% endwith %}
+                                        </span>
                                     </div>
-
                                     <p class="dataset-list-description my-1">
                                         {% if i.object %}
                                             {% objectlanguage i.object LANGUAGE_CODE %}
-                                                {{ i.object.description|markdown|safe }}
-                                            {% endobjectlanguage %}
-                                        {% else %}
-                                            {# TODO: https://github.com/atviriduomenys/katalogas/issues/240 #}
-                                            -
-                                        {% endif %}
-                                    </p>
-
-                                    <div class="tags mt-3 mb-1">
-                                      {% for group in i.object.get_all_groups %}
-                                      <p class="tag is-info is-light" style="background-color:Gainsboro; color: black;">
-                                        {{ group }}
-                                      </p>
-                                      {% endfor %}
-
-                                      {% for t in i.object.distinct_formats %}
-                                      <a href="?selected_facets=formats_exact:{{ t.pk }}"  class="tag is-info is-light">
-                                          {{ t }}
-                                      </a>
-                                      {% endfor %}
-                                    </div>
-
-                                </div>
-                            </div>
-                        </div>
-
-                        <div class="column is-2 is-align-self-center">
-                            <div class="has-text-centered">
-                                {% get_hit_count for i.object as total_hits %}
-                                <div>
-                                    <i class="fa fa-eye"></i>
-                                    <span>{{ total_hits }}</span>
-                                </div>
-                                <div>
-                                    <i class="fa fa-thumbs-up"></i>
-                                    <span>{{ i.object.get_likes }}</span>
-                                </div>
-                                <div>
-                                    <i class="fas fa-cloud-download-alt"></i>
-                                    <span>{{ i.object.get_download_count }}</span>
+                                            {{ i.object.description|markdown|safe }}
+                                        {% endobjectlanguage %}
+                                    {% else %}
+                                        {# TODO: https://github.com/atviriduomenys/katalogas/issues/240 #}
+                                        -
+                                    {% endif %}
+                                </p>
+                                <div class="tags mt-3 mb-1">
+                                    {% for group in i.object.get_all_groups %}
+                                        <p class="tag is-info is-light dataset-list-group-tag">{{ group }}</p>
+                                    {% endfor %}
+                                    {% for t in i.object.distinct_formats %}
+                                        <a href="?selected_facets=formats_exact:{{ t.pk }}"
+                                           class="tag is-info is-light">{{ t }}</a>
+                                    {% endfor %}
                                 </div>
                             </div>
                         </div>
                     </div>
-                </article>
-                {% endif %}
-            {% endfor %}
-            <br/>
-            {% include "vitrina/common/pagination.html" %}
-        </div>
-    </div>
+                    <div class="column is-2 is-align-self-center">
+                        <div class="has-text-centered">
+                            {% get_hit_count for i.object as total_hits %}
+                            <div>
+                                <i class="fa fa-eye"></i>
+                                <span>{{ total_hits }}</span>
+                            </div>
+                            <div>
+                                <i class="fa fa-thumbs-up"></i>
+                                <span>{{ i.object.get_likes }}</span>
+                            </div>
+                            <div>
+                                <i class="fas fa-cloud-download-alt"></i>
+                                <span>{{ i.object.get_download_count }}</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </article>
+        {% endif %}
+    {% endfor %}
+    <br />
+    {% include "vitrina/common/pagination.html" %}
+</div>
+</div>
 {% endblock %}
-
 {% block extraContent %}
     {% include '../component/requestBlock.twig' %}
 {% endblock %}

--- a/vitrina/datasets/templates/vitrina/datasets/list.html
+++ b/vitrina/datasets/templates/vitrina/datasets/list.html
@@ -178,6 +178,7 @@
 
             {% for i in page_obj %}
             {% get_current_language as LANGUAGE_CODE %}
+                {% if i.object %}
                 <article class="media adp-media is-block">
                     <div class="columns">
                         {% define i.object.get_icon as icon %}
@@ -300,6 +301,7 @@
                         </div>
                     </div>
                 </article>
+                {% endif %}
             {% endfor %}
             <br/>
             {% include "vitrina/common/pagination.html" %}


### PR DESCRIPTION
### Before (devel):
`post_save` signal indexes the object to elasticsearch immediately, while still inside the database transaction. If the transaction rolls back, the database row is removed but the elasticsearch document remains. This orphaned document appears in search results, and when the page tries to load it from the database, it gets `None` - causing a 500 error.

### After (this PR):
`post_save` signal registers the indexing as a `transaction.on_commit` callback. If the transaction commits successfully, the callback fires and the object is indexed. If the transaction rolls back, the callback is discarded - no elasticsearch document is created, no orphan, no 500.

### Reproducing the error with script:
It's difficult to reproduce organically because it requires a transaction to fail **after** the dataset is saved but **before** the transaction commits. In normal usage, saves usually succeed. The failures that cause this are transient - database constraint violations, network timeouts, concurrent edits, or errors in downstream signal handlers or middleware. They happen unpredictably in production under load, but are nearly impossible to trigger reliably by hand through the UI.

### Django shell (`devel` branch)
```python
from django.db import transaction
from vitrina.datasets.models import Dataset
from vitrina.orgs.models import Organization

org = Organization.objects.first()

try:
    with transaction.atomic():
        d = Dataset(organization=org, is_public=True)
        d.set_current_language("lt")
        d.title = "Ghost dataset"
        d.save()
        # First save: translation not in DB yet, not indexed
        # Now save again - translation exists from first save
        d.save()
        pk = d.pk
        print(f"Created dataset pk={pk}")
        raise Exception("Force rollback")
except Exception:
    pass
```
Causes the following error on `/datasets`:
<img width="1295" height="1047" alt="image" src="https://github.com/user-attachments/assets/ab3c7f74-8ba7-4218-977a-e9a4e119b94a" />

We can clear it with simple curl (need newly created dataset PK from previous script):
```curl
curl -X DELETE "http://localhost:9200/haystack/_doc/vitrina_datasets.dataset.PK"
```

### Testing this PR:
The same script that created the orphaned dataset on `devel` branch (causing 500 error) does not produce the error on this branch - the `on_commit` callback is discarded on rollback, so nothing is written to elasticsearch.

### Regarding some code changes:
The `_on_commit` indirection is only used for automated tests.