### PR TITLE
[2336] During manifest import not all comment fields are set

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -78,6 +78,10 @@ https://github.com/atviriduomenys/katalogas/issues/2334
 - Added _update_model_visibility_from_property which ensures a model's visibility is automatically elevated when one of its properties has higher visibility.
 - Added _update_parent_visibility_from_enum which propagates visibility upward through the full chain — from enum to its parent property, and from property to the model — applying the same rule at each level.
 
+https://github.com/atviriduomenys/katalogas/issues/2336
+
+- Set all manifest fields on the imported Comment objects
+
 v 1.15.0 (2026-02-27)
 ==================
 

--- a/tests/structure/test_services.py
+++ b/tests/structure/test_services.py
@@ -1985,9 +1985,9 @@ def test_structure_export__comments(app: DjangoTestApp):
         ",,,,,,,,,,,,,,,,,,,,\r\n"
         "3,,resource,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n"
         "4,,,,Country,,,,,,,,,,develop,,,,,,\r\n"
-        "5,,,,,,comment,type,,,,,,,,,open,,,Model comment,\r\n"
+        "5,,,,,,comment,type,,,,,,,develop,,open,,,Model comment,\r\n"
         "6,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
-        "7,,,,,,comment,type,,,,,,,,,open,,,Property comment,\r\n"
+        "7,,,,,,comment,type,,,,,,,develop,,open,,,Property comment,\r\n"
         ",,,,,,,,,,,,,,,,,,,,\r\n"
     )
 
@@ -2806,3 +2806,35 @@ class TestStructureBaseModels:
             "Nepavyko susieti bazinio modelio „example/Animal“. "
             "Įsitikinkite, kad jis egzistuoja ir turi patvirtintą (stabilią) versiją."
         )
+
+
+class TestStructureComments:
+    @pytest.mark.django_db
+    def test_structure_comments_are_created(self, app: DjangoTestApp):
+        manifest = (
+            "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description\n"
+            ",dataset,,,,,,,,,,,,,,,,\n"
+            ",,,,Animal,,,,source_animal_model,,,,,,,,,\n"
+            ',,,,,,comment,model,,"update(model: ""Animal/:part"")",2,completed,protected,open,https://github.com/example/issues/1,,,\n'
+            ",,,,,id,string,,source_animal_id,,4,,,,,,,\n"
+            ",,,Animal,,,,,,,,,,,,,,\n"
+            ',,,,,,comment,model,,"update(model: ""Animal"")",2,completed,protected,open,https://github.com/example/issues/2,,,\n'
+            ",,,,Dog,,,,,,,,,,,,,\n"
+            ",,,,,action,string,,source_dog_action,,4,,,,,,,\n"
+        )
+
+        structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+        structure.dataset.current_structure = structure
+        structure.dataset.save()
+
+        create_structure_objects(structure)
+
+        # Comments created for model.
+        comment_model = Comment.objects.get(content_type=ContentType.objects.get_for_model(Model))
+        assert comment_model.prepare == 'update(model: "Animal/:part")'
+        assert comment_model.uri == "https://github.com/example/issues/1"
+
+        # Comments created for base.
+        comment_base = Comment.objects.get(content_type=ContentType.objects.get_for_model(Base))
+        assert comment_base.prepare == 'update(model: "Animal")'
+        assert comment_base.uri == "https://github.com/example/issues/2"

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -991,8 +991,12 @@ def test_private_comment(app: DjangoTestApp):
     structure.dataset.save()
     version = create_structure_objects(structure)
 
-    resp = app.get(reverse("model-structure", args=[structure.dataset.pk, version.pk, "Country"]))
-    assert sorted([comment.body for comment, _, _ in resp.context["comments"]]) == ["Public comment"]
+    response = app.get(reverse("model-structure", args=[structure.dataset.pk, version.pk, "Country"]))
+
+    assert response.status_code == HTTPStatus.OK
+    comments = [comment_data[0] for comment_data in response.context["comments"]]
+    assert len(comments) == 1  # Private comment is hidden;
+    assert comments[0].body == "Public comment"
 
 
 @pytest.mark.django_db
@@ -7042,6 +7046,39 @@ class TestStructure(BaseTestCreateManifest):
             "Nepavyko susieti bazinio modelio „example/Animal“. "
             "Įsitikinkite, kad jis egzistuoja ir turi patvirtintą (stabilią) versiją."
         )
