### PR TITLE
[538]: Updating is_open_data_representative_for to check representative also for ancestor datasets

### DIFF
--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -256,3 +256,79 @@ class TestIsOpenDataRepresentativeFor:
         )
 
         assert user.is_open_data_representative_for(dataset) is False
+
+    def test_returns_true_if_user_represents_parent_dataset(self):
+        parent_dataset = DatasetFactory()
+        child_dataset = DatasetFactory()
+        child_dataset.move(parent_dataset, pos="sorted-child")
+        child_dataset.refresh_from_db()
+        user = UserFactory()
+
+        RepresentativeFactory(
+            content_type=ContentType.objects.get_for_model(parent_dataset),
+            object_id=parent_dataset.pk,
+            user=user,
+            role=Representative.OPEN_DATA_MANAGER,
+        )
+
+        assert user.is_open_data_representative_for(child_dataset) is True
+
+    def test_returns_true_if_user_represents_grandparent_dataset(self):
+        grandparent_dataset = DatasetFactory()
+        parent_dataset = DatasetFactory()
+        child_dataset = DatasetFactory()
+        parent_dataset.move(grandparent_dataset, pos="sorted-child")
+        parent_dataset.refresh_from_db()
+        child_dataset.move(parent_dataset, pos="sorted-child")
+        child_dataset.refresh_from_db()
+        grandparent_dataset.refresh_from_db()
+        user = UserFactory()
+
+        RepresentativeFactory(
+            content_type=ContentType.objects.get_for_model(grandparent_dataset),
+            object_id=grandparent_dataset.pk,
+            user=user,
+            role=Representative.OPEN_DATA_MANAGER,
+        )
+
+        assert user.is_open_data_representative_for(child_dataset) is True
+
+    def test_returns_false_if_user_represents_child_but_not_parent(self):
+        parent_dataset = DatasetFactory()
+        child_dataset = DatasetFactory()
+        child_dataset.move(parent_dataset, pos="sorted-child")
+        child_dataset.refresh_from_db()
+        user = UserFactory()
+
+        RepresentativeFactory(
+            content_type=ContentType.objects.get_for_model(child_dataset),
+            object_id=child_dataset.pk,
+            user=user,
+            role=Representative.OPEN_DATA_MANAGER,
+        )
+
+        assert user.is_open_data_representative_for(parent_dataset) is False
+
+    def test_returns_true_if_users_organization_represents_parent_dataset(self):
+        user_organization = OrganizationFactory()
+        parent_dataset = DatasetFactory()
+        child_dataset = DatasetFactory()
+        child_dataset.move(parent_dataset, pos="sorted-child")
+        child_dataset.refresh_from_db()
+        user = UserFactory()
+
+        RepresentativeFactory(
+            content_type=ContentType.objects.get_for_model(user_organization),
+            object_id=user_organization.pk,
+            user=user,
+            role=Representative.OPEN_DATA_MANAGER,
+        )
+
+        RepresentativeFactory(
+            content_type=ContentType.objects.get_for_model(parent_dataset),
+            object_id=parent_dataset.pk,
+            organization=user_organization,
+            role=Representative.OPEN_DATA_MANAGER,
+        )
+
+        assert user.is_open_data_representative_for(child_dataset) is True

--- a/vitrina/datasets/forms.py
+++ b/vitrina/datasets/forms.py
@@ -107,8 +107,7 @@ class ResourceSubclassForm(TranslatableModelForm, TranslatableModelFormMixin):
             parent = None
 
         if user and (
-            (self.organization and user.is_open_data_representative_for(self.organization))
-            or user.is_open_data_representative_for(parent)
+            user.is_open_data_representative_for(self.organization) or user.is_open_data_representative_for(parent)
         ):
             self.fields["subclass"].queryset = DCATResourceSubclass.objects.exclude(
                 name=DCATResourceSubclass.INFORMATION_SYSTEM

--- a/vitrina/orgs/forms.py
+++ b/vitrina/orgs/forms.py
@@ -455,11 +455,9 @@ class RepresentativeCreateForm(ModelForm):
         self.object = kwargs.pop("object")
         super().__init__(*args, **kwargs)
 
-        content_type = ContentType.objects.get_for_model(self.object_model)
-
         self.fields["role"].choices = (
             Representative.OPEN_DATA_ROLES
-            if Representative.is_open_data_coordinator(self.user, content_type, self.object.pk)
+            if self.user.is_open_data_coordinator_for(self.object)
             else Representative.ROLES
         )
 
@@ -497,7 +495,7 @@ class RepresentativeCreateForm(ModelForm):
         if (
             role
             and role not in dict(Representative.OPEN_DATA_ROLES)
-            and Representative.is_open_data_coordinator(self.user, content_type, self.object.pk)
+            and self.user.is_open_data_coordinator_for(self.object)
         ):
             self.add_error("role", _("Jūs neturite teisės priskirti šios rolės."))
         return super().clean()

--- a/vitrina/orgs/models.py
+++ b/vitrina/orgs/models.py
@@ -248,15 +248,6 @@ class Representative(models.Model):
 
         return False
 
-    @classmethod
-    def is_open_data_coordinator(cls, user: "User", content_type: ContentType, object_id: int) -> bool:
-        return cls.objects.filter(
-            user=user,
-            content_type=content_type,
-            object_id=object_id,
-            role=cls.OPEN_DATA_COORDINATOR,
-        ).exists()
-
 
 class PublishedReport(models.Model):
     created = models.DateTimeField(blank=True, null=True, auto_now_add=True)

--- a/vitrina/users/models.py
+++ b/vitrina/users/models.py
@@ -210,16 +210,13 @@ class User(AbstractUser):
         manager_equivalent_roles = [coordinator_to_manager.get(role, role) for role in open_data_roles]
 
         # Case 1: user directly holds an open data role on the object
-        if (
-            Representative.objects.filter(
-                content_type=content_type,
-                object_id=obj.pk,
-                role__in=open_data_roles,
-                user=self,
-            )
-            .exclude(deleted=True)
-            .exists()
-        ):
+        direct_representative = Representative.objects.filter(
+            content_type=content_type,
+            object_id=obj.pk,
+            role__in=open_data_roles,
+            user=self,
+        ).exclude(deleted=True)
+        if direct_representative.exists():
             return True
 
         # Case 2: access is resolved through the user's organizational membership.
@@ -234,7 +231,7 @@ class User(AbstractUser):
         )
 
         if user_organization_role_map:
