### PR TITLE
[2522] Adjust template formatting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,10 @@ https://github.com/atviriduomenys/katalogas/issues/2461
 
 -  Implement dataset name check in manifest read
 
+https://github.com/atviriduomenys/katalogas/issues/2522
+
+- Added formatting for HTML tags to be rendered correctly and we would not have laying HTML tags in description text fields.
+
 
 v 1.17.1 (2026-03-30)
 ==================

--- a/vitrina/datasets/templates/vitrina/datasets/detail.html
+++ b/vitrina/datasets/templates/vitrina/datasets/detail.html
@@ -4,6 +4,7 @@
 {% load hitcount_tags %}
 {% load subscription_tags %}
 {% load comment_tags %}
+{% load markdown_tags %}
 {% block pageTitle %}| {{ dataset.title }}{% endblock %}
 {% block pageDescription %}{{ dataset.description | escape }}{% endblock %}
 {% if dataset.organization %}
@@ -71,7 +72,7 @@
             <div class="content">
                 <p class="no-margin-bottom">
                     {% objectlanguage dataset LANGUAGE_CODE %}
-                    {{ dataset.description | linebreaks | urlizetrunc:42 }}
+                    {{ dataset.description | markdown | safe | urlizetrunc:42 }}
                 {% endobjectlanguage %}
             </p>
             {# tags #}

--- a/vitrina/datasets/templates/vitrina/datasets/list.html
+++ b/vitrina/datasets/templates/vitrina/datasets/list.html
@@ -3,6 +3,7 @@
 {% load i18n parler_tags %}
 {% load hitcount_tags %}
 {% load util_tags %}
+{% load markdown_tags %}
 
 {% block pageTitle %} | {% translate "Duomenų ištekliai" %}{% endblock %}
 {% block pageOgTitle %} | {% translate "Duomenų ištekliai" %}{% endblock %}
@@ -254,7 +255,7 @@
                                     <p class="dataset-list-description my-1">
                                         {% if i.object %}
                                             {% objectlanguage i.object LANGUAGE_CODE %}
-                                                {{ i.object.description|escape }}
+                                                {{ i.object.description|markdown|safe }}
                                             {% endobjectlanguage %}
                                         {% else %}
                                             {# TODO: https://github.com/atviriduomenys/katalogas/issues/240 #}

--- a/vitrina/tasks/templates/vitrina/tasks/detail.html
+++ b/vitrina/tasks/templates/vitrina/tasks/detail.html
@@ -21,7 +21,7 @@
                                 <p class="dataset-list-title">{{ task.created }}</p>
                                 <p class="dataset-list-description">
                                     {% if task.description is not None %}
-                                        {{ task.description | markdown }}
+                                        {{ task.description | markdown | safe }}
                                     {% endif %}
                                 </p>
                                 {% if task.content_object is not None %}

--- a/vitrina/tasks/templates/vitrina/tasks/list.html
+++ b/vitrina/tasks/templates/vitrina/tasks/list.html
@@ -132,7 +132,7 @@
                             </div>
                             <div class="columns">
                                 <div class="column is-12">
-                                    <p>{{ i.description | markdown }}</p>
+                                    <p>{{ i.description | markdown | safe }}</p>
                                 </div>
                             </div>
                         </div>

--- a/vitrina/templatetags/markdown_tags.py
+++ b/vitrina/templatetags/markdown_tags.py
@@ -12,12 +12,12 @@ register = template.Library()
 @stringfilter
 def markdown(value):
     """
-    Convert markdown to HTML and sanitize for XSS protection.
+    Convert Markdown to HTML and sanitize for XSS protection.
 
-    This filter processes markdown and ensures the output is safe
+    This filter processes Markdown and ensures the output is safe
     by removing any malicious scripts or HTML.
     """
-    # Convert markdown to HTML
+    # Convert Markdown to HTML
     html = md.markdown(value, extensions=["markdown.extensions.fenced_code"])
 
     # Sanitize the HTML to prevent XSS


### PR DESCRIPTION
Adjust the formatting for some templates.

### The problem

Some HTML templates were missing particular tags to ensure that HTML tags are rendered correctly.

- `markdown` is responsible for sanitizing the input
-  `safe` is responsible for telling Django it is OK to render the HTML tags (because they've been cleaned previously)

### Results:

#### Dataset list:

##### Before:
<img width="1053" height="288" alt="image" src="https://github.com/user-attachments/assets/204ae3f9-144d-49bb-8b06-d14424b5711d" />

##### After:
<img width="681" height="282" alt="image" src="https://github.com/user-attachments/assets/ba78210c-c549-49f1-bfb6-f6592e3c6f9b" />

#### Dataset detail:

##### Before:
<img width="1053" height="288" alt="image" src="https://github.com/user-attachments/assets/047c04b8-e8e9-4728-8035-a905d7f67ad4" />

##### After:
<img width="681" height="282" alt="image" src="https://github.com/user-attachments/assets/1e6fe740-3b64-49cb-8158-1baf5f73a33c" />

#### Task list:

##### Before:
<img width="1053" height="288" alt="image" src="https://github.com/user-attachments/assets/a44a877b-f439-4ced-abef-9dfb9f6550ad" />

##### After:
<img width="1053" height="288" alt="image" src="https://github.com/user-attachments/assets/adb5a312-77d4-4488-a24f-ba993f63d79f" />

#### Task detail:

##### Before:
<img width="1053" height="288" alt="image" src="https://github.com/user-attachments/assets/9392a9b3-8445-4994-a028-d88ca06485a8" />

##### After:
<img width="1053" height="288" alt="image" src="https://github.com/user-attachments/assets/3f0dae90-3958-4dbf-8eb2-ec3cbc4cc673" />