+
+    def test_export__comments_exported_correctly(self, app: DjangoTestApp):
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        manifest = (
+            "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description\n"
+            "1,dataset,,,,,,,,,,,,,,,,\n"
+            "2,,,,Animal,,,,source_animal_model,,,,,,,,,\n"
+            '3,,,,,,comment,model,,"update(model: ""Animal/:part"")",2,completed,protected,open,https://github.com/example/issues/1,,,\n'
+            "4,,,,,id,string,,source_animal_id,,4,,,,,,,\n"
+            "5,,,Animal,,,,,,,,,,,,,,\n"
+            '6,,,,,,comment,model,,"update(model: ""Animal"")",2,completed,protected,open,https://github.com/example/issues/2,,,\n'
+            "7,,,,Dog,,,,,,,,,,,,,\n"
+            "8,,,,,action,string,,source_dog_action,,4,,,,,,,\n"
+        )
+        dataset = self._create_manifest(manifest, "Dataset", "Dataset with ref property")
+
+        response = app.get(reverse("dataset-structure-export", args=[dataset.pk, dataset.latest_version().pk]))
+        assert response.status_code == HTTPStatus.OK
+        assert response.text.splitlines() == [
+            "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
+            "1,dataset,,,,,,,,,,,,,,,,,,Dataset,Dataset with ref property",
+            "2,,,,Animal,,,,source_animal_model,,,,,,develop,,,,,,",
+            '3,,,,,,comment,model,,,"update(model: ""Animal/:part"")",,,2,develop,,open,https://github.com/example/issues/1,,,',
+            "4,,,,,id,string,,source_animal_id,,,,,4,develop,,,,,,",
+            ",,,,,,,,,,,,,,,,,,,,",
+            "5,,,Animal,,,,,,,,,,,,,,,,,",
+            '6,,,,,,comment,model,,,"update(model: ""Animal"")",,,2,develop,,open,https://github.com/example/issues/2,,,',
+            "7,,,,Dog,,,,,,,,,,develop,,,,,,",
+            "8,,,,,action,string,,source_dog_action,,,,,4,develop,,,,,,",
+            ",,,,,,,,,,,,,,,,,,,,",
+        ]
 
 
 class TestStructureExportDependentModels(BaseTestCreateManifest):

--- a/vitrina/comments/models.py
+++ b/vitrina/comments/models.py
@@ -3,10 +3,12 @@ from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.urls import reverse
 from django.utils.safestring import mark_safe
+from django.utils.html import escape
 from django.utils.translation import gettext_lazy as _
 
 from vitrina.comments.managers import PublicCommentManager
 from vitrina.requests.models import Request
+from vitrina.structure.models import Metadata
 
 
 class Comment(models.Model):
@@ -132,6 +134,18 @@ class Comment(models.Model):
             body_text = mark_safe(
                 f'Įtraukta į planą <a href="{self.rel_content_object.get_absolute_url()}">{self.rel_content_object}</a>'
             )
+        elif self.type == self.STRUCTURE:
+            body_text = _("""Struktūros importavimo metu sukurtas sisteminis komentaras.<br>
+                <b>Objektas:</b> {content_type} | {content_object}<br>
+                <b>Parengimas:</b> <pre><code>{prepare}</code></pre><br>
+                <b>Nuoroda:</b> <a href="{uri}">{uri}</a>
+            """).format(
+                content_type=str(self.content_type).split("|")[-1] if self.content_type else None,
+                content_object=self.content_object,
+                prepare=escape(self.prepare),
+                uri=escape(self.uri),
+            )
+            return mark_safe(body_text)
         else:
             body_text = self.body
         return body_text
@@ -145,6 +159,17 @@ class Comment(models.Model):
 
     def is_error(self):
         return self.type == self.STRUCTURE_ERROR
+
+    def _get_structure_metadata(self) -> Metadata | None:
+        return self.metadata.first() if self.type == self.STRUCTURE and self.metadata.exists() else None
+
+    @property
+    def prepare(self) -> str | None:
+        return meta.prepare if (meta := self._get_structure_metadata()) else None
+
+    @property
+    def uri(self) -> str | None:
+        return meta.uri if (meta := self._get_structure_metadata()) else None
 
 
 # TODO: To be removed.

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -42,7 +42,6 @@ msgstr "client id"
 msgid "Nepriskirti"
 msgstr "Unassigned"
 
-#, python-brace-format
 msgid ""
 "Baigėsi Jūsų API rakto galiojimas. Raktą galite atsinaujinti savo "
 "organizacijos tvarkytojų sąraše: {url}"
@@ -516,6 +515,18 @@ msgstr "Evaluated"
 
 msgid "Viešas komentaras"
 msgstr "Public comment"
