### PR TITLE
[2335] Access level display adjustments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changes
 v 1.17.0 (2026-03-16)
 ==================
 
+https://github.com/atviriduomenys/katalogas/issues/2335
+
+- Access level display adjustments; If value exists, display the initial provided value, otherwise, default to average.
+
 
 v 1.16.0 (2026-03-16)
 ==================

--- a/vitrina/structure/templates/vitrina/structure/dataset_structure.html
+++ b/vitrina/structure/templates/vitrina/structure/dataset_structure.html
@@ -209,9 +209,9 @@
                         {% endif %}
                     </div>
                     <div class="column is-1">
-                        {% if metadata.average_level %}
+                        {% if metadata.level_given or metadata.average_level %}
                             <span>
-                                <span>{{ metadata.average_level|floatformat:"0" }}</span>
+                                <span>{{ metadata.level_given|default:metadata.average_level|floatformat:"0" }}</span>
                                 <span class="icon has-text-warning"><i class="fas fa-star"></i></span>
                             </span>
                         {% endif %}

--- a/vitrina/structure/templates/vitrina/structure/model_structure.html
+++ b/vitrina/structure/templates/vitrina/structure/model_structure.html
@@ -40,7 +40,7 @@
             {% if model.access_display_value %}
                 <span class="mr-3 tag is-info is-light">{{ model.access_display_value }}</span>
             {% endif %}
-            <span>{{ metadata.average_level|default:"0"|floatformat:"0" }}</span>
+            <span>{{ metadata.level_given|default:metadata.average_level|floatformat:"0" }}</span>
             <span class="icon has-text-warning pr-3"><i class="fas fa-star"></i></span>
             {% if metadata.metadata_version %}
 


### PR DESCRIPTION
Adjust access level display.

- Use the provided value in manifest
- If not provided - default to the already implemented avg calculations.