### PR TITLE
2461: Adding dataset name check in manifest read

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,10 @@ https://github.com/atviriduomenys/katalogas/issues/2337
 
 - Implement `number` type enums.
 
+https://github.com/atviriduomenys/katalogas/issues/2461
+
+-  Implement dataset name check in manifest read
+
 
 v 1.17.1 (2026-03-30)
 ==================

--- a/tests/datasets/test_helpers.py
+++ b/tests/datasets/test_helpers.py
@@ -1,0 +1,85 @@
+from vitrina.datasets.factories import DatasetFactory
+from vitrina.datasets.helpers import validate_name_prefix
+from vitrina.orgs.factories import OrganizationFactory
+from vitrina.orgs.models import WhitelistedCodeName
+import pytest
+
+
+@pytest.mark.django_db
+def test_validate_name_prefix_matches_main_prefix():
+    org = OrganizationFactory(name="datasets/gov/test")
+    WhitelistedCodeName.objects.filter(organization=org).delete()
+    matched, main, whitelisted = validate_name_prefix("datasets/gov/test/dataset", org)
+    assert matched == "datasets/gov/test"
+    assert main == "datasets/gov/test"
+    assert whitelisted == []
+
+
+@pytest.mark.django_db
+def test_validate_name_prefix_matches_whitelisted_prefix():
+    org = OrganizationFactory(name="datasets/gov/test", whitelisted_names=["datasets/org/test"])
+    WhitelistedCodeName.objects.filter(organization=org).exclude(code_name="datasets/org/test").delete()
+    matched, main, whitelisted = validate_name_prefix("datasets/org/test/dataset", org)
+    assert matched == "datasets/org/test"
+
+
+@pytest.mark.django_db
+def test_validate_name_prefix_matches_no_prefix():
+    org = OrganizationFactory(name="datasets/gov/test", whitelisted_names=["datasets/org/test"])
+    WhitelistedCodeName.objects.filter(organization=org).exclude(code_name="datasets/org/test").delete()
+    matched, main, whitelisted = validate_name_prefix("datasets/other/test/dataset", org)
+    assert matched is None
+
+
+@pytest.mark.django_db
+def test_validate_name_prefix_resolves_org_from_dataset_instance():
+    org = OrganizationFactory(name="datasets/gov/test")
+    WhitelistedCodeName.objects.filter(organization=org).delete()
+    dataset = DatasetFactory(title="testt", organization=org)
+    matched, main, whitelisted = validate_name_prefix("datasets/gov/test/dataset", None, dataset)
+    assert matched == "datasets/gov/test"
+    assert main == "datasets/gov/test"
+
+
+@pytest.mark.django_db
+def test_validate_name_prefix_organization_takes_precedence_over_dataset():
+    direct_org = OrganizationFactory(name="datasets/gov/test")
+    WhitelistedCodeName.objects.filter(organization=direct_org).delete()
+    dataset_org = OrganizationFactory(name="datasets/org/test")
+    dataset = DatasetFactory(title="testt", organization=dataset_org)
+    matched, main, _ = validate_name_prefix("datasets/gov/test/dataset", direct_org, dataset)
+    assert main == "datasets/gov/test"
+
+
+@pytest.mark.django_db
+def test_validate_name_prefix_returns_all_whitelisted_names():
+    org = OrganizationFactory(name="datasets/gov/test", whitelisted_names=["datasets/org/test", "datasets/org/other"])
+    WhitelistedCodeName.objects.filter(organization=org).exclude(
+        code_name__in=["datasets/org/test", "datasets/org/other"]
+    ).delete()
+    _, _, whitelisted = validate_name_prefix("datasets/gov/test/dataset", org)
+    assert set(whitelisted) == {"datasets/org/test", "datasets/org/other"}
+
+
+@pytest.mark.django_db
+def test_validate_name_prefix_empty_whitelisted_names():
+    org = OrganizationFactory(name="datasets/gov/test", whitelisted_names=[])
+    WhitelistedCodeName.objects.filter(organization=org).delete()
+    _, _, whitelisted = validate_name_prefix("datasets/gov/test/dataset", org)
+    assert whitelisted == []
+
+
+def test_validate_name_prefix_no_organization():
+    matched, main, whitelisted = validate_name_prefix("datasets/gov/test/dataset", None, None)
+    assert matched is None
+    assert main == ""
+    assert whitelisted == []
+
+
+@pytest.mark.django_db
+def test_validate_name_prefix_empty_name():
+    org = OrganizationFactory(name="datasets/gov/test")
+    WhitelistedCodeName.objects.filter(organization=org).delete()
+    matched, main, whitelisted = validate_name_prefix("", org)
+    assert matched is None
+    assert main == "datasets/gov/test"

--- a/tests/datasets/test_views.py
+++ b/tests/datasets/test_views.py
@@ -2250,7 +2250,7 @@ class TestDatasetCreateView:
         resp = form.submit()
         assert list(resp.context["form"].errors.values()) == [
             [
-                "Kodinis pavadinimas turi prasidėti nuo „data/gov/org“ arba vieno iš leidžiamų kodinio pavadinimo pradžių: datasets/gov/ivpk/"
+                "Kodinis pavadinimas turi prasidėti nuo „data/gov/org“ arba vieno iš leidžiamų kodinio pavadinimo pradžių: „datasets/gov/ivpk/“."
             ]
         ]
 

--- a/tests/datasets/test_views.py
+++ b/tests/datasets/test_views.py
@@ -2248,7 +2248,11 @@ class TestDatasetCreateView:
         form["name"] = "data/gov/creator/test"
         form["access_rights"] = Dataset.PUBLIC
         resp = form.submit()
-        assert list(resp.context["form"].errors.values()) == [["Kodinis pavadinimas turi prasidėti nuo „data/gov/org“"]]
+        assert list(resp.context["form"].errors.values()) == [
+            [
+                "Kodinis pavadinimas turi prasidėti nuo „data/gov/org“ arba vieno iš leidžiamų kodinio pavadinimo pradžių: datasets/gov/ivpk/"
+            ]
+        ]
 
     def test_create_with_allowed_name(self, app: DjangoTestApp):
         FrequencyFactory(is_default=True)
@@ -3517,7 +3521,7 @@ class TestDatasetStructureImport:
         )
 
         user = UserFactory(is_staff=True)
-        dataset = DatasetFactory()
+        dataset = DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/main/"]))
         version = VersionFactory(dataset=dataset)
 
         app.set_user(user)

--- a/tests/structure/test_services.py
+++ b/tests/structure/test_services.py
@@ -1321,7 +1321,10 @@ def test_structure_with_existing_dataset(app: DjangoTestApp):
         ",,,,City,,,,,,,,,,,\n"
         ",,,,,id,integer,,,,5,,,open,,,Identifikatorius,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
+    )
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -1335,7 +1338,10 @@ def test_structure_with_existing_dataset(app: DjangoTestApp):
         ",,,,City,,,,,,,,,,,,,,\n"
         ",,,,,id,integer,,,,5,,,open,,,Identifikatorius,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=DatasetFactory(organization=structure.dataset.organization),
+    )
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure, version)

--- a/tests/structure/test_services.py
+++ b/tests/structure/test_services.py
@@ -1377,7 +1377,7 @@ def test_structure_with_invalid_prefix_no_whitelist(app: DjangoTestApp):
             type=Comment.STRUCTURE_ERROR,
             content_type=ContentType.objects.get_for_model(structure),
         ).values_list("body", flat=True)
-    ) == ["Kodinis pavadinimas turi prasidėti nuo „datasets/gov/other“"]
+    ) == ["Kodinis pavadinimas turi prasidėti nuo „datasets/gov/other“."]
 
 
 @pytest.mark.django_db
@@ -3043,7 +3043,7 @@ class TestStructureComments:
 def test_structure_boolean_enums(app: DjangoTestApp):
     manifest = (
         "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description\n"
-        "1,dataset,,,,,,,,,,,,,,,,\n"
+        "1,datasets/gov/ivpk/dataset,,,,,,,,,,,,,,,,\n"
         "2,,,,Approver,,,,,,1,,,,,,,\n"
         "3,,,,,is_active,boolean,,IsActive/text(),,,,,4,,,,,,,\n"
         "4,,,,,,enum,,True,true,,,,,,,,,,,\n"
@@ -3068,7 +3068,7 @@ def test_structure_boolean_enums(app: DjangoTestApp):
 def test_structure_boolean_enums_invalid_source(app: DjangoTestApp):
     manifest = (
         "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description\n"
-        "1,dataset,,,,,,,,,,,,,,,,\n"
+        "1,datasets/gov/ivpk/dataset,,,,,,,,,,,,,,,,\n"
         "2,,,,Approver,,,,,,1,,,,,,,\n"
         "3,,,,,is_active,boolean,,IsActive/text(),,,,,4,,,,,,,\n"
         "4,,,,,,enum,,True,True,,,,,,,,,,,\n"
@@ -3093,7 +3093,7 @@ def test_structure_boolean_enums_invalid_source(app: DjangoTestApp):
 def test_structure_number_enums(app: DjangoTestApp):
     manifest = (
         "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description\n"
-        ",example,,,,,,,,,,,,,,,,\n"
+        ",datasets/gov/ivpk/example,,,,,,,,,,,,,,,,\n"
         ",,,,Dataset,,,,,,1,,,,,,,\n"
         ",,,,,type,number required,,TypeID/text(),,,,,4,,,,,,,\n"
         ",,,,,,enum,,1.1,1.2,,,,,,,,,,,\n"

--- a/tests/structure/test_services.py
+++ b/tests/structure/test_services.py
@@ -10,7 +10,7 @@ from vitrina.comments.factories import CommentFactory
 from vitrina.comments.models import Comment
 from vitrina.datasets.factories import DatasetFactory, DatasetStructureFactory
 from vitrina.datasets.models import Dataset
-from vitrina.orgs.factories import ViispRepresentativeFactory
+from vitrina.orgs.factories import ViispRepresentativeFactory, OrganizationFactory, WhitelistedCodeNameFactory
 from vitrina.resources.factories import DatasetDistributionFactory, FileFormat
 from vitrina.resources.models import DatasetDistribution
 from vitrina.structure import VersionStatus
@@ -272,6 +272,7 @@ def test_structure_with_base_model(app: DjangoTestApp):
 
 @pytest.mark.django_db
 def test_structure_with_base_model_two_manifests(app: DjangoTestApp):
+    organization = OrganizationFactory(whitelisted_names=["datasets/gov/rc/"])
     manifest_base = (
         "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
         ",datasets/gov/rc/ar/apskritis,,,,,,,,,,,,,,,,,\n"
@@ -284,7 +285,8 @@ def test_structure_with_base_model_two_manifests(app: DjangoTestApp):
     )
 
     base_structure = DatasetStructureFactory(
-        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest_base))
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest_base)),
+        dataset=DatasetFactory(organization=organization),
     )
 
     manifest_with_base = (
@@ -300,7 +302,8 @@ def test_structure_with_base_model_two_manifests(app: DjangoTestApp):
     )
 
     structure_with_base = DatasetStructureFactory(
-        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest_with_base))
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest_with_base)),
+        dataset=DatasetFactory(organization=organization),
     )
 
     base_structure.dataset.current_structure = base_structure
@@ -350,6 +353,7 @@ def test_structure_with_property_ref(app: DjangoTestApp):
 
 @pytest.mark.django_db
 def test_structure_with_property_ref_two_manifests(app: DjangoTestApp):
+    organization = OrganizationFactory(whitelisted_names=["datasets/gov/rc/"])
     ref_manifest = (
         "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
         ",datasets/gov/rc/ar/apskritis,,,,,,,,,,,,,,,,,\n"
@@ -362,7 +366,8 @@ def test_structure_with_property_ref_two_manifests(app: DjangoTestApp):
     )
 
     ref_object_structure = DatasetStructureFactory(
-        file=FilerFileFactory(file=FileField(filename="file.csv", data=ref_manifest))
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=ref_manifest)),
+        dataset=DatasetFactory(organization=organization),
     )
 
     ref_object_structure.dataset.current_structure = ref_object_structure
@@ -382,7 +387,8 @@ def test_structure_with_property_ref_two_manifests(app: DjangoTestApp):
     )
 
     structure_with_ref = DatasetStructureFactory(
-        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest_with_ref))
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest_with_ref)),
+        dataset=DatasetFactory(organization=organization),
     )
 
     structure_with_ref.dataset.current_structure = structure_with_ref
@@ -1682,7 +1688,11 @@ def test_structure_export__multiple_versions(app: DjangoTestApp):
     user = UserFactory(is_staff=True)
     app.set_user(user)
 
-    dataset = DatasetFactory(title="Multi-Version Dataset", description="Dataset with multiple versions")
+    dataset = DatasetFactory(
+        title="Multi-Version Dataset",
+        description="Dataset with multiple versions",
+        organization=OrganizationFactory(whitelisted_names=["datasets/gov/test/"]),
+    )
 
     # Version 1: one model, one property, one prefix, one enum, and one param
     version1 = VersionFactory(dataset=dataset, version=1)