+
+msgid "Struktūros importavimo metu sukurtas sisteminis komentaras.<br>"
+msgstr "Comment imported with a manifest.<br>"
+
+msgid "<b>Objektas:</b> {content_type} | {content_object}"
+msgstr "<b>Object:</b> {content_type} | {content_object}"
+
+msgid "<b>Parengimas:</b> <pre><code>{prepare}</code></pre>"
+msgstr "<b>Prepare:</b> <pre><code>{prepare}</code></pre>"
+
+msgid "<b>Nuoroda:</b> <a href='{uri}'>{uri}</a>"
+msgstr "<b>URI:</b> <a href='{uri}'>{uri}</a>"
 
 msgid "Negalima atmesti — patvirtinti/atidaryti priskyrimai egzistuoja."
 msgstr "Cannot reject - approved/opened assignments exist"
@@ -1257,6 +1268,27 @@ msgstr "The organization can only be assigned the role of a data editor"
 
 msgid "Naudotojui išsiųstas laiškas dėl registracijos"
 msgstr "The user has been sent an email for registration"
+
+msgid ""
+"Duomenų lauko \"{0}\" metaduomenų matomumo lygis \"{1}\" negali būti "
+"aukštesnis už modelio metaduomenų matomumo lygį \"{2}\". "
+msgstr ""
+"Data field \"{0}\" metadata visibility level \"{1}\" must not be higher than "
+"the model metadata visibility level \"{2}\". "
+
+msgid ""
+"Duomenų reikšmės \"{0}\" metaduomenų matomumo lygis \"{1}\" negali būti "
+"aukštesnis už duomenų lauko metaduomenų matomumo lygį \"{2}\". "
+msgstr ""
+"Enum field \"{0}\" metadata visibility level \"{1}\" must not be higher than "
+"the property metadata visibility level \"{2}\" . "
+
+msgid ""
+"Duomenų reikšmės \"{0}\" metaduomenų matomumo lygis \"{1}\" negali būti "
+"aukštesnis už duomenų modelio metaduomenų matomumo lygį \"{2}\". "
+msgstr ""
+"Enum field \"{0}\" metadata visibility level \"{1}\" must not be higher than "
+"the model metadata visibility level \"{2}\" . "
 
 msgid ""
 "Modelio kodiniame pavadinime gali būti didžiosos/mažosios raidės ir "
@@ -2897,7 +2929,6 @@ msgstr "Contact editing"
 msgid "Šio kontakto ištrinti negalima, nes jis yra naudojamas sutartyse."
 msgstr "This contact can not be deleted, because it is used in agreements."
 
-#, python-brace-format
 msgid "Ar tikrai norite ištrinti kontaktą \"{contact}\"?"
 msgstr "Are you sure you want to delete the contact \"{contact}\"?"
 
@@ -3223,11 +3254,9 @@ msgstr "API key will be shown only one time, so you must copy it. Created key:"
 msgid "Kurti klientą"
 msgstr "Create client"
 
-#, python-brace-format
 msgid "Klientas \"{0}\" sukurtas sėkmingai."
 msgstr "Client \"{0}\" created successfully."
 
-#, python-brace-format
 msgid "Kliento raktas - {0}. Butinai išsisaugokite raktą, jis nebebus rodomas!"
 msgstr ""
 "Client key – {0}. Be sure to save this key; it will not be shown again!"
@@ -3238,14 +3267,12 @@ msgstr "Client registration"
 msgid "Kliento redagavimas"
 msgstr "Client edit"
 
-#, python-brace-format
 msgid "Klientas \"{0}\" atnaujintas sėkmingai"
 msgstr "Client \"{0}\" changed successfully"
 
 msgid "Šiam klientui aktyvių leidimų nėra"
 msgstr "There are no active scopes for this client"
 
-#, python-brace-format
 msgid "Leidimas \"{0}\" sukurtas sėkmingai"
 msgstr "Use case \"{0}\" created successfully"
 
@@ -3851,7 +3878,6 @@ msgstr "Confirm proposal"
 msgid "Dokumentas turi būti adoc formato."
 msgstr "The document must be in adoc format."
 
-#, python-brace-format
 msgid "ADOC klaida: {error}"
 msgstr "ADOC error: {error}"
 
@@ -3864,7 +3890,6 @@ msgstr "Upload document signed by data receiver"
 msgid "Veiksmas įvykdytas sėkmingai."
 msgstr "Action was executed successfully"
 
-#, python-brace-format
 msgid ""
 "Veiksmas gali būti atliekamas tik sutarčiai esant būsenoje "
 "{expected_status}.Dabartinė būsena: {current_status}."
@@ -3928,14 +3953,12 @@ msgstr "Legal basis for data provision (obligation)"
 msgid "Mokėjimo sąlygos"
 msgstr "Payment terms"
 
-#, python-brace-format
 msgid "Sutartis: {organization}"
 msgstr "Agreement: {organization}"
 
 msgid "Sutartis neturi sugeneruoto ODRL JSON failo."
 msgstr "The agreement does not have a generated ODRL JSON file."
 
-#, python-brace-format
 msgid ""
 "Nepavyko rasti 'assignee.ex:representative' sutarties '{0}' ODRL JSON faile. "
 "Klaida: {1}"
