### PR TITLE
2419 Separate filter hitboxes

### DIFF
--- a/vitrina/datasets/templates/vitrina/datasets/filters.html
+++ b/vitrina/datasets/templates/vitrina/datasets/filters.html
@@ -97,7 +97,7 @@
                id="{{ item.name }}_id"
                title="{{ item.name }}"
                aria-label="{{ item.name }}">
-                  <div class="columns">
+                  <div class="columns is-gapless is-vcentered m-0">
                   <div class="column is-1">
                       {% if item.selected %}
                       <span class="icon">


### PR DESCRIPTION
Before:
<img width="348" height="182" alt="image" src="https://github.com/user-attachments/assets/04db7f6e-85da-4c8c-a09f-f68bd7bc590a" />

After:
<img width="370" height="213" alt="image" src="https://github.com/user-attachments/assets/2835e3f4-3cf4-423e-8894-caf033572ab3" />