@@ -2295,7 +2305,7 @@ def test_structure_export_after_changing_model_name(app: DjangoTestApp):
     app.set_user(user)
     manifest = (
         "id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n"
-        "1,test_dataset,,,,,,,,,,,,,,,,,\n"
+        "1,dataset/org/test/test_dataset,,,,,,,,,,,,,,,,,\n"
         "2,,resource1,,,,,,http://www.example.com,,,,,,,,,Title,Description\n"
         "3,,,,Model,,,id,,,,,,,,,,,\n"
         "4,,,,,id,integer,,,,,,,,,,,,\n"
@@ -2313,35 +2323,40 @@ def test_structure_export_after_changing_model_name(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description", metadata=False),
+        dataset=DatasetFactory(
+            title="Title",
+            description="Description",
+            metadata=False,
+            organization=OrganizationFactory(whitelisted_names=["dataset/org/test/"]),
+        ),
     )
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
 
-    model = Model.objects.get(dataset=structure.dataset, metadata__name="test_dataset/Model")
+    model = Model.objects.get(dataset=structure.dataset, metadata__name="dataset/org/test/test_dataset/Model")
     form = app.get(reverse("model-update", args=[structure.dataset.pk, version.pk, model.name])).forms["model-form"]
     form["name"] = "Modelis"
     resp = form.submit()
     assert resp.url == model.get_absolute_url()
-    assert model.metadata.first().name == "test_dataset/Modelis"
+    assert model.metadata.first().name == "dataset/org/test/test_dataset/Modelis"
     assert model.ref_model_base.count() == 1
-    assert model.ref_model_base.first().metadata.first().name == "test_dataset/Modelis"
+    assert model.ref_model_base.first().metadata.first().name == "dataset/org/test/test_dataset/Modelis"
 
-    model = Model.objects.get(dataset=structure.dataset, metadata__name="test_dataset/Country")
+    model = Model.objects.get(dataset=structure.dataset, metadata__name="dataset/org/test/test_dataset/Country")
     form = app.get(reverse("model-update", args=[structure.dataset.pk, version.pk, model.name])).forms["model-form"]
     form["name"] = "Salis"
     resp = form.submit()
     assert resp.url == model.get_absolute_url()
-    assert model.metadata.first().name == "test_dataset/Salis"
+    assert model.metadata.first().name == "dataset/org/test/test_dataset/Salis"
     assert model.ref_model_properties.count() == 1
-    assert model.ref_model_properties.first().metadata.first().ref == "test_dataset/Salis"
+    assert model.ref_model_properties.first().metadata.first().ref == "dataset/org/test/test_dataset/Salis"
 
     resp = app.get(reverse("dataset-structure-export-no-version", args=[structure.dataset.pk]))
     assert resp.text == (
         "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
-        "1,test_dataset,,,,,,,,,,,,,,,,,,Title,Description\r\n"
+        "1,dataset/org/test/test_dataset,,,,,,,,,,,,,,,,,,Title,Description\r\n"
         "2,,resource1,,,,,,http://www.example.com,,,,,,,,,,,Title,Description\r\n"
         "3,,,,Modelis,,,id,,,,,,,develop,,,,,,\r\n"
         "4,,,,,id,integer,,,,,,,,develop,,,,,,\r\n"
@@ -2366,13 +2381,14 @@ def test_structure_export_after_changing_dataset_title_and_description(app: Djan
     app.set_user(user)
     manifest = (
         "id,dataset,resource,base,model,property,type,ref,source,prepare,prepare,level,status,visibility,access,uri,eli,title,description\n"
-        "1,test_dataset,,,,,,,,,,,,,,,,Title,Description\n"
+        "1,dataset/org/test/test_dataset,,,,,,,,,,,,,,,,Title,Description\n"
     )
     structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
 
     structure.dataset.current_structure = structure
     structure.dataset.organization = representative.content_object
     structure.dataset.save()
+    WhitelistedCodeNameFactory(organization=representative.content_object, code_name="dataset/org/test/")
     version = create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
 
     form = app.get(reverse("dataset-change", kwargs={"pk": structure.dataset.pk})).forms["dataset-form"]
@@ -2398,13 +2414,18 @@ def test_structure_export_after_changing_distribution_title_and_description(app:
     app.set_user(user)
     manifest = (
         "id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n"
-        "1,test_dataset,,,,,,,,,,,,,,,,Dataset,Dataset description\n"
+        "1,dataset/gov/test/test_dataset,,,,,,,,,,,,,,,,Dataset,Dataset description\n"
         "2,,test_resource,,,,,,https://example.com,,,,,,,,,Resource,Resource description\n"
         "3,,,,Model,,,,,,,,,,,,,,\n"
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Dataset", description="Dataset description", metadata=False),
+        dataset=DatasetFactory(
+            title="Dataset",
+            description="Dataset description",
+            metadata=False,
+            organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]),
+        ),
     )
 
     structure.dataset.current_structure = structure
@@ -2430,7 +2451,7 @@ def test_structure_export_after_changing_distribution_title_and_description(app:
     resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk, version.pk]))
     assert resp.text == (
         "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
-        "1,test_dataset,,,,,,,,,,,,,,,,,,Dataset,Dataset description\r\n"
+        "1,dataset/gov/test/test_dataset,,,,,,,,,,,,,,,,,,Dataset,Dataset description\r\n"
         "2,,test_resource,,,,,,https://example.com,,,,,,,,,,,Edited title,Edited description\r\n"
         "3,,,,Model,,,,,,,,,,develop,,,,,,\r\n"
         ",,,,,,,,,,,,,,,,,,,,\r\n"
@@ -2443,13 +2464,18 @@ def test_structure_export_after_changing_distribution_level(app: DjangoTestApp):
     app.set_user(user)
     manifest = (
         "id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n"
-        "1,test_dataset,,,,,,,,,,,,,,,,Dataset,Dataset description\n"
+        "1,dataset/gov/test/test_dataset,,,,,,,,,,,,,,,,Dataset,Dataset description\n"
         "2,,test_resource,,,,,,https://example.com,,,,,,,,,Resource,Resource description\n"
         "3,,,,Model,,,,,,,,,,,,,,\n"
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Dataset", description="Dataset description", metadata=False),
+        dataset=DatasetFactory(
+            title="Dataset",
+            description="Dataset description",
+            metadata=False,
+            organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]),
+        ),
     )
 
     structure.dataset.current_structure = structure
@@ -2473,7 +2499,7 @@ def test_structure_export_after_changing_distribution_level(app: DjangoTestApp):
     resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk, version.pk]))
     assert resp.text == (
         "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
-        "1,test_dataset,,,,,,,,,,,,,,,,,,Dataset,Dataset description\r\n"
+        "1,dataset/gov/test/test_dataset,,,,,,,,,,,,,,,,,,Dataset,Dataset description\r\n"
         "2,,test_resource,,,,,,https://example.com,,,,,2,,,,,,Resource,Resource description\r\n"
         "3,,,,Model,,,,,,,,,,develop,,,,,,\r\n"
         ",,,,,,,,,,,,,,,,,,,,\r\n"
@@ -2487,7 +2513,7 @@ def test_structure_export__visibility_row(app: DjangoTestApp):
 
     manifest = (
         "id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n"
-        "1,example,,,,,,,,,,,,,,,,,\n"
+        "1,dataset/gov/test/example,,,,,,,,,,,,,,,,,\n"
         "2,,resource,,,,xml,,resource.xml,,,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
         "3,,,,Pavadinimas,,,id,,,,4,,package,protected,,,Pavadinimas,\n"
@@ -2497,7 +2523,11 @@ def test_structure_export__visibility_row(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Pavadinimas", description="Aprašymas"),
+        dataset=DatasetFactory(
+            title="Pavadinimas",
+            description="Aprašymas",
+            organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]),
+        ),
     )
 
     structure.dataset.current_structure = structure
@@ -2507,7 +2537,7 @@ def test_structure_export__visibility_row(app: DjangoTestApp):
     resp = app.get(reverse("dataset-structure-export-no-version", args=[structure.dataset.pk]))
     assert resp.text == (
         "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
-        "1,example,,,,,,,,,,,,,,,,,,Pavadinimas,Aprašymas\r\n"
+        "1,dataset/gov/test/example,,,,,,,,,,,,,,,,,,Pavadinimas,Aprašymas\r\n"
         "2,,resource,,,,xml,,resource.xml,,,,,,,,,,,resource,\r\n"
         "3,,,,Pavadinimas,,,id,,,,,,4,develop,package,protected,,,Pavadinimas,\r\n"
         "4,,,,,id,integer,,,,,,,4,develop,package,protected,,,ID,\r\n"
@@ -2524,7 +2554,7 @@ def test_structure_export__eli_row(app: DjangoTestApp):
 
     manifest = (
         "id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n"
-        "1,example,,,,,,,,,,,,,,,,,\n"
+        "1,dataset/gov/test/example,,,,,,,,,,,,,,,,,\n"
         "2,,resource,,,,xml,,resource.xml,,,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
         "3,,,,Pavadinimas,,,id,,,,4,,,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.1,Pavadinimas,\n"
@@ -2534,7 +2564,11 @@ def test_structure_export__eli_row(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Pavadinimas", description="Aprašymas"),
+        dataset=DatasetFactory(
+            title="Pavadinimas",
+            description="Aprašymas",
+            organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]),
+        ),
     )
 
     structure.dataset.current_structure = structure
@@ -2544,7 +2578,7 @@ def test_structure_export__eli_row(app: DjangoTestApp):
     resp = app.get(reverse("dataset-structure-export-no-version", args=[structure.dataset.pk]))
     assert resp.text == (
         "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
-        "1,example,,,,,,,,,,,,,,,,,,Pavadinimas,Aprašymas\r\n"
+        "1,dataset/gov/test/example,,,,,,,,,,,,,,,,,,Pavadinimas,Aprašymas\r\n"
         "2,,resource,,,,xml,,resource.xml,,,,,,,,,,,resource,\r\n"
         "3,,,,Pavadinimas,,,id,,,,,,4,develop,,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.1,Pavadinimas,\r\n"
         "4,,,,,id,integer,,,,,,,4,develop,,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.2,ID,\r\n"
@@ -2561,7 +2595,7 @@ def test_structure_export__status_row(app: DjangoTestApp, setup_default_status_d
 
     manifest = (
         "id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n"
-        "1,example,,,,,,,,,,,,,,,,,\n"
+        "1,dataset/gov/test/example,,,,,,,,,,,,,,,,,\n"
         "2,,resource,,,,xml,,resource.xml,,,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
         "3,,,,Pavadinimas,,,id,,,,4,completed,,protected,,,Pavadinimas,\n"
@@ -2571,7 +2605,11 @@ def test_structure_export__status_row(app: DjangoTestApp, setup_default_status_d
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Pavadinimas", description="Aprašymas"),
+        dataset=DatasetFactory(
+            title="Pavadinimas",
+            description="Aprašymas",
+            organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]),
+        ),
     )
 
     structure.dataset.current_structure = structure
@@ -2581,7 +2619,7 @@ def test_structure_export__status_row(app: DjangoTestApp, setup_default_status_d
     resp = app.get(reverse("dataset-structure-export-no-version", args=[structure.dataset.pk]))
     assert resp.text == (
         "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
-        "1,example,,,,,,,,,,,,,,,,,,Pavadinimas,Aprašymas\r\n"
+        "1,dataset/gov/test/example,,,,,,,,,,,,,,,,,,Pavadinimas,Aprašymas\r\n"
         "2,,resource,,,,xml,,resource.xml,,,,,,,,,,,resource,\r\n"
         "3,,,,Pavadinimas,,,id,,,,,,4,completed,,protected,,,Pavadinimas,\r\n"
         "4,,,,,id,integer,,,,,,,4,withdrawn,,protected,,,ID,\r\n"
@@ -2595,7 +2633,7 @@ def test_structure_export__status_row(app: DjangoTestApp, setup_default_status_d
 def test_structure_models_props_and_enums_with_visibility_status_eli(app: DjangoTestApp, setup_default_status_data):
     manifest = (
         "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
-        "1,example,,,,,,,,,,,,,,,,,\n"
+        "1,dataset/gov/test/example,,,,,,,,,,,,,,,,,\n"
         "2,,resource,,,,xml,,resource.xml,,,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
         "3,,,,Pavadinimas,,,id,,,4,completed,package,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.1,Pavadinimas,,\n"
@@ -2603,7 +2641,10 @@ def test_structure_models_props_and_enums_with_visibility_status_eli(app: Django
         "5,,,,,class,integer,,,,4,discont,protected,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.3,class,,\n"
         "6,,,,,,enum,,1,1,4,deprecated,protected,protected,,https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/TAIS.296815/asr#11.3.1,Class One,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"])),
+    )
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -2651,13 +2692,16 @@ def test_structure_models_props_and_enums_with_visibility_status_eli(app: Django
 def test_structure_with_property_level_higher_then_model(app: DjangoTestApp):
     manifest = (
         "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
-        "1,example,,,,,,,,,,,,,,,,,\n"
+        "1,dataset/gov/test/example,,,,,,,,,,,,,,,,,\n"
         "2,,resource,,,,xml,,resource.xml,,,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
         "3,,,,Pavadinimas,,,id,,,4,,package,protected,,,Pavadinimas,,\n"
         "4,,,,,id,integer,,,,4,,public,protected,,,ID,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"])),
+    )
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -2670,7 +2714,7 @@ def test_structure_with_property_level_higher_then_model(app: DjangoTestApp):
 def test_structure_with_enum_level_higher_then_property(app: DjangoTestApp):
     manifest = (
         "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
-        "1,example,,,,,,,,,,,,,,,,,\n"
+        "1,dataset/gov/test/example,,,,,,,,,,,,,,,,,\n"
         "2,,resource,,,,xml,,resource.xml,,,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
         "3,,,,Pavadinimas,,,id,,,4,,package,protected,,,Pavadinimas,,\n"
@@ -2678,7 +2722,10 @@ def test_structure_with_enum_level_higher_then_property(app: DjangoTestApp):
         "5,,,,,class,integer,,,,4,,package,protected,,,class,,\n"
         "6,,,,,,enum,,1,1,4,,public,protected,,,Class One,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"])),
