### PR TITLE
[2467] Comment are not displayed after import from manifest

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -82,6 +82,10 @@ https://github.com/atviriduomenys/katalogas/issues/2336
 
 - Set all manifest fields on the imported Comment objects
 
+https://github.com/atviriduomenys/katalogas/issues/2467
+
+- Comments for `Base` manifest rows are now imported & displayed correctly in Catalog & after export.
+
 v 1.15.0 (2026-02-27)
 ==================
 

--- a/tests/comments/test_views.py
+++ b/tests/comments/test_views.py
@@ -3,7 +3,9 @@ from django.contrib.contenttypes.models import ContentType
 from django.core import mail
 from django.urls import reverse, resolve
 from django_webtest import DjangoTestApp
+from vitrina.structure import VersionStatus
 from reversion.models import Version
+from vitrina.structure.models import Metadata
 
 from vitrina.classifiers.factories import FrequencyFactory
 from vitrina.comments.factories import CommentFactory
@@ -16,7 +18,7 @@ from vitrina.projects.factories import ProjectFactory
 from vitrina.projects.models import Project
 from vitrina.requests.factories import RequestFactory, RequestAssignmentFactory
 from vitrina.requests.models import Request
-from vitrina.structure.factories import PropertyFactory, ModelFactory, MetadataFactory, VersionFactory
+from vitrina.structure.factories import PropertyFactory, ModelFactory, MetadataFactory, VersionFactory, BaseFactory
 from vitrina.users.factories import UserFactory
 from vitrina.orgs.factories import OrganizationFactory, RepresentativeFactory
 from vitrina.utils import RevisionComment, RevisionSource
@@ -1103,3 +1105,73 @@ def test_comment_on_unapproved_project(app: DjangoTestApp):
     )
 
     assert resp.status_code == 403
+
+
+@pytest.mark.django_db
+def test_model_comments_exported_together_with_base_model_comments(app: DjangoTestApp):
+    user = UserFactory(is_superuser=True)
+    app.set_user(user)
+
+    dataset = DatasetFactory(is_public=True, access_rights=Dataset.PUBLIC)
+    metadata_version = VersionFactory(dataset=dataset, status=VersionStatus.STABLE)
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(dataset),
+        object_id=dataset.pk,
+        dataset=dataset,
+        name="test/dataset",
+        metadata_version=metadata_version,
+    )
+
+    base_model = ModelFactory(dataset=dataset, metadata_version=metadata_version)
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(base_model),
+        object_id=base_model.pk,
+        dataset=dataset,
+        name="test/dataset/BaseModel",
+        metadata_version=metadata_version,
+    )
+    base_object = BaseFactory(model=base_model, metadata_version=metadata_version)
+
+    inheriting_model = ModelFactory(dataset=dataset, base=base_object, metadata_version=metadata_version)
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(inheriting_model),
+        object_id=inheriting_model.pk,
+        dataset=dataset,
+        name="test/dataset/InheritingModel",
+        metadata_version=metadata_version,
+    )
+
+    inheriting_property = PropertyFactory(
+        model=inheriting_model,
+        metadata_version=metadata_version,
+    )
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(inheriting_property),
+        object_id=inheriting_property.pk,
+        dataset=dataset,
+        name="InheritingProperty",
+        metadata_version=metadata_version,
+        access=Metadata.PUBLIC,
+    )
+
+    comment_base = CommentFactory(
+        content_type=ContentType.objects.get_for_model(base_object),
+        object_id=base_object.pk,
+        user=user,
+        body="Comment for base",
+        is_public=True,
+    )
+    comment_model = CommentFactory(
+        content_type=ContentType.objects.get_for_model(inheriting_model),
+        object_id=inheriting_model.pk,
+        user=user,
+        body="Comment for model",
+        is_public=True,
+    )
+
+    resp = app.get(inheriting_model.get_absolute_url())
+
+    comments = [comment_data[0] for comment_data in resp.context["comments"]]
+    assert len(comments) == 2
+    assert comment_base in comments
+    assert comment_model in comments

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -982,8 +982,8 @@ def test_private_comment(app: DjangoTestApp):
         ",,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n"
         ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
         ",,,,Country,,,,,,,,,,,,,,\n"
-        ",,,,,,comment,type,,,,,,public,,,Public comment,,\n"
-        ",,,,,,comment,type,,,,,,private,,,Private comment,,\n"
+        ",,,,,,comment,type,,,,,,public,,,,Public comment,\n"
+        ",,,,,,comment,type,,,,,,private,,,,Private comment,\n"
         ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
     structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
@@ -994,9 +994,11 @@ def test_private_comment(app: DjangoTestApp):
     response = app.get(reverse("model-structure", args=[structure.dataset.pk, version.pk, "Country"]))
 
     assert response.status_code == HTTPStatus.OK
-    comments = [comment_data[0] for comment_data in response.context["comments"]]
+    comments = [comment for comment, _, _ in response.context["comments"]]
     assert len(comments) == 1  # Private comment is hidden;
