### PR TITLE
[2329] Ensure that it is possible to set referenced properties for `ref` type properties on property create/edit form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,15 @@ https://github.com/atviriduomenys/katalogas/issues/2324
     - Boolean type enum items can now be created/changed via UI.
     - Enum item uniqueness is checked for source+prepare values instead of prepare only. This allows creating enums with same prepare but different source values
 
+Improvements:
+
+https://github.com/atviriduomenys/katalogas/issues/2329
+
+- Ensure that it is possible to set referenced properties for `ref` type properties on property create/edit form.
+    - Re-use already introduced widget for the field.
+    - Adjust the DOM to show/hide/clear field on different selections.
+    - Change the logic for the Create/Update view of property to create PropertyList objects.
+
 v 1.17.0 (2026-03-16)
 ==================
 

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -40,7 +40,7 @@ from vitrina.structure.factories import (
     BaseFactory,
     VersionFactory,
 )
-from vitrina.structure.models import Metadata, Enum, EnumItem, VersionType, Model, Property, Base
+from vitrina.structure.models import Metadata, Enum, EnumItem, VersionType, Model, Property, Base, PropertyList
 from vitrina.structure.services import create_structure_objects
 from vitrina.users.factories import UserFactory
 from vitrina.structure.models import Version as _Version
@@ -4299,6 +4299,78 @@ def test_model_create_with_public_visibility_without_uri_with_error(app: DjangoT
 
 
 @pytest.mark.django_db
+def test_property_create__ref_with_composite_key(app: DjangoTestApp):
+    # Arrange
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+
+    version = VersionFactory()
+    dataset = version.dataset
+
+    model = ModelFactory(dataset=dataset, metadata_version=version)
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(model),
+        object_id=model.pk,
+        dataset=dataset,
+        name="test/dataset/TestModel",
+        metadata_version=version,
+    )
+
+    # The model being referenced via `ref`
+    ref_model = ModelFactory(dataset=dataset, metadata_version=version)
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(ref_model),
+        object_id=ref_model.pk,
+        dataset=dataset,
+        name="test/dataset/RefModel",
+        metadata_version=version,
+    )
+
+    # Two properties on the `ref` model to use as composite key
+    ref_property_1 = PropertyFactory(model=ref_model, metadata_version=version)
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(ref_property_1),
+        object_id=ref_property_1.pk,
+        dataset=dataset,
+        name="id",
+        metadata_version=version,
+    )
+    ref_property_2 = PropertyFactory(model=ref_model, metadata_version=version)
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(ref_property_2),
+        object_id=ref_property_2.pk,
+        dataset=dataset,
+        name="name",
+        metadata_version=version,
+    )
+
+    # Act
+    form = app.get(reverse("property-create", args=[dataset.pk, version.pk, model.name])).forms["property-form"]
+
+    form["name"] = "ref_field"
+    form["type"] = "ref"
+    # Select2 fields load options dynamically via AJAX, so webtest cannot see
+    # any options in the rendered HTML. force_value() bypasses option validation
+    # and sets the value directly, skipping the "Option not found" error.
+    form["ref"].force_value(ref_model.pk)
+    form["ref_props"].force_value([ref_property_1.pk, ref_property_2.pk])
+
+    response = form.submit().follow()
+
+    # Assert
+    assert response.status_code == HTTPStatus.OK
+    # Check PropertyList entries were created
+    property = Property.objects.get(model=model)
+    property_list = PropertyList.objects.filter(
+        content_type=ContentType.objects.get_for_model(Property),
+        object_id=property.pk,
+    ).order_by("order")
+
+    assert property_list.count() == 2
+    assert list(property_list.values_list("property", "order")) == [(ref_property_1.pk, 1), (ref_property_2.pk, 2)]
+
+
+@pytest.mark.django_db
 def test_property_create_with_in_released_version(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
@@ -6745,6 +6817,91 @@ def test_publishing_property_with_draft_model_ref_different_dataset(app: DjangoT
         response.context["form"].errors["__all__"][0]
         == "Laukas prop2 turi nuorodą į nepublikuotą lauką kitame duomenų ištekliuje."
     )
+
+
+@pytest.mark.django_db
+def test_property_update__ref_with_composite_key(app: DjangoTestApp):
+    # Arrange
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+
+    version = VersionFactory()
+    dataset = version.dataset
+
+    model = ModelFactory(dataset=dataset, metadata_version=version)
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(model),
+        object_id=model.pk,
+        dataset=dataset,
+        name="test/dataset/TestModel",
+        metadata_version=version,
+    )
+
+    # The model being referenced via ref
+    ref_model = ModelFactory(dataset=dataset, metadata_version=version)
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(ref_model),
+        object_id=ref_model.pk,
+        dataset=dataset,
+        name="test/dataset/RefModel",
+        metadata_version=version,
+    )
+
+    # Two properties on the ref model to use as composite key
+    ref_property_1 = PropertyFactory(model=ref_model, metadata_version=version)
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(ref_property_1),
+        object_id=ref_property_1.pk,
+        dataset=dataset,
+        name="id",
+        metadata_version=version,
+    )
+    ref_property_2 = PropertyFactory(model=ref_model, metadata_version=version)
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(ref_property_2),
+        object_id=ref_property_2.pk,
+        dataset=dataset,
+        name="name",
+        metadata_version=version,
+    )
+
+    # Existing property that will be updated
+    existing_prop = PropertyFactory(model=model, metadata_version=version)
+    existing_metadata = MetadataFactory(
+        content_type=ContentType.objects.get_for_model(existing_prop),
+        object_id=existing_prop.pk,
+        dataset=dataset,
+        name="ref_field",
+        type="string",
+        metadata_version=version,
+    )
+
+    # Act
+    form = app.get(
+        reverse("property-update", args=[dataset.pk, version.pk, model.name, existing_prop.metadata.first().name])
+    ).forms["property-form"]
+
+    form["type"] = "ref"
+    # Select2 fields load options dynamically via AJAX, so webtest cannot see
+    # any options in the rendered HTML. force_value() bypasses option validation
+    # and sets the value directly, skipping the "Option not found" error.
+    form["ref"].force_value(ref_model.pk)
+    form["ref_props"].force_value([ref_property_1.pk, ref_property_2.pk])
+
+    response = form.submit().follow()
+
+    # Assert
+    assert response.status_code == HTTPStatus.OK
+    existing_prop.refresh_from_db()
+    existing_metadata.refresh_from_db()
+    # Check old PropertyList entries were cleared and new ones created
+    property_list = PropertyList.objects.filter(
+        content_type=ContentType.objects.get_for_model(Property),
+        object_id=existing_prop.pk,
+    ).order_by("order")
+
+    assert property_list.count() == 2
+    assert list(property_list.values_list("property", "order")) == [(ref_property_1.pk, 1), (ref_property_2.pk, 2)]
 
 
 @pytest.mark.django_db

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-19 12:50+0200\n"
+"POT-Creation-Date: 2026-03-25 09:50+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,9 +17,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-
-msgid "Organizacija"
-msgstr "Organization"
 
 msgid "Versijos duomenys"
 msgstr "Version data"