+    )
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -2696,7 +2743,7 @@ def test_structure_with_enum_level_higher_then_property(app: DjangoTestApp):
 def test_structure_with_enum_level_higher_then_model(app: DjangoTestApp):
     manifest = (
         "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
-        "1,example,,,,,,,,,,,,,,,,,\n"
+        "1,dataset/gov/test/example,,,,,,,,,,,,,,,,,\n"
         "2,,resource,,,,xml,,resource.xml,,,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
         "3,,,,Pavadinimas,,,id,,,4,,package,protected,,,Pavadinimas,,\n"
@@ -2704,7 +2751,10 @@ def test_structure_with_enum_level_higher_then_model(app: DjangoTestApp):
         "5,,,,,class,integer,,,,4,,,protected,,,class,,\n"
         "6,,,,,,enum,,1,1,4,,public,protected,,,Class One,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"])),
+    )
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -2744,7 +2794,7 @@ class TestStructureBaseModels:
         """Model for Base is defined in the same file."""
         manifest = (
             "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description\n"
-            ",example,,,,,,,,,,,,,,,,\n"
+            ",dataset/gov/test/example,,,,,,,,,,,,,,,,\n"
             ",,,,Animal,,,,,,0,completed,public,,,,,\n"
             ",,,,,id,string,,source_animal_id,,4,completed,package,protected,,,,\n"
             ",,,Animal,,,,,,,1,completed,public,,,,,\n"
@@ -2753,17 +2803,20 @@ class TestStructureBaseModels:
             ",,,/,,,,,,,,,,,,,,\n"
         )
 
-        structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+        structure = DatasetStructureFactory(
+            file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"])),
+        )
         structure.dataset.current_structure = structure
         structure.dataset.save()
         create_structure_objects(structure)
 
         assert Base.objects.count() == 1
-        base_object = Base.objects.get(metadata__name="example/Animal")
+        base_object = Base.objects.get(metadata__name="dataset/gov/test/example/Animal")
         assert Base.objects.first().model.name == "Animal"
         assert Model.objects.count() == 2
-        assert Model.objects.get(metadata__name="example/Animal")
-        assert Model.objects.get(metadata__name="example/Dog").base == base_object
+        assert Model.objects.get(metadata__name="dataset/gov/test/example/Animal")
+        assert Model.objects.get(metadata__name="dataset/gov/test/example/Dog").base == base_object
 
     @pytest.mark.django_db
     def test_structure_two_imports_first_model_secondly_reference_the_model_as_base(self, app: DjangoTestApp):