@@ -3943,7 +3966,6 @@ msgstr ""
 "Failed to find 'assignee.ex:representative' in the ODRL JSON file of "
 "agreement '{0}'. Error: {1}"
 
-#, python-brace-format
 msgid ""
 "Nepavyko rasti 'assigner.ex:representative' sutarties '{0}' ODRL JSON faile. "
 "Klaida: {1}"
@@ -4003,13 +4025,11 @@ msgstr "The uploaded agreement is not signed with the assigner's signature."
 msgid "Įkeltoje sutartyje rasti daugiau nei 2 parašai."
 msgstr "More than two signatures were found in the uploaded agreement."
 
-#, python-brace-format
 msgid ""
 "Pasirašyti galima tik sutartis su būsenomis `{formed}` arba `{initiated}`."
 msgstr ""
 "Only agreements with the statuses `{formed}` or `{initiated}` can be signed."
 
-#, python-brace-format
 msgid ""
 "Nesutampa pasirašiusių asmenų vardai ir pavardės. Reikalingi parašai: "
 "{expected}, ADOC rasti parašai: {found}."
@@ -4020,7 +4040,6 @@ msgstr ""
 msgid "Nerastas PDF failas."
 msgstr "PDF file not found."
 
-#, python-brace-format
 msgid "Blogas ADOC failas: {error}"
 msgstr "Invalid ADOC file: {error}"
 
@@ -4190,7 +4209,6 @@ msgstr "Value must be integer."
 msgid "Aprašymas neatitinka Markdown formato."
 msgstr "Description doesn't match Markdown format."
 
-#, python-brace-format
 msgid ""
 "Metaduomenų matomumas '{0}' negali būti didesnis nei duomenų modelio "
 "matomumas '{1}'."
@@ -4198,7 +4216,6 @@ msgstr ""
 "Metadata visibility '{0}' should not be higher than data model visibility "
 "'{1}'."
 
-#, python-brace-format
 msgid ""
 "Metaduomenų matomumas '{0}' negali būti didesnis nei duomenų lauko matomumas "
 "'{1}'."
@@ -4952,25 +4969,21 @@ msgstr "Published version can not be published again"
 msgid "Privalote publikuoti duomenų rinkinį."
 msgstr "You must publish the dataset"
 
-#, python-brace-format
 msgid ""
 "Laukas {0} turi nuorodą į nepublikuojamą lauką tame pačiame duomenų "
 "ištekliuje."
 msgstr "Field {0} has a reference to an unpublished field in the same dataset."
 
-#, python-brace-format
 msgid ""
 "Laukas {0} turi nuorodą į nepublikuotą lauką {1} tame pačiame duomenų "
 "ištekliuje."
 msgstr ""
 "Field {0} has a reference to an unpublished field {1} in the same dataset."
 
-#, python-brace-format
 msgid ""
 "Laukas {0} privalo būti publikuojamas, nes laukas {1} turi nuorodą į jį."
 msgstr "Field {0} must be published, because field {1} has a reference to it."
 
-#, python-brace-format
 msgid "Laukas {0} turi nuorodą į nepublikuotą lauką kitame duomenų ištekliuje."
 msgstr ""
 "Field {0} has a reference to an unpublished field in a different dataset."

--- a/vitrina/structure/services.py
+++ b/vitrina/structure/services.py
@@ -414,7 +414,7 @@ def _load_comments(dataset: Dataset, comments: List[struct.Comment], obj: models
             content_type=ct,
             object_id=obj.pk,
             type=Comment.STRUCTURE,
-            body=meta.title,
+            body=meta.description or meta.title or "",
         )
         comment, metadata = _create_or_update_metadata(dataset, meta, comment, order)
         loaded_comments.append(comment)
@@ -1678,7 +1678,12 @@ def _comments_to_tabular(obj: models.Model) -> Generator:
                     "type": "comment" if first else "",
                     "ref": meta.ref,
                     "source": meta.source,
+                    "prepare": meta.prepare,
+                    "level": meta.level_given,
+                    "status": _get_title(meta.status),
+                    "visibility": _get_visibility(meta.visibility),
                     "access": _get_access(meta.access),
+                    "uri": meta.uri,
                     "title": meta.title,
                     "description": meta.description,
                 },
@@ -1699,6 +1704,7 @@ def _base_to_tabular(base: Base, version: Version | None = None) -> Generator:
                 "ref": meta.ref,
             },
         )
+        yield from _comments_to_tabular(base)
 
 
 def _properties_to_tabular(model: Model, version: Version | None = None) -> Generator:


### PR DESCRIPTION
Fix import of `comment` values, not all are set in the database. Thus, causing the export to wrongly export the manifest as well.