@@ -55,6 +52,9 @@ msgstr "API key"
 
 msgid "Taikymo sritis"
 msgstr "Application area"
+
+msgid "Organizacija"
+msgstr "Organization"
 
 msgid "Duomenų išteklius"
 msgstr "Resource"
@@ -4582,6 +4582,12 @@ msgstr "Type parameters"
 
 msgid "Nurodo duomenų lauko tipo parametrus."
 msgstr "Indicates the type parameters for the data field."
+
+msgid "Ryšio raktai"
+msgstr "Relation keys"
+
+msgid "Savybės iš susieto modelio, kurios naudojamos kaip ryšio raktas."
+msgstr "Properties from related model, which act as the relation key."
 
 msgid "Kodiniame pavadinime negali būti naudojamos didžiosios raidės."
 msgstr "Code name can not include upper case letters."

--- a/vitrina/structure/forms.py
+++ b/vitrina/structure/forms.py
@@ -456,6 +456,12 @@ class BaseRefWidget(OrderMixin, ModelSelect2MultipleWidget):
     dependent_fields = {"base": "model"}
 
 
+class RefPropsWidget(OrderMixin, ModelSelect2MultipleWidget):
+    model = Property
+    search_fields = ["metadata__name__icontains"]
+    dependent_fields = {"ref": "model"}
+
+
 def _check_prepare_ast(ast, model_props, bind=False):
     if isinstance(ast, dict):
         if ast.get("name") == "bind":