@@ -2773,12 +2826,13 @@ class TestStructureBaseModels:
         """
         manifest_with_model_definition = (
             "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description\n"
-            ",example,,,,,,,,,,,,,,,,\n"
+            ",dataset/gov/test/example,,,,,,,,,,,,,,,,\n"
             ",,,,Animal,,,,,,0,completed,public,,,,,\n"
             ",,,,,id,string,,source_animal_id,,4,completed,package,protected,,,,\n"
         )
         structure_model = DatasetStructureFactory(
-            file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest_with_model_definition))
+            file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest_with_model_definition)),
+            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"])),
         )
         structure_model.dataset.current_structure = structure_model
         structure_model.dataset.save()
@@ -2788,25 +2842,26 @@ class TestStructureBaseModels:
 
         manifest_with_base_reference = (
             "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description\n"
-            ",example2,,,,,,,,,,,,,,,,\n"
-            ",,,example/Animal,,,,,,,1,completed,public,,,,,\n"
+            ",dataset/org/test/example2,,,,,,,,,,,,,,,,\n"
+            ",,,dataset/gov/test/example/Animal,,,,,,,1,completed,public,,,,,\n"
             ",,,,Dog,,,,,,0,completed,public,,,,,\n"
             ",,,,,action,string,,source_dog_action,,4,completed,package,protected,,,,\n"
             ",,,/,,,,,,,,,,,,,,\n"
         )
         structure_base = DatasetStructureFactory(
-            file=FilerFileFactory(file=FileField(filename="file2.csv", data=manifest_with_base_reference))
+            file=FilerFileFactory(file=FileField(filename="file2.csv", data=manifest_with_base_reference)),
+            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/org/test/"])),
         )
         structure_base.dataset.current_structure = structure_base
         structure_base.dataset.save()
         create_structure_objects(structure_base)
 
         assert Model.objects.count() == 2
-        animal_model = Model.objects.get(metadata__name="example/Animal")
-        dog_model = Model.objects.get(metadata__name="example2/Dog")
+        animal_model = Model.objects.get(metadata__name="dataset/gov/test/example/Animal")
+        dog_model = Model.objects.get(metadata__name="dataset/org/test/example2/Dog")
 
         assert Base.objects.count() == 1
-        base_object = Base.objects.get(metadata__name="example/Animal")
+        base_object = Base.objects.get(metadata__name="dataset/gov/test/example/Animal")
 
         assert base_object.model == animal_model
         assert dog_model.base == base_object
@@ -2817,12 +2872,13 @@ class TestStructureBaseModels:
     ):
         manifest_with_model_definition = (
             "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description\n"
-            ",example,,,,,,,,,,,,,,,,\n"
+            ",dataset/gov/test/example,,,,,,,,,,,,,,,,\n"
             ",,,,Animal,,,,,,0,completed,public,,,,,\n"
             ",,,,,id,string,,source_animal_id,,4,completed,package,protected,,,,\n"
         )
         structure_model = DatasetStructureFactory(
-            file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest_with_model_definition))
+            file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest_with_model_definition)),
+            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"])),
         )
         structure_model.dataset.current_structure = structure_model
         structure_model.dataset.save()
@@ -2832,14 +2888,15 @@ class TestStructureBaseModels:
 
         manifest_with_base_reference = (
             "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description\n"
-            ",example2,,,,,,,,,,,,,,,,\n"
-            ",,,example/Animal,,,,,,,1,completed,public,,,,,\n"
+            ",dataset/org/test/example2,,,,,,,,,,,,,,,,\n"
+            ",,,dataset/gov/test/example/Animal,,,,,,,1,completed,public,,,,,\n"
             ",,,,Dog,,,,,,0,completed,public,,,,,\n"
             ",,,,,action,string,,source_dog_action,,4,completed,package,protected,,,,\n"
             ",,,/,,,,,,,,,,,,,,\n"
         )
         structure_base = DatasetStructureFactory(
-            file=FilerFileFactory(file=FileField(filename="file2.csv", data=manifest_with_base_reference))
+            file=FilerFileFactory(file=FileField(filename="file2.csv", data=manifest_with_base_reference)),
+            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/org/test/"])),
         )
         structure_base.dataset.current_structure = structure_base
         structure_base.dataset.save()
@@ -2847,12 +2904,12 @@ class TestStructureBaseModels:
 
         assert Base.objects.count() == 0
         assert Model.objects.count() == 2
-        assert Model.objects.get(metadata__name="example2/Dog").base is None
+        assert Model.objects.get(metadata__name="dataset/org/test/example2/Dog").base is None
 
         error_comment = Comment.objects.get(content_type=ContentType.objects.get_for_model(Model))
         assert error_comment.type == Comment.STRUCTURE_ERROR
         assert error_comment.body == (
-            "Nepavyko susieti bazinio modelio „example/Animal“. "
+            "Nepavyko susieti bazinio modelio „dataset/gov/test/example/Animal“. "
             "Įsitikinkite, kad jis egzistuoja ir turi patvirtintą (stabilią) versiją."
         )
 
@@ -2861,26 +2918,29 @@ class TestStructureBaseModels:
         """No model exists for the defined Base"""
         manifest = (
             "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description\n"
-            ",example,,,,,,,,,,,,,,,,\n"
+            ",dataset/gov/test/example,,,,,,,,,,,,,,,,\n"
             ",,,Animal,,,,,,,1,completed,public,,,,,\n"
             ",,,,Dog,,,,,,0,completed,public,,,,,\n"
             ",,,,,action,string,,source_dog_action,,4,completed,package,protected,,,,\n"
             ",,,/,,,,,,,,,,,,,,\n"
         )
 
-        structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+        structure = DatasetStructureFactory(
+            file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"])),
+        )
         structure.dataset.current_structure = structure
         structure.dataset.save()
         create_structure_objects(structure)
 
         assert Base.objects.count() == 0  # No model to link with - no base is created.
         assert Model.objects.count() == 1
-        assert Model.objects.get(metadata__name="example/Dog").base is None
+        assert Model.objects.get(metadata__name="dataset/gov/test/example/Dog").base is None
 
         error_comment = Comment.objects.get(content_type=ContentType.objects.get_for_model(Model))
         assert error_comment.type == Comment.STRUCTURE_ERROR
         assert error_comment.body == (
-            "Nepavyko susieti bazinio modelio „example/Animal“. "
+            "Nepavyko susieti bazinio modelio „dataset/gov/test/example/Animal“. "
             "Įsitikinkite, kad jis egzistuoja ir turi patvirtintą (stabilią) versiją."
         )
 
@@ -2890,7 +2950,7 @@ class TestStructureComments:
     def test_structure_comments_are_created(self, app: DjangoTestApp):
         manifest = (
             "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description\n"
-            ",dataset,,,,,,,,,,,,,,,,\n"
+            ",dataset/gov/test/dataset,,,,,,,,,,,,,,,,\n"
             ",,,,Animal,,,,source_animal_model,,,,,,,,,\n"
             ',,,,,,comment,model,,"update(model: ""Animal/:part"")",2,completed,protected,open,https://github.com/example/issues/1,,,\n'
             ",,,,,id,string,,source_animal_id,,4,,,,,,,\n"
@@ -2900,7 +2960,10 @@ class TestStructureComments:
             ",,,,,action,string,,source_dog_action,,4,,,,,,,\n"
         )
 
-        structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+        structure = DatasetStructureFactory(
+            file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"])),
+        )
         structure.dataset.current_structure = structure
         structure.dataset.save()
 

--- a/tests/structure/test_services.py
+++ b/tests/structure/test_services.py
@@ -11,6 +11,7 @@ from vitrina.comments.models import Comment
 from vitrina.datasets.factories import DatasetFactory, DatasetStructureFactory
 from vitrina.datasets.models import Dataset
 from vitrina.orgs.factories import ViispRepresentativeFactory, OrganizationFactory, WhitelistedCodeNameFactory
+from vitrina.orgs.models import WhitelistedCodeName
 from vitrina.resources.factories import DatasetDistributionFactory, FileFormat
 from vitrina.resources.models import DatasetDistribution
 from vitrina.structure import VersionStatus
@@ -1352,6 +1353,57 @@ def test_structure_with_existing_dataset(app: DjangoTestApp):
         ).values_list("body", flat=True)
     ) == ['Duomenų išteklius "datasets/gov/ivpk/adp" jau egzistuoja.']
     assert Metadata.objects.filter(dataset=structure.dataset, metadata_version=version).count() == 0
+
+
+@pytest.mark.django_db
+def test_structure_with_invalid_prefix_no_whitelist(app: DjangoTestApp):
+    manifest = (
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/test/adp,,,,,,,,,,,,,,,,,\n"
+        ",,resource1,,,,,,,,,,,,,,,,\n"
+        ",,,,City,,,,,,,,,,,\n"
+        ",,,,,id,integer,,,,5,,,open,,,Identifikatorius,,,\n"
+    )
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=DatasetFactory(organization=OrganizationFactory(name="datasets/gov/other")),
+    )
+    WhitelistedCodeName.objects.filter(organization=structure.dataset.organization).delete()
+    structure.dataset.current_structure = structure
+    structure.dataset.save()
+    create_structure_objects(structure)
+    assert list(
+        Comment.objects.filter(
+            type=Comment.STRUCTURE_ERROR,
+            content_type=ContentType.objects.get_for_model(structure),
+        ).values_list("body", flat=True)
+    ) == ['Kodinis pavadinimas turi prasidėti nuo „datasets/gov/other“']
+
+
+@pytest.mark.django_db
+def test_structure_with_invalid_prefix_with_whitelist(app: DjangoTestApp):
+    manifest = (
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/test/adp,,,,,,,,,,,,,,,,,\n"
+        ",,resource1,,,,,,,,,,,,,,,,\n"
+        ",,,,City,,,,,,,,,,,\n"
+        ",,,,,id,integer,,,,5,,,open,,,Identifikatorius,,,\n"
+    )
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=DatasetFactory(
+            organization=OrganizationFactory(name="datasets/gov/other", whitelisted_names=["datasets/gov/allowed/"])
+        ),
+    )
+    structure.dataset.current_structure = structure
+    structure.dataset.save()
+    create_structure_objects(structure)
+    assert list(
+        Comment.objects.filter(
+            type=Comment.STRUCTURE_ERROR,
+            content_type=ContentType.objects.get_for_model(structure),
+        ).values_list("body", flat=True)
+    ) == ['Kodinis pavadinimas turi prasidėti nuo „datasets/gov/other“ arba vieno iš leidžiamų kodinio pavadinimo pradžių: „datasets/gov/allowed/“']
 
 
 @pytest.mark.django_db

--- a/tests/structure/test_services.py
+++ b/tests/structure/test_services.py
@@ -1377,7 +1377,7 @@ def test_structure_with_invalid_prefix_no_whitelist(app: DjangoTestApp):
             type=Comment.STRUCTURE_ERROR,
             content_type=ContentType.objects.get_for_model(structure),
         ).values_list("body", flat=True)
-    ) == ['Kodinis pavadinimas turi prasidėti nuo „datasets/gov/other“']
+    ) == ["Kodinis pavadinimas turi prasidėti nuo „datasets/gov/other“"]
 
 
 @pytest.mark.django_db
@@ -1403,7 +1403,9 @@ def test_structure_with_invalid_prefix_with_whitelist(app: DjangoTestApp):
             type=Comment.STRUCTURE_ERROR,
             content_type=ContentType.objects.get_for_model(structure),
         ).values_list("body", flat=True)
-    ) == ['Kodinis pavadinimas turi prasidėti nuo „datasets/gov/other“ arba vieno iš leidžiamų kodinio pavadinimo pradžių: „datasets/gov/allowed/“']
+    ) == [
+        "Kodinis pavadinimas turi prasidėti nuo „datasets/gov/other“ arba vieno iš leidžiamų kodinio pavadinimo pradžių: „datasets/gov/allowed/“"
+    ]
 
 
 @pytest.mark.django_db

--- a/tests/structure/test_services.py
+++ b/tests/structure/test_services.py
@@ -1404,7 +1404,7 @@ def test_structure_with_invalid_prefix_with_whitelist(app: DjangoTestApp):
             content_type=ContentType.objects.get_for_model(structure),
         ).values_list("body", flat=True)
     ) == [
-        "Kodinis pavadinimas turi prasidėti nuo „datasets/gov/other“ arba vieno iš leidžiamų kodinio pavadinimo pradžių: „datasets/gov/allowed/“"
+        "Kodinis pavadinimas turi prasidėti nuo „datasets/gov/other“ arba vieno iš leidžiamų kodinio pavadinimo pradžių: „datasets/gov/allowed/“."
     ]
 
 

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -57,7 +57,6 @@ class BaseTestCreateManifest:
             metadata=False,
             organization=OrganizationFactory(whitelisted_names=whitelisted_names if whitelisted_names else []),
         )
-        print(dataset.organization.whitelisted_names)
         structure = DatasetStructureFactory(
             file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset
         )

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -4920,7 +4920,10 @@ def test_manifest_export_openapi(app: DjangoTestApp):
         ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
         ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
+    )
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
@@ -4983,7 +4986,8 @@ def test_manifest_export_openapi_with_dependent_models(app: DjangoTestApp):
         ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
     )
     city_structure = DatasetStructureFactory(
-        file=FilerFileFactory(file=FileField(filename="file.csv", data=city_manifest))
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=city_manifest)),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/test/"])),
     )
     city_structure.dataset.current_structure = city_structure
     city_structure.dataset.save()
@@ -5035,7 +5039,10 @@ def test_manifest_export_openapi_soap_params(app: DjangoTestApp):
         ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
         ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/test/"])),
+    )
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -5074,7 +5081,10 @@ def test_imported_metadata_gets_develop_status(app: DjangoTestApp):
         ",,,,,,,,,BIG,,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/test/"])),
+    )
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -5121,7 +5131,10 @@ def test_updating_metadata_in_not_draft_version_not_allowed(app: DjangoTestApp, 
         ",,,,,,enum,small,,'''SMALL''',,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/test/"])),
+    )
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -5180,7 +5193,10 @@ def test_published_metadata_gets_completed_status(app: DjangoTestApp):
         ",,,,,,,,,'''BIG''',,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/test/"])),
+    )
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -48,12 +48,16 @@ from vitrina.utils import RevisionComment, RevisionSource
 
 
 class BaseTestCreateManifest:
-    def _create_manifest(self, manifest: str, title: str = "", description: str = ""):
+    def _create_manifest(
+        self, manifest: str, title: str = "", description: str = "", whitelisted_names: list[str] | None = None
+    ):
         dataset = DatasetFactory(
             title=title,
             description=description,
             metadata=False,
+            organization=OrganizationFactory(whitelisted_names=whitelisted_names if whitelisted_names else []),
         )
+        print(dataset.organization.whitelisted_names)
         structure = DatasetStructureFactory(
             file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset
         )
@@ -5041,7 +5045,7 @@ def test_manifest_export_openapi_soap_params(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/test/"])),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -5083,7 +5087,7 @@ def test_imported_metadata_gets_develop_status(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/test/"])),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -5133,7 +5137,7 @@ def test_updating_metadata_in_not_draft_version_not_allowed(app: DjangoTestApp, 
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/test/"])),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -5195,7 +5199,7 @@ def test_published_metadata_gets_completed_status(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/test/"])),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -5973,7 +5977,7 @@ def test_publish_form_shows_all_metadata_rows_single_defined_resource(app: Djang
     app.set_user(user)
     manifest = (
         "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
-        "1,datasets/govsssss/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
         "2,,,,City,,,,,,5,,,,,,,,,\n"
         "3,,,,,id,integer,,,,5,,,,,,,,,\n"
         "4,,,,,title,string,,,,5,,,,,,,,,\n"
@@ -5984,7 +5988,10 @@ def test_publish_form_shows_all_metadata_rows_single_defined_resource(app: Djang
         "9,,,,,title,string,,,,2,,,,,,,,,\n"
     )
 
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
+    )
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -5998,7 +6005,7 @@ def test_publish_form_shows_all_metadata_rows_multiple_resources(app: DjangoTest
     app.set_user(user)
     manifest = (
         "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
-        "1,datasets/govsssss/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
         "2,,resource1,,,,,,http://www.example.com,,,,,,,,,Title,Description\n"
         "3,,,,City,,,,,,5,,,,,,,,,\n"
         "4,,,,,id,integer,,,,5,,,,,,,,,\n"
@@ -6010,7 +6017,10 @@ def test_publish_form_shows_all_metadata_rows_multiple_resources(app: DjangoTest
         "10,,,,,title,string,,,,2,,,,,,,,,\n"
     )
 
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
+    )
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -6029,7 +6039,7 @@ def test_publish_form_shows_all_metadata_rows_denorm_props(app: DjangoTestApp):
     app.set_user(user)
     manifest = (
         "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
-        "1,datasets/govsssss/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
         "2,,,,City,,,,,,,,,,,,,,\n"
         "3,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n"
         "4,,,,,title,string,,,,5,,,open,dct:title,,,,\n"
@@ -6042,7 +6052,10 @@ def test_publish_form_shows_all_metadata_rows_denorm_props(app: DjangoTestApp):
         "11,,,,,title,string,,,,2,,,,,,,,,\n"
     )
 
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
+    )
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -6586,13 +6599,16 @@ def test_publishing_property_with_ref_to_another_model(app: DjangoTestApp):
     app.set_user(user)
     manifest = (
         "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
-        "1,datasets/govsssss/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
         "3,,,,City,,,,,,5,,,,,,,City,,\n"
         "4,,,,,id,ref,Country,,,5,,,,,,,Id,,\n"
         "8,,,,Country,,,,,,4,,,,,,,Country,,\n"
     )
 
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
+    )
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
@@ -6609,7 +6625,7 @@ def test_publishing_property_with_ref_to_another_model(app: DjangoTestApp):
 
     publish_metadata = list(
         Metadata.objects.filter(
-            dataset=structure.dataset, name__in=["datasets/govsssss/ivpk/adp", "datasets/govsssss/ivpk/adp/City", "id"]
+            dataset=structure.dataset, name__in=["datasets/gov/ivpk/adp", "datasets/gov/ivpk/adp/City", "id"]
         ).values_list("pk", flat=True)
     )
     form = app.get(reverse("version-create", args=[structure.dataset.pk, version.pk])).forms["version-form"]
@@ -6636,14 +6652,17 @@ def test_publishing_property_with_ref_to_another_property(app: DjangoTestApp):
     app.set_user(user)
     manifest = (
         "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
-        "1,datasets/govsssss/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
         "3,,,,City,,,,,,5,,,,,,,City,,\n"
         "4,,,,,country,integer,Country,,,5,,,,,,,country_prop,,\n"
         "5,,,,,country.id,integer,,,,5,,,,,,,country_id,,\n"
         "8,,,,Country,,,,,,4,,,,,,,Country,,\n"
     )
 
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
+    )
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
@@ -6657,9 +6676,9 @@ def test_publishing_property_with_ref_to_another_property(app: DjangoTestApp):
         Metadata.objects.filter(
             dataset=structure.dataset,
             name__in=[
-                "datasets/govsssss/ivpk/adp",
-                "datasets/govsssss/ivpk/adp/City",
-                "datasets/govsssss/ivpk/adp/Country",
+                "datasets/gov/ivpk/adp",
+                "datasets/gov/ivpk/adp/City",
+                "datasets/gov/ivpk/adp/Country",
                 "country.id",
             ],
         ).values_list("pk", flat=True)
@@ -6683,11 +6702,14 @@ def test_publishing_model_with_base_from_published_version_same_dataset(app: Dja
     app.set_user(user)
     manifest = (
         "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
-        "1,datasets/govsssss/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
         "3,,,,City,,,,,,5,,,,,,,City,,\n"
         "8,,,,Country,,,,,,4,,,,,,,Country,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
+    )
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
@@ -6698,7 +6720,7 @@ def test_publishing_model_with_base_from_published_version_same_dataset(app: Dja
 
     publish_metadata = list(
         Metadata.objects.filter(
-            dataset=structure.dataset, name__in=["datasets/govsssss/ivpk/adp", "datasets/govsssss/ivpk/adp/City"]
+            dataset=structure.dataset, name__in=["datasets/gov/ivpk/adp", "datasets/gov/ivpk/adp/City"]
         ).values_list("pk", flat=True)
     )
     form = app.get(reverse("version-create", args=[structure.dataset.pk, version.pk])).forms["version-form"]
@@ -6723,7 +6745,7 @@ def test_publishing_model_with_base_from_published_version_same_dataset(app: Dja
 
     publish_metadata = list(
         Metadata.objects.filter(
-            dataset=structure.dataset, name__in=["datasets/govsssss/ivpk/adp", "datasets/govsssss/ivpk/adp/Country"]
+            dataset=structure.dataset, name__in=["datasets/gov/ivpk/adp", "datasets/gov/ivpk/adp/Country"]
         ).values_list("pk", flat=True)
     )
 
@@ -7377,7 +7399,7 @@ class TestStructure(BaseTestCreateManifest):
 
         manifest = (
             "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
-            "1,datasets/gov/main/dataset,,,,,,,,,,,,,,,,,\n"
+            "1,datasets/gov/ivpk/dataset,,,,,,,,,,,,,,,,,\n"
             "2,,dataset,,,,,,https://get.data.gov.lt/datasets/gov/main/dataset/:ns,,,,,,,,,,,dataset,\n"
             '3,,,,Country,,,"id,title",,,,,,,,,,,\n'
             "4,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n"
@@ -7390,7 +7412,7 @@ class TestStructure(BaseTestCreateManifest):
         assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
-            "1,datasets/gov/main/dataset,,,,,,,,,,,,,,,,,,Dataset,Dataset with ref property",
+            "1,datasets/gov/ivpk/dataset,,,,,,,,,,,,,,,,,,Dataset,Dataset with ref property",
             "2,,dataset,,,,,,https://get.data.gov.lt/datasets/gov/main/dataset/:ns,,,,,,,,,,,dataset,",
             "3,,,,Country,,,id,,,,,,,develop,,,,,,",
             "4,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,",
@@ -7404,7 +7426,7 @@ class TestStructure(BaseTestCreateManifest):
 
         manifest = (
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\n"
-            "1,dataset,,,,,,,,,,,,,,,,,,,\n"
+            "1,datasets/gov/ivpk/test,,,,,,,,,,,,,,,,,,,\n"
             "2,,resource_wsdl,,,,wsdl,,http://127.0.0.1:8001/api/v1/test/testing/?wsdl,,,,,,,,,,,,\n"
             "3,,resource_soap,,,,soap,,TestTesting.TestPort.TestPort.test,,wsdl(rc_wsdl),,,,,,,,,,\n"
             "4,,,,,,param,action_type,input/ActionType,,input(),,,,,,,,,,\n"
@@ -7424,7 +7446,7 @@ class TestStructure(BaseTestCreateManifest):
         assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
-            "1,dataset,,,,,,,,,,,,,,,,,,Title,Description",
+            "1,datasets/gov/ivpk/test,,,,,,,,,,,,,,,,,,Title,Description",
             "2,,resource_wsdl,,,,wsdl,,http://127.0.0.1:8001/api/v1/test/testing/?wsdl,,,,,,,,,,,resource_wsdl,",
             "3,,resource_soap,,,,soap,,TestTesting.TestPort.TestPort.test,,wsdl(rc_wsdl),,,,,,,,,resource_soap,",
             "4,,,,,,param,action_type,input/ActionType,,input(),,,,develop,,,,,,",
@@ -7446,7 +7468,7 @@ class TestStructure(BaseTestCreateManifest):
 
         manifest_no_prepare = (
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\n"
-            "1,dataset,,,,,,,,,,,,,,,,,,,\n"
+            "1,datasets/gov/ivpk/test,,,,,,,,,,,,,,,,,,,\n"
             "2,,service,,,,dask/xml,,,,,,,,,,,,,\n"
         )
         dataset = self._create_manifest(manifest_no_prepare, "Title", "Description")
@@ -7454,7 +7476,7 @@ class TestStructure(BaseTestCreateManifest):
 
         manifest_with_prepare = (
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\n"
-            "1,dataset,,,,,,,,,,,,,,,,,,,\n"
+            "1,datasets/gov/ivpk/test,,,,,,,,,,,,,,,,,,,\n"
             "2,,service,,,,dask/xml,,,,eval(param(nested_xml)),,,,,,,,\n"
         )
 
@@ -7471,7 +7493,7 @@ class TestStructure(BaseTestCreateManifest):
         assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
-            "1,dataset,,,,,,,,,,,,,,,,,,Title,Description",
+            "1,datasets/gov/ivpk/test,,,,,,,,,,,,,,,,,,Title,Description",
             "2,,service,,,,dask/xml,,,,eval(param(nested_xml)),,,,,,,,,service,",
         ]
 
@@ -7482,7 +7504,7 @@ class TestStructure(BaseTestCreateManifest):
 
         manifest = (
             "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description\n"
-            "1,dataset,,,,,dataset,,,,,,,,,,,\n"
+            "1,datasets/gov/ivpk/test,,,,,dataset,,,,,,,,,,,\n"
             "2,,nested_read,,,,dask/xml,,,eval(param(nested_xml)),,,,,,,,\n"
             "3,,,,,,param,nested_xml,GetData,read().response_data,,,,,,,,\n"
             "4,,,,,,param,action_type,input/ActionType,input(),,,,,,,,\n"
@@ -7502,7 +7524,7 @@ class TestStructure(BaseTestCreateManifest):
         assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
-            "1,dataset,,,,,,,,,,,,,,,,,,Dataset,Dataset with ref property",
+            "1,datasets/gov/ivpk/test,,,,,,,,,,,,,,,,,,Dataset,Dataset with ref property",
             "2,,nested_read,,,,dask/xml,,,,eval(param(nested_xml)),,,,,,,,,nested_read,",
             "3,,,,,,param,nested_xml,GetData,,read().response_data,,,,develop,,,,,,",
             "4,,,,,,param,action_type,input/ActionType,,input(),,,,develop,,,,,,",
@@ -7523,7 +7545,7 @@ class TestStructure(BaseTestCreateManifest):
 
         manifest = (
             "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description\n"
-            "1,example,,,,,,,,,,,,,,,,\n"
+            "1,datasets/gov/ivpk/example,,,,,,,,,,,,,,,,\n"
             "2,,,,Animal,,,,,,0,completed,public,,,,,\n"
             "3,,,,,id,string,,source_animal_id,,4,completed,package,protected,,,,\n"
             "4,,,Animal,,,,,,,1,completed,public,,,,,\n"
@@ -7539,7 +7561,7 @@ class TestStructure(BaseTestCreateManifest):
         assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
-            "1,example,,,,,,,,,,,,,,,,,,Dataset,Dataset with ref property",
+            "1,datasets/gov/ivpk/example,,,,,,,,,,,,,,,,,,Dataset,Dataset with ref property",
             "2,,,,Animal,,,,,,,,,0,completed,public,,,,,",
             "3,,,,,id,string,,source_animal_id,,,,,4,completed,package,protected,,,,",
             ",,,,,,,,,,,,,,,,,,,,",
@@ -7555,7 +7577,7 @@ class TestStructure(BaseTestCreateManifest):
 
         model_manifest = (
             "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description\n"
-            "1,example,,,,,,,,,,,,,,,,\n"
+            "1,datasets/gov/ivpk/example,,,,,,,,,,,,,,,,\n"
             "2,,,,Animal,,,,,,0,completed,public,,,,,\n"
             "3,,,,,id,string,,source_animal_id,,4,completed,package,protected,,,,\n"
         )
@@ -7566,21 +7588,26 @@ class TestStructure(BaseTestCreateManifest):
 
         base_manifest = (
             "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description\n"
-            "1,example2,,,,,,,,,,,,,,,,\n"
-            "2,,,example/Animal,,,,,,,1,completed,public,,,,,\n"
+            "1,datasets/gov/test/example2,,,,,,,,,,,,,,,,\n"
+            "2,,,datasets/gov/ivpk/example/Animal,,,,,,,1,completed,public,,,,,\n"
             "3,,,,Dog,,,,,,0,completed,public,,,,,\n"
             "4,,,,,action,string,,source_dog_action,,4,completed,package,protected,,,,\n"
             ",,,/,,,,,,,,,,,,,,\n"
         )
-        dataset = self._create_manifest(base_manifest, "Base Dataset", "Dataset that references model with base")
+        dataset = self._create_manifest(
+            base_manifest,
+            "Base Dataset",
+            "Dataset that references model with base",
+            whitelisted_names=["datasets/gov/test/"],
+        )
 
         response = app.get(reverse("dataset-structure-export", args=[dataset.pk, dataset.latest_version().pk]))
 
         assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
-            "1,example2,,,,,,,,,,,,,,,,,,Base Dataset,Dataset that references model with base",
-            "2,,,example/Animal,,,,,,,,,,,,,,,,,",
+            "1,datasets/gov/test/example2,,,,,,,,,,,,,,,,,,Base Dataset,Dataset that references model with base",
+            "2,,,datasets/gov/ivpk/example/Animal,,,,,,,,,,,,,,,,,",
             "3,,,,Dog,,,,,,,,,0,completed,public,,,,,",
             "4,,,,,action,string,,source_dog_action,,,,,4,completed,package,protected,,,,",
             ",,,,,,,,,,,,,,,,,,,,",
@@ -7592,7 +7619,7 @@ class TestStructure(BaseTestCreateManifest):
 
         model_manifest = (
             "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description\n"
-            "1,example,,,,,,,,,,,,,,,,\n"
+            "1,datasets/gov/ivpk/example,,,,,,,,,,,,,,,,\n"
             "2,,,,Animal,,,,,,0,completed,public,,,,,\n"
             "3,,,,,id,string,,source_animal_id,,4,completed,package,protected,,,,\n"
         )
@@ -7600,20 +7627,25 @@ class TestStructure(BaseTestCreateManifest):
 
         base_manifest = (
             "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description\n"
-            "1,example2,,,,,,,,,,,,,,,,\n"
-            "2,,,example/Animal,,,,,,,1,completed,public,,,,,\n"
+            "1,datasets/gov/test/example2,,,,,,,,,,,,,,,,\n"
+            "2,,,datasets/gov/ivpk/example/Animal,,,,,,,1,completed,public,,,,,\n"
             "3,,,,Dog,,,,,,0,completed,public,,,,,\n"
             "4,,,,,action,string,,source_dog_action,,4,completed,package,protected,,,,\n"
             ",,,/,,,,,,,,,,,,,,\n"
         )
-        dataset = self._create_manifest(base_manifest, "Base Dataset", "Dataset that references model with base")
+        dataset = self._create_manifest(
+            base_manifest,
+            "Base Dataset",
+            "Dataset that references model with base",
+            whitelisted_names=["datasets/gov/test/"],
+        )
 
         response = app.get(reverse("dataset-structure-export", args=[dataset.pk, dataset.latest_version().pk]))
 
         assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
-            "1,example2,,,,,,,,,,,,,,,,,,Base Dataset,Dataset that references model with base",
+            "1,datasets/gov/test/example2,,,,,,,,,,,,,,,,,,Base Dataset,Dataset that references model with base",
             "3,,,,Dog,,,,,,,,,0,completed,public,,,,,",
             "4,,,,,action,string,,source_dog_action,,,,,4,completed,package,protected,,,,",
             ",,,,,,,,,,,,,,,,,,,,",
@@ -7622,7 +7654,7 @@ class TestStructure(BaseTestCreateManifest):
         error_comment = Comment.objects.get(content_type=ContentType.objects.get_for_model(Model))
         assert error_comment.type == Comment.STRUCTURE_ERROR
         assert error_comment.body == (
-            "Nepavyko susieti bazinio modelio „example/Animal“. "
+            "Nepavyko susieti bazinio modelio „datasets/gov/ivpk/example/Animal“. "
             "Įsitikinkite, kad jis egzistuoja ir turi patvirtintą (stabilią) versiją."
         )
 
@@ -7632,7 +7664,7 @@ class TestStructure(BaseTestCreateManifest):
 
         manifest = (
             "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description\n"
-            "1,example,,,,,,,,,,,,,,,,\n"
+            "1,datasets/gov/ivpk/example,,,,,,,,,,,,,,,,\n"
             "2,,,Animal,,,,,,,1,completed,public,,,,,\n"
             "3,,,,Dog,,,,,,0,completed,public,,,,,\n"
             "4,,,,,action,string,,source_dog_action,,4,completed,package,protected,,,,\n"
@@ -7646,7 +7678,7 @@ class TestStructure(BaseTestCreateManifest):
         assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [  # Base could not be linked, so it is missing.
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
-            "1,example,,,,,,,,,,,,,,,,,,Dataset,Dataset with ref property",
+            "1,datasets/gov/ivpk/example,,,,,,,,,,,,,,,,,,Dataset,Dataset with ref property",
             "3,,,,Dog,,,,,,,,,0,completed,public,,,,,",
             "4,,,,,action,string,,source_dog_action,,,,,4,completed,package,protected,,,,",
             ",,,,,,,,,,,,,,,,,,,,",
@@ -7655,7 +7687,7 @@ class TestStructure(BaseTestCreateManifest):
         error_comment = Comment.objects.get(content_type=ContentType.objects.get_for_model(Model))
         assert error_comment.type == Comment.STRUCTURE_ERROR
         assert error_comment.body == (
-            "Nepavyko susieti bazinio modelio „example/Animal“. "
+            "Nepavyko susieti bazinio modelio „datasets/gov/ivpk/example/Animal“. "
             "Įsitikinkite, kad jis egzistuoja ir turi patvirtintą (stabilią) versiją."
         )
 
@@ -7665,7 +7697,7 @@ class TestStructure(BaseTestCreateManifest):
 
         manifest = (
             "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description\n"
-            "1,dataset,,,,,,,,,,,,,,,,\n"
+            "1,datasets/gov/ivpk/test,,,,,,,,,,,,,,,,\n"
             "2,,,,Animal,,,,source_animal_model,,,,,,,,,\n"
             '3,,,,,,comment,model,,"update(model: ""Animal/:part"")",2,completed,protected,open,https://github.com/example/issues/1,,,\n'
             "4,,,,,id,string,,source_animal_id,,4,,,,,,,\n"
@@ -7680,7 +7712,7 @@ class TestStructure(BaseTestCreateManifest):
         assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
-            "1,dataset,,,,,,,,,,,,,,,,,,Dataset,Dataset with ref property",
+            "1,datasets/gov/ivpk/test,,,,,,,,,,,,,,,,,,Dataset,Dataset with ref property",
             "2,,,,Animal,,,,source_animal_model,,,,,,develop,,,,,,",
             '3,,,,,,comment,model,,,"update(model: ""Animal/:part"")",,,2,develop,,open,https://github.com/example/issues/1,,,',
             "4,,,,,id,string,,source_animal_id,,,,,4,develop,,,,,,",
@@ -7752,7 +7784,6 @@ class TestStructureExportDependentModels(BaseTestCreateManifest):
     def test_structure_export_dependent_models(self, app: DjangoTestApp):
         user = UserFactory(is_staff=True)
         app.set_user(user)
-
         ref_manifest = (
             "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
             "7,datasets/gov/ref/dataset,,,,,,,,,,,,,,,,,\n"
@@ -7760,7 +7791,12 @@ class TestStructureExportDependentModels(BaseTestCreateManifest):
             "9,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n"
             "10,,,,,title,string,,,,5,,,open,dct:title,,,,\n"
         )
-        ref_dataset = self._create_manifest(ref_manifest, "Referenced Dataset", "Dataset that will be referenced")
+        ref_dataset = self._create_manifest(
+            ref_manifest,
+            "Referenced Dataset",
+            "Dataset that will be referenced",
+            whitelisted_names=["datasets/gov/ref/"],
+        )
 
         main_manifest = (
             "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
@@ -7771,7 +7807,12 @@ class TestStructureExportDependentModels(BaseTestCreateManifest):
             "5,,,,,title,string,,,,5,,,open,dct:title,,,,\n"
             "6,,,,,continent,ref,/datasets/gov/ref/dataset/Continent,,,5,,,open,dct:continent,,,,\n"
         )
-        main_dataset = self._create_manifest(main_manifest, "Main Dataset", "Dataset with reference to other dataset")
+        main_dataset = self._create_manifest(
+            main_manifest,
+            "Main Dataset",
+            "Dataset with reference to other dataset",
+            whitelisted_names=["datasets/gov/main/"],
+        )
 
         country_model = Model.objects.get(dataset=main_dataset, metadata__name="datasets/gov/main/dataset/Country")
         continent_model = Model.objects.get(dataset=ref_dataset, metadata__name="datasets/gov/ref/dataset/Continent")
@@ -7811,7 +7852,12 @@ class TestStructureExportDependentModels(BaseTestCreateManifest):
             "10,,,,,title,string,,,,5,,,open,dct:title,,,,\n"
             "11,,,,,other,string,,,,5,,,open,dct:other,,,,\n"
         )
-        self._create_manifest(ref_manifest, "Referenced Dataset", "Dataset that will be referenced")
+        self._create_manifest(
+            ref_manifest,
+            "Referenced Dataset",
+            "Dataset that will be referenced",
+            whitelisted_names=["datasets/gov/ref/"],
+        )
 
         main_manifest = (
             "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
@@ -7822,7 +7868,12 @@ class TestStructureExportDependentModels(BaseTestCreateManifest):
             "5,,,,,title,string,,,,5,,,open,dct:title,,,,\n"
             "6,,,,,continent,ref,/datasets/gov/ref/dataset/Continent,,,5,,,open,dct:continent,,,,\n"
         )
-        main_dataset = self._create_manifest(main_manifest, "Main Dataset", "Dataset with reference to other dataset")
+        main_dataset = self._create_manifest(
+            main_manifest,
+            "Main Dataset",
+            "Dataset with reference to other dataset",
+            whitelisted_names=["datasets/gov/main/"],
+        )
 
         resp = app.get(reverse("dataset-structure-export", args=[main_dataset.pk, main_dataset.latest_version().pk]))
         assert resp.text == (
@@ -7852,7 +7903,9 @@ class TestStructureExportDependentModels(BaseTestCreateManifest):
             "14,,,,,title,string,,,,5,,,open,dct:title,,,,\n"
             "15,,,,,other,string,,,,5,,,open,dct:other,,,,\n"
         )
-        self._create_manifest(other_manifest, "Other Dataset", "Dependent dataset depth 2")
+        self._create_manifest(
+            other_manifest, "Other Dataset", "Dependent dataset depth 2", whitelisted_names=["datasets/gov/other/"]
+        )
         ref_manifest = (
             "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
             "7,datasets/gov/ref/dataset,,,,,,,,,,,,,,,,,\n"
@@ -7861,7 +7914,9 @@ class TestStructureExportDependentModels(BaseTestCreateManifest):
             "10,,,,,title,ref,/datasets/gov/other/dataset/Other,,,5,,,open,dct:title,,,,\n"
             "11,,,,,other,string,,,,5,,,open,dct:other,,,,\n"
         )
-        self._create_manifest(ref_manifest, "Referenced Dataset", "Dependent dataset depth 1")
+        self._create_manifest(
+            ref_manifest, "Referenced Dataset", "Dependent dataset depth 1", whitelisted_names=["datasets/gov/ref/"]
+        )
 
         main_manifest = (
             "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
@@ -7872,7 +7927,9 @@ class TestStructureExportDependentModels(BaseTestCreateManifest):
             "5,,,,,title,string,,,,5,,,open,dct:title,,,,\n"
             "6,,,,,continent,ref,/datasets/gov/ref/dataset/Continent,,,5,,,open,dct:continent,,,,\n"
         )
-        main_dataset = self._create_manifest(main_manifest, "Main Dataset", "Root dataset")
+        main_dataset = self._create_manifest(
+            main_manifest, "Main Dataset", "Root dataset", whitelisted_names=["datasets/gov/main/"]
+        )
 
         resp = app.get(reverse("dataset-structure-export", args=[main_dataset.pk, main_dataset.latest_version().pk]))
         assert resp.text == (
@@ -7907,7 +7964,12 @@ class TestStructureExportDependentModels(BaseTestCreateManifest):
             "5,,,,,title,string,,,,5,,,open,dct:title,,,,\n"
             "6,,,,,continent,ref,/datasets/gov/ref/dataset/Continent,,,5,,,open,dct:continent,,,,\n"
         )
-        main_dataset = self._create_manifest(main_manifest, "Main Dataset", "Dataset with reference to other dataset")
+        main_dataset = self._create_manifest(
+            main_manifest,
+            "Main Dataset",
+            "Dataset with reference to other dataset",
+            whitelisted_names=["datasets/gov/main/"],
+        )
 
         resp = app.get(reverse("dataset-structure-export", args=[main_dataset.pk, main_dataset.latest_version().pk]))
         assert resp.text == (
@@ -7940,7 +8002,12 @@ class TestStructureExportDependentModels(BaseTestCreateManifest):
             "16,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n"
             "17,,,,,prop2,string,,,,5,,,open,dct:prop2,,,,\n"
         )
-        self._create_manifest(ref_depth_1_manifest, "Referenced Dataset", "Dataset with reference to other dataset")
+        self._create_manifest(
+            ref_depth_1_manifest,
+            "Referenced Dataset",
+            "Dataset with reference to other dataset",
+            whitelisted_names=["datasets/gov/ref/"],
+        )
         main_manifest = (
             "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
             "1,datasets/gov/main/dataset,,,,,,,,,,,,,,,,,\n"
@@ -7951,7 +8018,12 @@ class TestStructureExportDependentModels(BaseTestCreateManifest):
             "6,,,,,prop2,ref,/datasets/gov/ref/d1/D1Model1,,,5,,,open,dct:prop2,,,,\n"
             "7,,,,,prop3,ref,/datasets/gov/ref/d1/D1Model2,,,5,,,open,dct:prop3,,,,\n"
         )
-        main_dataset = self._create_manifest(main_manifest, "Main Dataset", "Dataset with reference to other dataset")
+        main_dataset = self._create_manifest(
+            main_manifest,
+            "Main Dataset",
+            "Dataset with reference to other dataset",
+            whitelisted_names=["datasets/gov/main/"],
+        )
         resp = app.get(reverse("dataset-structure-export", args=[main_dataset.pk, main_dataset.latest_version().pk]))
         assert resp.text == (
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
@@ -7981,35 +8053,39 @@ class TestStructureExportDependentModels(BaseTestCreateManifest):
 
         orphan_manifest = (
             "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
-            "20,datasets/gov/orphan,,,,,,,,,,,,,,,,,\n"
+            "20,datasets/gov/orphan/dataset,,,,,,,,,,,,,,,,,\n"
             "21,,,,Orphan,,,id,,,,,,,,,,,\n"
             "22,,,,,id,integer,,,,5,,,open,,,,,\n"
         )
-        self._create_manifest(orphan_manifest, "Orphan Dataset", "Should not be included")
+        self._create_manifest(
+            orphan_manifest, "Orphan Dataset", "Should not be included", whitelisted_names=["datasets/gov/orphan/"]
+        )
 
         ref_manifest = (
             "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
-            "10,datasets/gov/ref,,,,,,,,,,,,,,,,,\n"
+            "10,datasets/gov/ref/dataset,,,,,,,,,,,,,,,,,\n"
             "11,,,,RefModel,,,id,,,,,,,,,,,\n"
             "12,,,,,id,integer,,,,5,,,open,,,,,\n"
-            "13,,,,,non_pk_ref,ref,/datasets/gov/orphan/Orphan,,,5,,,open,,,,,\n"
+            "13,,,,,non_pk_ref,ref,/datasets/gov/orphan/dataset/Orphan,,,5,,,open,,,,,\n"
         )
-        self._create_manifest(ref_manifest, "Ref Dataset", "Has non-PK ref")
+        self._create_manifest(ref_manifest, "Ref Dataset", "Has non-PK ref", whitelisted_names=["datasets/gov/ref/"])
 
         main_manifest = (
             "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
-            "1,datasets/gov/main,,,,,,,,,,,,,,,,,\n"
+            "1,datasets/gov/main/dataset,,,,,,,,,,,,,,,,,\n"
             "2,,,,Main,,,id,,,,,,,,,,,\n"
             "3,,,,,id,integer,,,,5,,,open,,,,,\n"
-            "4,,,,,ref_prop,ref,/datasets/gov/ref/RefModel,,,5,,,open,,,,,\n"
+            "4,,,,,ref_prop,ref,/datasets/gov/ref/dataset/RefModel,,,5,,,open,,,,,\n"
         )
-        main_dataset = self._create_manifest(main_manifest, "Main Dataset", "Root")
+        main_dataset = self._create_manifest(
+            main_manifest, "Main Dataset", "Root", whitelisted_names=["datasets/gov/main/"]
+        )
 
         resp = app.get(reverse("dataset-structure-export", args=[main_dataset.pk, main_dataset.latest_version().pk]))
 
-        assert "datasets/gov/ref" in resp.text
+        assert "datasets/gov/ref/dataset" in resp.text
         assert "RefModel" in resp.text
-        assert "datasets/gov/orphan" not in resp.text
+        assert "datasets/gov/orphan/dataset" not in resp.text
         assert "Orphan" not in resp.text
 
     @pytest.mark.django_db
@@ -8019,37 +8095,46 @@ class TestStructureExportDependentModels(BaseTestCreateManifest):
 
         orphan_manifest = (
             "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
-            "20,datasets/gov/orphan,,,,,,,,,,,,,,,,,\n"
+            "20,datasets/gov/orphan/dataset,,,,,,,,,,,,,,,,,\n"
             "21,,,,OrphanModel,,,id,,,,,,,,,,,\n"
             "22,,,,,id,integer,,,,5,,,open,dct:identifier,,,,\n"
         )
-        self._create_manifest(orphan_manifest, "Orphan Dataset", "Should NOT be included - no path through no-PK model")
+        self._create_manifest(
+            orphan_manifest,
+            "Orphan Dataset",
+            "Should NOT be included - no path through no-PK model",
+            whitelisted_names=["datasets/gov/orphan/"],
+        )
 
         ref_manifest = (
             "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
-            "10,datasets/gov/ref,,,,,,,,,,,,,,,,,\n"
+            "10,datasets/gov/ref/dataset,,,,,,,,,,,,,,,,,\n"
             "11,,,,NoPkModel,,,,,,,,,,,,,,\n"  # No PK defined (empty ref column)
             "12,,,,,id,integer,,,,5,,,open,dct:identifier,,,,\n"
             "13,,,,,title,string,,,,5,,,open,dct:title,,,,\n"
-            "14,,,,,orphan_ref,ref,/datasets/gov/orphan/OrphanModel,,,5,,,open,dct:orphan,,,,\n"
+            "14,,,,,orphan_ref,ref,/datasets/gov/orphan/dataset/OrphanModel,,,5,,,open,dct:orphan,,,,\n"
         )
-        self._create_manifest(ref_manifest, "Ref Dataset", "Has no PK, refs to orphan")
+        self._create_manifest(
+            ref_manifest, "Ref Dataset", "Has no PK, refs to orphan", whitelisted_names=["datasets/gov/ref/"]
+        )
 
         main_manifest = (
             "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
-            "1,datasets/gov/main,,,,,,,,,,,,,,,,,\n"
+            "1,datasets/gov/main/dataset,,,,,,,,,,,,,,,,,\n"
             "2,,,,MainModel,,,id,,,,,,,,,,,\n"
             "3,,,,,id,integer,,,,5,,,open,dct:identifier,,,,\n"
-            "4,,,,,no_pk_ref,ref,/datasets/gov/ref/NoPkModel,,,5,,,open,dct:ref,,,,\n"
+            "4,,,,,no_pk_ref,ref,/datasets/gov/ref/dataset/NoPkModel,,,5,,,open,dct:ref,,,,\n"
         )
-        main_dataset = self._create_manifest(main_manifest, "Main Dataset", "Root")
+        main_dataset = self._create_manifest(
+            main_manifest, "Main Dataset", "Root", whitelisted_names=["datasets/gov/main/"]
+        )
 
         resp = app.get(reverse("dataset-structure-export", args=[main_dataset.pk, main_dataset.latest_version().pk]))
 
-        assert "datasets/gov/ref" in resp.text
+        assert "datasets/gov/ref/dataset" in resp.text
         assert "NoPkModel" in resp.text
 
-        assert "datasets/gov/orphan" not in resp.text
+        assert "datasets/gov/orphan/dataset" not in resp.text
         assert "OrphanModel" not in resp.text
 
         lines = resp.text.split("\r\n")

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -7729,7 +7729,7 @@ class TestStructure(BaseTestCreateManifest):
 
         manifest = (
             "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description\n"
-            "1,dataset,,,,,,,,,,,,,,,,\n"
+            "1,datasets/gov/ivpk/dataset,,,,,,,,,,,,,,,,\n"
             "2,,,,Approver,,,,,,1,,,,,,,\n"
             "3,,,,,is_active,boolean,,IsActive/text(),,,,,4,,,,,,,\n"
             "4,,,,,,enum,,True,true,,,,,,,,,,,\n"
@@ -7742,7 +7742,7 @@ class TestStructure(BaseTestCreateManifest):
         assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
-            "1,dataset,,,,,,,,,,,,,,,,,,Dataset,Dataset",
+            "1,datasets/gov/ivpk/dataset,,,,,,,,,,,,,,,,,,Dataset,Dataset",
             "2,,,,Approver,,,,,,,,,1,develop,,,,,,",
             "3,,,,,is_active,boolean,,IsActive/text(),,,,,,develop,,,,,,",
             "4,,,,,,enum,,True,,true,,,,develop,,,,,,",
@@ -7756,7 +7756,7 @@ class TestStructure(BaseTestCreateManifest):
 
         manifest = (
             "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description\n"
-            "1,example,,,,,,,,,,,,,,,,\n"
+            "1,datasets/gov/ivpk/example,,,,,,,,,,,,,,,,\n"
             "2,,,,Dataset,,,,,,1,,,,,,,\n"
             "3,,,,,type,number required,,TypeID/text(),,,,,4,,,,,,,\n"
             "4,,,,,,enum,,1.1,1.2,,,,,,,,,,,\n"
@@ -7769,7 +7769,7 @@ class TestStructure(BaseTestCreateManifest):
         assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
-            "1,example,,,,,,,,,,,,,,,,,,Dataset,Dataset",
+            "1,datasets/gov/ivpk/example,,,,,,,,,,,,,,,,,,Dataset,Dataset",
             "2,,,,Dataset,,,,,,,,,1,develop,,,,,,",
             "3,,,,,type,number required,,TypeID/text(),,,,,,develop,,,,,,",
             "4,,,,,,enum,,1.1,,1.2,,,,develop,,,,,,",

--- a/tests/uapi/conftest.py
+++ b/tests/uapi/conftest.py
@@ -121,7 +121,7 @@ def dataset(organization: Organization, agent: Agent) -> Dataset:
         organization=organization,
         title="Title of the Dataset",
         description="Description of the Dataset.",
-        metadata=organization.name + "test/dataset",
+        metadata=f"{organization.name}test/dataset",
         agent=agent,
     )
     return dataset
@@ -156,7 +156,7 @@ def distribution(organization: Organization, dataset: Dataset) -> DatasetDistrib
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(DatasetDistribution),
         object_id=distribution.pk,
-        name=organization.name + "test/dataset/TestModel/TestDistribution",
+        name=f"{organization.name}test/dataset/TestModel/TestDistribution",
     )
     return distribution
 

--- a/tests/uapi/conftest.py
+++ b/tests/uapi/conftest.py
@@ -121,7 +121,7 @@ def dataset(organization: Organization, agent: Agent) -> Dataset:
         organization=organization,
         title="Title of the Dataset",
         description="Description of the Dataset.",
-        metadata="test/dataset",
+        metadata=organization.name + "test/dataset",
         agent=agent,
     )
     return dataset
@@ -156,7 +156,7 @@ def distribution(organization: Organization, dataset: Dataset) -> DatasetDistrib
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(DatasetDistribution),
         object_id=distribution.pk,
-        name="test/dataset/TestModel/TestDistribution",
+        name=organization.name + "test/dataset/TestModel/TestDistribution",
     )
     return distribution
 
@@ -197,9 +197,10 @@ def agreement_url() -> str:
 
 
 @pytest.fixture
-def dsa() -> str:
-    return """id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description
-,test/dataset,,,,,,,,,,,,,,,,,
+def dsa(organization: Organization) -> str:
+    name = organization.name
+    return f"""id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description
+,{name}test/dataset,,,,,,,,,,,,,,,,,
 ,,users,,,,dask/json,,/path,,,,,,,,,,
 ,,,,,,,,,,,,,,,,,,
 ,,,,User,,,id,users,,,4,completed,package,open,,,Pavadinimas,

--- a/tests/uapi/dataset/test_views.py
+++ b/tests/uapi/dataset/test_views.py
@@ -1063,12 +1063,12 @@ class TestActionGetDatasetStructure:
 
         assert response.status_code == status.HTTP_200_OK
         assert response.headers["Content-Type"] == "text/csv"
-
+        name = dataset.organization.name
         metadata_to_id_map = dict(Metadata.objects.filter(metadata_version=version).values_list("name", "uuid"))
         expected_csv = f"""id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description