-    assert comments[0].body == "Public comment"
+    comment = comments[0]
+    assert comment.is_public
+    assert comment.body == "Public comment"
 
 
 @pytest.mark.django_db
@@ -1006,8 +1008,8 @@ def test_private_comment_with_access(app: DjangoTestApp):
         ",,,,,,prefix,dct,,,,,,,http://purl.org/dc/terms/,,,,\n"
         ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
         ",,,,Country,,,,,,,,,,,\n"
-        ",,,,,,comment,type,,,,public,,,,,Public comment,,\n"
-        ",,,,,,comment,type,,,,private,,,,,Private comment,,\n"
+        ",,,,,,comment,type,,,,public,,,,,,Public comment,\n"
+        ",,,,,,comment,type,,,,private,,,,,,Private comment,\n"
         ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
     structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
@@ -1022,11 +1024,13 @@ def test_private_comment_with_access(app: DjangoTestApp):
     )
     app.set_user(representative.user)
 
-    resp = app.get(reverse("model-structure", args=[structure.dataset.pk, version.pk, "Country"]))
-    assert sorted([comment.body for comment, _, _ in resp.context["comments"]]) == [
-        "Private comment",
-        "Public comment",
-    ]
+    response = app.get(reverse("model-structure", args=[structure.dataset.pk, version.pk, "Country"]))
+
+    assert response.status_code == HTTPStatus.OK
+    comments = [comment for comment, _, _ in response.context["comments"]]
+    assert len(comments) == 2
+    assert all(comment.is_public for comment in comments)
+    assert sorted([comment.body for comment in comments]) == ["Private comment", "Public comment"]
 
 
 @pytest.mark.django_db

--- a/vitrina/structure/services.py
+++ b/vitrina/structure/services.py
@@ -414,7 +414,7 @@ def _load_comments(dataset: Dataset, comments: List[struct.Comment], obj: models
             content_type=ct,
             object_id=obj.pk,
             type=Comment.STRUCTURE,
-            body=meta.description or meta.title or "",
+            body=meta.description if meta.description else "",
         )
         comment, metadata = _create_or_update_metadata(dataset, meta, comment, order)
         loaded_comments.append(comment)

--- a/vitrina/templatetags/comment_tags.py
+++ b/vitrina/templatetags/comment_tags.py
@@ -1,6 +1,10 @@
+from typing import Any
+
 from django import template
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.contenttypes.models import ContentType
+from django.db.models import Q
+from django.utils.functional import SimpleLazyObject
 
 from vitrina.comments.forms import CommentForm
 from vitrina.comments.models import Comment
@@ -13,25 +17,33 @@ from vitrina.orgs.services import has_perm, Action
 from vitrina.requests.models import Request, RequestAssignment
 from vitrina.structure.models import Metadata, Model, Property
 
+
 register = template.Library()
 assignment_tag = getattr(register, "assignment_tag", register.simple_tag)
 
 
 @register.inclusion_tag("component/comments.html")
-def comments(obj, user, is_structure=False):
-    content_type = ContentType.objects.get_for_model(obj)
-    obj_comments = Comment.objects.filter(content_type=content_type, object_id=obj.pk, parent_id__isnull=True).order_by(
-        "-created"
-    )
+def comments(obj: "Model", user: SimpleLazyObject, is_structure: bool = False) -> dict[str, Any]:
+    object_content_type = ContentType.objects.get_for_model(obj)
+
+    query_filters = Q(content_type=object_content_type, object_id=obj.pk)
+    if isinstance(obj, Model) and obj.base:
+        base_obj = obj.base
+        base_content_type = ContentType.objects.get_for_model(base_obj)
+        query_filters |= Q(content_type=base_content_type, object_id=base_obj.pk)
+
+    object_comments = Comment.objects.filter(query_filters, parent_id__isnull=True).order_by("-created")
+
     if is_structure:
         can_manage_structure = has_perm(user, Action.STRUCTURE, Dataset, obj)
         if not can_manage_structure:
-            obj_comments = obj_comments.exclude(type=Comment.STRUCTURE, metadata__access__lt=Metadata.PUBLIC)
+            object_comments = object_comments.exclude(type=Comment.STRUCTURE, metadata__access__lt=Metadata.PUBLIC)
+
     comment_form_class = get_comment_form_class(obj, user)
     is_opened = obj.is_opened() if hasattr(obj, "is_opened") else None
 
     comments_array = []
-    for comment in obj_comments:
+    for comment in object_comments:
         if has_comment_view_perm(comment, obj, user):
             descendants = comment.descendants(include_self=True, permission=True)
             for reply in descendants:
@@ -43,7 +55,7 @@ def comments(obj, user, is_structure=False):
     return {
         "comments": comments_array,
         "user": user,
-        "content_type": content_type,
+        "content_type": object_content_type,
         "object": obj,
         "comment_form": comment_form_class(obj, is_opened=is_opened),
         "submit_button_id": "id_submit_button_request" if isinstance(obj, Request) else "id_submit_button",


### PR DESCRIPTION
Display `base` row comments imported with the manifest on the respective Model that uses that Base.