@@ -1065,6 +1071,7 @@ class PropertyForm(forms.ModelForm):
             "type",
             "type_args",
             "ref",
+            "ref_props",
             "ref_others",
             "source",
             "prepare",
@@ -1077,6 +1084,14 @@ class PropertyForm(forms.ModelForm):
             "title",
             "description",
         )
+
+    ref_props = OrderedModelMultipleChoiceField(
+        label=_("Ryšio raktai"),
+        required=False,
+        widget=RefPropsWidget(attrs={"data-width": "100%", "data-minimum-input-length": 0, "style": "width: 100%"}),
+        queryset=Property.objects.all(),
+        help_text=_("Savybės iš susieto modelio, kurios naudojamos kaip ryšio raktas."),
+    )
 
     def __init__(self, model, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -1091,6 +1106,7 @@ class PropertyForm(forms.ModelForm):
             Field("type"),
             Field("type_args"),
             Field("ref"),
+            Field("ref_props"),
             Field("ref_others"),
             Field("source"),
             Field("prepare"),
@@ -1121,6 +1137,9 @@ class PropertyForm(forms.ModelForm):
             self.initial["status"] = instance.status
             if instance.object.ref_model:
                 self.initial["ref"] = instance.object.ref_model
+                self.initial["ref_props"] = instance.object.property_list.order_by("order").values_list(
+                    "property", flat=True
+                )
                 self.initial["ref_others"] = None
             else:
                 self.initial["ref_others"] = instance.ref

--- a/vitrina/structure/templates/vitrina/structure/model_structure.html
+++ b/vitrina/structure/templates/vitrina/structure/model_structure.html
@@ -207,12 +207,16 @@
                             {% if prop.ref_model %}
                             <span class="pr-3">
                                 model:
-                                <a href="{{ prop.ref_model.get_absolute_url }}">{{ prop.ref_model.name }}</a>
+                                <a href="{{ prop.ref_model.get_absolute_url }}">
+                                    {{ prop.ref_model.name }}
+                                </a>
                                 {% if prop.property_list.all %}
                                     <span class="is-italic">
-                                        {% for p in prop.property_list.all %}
-                                            {{ p }}
-                                        {% endfor %}
+                                        [
+                                            {% for p in prop.property_list.all %}
+                                                {{ p }}{% if not forloop.last %}, {% endif %}
+                                            {% endfor %}
+                                        ]
                                     </span>
                                 {% endif %}
                             </span>
@@ -386,17 +390,19 @@
                                     {% endif %}
 
                                     {% if prop.ref_model %}
-                                    <span class="pr-3">
-                                        model:
-                                        <a href="{{ prop.ref_model.get_absolute_url }}">{{ prop.ref_model.name }}</a>
-                                        {% if prop.property_list.all %}
-                                            <span class="is-italic">
-                                                {% for p in prop.property_list.all %}
-                                                    {{ p }}
-                                                {% endfor %}
-                                            </span>
-                                        {% endif %}
-                                    </span>
+                                        <span class="pr-3">
+                                            model:
+                                                <a href="{{ prop.ref_model.get_absolute_url }}">{{ prop.ref_model.name }}</a>
+                                                {% if prop.property_list.all %}
+                                                    <span class="is-italic">
+                                                        [
+                                                            {% for p in prop.property_list.all %}
+                                                                {{ p }}{% if not forloop.last %},{% endif %}
+                                                            {% endfor %}
+                                                        ]
+                                                    </span>
+                                                {% endif %}
+                                        </span>
                                     {% endif %}
 
                                     {% if prop_metadata.uri %}

--- a/vitrina/structure/templates/vitrina/structure/property_form.html
+++ b/vitrina/structure/templates/vitrina/structure/property_form.html
@@ -11,6 +11,9 @@
 
 {% block head %}
     <style>
+        div.select.is-multiple {
+            width: 100%;
+        }
         div#div_id_ref .select {
             width: 100%;
         }