-{metadata_to_id_map["test/dataset"]},test/dataset,,,,,,,,,,,,,,,,,,Title of the Dataset,Description of the Dataset.
+{metadata_to_id_map[f"{name}test/dataset"]},{name}test/dataset,,,,,,,,,,,,,,,,,,Title of the Dataset,Description of the Dataset.
 {metadata_to_id_map["users"]},,users,,,,dask/json,,/path,,,,,,,,,,,users,
-{metadata_to_id_map["test/dataset/User"]},,,,User,,,id,users,,,,,4,completed,package,open,,,Pavadinimas,
+{metadata_to_id_map[f"{name}test/dataset/User"]},,,,User,,,id,users,,,,,4,completed,package,open,,,Pavadinimas,
 {metadata_to_id_map["id"]},,,,,id,integer,,id,,,,,,develop,,,,,,
 {metadata_to_id_map["full_name"]},,,,,full_name,string,,name,,,,,,develop,,,,,,
 {metadata_to_id_map["email_address"]},,,,,email_address,string,,email,,,,,,develop,,,,,,

--- a/vitrina/datasets/factories.py
+++ b/vitrina/datasets/factories.py
@@ -132,7 +132,7 @@ class DatasetFactory(DjangoModelFactory):
             return
         if extracted is False:
             return