-            for organization_id, organization_role in (
+            organization_representatives = (
                 Representative.objects.filter(
                     content_type=content_type,
                     object_id=obj.pk,
@@ -242,7 +239,9 @@ class User(AbstractUser):
                 )
                 .exclude(deleted=True)
                 .values_list("organization_id", "role")
-            ):
+            )
+
+            for organization_id, organization_role in organization_representatives:
                 user_role = coordinator_to_manager.get(
                     user_organization_role_map[organization_id], user_organization_role_map[organization_id]
                 )
@@ -259,6 +258,13 @@ class User(AbstractUser):
         return False
 
     def is_open_data_coordinator_for(self, obj: Union[Organization, "Dataset", None]) -> bool:
+        """
+        Check if this user is an Open Data Coordinator for the given object.
+
+        'Coordinator' is a specific role within the representative system.
+        Delegates to `is_open_data_representative_for` with the
+        `OPEN_DATA_COORDINATOR` role.
+        """
         return self.is_open_data_representative_for(obj, roles=[Representative.OPEN_DATA_COORDINATOR])
 
 

--- a/vitrina/users/models.py
+++ b/vitrina/users/models.py
@@ -194,13 +194,20 @@ class User(AbstractUser):
             user=self, content_type=org_type, object_id=organization.pk, role=Representative.RESOURCE_COORDINATOR
         ).exists()
 
-    def is_open_data_representative_for(self, obj: Union[Organization, "Dataset", None]) -> bool:
+    def is_open_data_representative_for(
+        self,
+        obj: Union[Organization, "Dataset", None],
+        roles: list | None = None,
+    ) -> bool:
         if obj is None:
             return False
 
         content_type = ContentType.objects.get_for_model(obj)
-        open_data_roles = [Representative.OPEN_DATA_COORDINATOR, Representative.OPEN_DATA_MANAGER]
+        open_data_roles = (
+            roles if roles is not None else [Representative.OPEN_DATA_COORDINATOR, Representative.OPEN_DATA_MANAGER]
+        )
         coordinator_to_manager = dict(zip(Representative.COORDINATOR_ROLES, Representative.MANAGER_ROLES))
+        manager_equivalent_roles = [coordinator_to_manager.get(role, role) for role in open_data_roles]
 
         # Case 1: user directly holds an open data role on the object
         if (
@@ -226,26 +233,33 @@ class User(AbstractUser):
             .values_list("object_id", "role")
         )
 
-        if not user_organization_role_map:
-            return False
+        if user_organization_role_map:
+            for organization_id, organization_role in (
+                Representative.objects.filter(
+                    content_type=content_type,
+                    object_id=obj.pk,
+                    organization_id__in=user_organization_role_map.keys(),
+                )
+                .exclude(deleted=True)
+                .values_list("organization_id", "role")
+            ):
+                user_role = coordinator_to_manager.get(
+                    user_organization_role_map[organization_id], user_organization_role_map[organization_id]
+                )
+                least_privileged_role = max(organization_role, user_role, key=Representative.MANAGER_ROLES.index)
+                if least_privileged_role in manager_equivalent_roles:
+                    return True
 
-        for organization_id, organization_role in (
-            Representative.objects.filter(
-                content_type=content_type,
-                object_id=obj.pk,
-                organization_id__in=user_organization_role_map.keys(),
-            )
-            .exclude(deleted=True)
-            .values_list("organization_id", "role")
-        ):
-            user_role = coordinator_to_manager.get(
-                user_organization_role_map[organization_id], user_organization_role_map[organization_id]
-            )
-            least_privileged_role = max(organization_role, user_role, key=Representative.MANAGER_ROLES.index)
-            if least_privileged_role in open_data_roles:
-                return True
+        # Case 3: check ancestors if the object supports it
+        if hasattr(obj, "get_ancestors"):
+            for ancestor in obj.get_ancestors():
+                if self.is_open_data_representative_for(ancestor, roles=roles):
+                    return True
 
         return False
+
+    def is_open_data_coordinator_for(self, obj: Union[Organization, "Dataset", None]) -> bool:
+        return self.is_open_data_representative_for(obj, roles=[Representative.OPEN_DATA_COORDINATOR])
 
 
 class UserTablePreferences(models.Model):


### PR DESCRIPTION
Summary:

- Updated `is_open_data_representative_for` function to add a optional parameter `role` to check coordinators explicitly.
- Updated `is_open_data_representative_for` function to check for objects which has get_ancestors functionality.

Ticket: https://github.com/atviriduomenys/dvms/issues/538