@@ -36,17 +39,30 @@
 {% block scripts %}
     <script>
         $(document).ready(function() {
-            $('select#id_type').on('change', function() {
+            function toggleRefFields() {
                 let type = $('select#id_type').val();
+                let ref_val = $('select#id_ref').val();
+
                 if (type == 'ref') {
                     $('div#div_id_ref').show();
                     $('div#div_id_ref_others').hide();
+                    if (ref_val) {
+                        $('div#div_id_ref_props').show();
+                    } else {
+                        $('div#div_id_ref_props').hide();
+                        $('select#id_ref_props').empty().trigger('change');
+                    }
                 } else {
                     $('div#div_id_ref').hide();
+                    $('div#div_id_ref_props').hide();
                     $('div#div_id_ref_others').show();
                 }
-            });
-            $('select#id_type').trigger('change');
+            }
+
+            $('select#id_type').on('change', toggleRefFields);
+            $('select#id_ref').on('change', toggleRefFields);
+
+            toggleRefFields();
         });
     </script>
 {% endblock %}

--- a/vitrina/structure/views.py
+++ b/vitrina/structure/views.py
@@ -2650,10 +2650,20 @@ class PropertyCreateView(DatasetBreadcrumbsMixin, PermissionRequiredMixin, Creat
             self.object.prepare_ast = ""
         if self.object.type == "ref":
             ref = form.cleaned_data.get("ref")
+            ref_props = form.cleaned_data.get("ref_props")
             if ref and ref.metadata.first():
                 self.object.ref = ref.metadata.first().name
                 prop.ref_model = ref
                 prop.save()
+                if ref_props:
+                    for i, ref_prop in enumerate(ref_props, start=1):
+                        PropertyList.objects.create(
+                            content_type=ContentType.objects.get_for_model(Property),
+                            object_id=prop.pk,
+                            property=ref_prop,
+                            order=i,
+                            metadata_version=self.metadata_version,
+                        )
         else:
             self.object.ref = form.cleaned_data.get("ref_others")
         if not self.object.status:
@@ -2770,13 +2780,25 @@ class PropertyUpdateView(DatasetBreadcrumbsMixin, PermissionRequiredMixin, Updat
             self.object.prepare_ast = ""
         if self.object.type == "ref":
             ref = form.cleaned_data.get("ref")
+            ref_props = form.cleaned_data.get("ref_props")
             if ref and ref.metadata.first():
                 self.object.ref = ref.metadata.first().name
                 prop.ref_model = ref
+                prop.property_list.all().delete()
+                if ref_props:
+                    for i, ref_prop in enumerate(ref_props, start=1):
+                        PropertyList.objects.create(
+                            content_type=ContentType.objects.get_for_model(Property),
+                            object_id=prop.pk,
+                            property=ref_prop,
+                            order=i,
+                            metadata_version=self.metadata_version,
+                        )
         else:
             self.object.ref = form.cleaned_data.get("ref_others")
             if prop.ref_model:
                 prop.ref_model = None
+            prop.property_list.all().delete()
 
         if latest_version := self.object.metadataversion_set.order_by("-version__created").first():
             latest_version_fields_changed = (


### PR DESCRIPTION
- Re-use already introduced widget for the field.
- Adjust the DOM to show/hide/clear field on different selections.
- Change the logic for the Create/Update view of property to create PropertyList objects.