-        name = extracted if extracted is not None else ((self.organization.name or "test/dataset/") + "abcd")
+        name = extracted if extracted is not None else ((self.organization.name or "datasets/gov/test/") + "abcd")
 
         MetadataFactory.create(
             dataset=self, content_type=ContentType.objects.get_for_model(self), object_id=self.pk, name=name

--- a/vitrina/datasets/forms.py
+++ b/vitrina/datasets/forms.py
@@ -324,7 +324,7 @@ class BaseResourceForm(TranslatableModelForm):
             if any(ch.isupper() for ch in name):
                 raise ValidationError(_("Kodiniame pavadinime gali būti naudojamos tik mažosios raidės."))
             organization = self.organization or dataset_instance.organization
-            matched_prefix, main_prefix, whitelisted = validate_name_prefix(name, organization, dataset_instance)
+            _, main_prefix, whitelisted = validate_name_prefix(name, organization, dataset_instance)
             allowed_prefixes = [main_prefix] + list(whitelisted)
 
             representatives = Representative.objects.filter(
@@ -350,6 +350,7 @@ class BaseResourceForm(TranslatableModelForm):
                     allowed_prefixes.append(rep.content_object.name)
                     whitelisted.append(rep.content_object.name)
 
+            matched_prefix = next((prefix for prefix in allowed_prefixes if name.startswith(prefix)), None)
             if not matched_prefix:
                 if whitelisted:
                     message = _(

--- a/vitrina/datasets/forms.py
+++ b/vitrina/datasets/forms.py
@@ -31,6 +31,7 @@ from crispy_forms.layout import Field, Submit, Layout, HTML
 from haystack.forms import FacetedSearchForm
 from treebeard.forms import MoveNodeForm
 
+from vitrina.datasets.helpers import validate_name_prefix
 from vitrina.datasets.services import get_requests
 from vitrina.classifiers.models import Frequency, Category, Concept
 
@@ -323,8 +324,7 @@ class BaseResourceForm(TranslatableModelForm):
             if any(ch.isupper() for ch in name):
                 raise ValidationError(_("Kodiniame pavadinime gali būti naudojamos tik mažosios raidės."))
             organization = self.organization or dataset_instance.organization
-            whitelisted = organization.whitelisted_names or []
-            main_prefix = organization.name or ""
+            matched_prefix, main_prefix, whitelisted = validate_name_prefix(name, organization, dataset_instance)
             allowed_prefixes = [main_prefix] + list(whitelisted)
 
             representatives = Representative.objects.filter(
@@ -350,11 +350,6 @@ class BaseResourceForm(TranslatableModelForm):
                     allowed_prefixes.append(rep.content_object.name)
                     whitelisted.append(rep.content_object.name)
 
-            matched_prefix = None
-            for prefix in allowed_prefixes:
-                if name.startswith(prefix):
-                    matched_prefix = prefix
-                    break
             if not matched_prefix:
                 if whitelisted:
                     message = _(

--- a/vitrina/datasets/forms.py
+++ b/vitrina/datasets/forms.py
@@ -31,6 +31,7 @@ from crispy_forms.layout import Field, Submit, Layout, HTML
 from haystack.forms import FacetedSearchForm
 from treebeard.forms import MoveNodeForm
 
+from vitrina.datasets.helpers import validate_name_prefix
 from vitrina.datasets.services import get_requests
 from vitrina.classifiers.models import Frequency, Category, Concept
 

--- a/vitrina/datasets/forms.py
+++ b/vitrina/datasets/forms.py
@@ -31,7 +31,6 @@ from crispy_forms.layout import Field, Submit, Layout, HTML
 from haystack.forms import FacetedSearchForm
 from treebeard.forms import MoveNodeForm
 
-from vitrina.datasets.helpers import validate_name_prefix
 from vitrina.datasets.services import get_requests
 from vitrina.classifiers.models import Frequency, Category, Concept
 

--- a/vitrina/datasets/forms.py
+++ b/vitrina/datasets/forms.py
@@ -354,10 +354,10 @@ class BaseResourceForm(TranslatableModelForm):
             if not matched_prefix:
                 if whitelisted:
                     message = _(
-                        "Kodinis pavadinimas turi prasidėti nuo „%(expected)s“ arba vieno iš leidžiamų kodinio pavadinimo pradžių: %(whitelisted)s"
+                        "Kodinis pavadinimas turi prasidėti nuo „%(expected)s“ arba vieno iš leidžiamų kodinio pavadinimo pradžių: „%(whitelisted)s“."
                     ) % {"expected": main_prefix, "whitelisted": ", ".join(whitelisted)}
                 else:
-                    message = _("Kodinis pavadinimas turi prasidėti nuo „%(expected)s“") % {"expected": main_prefix}
+                    message = _("Kodinis pavadinimas turi prasidėti nuo „%(expected)s“.") % {"expected": main_prefix}
 
                 raise ValidationError(message)
             suffix = name[len(matched_prefix) :]

--- a/vitrina/datasets/forms.py
+++ b/vitrina/datasets/forms.py
@@ -324,7 +324,7 @@ class BaseResourceForm(TranslatableModelForm):
             if any(ch.isupper() for ch in name):
                 raise ValidationError(_("Kodiniame pavadinime gali būti naudojamos tik mažosios raidės."))
             organization = self.organization or dataset_instance.organization
-            _, main_prefix, whitelisted = validate_name_prefix(name, organization, dataset_instance)
+            _matched, main_prefix, whitelisted = validate_name_prefix(name, organization, dataset_instance)
             allowed_prefixes = [main_prefix] + list(whitelisted)
 
             representatives = Representative.objects.filter(

--- a/vitrina/datasets/helpers.py
+++ b/vitrina/datasets/helpers.py
@@ -70,3 +70,16 @@ def generate_unique_dataset_name(organization: Organization, dataset: Dataset) -
                 max_index = index + 1
 
     return f"{base_name}_{max_index}"
+
+
+def validate_name_prefix(
+    name: str,
+    organization: Organization | None,
+    dataset_instance: Dataset | None = None,
+) -> tuple[str | None, str, list[str]]:
+    resolved_organization = organization or (dataset_instance.organization if dataset_instance else None)
+    whitelisted: list[str] = resolved_organization.whitelisted_names or []
+    main_prefix: str = resolved_organization.name or ""
+    allowed_prefixes: list[str] = [main_prefix] + list(whitelisted)
+    matched_prefix: str | None = next((prefix for prefix in allowed_prefixes if name.startswith(prefix)), None)
+    return matched_prefix, main_prefix, whitelisted

--- a/vitrina/datasets/helpers.py
+++ b/vitrina/datasets/helpers.py
@@ -78,8 +78,8 @@ def validate_name_prefix(
     dataset_instance: Dataset | None = None,
 ) -> tuple[str | None, str, list[str]]:
     resolved_organization = organization or (dataset_instance.organization if dataset_instance else None)
-    whitelisted = resolved_organization.whitelisted_names or []
-    main_prefix = resolved_organization.name or ""
+    whitelisted = getattr(resolved_organization, "whitelisted_names", [])
+    main_prefix = getattr(resolved_organization, "name", "")
     allowed_prefixes = [main_prefix] + list(whitelisted)
-    matched_prefix = next((prefix for prefix in allowed_prefixes if name.startswith(prefix)), None)
+    matched_prefix = next((prefix for prefix in allowed_prefixes if prefix and name.startswith(prefix)), None)
     return matched_prefix, main_prefix, whitelisted

--- a/vitrina/datasets/helpers.py
+++ b/vitrina/datasets/helpers.py
@@ -78,8 +78,8 @@ def validate_name_prefix(
     dataset_instance: Dataset | None = None,
 ) -> tuple[str | None, str, list[str]]:
     resolved_organization = organization or (dataset_instance.organization if dataset_instance else None)
-    whitelisted: list[str] = resolved_organization.whitelisted_names or []
-    main_prefix: str = resolved_organization.name or ""
-    allowed_prefixes: list[str] = [main_prefix] + list(whitelisted)
-    matched_prefix: str | None = next((prefix for prefix in allowed_prefixes if name.startswith(prefix)), None)
+    whitelisted = resolved_organization.whitelisted_names or []
+    main_prefix = resolved_organization.name or ""
+    allowed_prefixes = [main_prefix] + list(whitelisted)
+    matched_prefix = next((prefix for prefix in allowed_prefixes if name.startswith(prefix)), None)
     return matched_prefix, main_prefix, whitelisted

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -711,14 +711,14 @@ msgstr "Code name can only include lowercase letters."
 #, python-format
 msgid ""
 "Kodinis pavadinimas turi prasidėti nuo „%(expected)s“ arba vieno iš "
-"leidžiamų kodinio pavadinimo pradžių: %(whitelisted)s"
+"leidžiamų kodinio pavadinimo pradžių: „%(whitelisted)s“."
 msgstr ""
 "The code name must begin with „%(expected)s“ or one of the following "
-"whitelisted code name prefixes: %(whitelisted)s"
+"whitelisted code name prefixes: „%(whitelisted)s“."
 
 #, python-format
-msgid "Kodinis pavadinimas turi prasidėti nuo „%(expected)s“"
-msgstr "The code name must begin with „%(expected)s“"
+msgid "Kodinis pavadinimas turi prasidėti nuo „%(expected)s“."
+msgstr "The code name must begin with „%(expected)s“."
 
 #, python-format
 msgid "Po „%(prefix)s“ turi būti bent vienas simbolis."

--- a/vitrina/orgs/factories.py
+++ b/vitrina/orgs/factories.py
@@ -37,7 +37,7 @@ class OrganizationFactory(DjangoModelFactory):
         return model_class.add_root(**kwargs)
 
     @factory.post_generation
-    def whitelisted_names(self, create, extracted, **kwargs):
+    def whitelisted_names(self, create: bool, extracted: list[str] | None, **kwargs) -> None:
         if not create:
             return
         if extracted:

--- a/vitrina/orgs/factories.py
+++ b/vitrina/orgs/factories.py
@@ -36,15 +36,22 @@ class OrganizationFactory(DjangoModelFactory):
             kwargs["created"] = timezone.now()
         return model_class.add_root(**kwargs)
 
-    @factory.post_generation
-    def whitelisted_names(self, create: bool, extracted: list[str] | None, **kwargs) -> None:
-        if not create:
-            return
-        if extracted:
-            for name in extracted:
-                WhitelistedCodeNameFactory(organization=self, code_name=name)
-        else:
-            WhitelistedCodeNameFactory(organization=self, code_name="datasets/gov/ivpk/")
+
+DEFAULT_WHITELISTED_NAMES = ["datasets/gov/ivpk/"]
+
+
+@factory.post_generation
+def whitelisted_names(self, create: bool, extracted: list[str] | None, **kwargs) -> None:
+    if not create:
+        return
+
+    names = extracted or DEFAULT_WHITELISTED_NAMES
+
+    for name in names:
+        WhitelistedCodeNameFactory(
+            organization=self,
+            code_name=name,
+        )
 
 
 class RepresentativeFactory(DjangoModelFactory):

--- a/vitrina/orgs/factories.py
+++ b/vitrina/orgs/factories.py
@@ -7,6 +7,9 @@ from vitrina.orgs.models import Organization, Representative, WhitelistedCodeNam
 from vitrina.users.factories import UserFactory
 
 
+DEFAULT_WHITELISTED_NAMES = ["datasets/gov/ivpk/"]
+
+
 class OrganizationFactory(DjangoModelFactory):
     class Meta:
         model = Organization
@@ -36,22 +39,18 @@ class OrganizationFactory(DjangoModelFactory):
             kwargs["created"] = timezone.now()
         return model_class.add_root(**kwargs)
 
+    @factory.post_generation
+    def whitelisted_names(self, create: bool, extracted: list[str] | None, **kwargs) -> None:
+        if not create:
+            return
 
-DEFAULT_WHITELISTED_NAMES = ["datasets/gov/ivpk/"]
+        names = extracted or DEFAULT_WHITELISTED_NAMES
 
-
-@factory.post_generation
-def whitelisted_names(self, create: bool, extracted: list[str] | None, **kwargs) -> None:
-    if not create:
-        return
-
-    names = extracted or DEFAULT_WHITELISTED_NAMES
-
-    for name in names:
-        WhitelistedCodeNameFactory(
-            organization=self,
-            code_name=name,
-        )
+        for name in names:
+            WhitelistedCodeNameFactory(
+                organization=self,
+                code_name=name,
+            )
 
 
 class RepresentativeFactory(DjangoModelFactory):

--- a/vitrina/orgs/factories.py
+++ b/vitrina/orgs/factories.py
@@ -36,6 +36,16 @@ class OrganizationFactory(DjangoModelFactory):
             kwargs["created"] = timezone.now()
         return model_class.add_root(**kwargs)
 
+    @factory.post_generation
+    def whitelisted_names(self, create, extracted, **kwargs):
+        if not create:
+            return
+        if extracted:
+            for name in extracted:
+                WhitelistedCodeNameFactory(organization=self, code_name=name)
+        else:
+            WhitelistedCodeNameFactory(organization=self, code_name="datasets/gov/ivpk/")
+
 
 class RepresentativeFactory(DjangoModelFactory):
     class Meta:
@@ -73,6 +83,7 @@ class ViispRepresentativeFactory(RepresentativeFactory):
 
 class WhitelistedCodeNameFactory(DjangoModelFactory):
     class Meta:
+        django_get_or_create = ("code_name",)
         model = WhitelistedCodeName
 
     organization = factory.SubFactory(OrganizationFactory)

--- a/vitrina/structure/services.py
+++ b/vitrina/structure/services.py
@@ -215,7 +215,6 @@ def _load_datasets(state: struct.State, dataset: Dataset, metadata_version: Vers
         ).only("pk", "object_id")
     )
     to_process, main_prefix, whitelisted = _get_manifest_datasets_to_import(state, dataset)
-    to_process = list(to_process)
     if not to_process:
         if whitelisted:
             message = _(

--- a/vitrina/structure/services.py
+++ b/vitrina/structure/services.py
@@ -218,10 +218,10 @@ def _load_datasets(state: struct.State, dataset: Dataset, metadata_version: Vers
     if not to_process:
         if whitelisted:
             message = _(
-                "Kodinis pavadinimas turi prasidėti nuo „%(expected)s“ arba vieno iš leidžiamų kodinio pavadinimo pradžių: „%(whitelisted)s“"
+                "Kodinis pavadinimas turi prasidėti nuo „%(expected)s“ arba vieno iš leidžiamų kodinio pavadinimo pradžių: „%(whitelisted)s“."
             ) % {"expected": main_prefix, "whitelisted": ", ".join(whitelisted)}
         else:
-            message = _("Kodinis pavadinimas turi prasidėti nuo „%(expected)s“") % {"expected": main_prefix}
+            message = _("Kodinis pavadinimas turi prasidėti nuo „%(expected)s“.") % {"expected": main_prefix}
         _create_errors([message], dataset.current_structure)
         metadata_version.delete()
         return metadata_version

--- a/vitrina/structure/services.py
+++ b/vitrina/structure/services.py
@@ -333,6 +333,22 @@ def _get_manifest_datasets_to_process(state: struct.State, dataset: Dataset) -> 
     return result
 
 
+def _get_manifest_dataset_to_import(state: struct.State, dataset: Dataset) -> tuple[int, struct.Dataset] | None:
+    """
+    Get the first manifest dataset to import.
+
+    - Name matches dataset.name: direct re-import case.
+    - Prefix matches: dataset belongs to the same organization namespace.
+    - Returns None if no valid dataset found.
+    """
+    datasets = list(state.manifest.datasets.values())
+    for order, meta in enumerate(datasets, 1):
+        matched_prefix, _, _ = validate_name_prefix(meta.name, dataset.organization, dataset)
+        if meta.name == dataset.name or matched_prefix:
+            return order, meta
+    return None
+
+
 def _load_prefixes(
     dataset: Dataset,
     prefixes: Dict[str, struct.Prefix],

--- a/vitrina/structure/services.py
+++ b/vitrina/structure/services.py
@@ -21,6 +21,7 @@ from django.utils.translation import gettext, gettext_lazy as _, get_language
 from vitrina import settings
 from vitrina.classifiers.models import Status
 from vitrina.comments.models import Comment
+from vitrina.datasets.helpers import validate_name_prefix
 from vitrina.datasets.models import DatasetStructure, Dataset
 from vitrina.datasets.structure import detect_read_errors, read
 from vitrina.helpers import none_to_string, get_encoding

--- a/vitrina/structure/services.py
+++ b/vitrina/structure/services.py
@@ -333,20 +333,21 @@ def _get_manifest_datasets_to_process(state: struct.State, dataset: Dataset) -> 
     return result
 
 
-def _get_manifest_dataset_to_import(state: struct.State, dataset: Dataset) -> tuple[int, struct.Dataset] | None:
+def _get_manifest_datasets_to_import(state: struct.State, dataset: Dataset) -> list[tuple[int, struct.Dataset]]:
     """
-    Get the first manifest dataset to import.
+    Get manifest datasets to import.
 
-    - Name matches dataset.name: direct re-import case.
-    - Prefix matches: dataset belongs to the same organization namespace.
-    - Returns None if no valid dataset found.
+    - Re-import: matches by dataset.name.
+    - First import: falls back to last dataset with a matching organization prefix.
     """
     datasets = list(state.manifest.datasets.values())
+    result: list[tuple[int, struct.Dataset]] = []
     for order, meta in enumerate(datasets, 1):
+        is_last = order == len(datasets)
         matched_prefix, _, _ = validate_name_prefix(meta.name, dataset.organization, dataset)
-        if meta.name == dataset.name or matched_prefix:
-            return order, meta
-    return None
+        if meta.name == dataset.name or (matched_prefix and is_last):
+            result.append((order, meta))
+    return result
 
 
 def _load_prefixes(

--- a/vitrina/structure/services.py
+++ b/vitrina/structure/services.py
@@ -214,7 +214,19 @@ def _load_datasets(state: struct.State, dataset: Dataset, metadata_version: Vers
             type=Comment.STRUCTURE,
         ).only("pk", "object_id")
     )
-    to_process = list(_get_manifest_datasets_to_process(state, dataset))
+    to_process, main_prefix, whitelisted = _get_manifest_datasets_to_import(state, dataset)
+    to_process = list(to_process)
+    if not to_process:
+        if whitelisted:
+            message = _(
+                "Kodinis pavadinimas turi prasidėti nuo „%(expected)s“ arba vieno iš leidžiamų kodinio pavadinimo pradžių: „%(whitelisted)s“"
+            ) % {"expected": main_prefix, "whitelisted": ", ".join(whitelisted)}
+        else:
+            message = _("Kodinis pavadinimas turi prasidėti nuo „%(expected)s“") % {"expected": main_prefix}
+        _create_errors([message], dataset.current_structure)
+        metadata_version.delete()
+        return metadata_version
+
     manifest_names = list({manifest.name for _, manifest in to_process if manifest.name})
 
     dataset_meta_uuid_by_name: dict[str, uuid.UUID] = {}
@@ -333,21 +345,26 @@ def _get_manifest_datasets_to_process(state: struct.State, dataset: Dataset) -> 
     return result
 
 
-def _get_manifest_datasets_to_import(state: struct.State, dataset: Dataset) -> list[tuple[int, struct.Dataset]]:
+def _get_manifest_datasets_to_import(
+    state: struct.State, dataset: Dataset
+) -> tuple[list[tuple[int, struct.Dataset]], str, list[str]]:
     """
     Get manifest datasets to import.
 
     - Re-import: matches by dataset.name.
     - First import: falls back to last dataset with a matching organization prefix.
+
+    Also returns main_prefix and whitelisted for error reporting.
     """
     datasets = list(state.manifest.datasets.values())
     result: list[tuple[int, struct.Dataset]] = []
+    main_prefix, whitelisted = "", []
     for order, meta in enumerate(datasets, 1):
         is_last = order == len(datasets)
-        matched_prefix, _, _ = validate_name_prefix(meta.name, dataset.organization, dataset)
+        matched_prefix, main_prefix, whitelisted = validate_name_prefix(meta.name, dataset.organization, dataset)
         if meta.name == dataset.name or (matched_prefix and is_last):
             result.append((order, meta))
-    return result
+    return result, main_prefix, whitelisted
 
 
 def _load_prefixes(


### PR DESCRIPTION
Summary:

- Moved inline prefix validation into a reusable `validate_name_prefix` function to eliminate duplicated logic across call sites.

- Added `_get_manifest_datasets_to_import` mirroring `_get_manifest_datasets_to_process`, but matching by organization prefix instead of `is_last`. Returns `main_prefix` and `whitelisted` alongside results to avoid redundant calls in the caller.
- Updated tests to use correct `dataset` `name` values

Ticket: https://github.com/atviriduomenys/katalogas/issues/2461