### PR TITLE
[538]: Open Data Coordinator is not checked in ancestor datasets

### DIFF
--- a/tests/datasets/test_forms.py
+++ b/tests/datasets/test_forms.py
@@ -304,7 +304,7 @@ class TestResourceSubclassForm:
         self, app: DjangoTestApp
     ):
         organization = OrganizationFactory()
-        user = UserFactory(is_staff=True)
+        user = UserFactory()
         app.set_user(user)
         subclass = DCATResourceSubclassFactory(name="dataset")
 
@@ -336,7 +336,7 @@ class TestResourceSubclassForm:
         self, app: DjangoTestApp
     ):
         organization = OrganizationFactory()
-        user = UserFactory(is_staff=True)
+        user = UserFactory()
         subclass = DCATResourceSubclassFactory(name="dataset")
 
         parent_dataset = DatasetFactory(organization=organization)

--- a/tests/orgs/test_models.py
+++ b/tests/orgs/test_models.py
@@ -1,6 +1,7 @@
 import pytest
 from django.contrib.contenttypes.models import ContentType
 
+from vitrina.datasets.factories import DatasetFactory
 from vitrina.orgs.factories import OrganizationFactory, RepresentativeFactory
 from vitrina.orgs.models import Representative
 from vitrina.users.factories import UserFactory
@@ -38,6 +39,45 @@ def test_open_data_coordinator_can_be_updated_by(target_role, expected):
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
+    "target_role, expected",
+    [
+        (Representative.OPEN_DATA_COORDINATOR, True),
+        (Representative.OPEN_DATA_MANAGER, True),
+        (Representative.RESOURCE_COORDINATOR, False),
+        (Representative.RESOURCE_MANAGER, False),
+    ],
+)
+def test_grandparent_dataset_open_data_coordinator_can_be_updated_by(target_role, expected):
+    organization = OrganizationFactory()
+
+    grandparent_dataset = DatasetFactory(organization=organization)
+    parent_dataset = DatasetFactory(organization=organization)
+    child_dataset = DatasetFactory(organization=organization)
+    parent_dataset.move(grandparent_dataset, pos="sorted-child")
+    parent_dataset.refresh_from_db()
+    child_dataset.move(parent_dataset, pos="sorted-child")
+    child_dataset.refresh_from_db()
+    grandparent_dataset.refresh_from_db()
+    user = UserFactory()
+
+    RepresentativeFactory(
+        content_type=ContentType.objects.get_for_model(grandparent_dataset),
+        object_id=grandparent_dataset.pk,
+        user=user,
+        role=Representative.OPEN_DATA_COORDINATOR,
+    )
+
+    target_rep = RepresentativeFactory(
+        content_type=ContentType.objects.get_for_model(child_dataset),
+        object_id=child_dataset.pk,
+        role=target_role,
+    )
+
+    assert target_rep.can_be_updated_by(user) is expected
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
     "target_role",
     [
         Representative.OPEN_DATA_COORDINATOR,
@@ -64,6 +104,45 @@ def test_resource_coordinator_can_update_all_roles(target_role):
     )
 
     assert target_rep.can_be_updated_by(user) is True
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "target_role, expected",
+    [
+        (Representative.OPEN_DATA_COORDINATOR, True),
+        (Representative.OPEN_DATA_MANAGER, True),
+        (Representative.RESOURCE_COORDINATOR, True),
+        (Representative.RESOURCE_MANAGER, True),
+    ],
+)
+def test_grandparent_dataset_resource_coordinator_can_update_all_roles(target_role, expected):
+    organization = OrganizationFactory()
+
+    grandparent_dataset = DatasetFactory(organization=organization)
+    parent_dataset = DatasetFactory(organization=organization)
+    child_dataset = DatasetFactory(organization=organization)
+    parent_dataset.move(grandparent_dataset, pos="sorted-child")
+    parent_dataset.refresh_from_db()
+    child_dataset.move(parent_dataset, pos="sorted-child")
+    child_dataset.refresh_from_db()
+    grandparent_dataset.refresh_from_db()
+    user = UserFactory()
+
+    RepresentativeFactory(
+        content_type=ContentType.objects.get_for_model(grandparent_dataset),
+        object_id=grandparent_dataset.pk,
+        user=user,
+        role=Representative.RESOURCE_COORDINATOR,
+    )
+
+    target_rep = RepresentativeFactory(
+        content_type=ContentType.objects.get_for_model(child_dataset),
+        object_id=child_dataset.pk,
+        role=target_role,
+    )
+
+    assert target_rep.can_be_updated_by(user) is expected
 
 
 @pytest.mark.django_db

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -311,6 +311,26 @@ class TestIsOpenDataRepresentativeFor:
 
         assert user.is_open_data_representative_for(child_dataset) is True
 
+    def test_returns_false_if_user_is_open_data_representative_on_child_but_resource_representative_on_parent(self):
+        organization = OrganizationFactory()
+        dataset = DatasetFactory(organization=organization)
+        user = UserFactory()
+
+        RepresentativeFactory(
+            content_type=ContentType.objects.get_for_model(dataset),
+            object_id=dataset.pk,
+            user=user,
+            role=Representative.OPEN_DATA_MANAGER,
+        )
+        RepresentativeFactory(
+            content_type=ContentType.objects.get_for_model(organization),
+            object_id=organization.pk,
+            user=user,
+            role=Representative.RESOURCE_COORDINATOR,
+        )
+
+        assert user.is_open_data_representative_for(dataset) is False
+
 
 class TestIsCoordinatorFor:
     def test_is_staff_user_returns_true(self):
@@ -367,8 +387,7 @@ class TestIsCoordinatorFor:
             role=Representative.RESOURCE_COORDINATOR,
         )
 
-        assert user.is_open_data_representative_for(dataset, roles=[Representative.RESOURCE_COORDINATOR]) is True
-        assert user.is_open_data_representative_for(dataset, roles=[Representative.OPEN_DATA_COORDINATOR]) is False
+        assert user.is_open_data_representative_for(dataset) is False
 
     def test_returns_true_for_resource_coordinator_if_child_represented_as_resource(self):
         parent_dataset = DatasetFactory()

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -310,3 +310,103 @@ class TestIsOpenDataRepresentativeFor:
         )
 
         assert user.is_open_data_representative_for(child_dataset) is True
+
+
+class TestIsCoordinatorFor:
+    def test_is_staff_user_returns_true(self):
+        user = UserFactory(is_staff=True)
+        organization = OrganizationFactory()
+        assert user.is_coordinator_for(organization, roles=[Representative.RESOURCE_COORDINATOR]) is True
+
+    def test_returns_false_if_obj_is_none(self):
+        user = UserFactory()
+        assert user.is_coordinator_for(None, roles=[Representative.OPEN_DATA_COORDINATOR]) is False
+
+    def test_returns_true_if_user_is_direct_coordinator_of_organization(self):
+        organization = OrganizationFactory()
+        user = UserFactory()
+
+        RepresentativeFactory(
+            content_type=ContentType.objects.get_for_model(organization),
+            object_id=organization.pk,
+            user=user,
+            role=Representative.RESOURCE_COORDINATOR,
+        )
+
+        assert user.is_coordinator_for(organization, roles=[Representative.RESOURCE_COORDINATOR]) is True
+        assert user.is_coordinator_for(organization, roles=[Representative.OPEN_DATA_COORDINATOR]) is False
+
+    def test_returns_false_if_user_representative_is_deleted_for_organization(self):
+        organization = OrganizationFactory()
+        user = UserFactory()
+
+        RepresentativeFactory(
+            content_type=ContentType.objects.get_for_model(organization),
+            object_id=organization.pk,
+            user=user,
+            role=Representative.OPEN_DATA_MANAGER,
+            deleted=True,
+        )
+
+        assert user.is_coordinator_for(organization, roles=[Representative.OPEN_DATA_COORDINATOR]) is False
+
+    def test_returns_false_if_user_has_no_representatives_for_organization(self):
+        organization = OrganizationFactory()
+        user = UserFactory()
+
+        assert user.is_open_data_representative_for(organization, roles=[Representative.OPEN_DATA_COORDINATOR]) is False
+
+    def test_returns_true_if_user_is_direct_representative_of_dataset(self):
+        dataset = DatasetFactory()
+        user = UserFactory()
+
+        RepresentativeFactory(
+            content_type=ContentType.objects.get_for_model(dataset),
+            object_id=dataset.pk,
+            user=user,
+            role=Representative.RESOURCE_COORDINATOR,
+        )
+
+        assert user.is_open_data_representative_for(dataset, roles=[Representative.RESOURCE_COORDINATOR]) is True
+        assert user.is_open_data_representative_for(dataset, roles=[Representative.OPEN_DATA_COORDINATOR]) is False
+
+    def test_returns_true_for_resource_coordinator_if_child_represented_as_resource(self):
+        parent_dataset = DatasetFactory()
+        child_dataset = DatasetFactory()
+        child_dataset.move(parent_dataset, pos="sorted-child")
+        child_dataset.refresh_from_db()
+        user = UserFactory()
+
+        RepresentativeFactory(
+            content_type=ContentType.objects.get_for_model(parent_dataset),
+            object_id=parent_dataset.pk,
+            user=user,
+            role=Representative.OPEN_DATA_COORDINATOR,  # Only Open Data Coordinator here
+        )
+
+        RepresentativeFactory(
+            content_type=ContentType.objects.get_for_model(child_dataset),
+            object_id=child_dataset.pk,
+            user=user,
+            role=Representative.RESOURCE_COORDINATOR,  # Resource Coordinator for this dataset
+        )
+
+        assert user.is_coordinator_for(parent_dataset, roles=[Representative.RESOURCE_COORDINATOR]) is False
+        assert user.is_coordinator_for(child_dataset, roles=[Representative.RESOURCE_COORDINATOR]) is True
+
+    def test_returns_false_if_user_represents_child_but_not_parent(self):
+        parent_dataset = DatasetFactory()
+        child_dataset = DatasetFactory()
+        child_dataset.move(parent_dataset, pos="sorted-child")
+        child_dataset.refresh_from_db()
+        user = UserFactory()
+
+        RepresentativeFactory(
+            content_type=ContentType.objects.get_for_model(child_dataset),
+            object_id=child_dataset.pk,
+            user=user,
+            role=Representative.OPEN_DATA_COORDINATOR,
+        )
+
+        assert user.is_coordinator_for(parent_dataset, roles=[Representative.RESOURCE_COORDINATOR]) is False
+        assert user.is_coordinator_for(parent_dataset, roles=[Representative.OPEN_DATA_COORDINATOR]) is False

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -213,28 +213,6 @@ class TestIsOpenDataRepresentativeFor:
 
         assert user.is_open_data_representative_for(dataset) is True
 
-    def test_returns_false_if_datasets_organization_representative_record_is_deleted(self):
-        organization = OrganizationFactory()
-        dataset = DatasetFactory(organization=organization)
-        user = UserFactory()
-
-        RepresentativeFactory(
-            content_type=ContentType.objects.get_for_model(dataset),
-            object_id=dataset.pk,
-            organization=organization,
-            role=Representative.OPEN_DATA_MANAGER,
-            deleted=True,
-        )
-
-        RepresentativeFactory(
-            content_type=ContentType.objects.get_for_model(organization),
-            object_id=organization.pk,
-            user=user,
-            role=Representative.OPEN_DATA_MANAGER,
-        )
-
-        assert user.is_open_data_representative_for(dataset) is False
-
     def test_returns_false_if_user_is_not_representative_of_datasets_organization(self):
         organization = OrganizationFactory()
         other_organization = OrganizationFactory()

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -256,3 +256,79 @@ class TestIsOpenDataRepresentativeFor:
         )
 
         assert user.is_open_data_representative_for(dataset) is False
+
+    def test_returns_true_if_user_represents_parent_dataset(self):
+        parent_dataset = DatasetFactory()
+        child_dataset = DatasetFactory()
+        child_dataset.move(parent_dataset, pos="sorted-child")
+        child_dataset.refresh_from_db()
+        user = UserFactory()
+
+        RepresentativeFactory(
+            content_type=ContentType.objects.get_for_model(parent_dataset),
+            object_id=parent_dataset.pk,
+            user=user,
+            role=Representative.OPEN_DATA_MANAGER,
+        )
+
+        assert user.is_open_data_representative_for(child_dataset) is True
+
+    def test_returns_true_if_user_represents_grandparent_dataset(self):
+        grandparent_dataset = DatasetFactory()
+        parent_dataset = DatasetFactory()
+        child_dataset = DatasetFactory()
+        parent_dataset.move(grandparent_dataset, pos="sorted-child")
+        parent_dataset.refresh_from_db()
+        child_dataset.move(parent_dataset, pos="sorted-child")
+        child_dataset.refresh_from_db()
+        grandparent_dataset.refresh_from_db()
+        user = UserFactory()
+
+        RepresentativeFactory(
+            content_type=ContentType.objects.get_for_model(grandparent_dataset),
+            object_id=grandparent_dataset.pk,
+            user=user,
+            role=Representative.OPEN_DATA_MANAGER,
+        )
+
+        assert user.is_open_data_representative_for(child_dataset) is True
+
+    def test_returns_false_if_user_represents_child_but_not_parent(self):
+        parent_dataset = DatasetFactory()
+        child_dataset = DatasetFactory()
+        child_dataset.move(parent_dataset, pos="sorted-child")
+        child_dataset.refresh_from_db()
+        user = UserFactory()
+
+        RepresentativeFactory(
+            content_type=ContentType.objects.get_for_model(child_dataset),
+            object_id=child_dataset.pk,
+            user=user,
+            role=Representative.OPEN_DATA_MANAGER,
+        )
+
+        assert user.is_open_data_representative_for(parent_dataset) is False
+
+    def test_returns_true_if_users_organization_represents_parent_dataset(self):
+        user_organization = OrganizationFactory()
+        parent_dataset = DatasetFactory()
+        child_dataset = DatasetFactory()
+        child_dataset.move(parent_dataset, pos="sorted-child")
+        child_dataset.refresh_from_db()
+        user = UserFactory()
+
+        RepresentativeFactory(
+            content_type=ContentType.objects.get_for_model(user_organization),
+            object_id=user_organization.pk,
+            user=user,
+            role=Representative.OPEN_DATA_MANAGER,
+        )
+
+        RepresentativeFactory(
+            content_type=ContentType.objects.get_for_model(parent_dataset),
+            object_id=parent_dataset.pk,
+            organization=user_organization,
+            role=Representative.OPEN_DATA_MANAGER,
+        )
+
+        assert user.is_open_data_representative_for(child_dataset) is True

--- a/vitrina/datasets/forms.py
+++ b/vitrina/datasets/forms.py
@@ -106,9 +106,7 @@ class ResourceSubclassForm(TranslatableModelForm, TranslatableModelFormMixin):
         else:
             parent = None
 
-        if user and (
-            user.is_open_data_representative_for(self.organization) or user.is_open_data_representative_for(parent)
-        ):
+        if user and (user.is_open_data_representative_for(parent or self.organization)):
             self.fields["subclass"].queryset = DCATResourceSubclass.objects.exclude(
                 name=DCATResourceSubclass.INFORMATION_SYSTEM
             )
@@ -226,9 +224,7 @@ class BaseResourceForm(TranslatableModelForm):
         organization = self.organization if self.organization else instance.organization
 
         is_open_data_representative = request.user and (
-            request.user.is_open_data_representative_for(organization)
-            or request.user.is_open_data_representative_for(parent)
-            or request.user.is_open_data_representative_for(instance)
+            request.user.is_open_data_representative_for(instance or parent or organization)
         )
 
         if is_open_data_representative:

--- a/vitrina/datasets/forms.py
+++ b/vitrina/datasets/forms.py
@@ -107,8 +107,7 @@ class ResourceSubclassForm(TranslatableModelForm, TranslatableModelFormMixin):
             parent = None
 
         if user and (
-            (self.organization and user.is_open_data_representative_for(self.organization))
-            or user.is_open_data_representative_for(parent)
+            user.is_open_data_representative_for(self.organization) or user.is_open_data_representative_for(parent)
         ):
             self.fields["subclass"].queryset = DCATResourceSubclass.objects.exclude(
                 name=DCATResourceSubclass.INFORMATION_SYSTEM

--- a/vitrina/datasets/models.py
+++ b/vitrina/datasets/models.py
@@ -856,6 +856,7 @@ class Dataset(Resource):
 
     def get_acl_parents(self):
         parents = [self]
+        parents.extend(self.get_ancestors())
         if self.organization:
             parents.extend(self.organization.get_acl_parents())
         return parents

--- a/vitrina/orgs/forms.py
+++ b/vitrina/orgs/forms.py
@@ -357,11 +357,17 @@ class RepresentativeUpdateForm(ModelForm):
         self.object = kwargs.pop("object", None)
         super().__init__(*args, **kwargs)
 
-        organization = self.object if self.object_model == Organization else getattr(self.object, "organization", None)
+        self.is_resource_coordinator = self.user.is_coordinator_for(
+            self.object, roles=[Representative.RESOURCE_COORDINATOR]
+        )
+        self.is_open_data_coordinator = self.user.is_coordinator_for(
+            self.object, roles=[Representative.OPEN_DATA_COORDINATOR]
+        )
+
+        # If they are JUST an OD coordinator, restrict them.
         self.fields["role"].choices = (
             Representative.OPEN_DATA_ROLES
-            if self.user.is_open_data_coordinator_for(self.object)
-            or (organization and self.user.is_open_data_coordinator_for(organization))
+            if self.is_open_data_coordinator and not self.is_resource_coordinator
             else Representative.ROLES
         )
 
@@ -425,13 +431,11 @@ class RepresentativeUpdateForm(ModelForm):
         if self.instance.organization and role in Representative.COORDINATOR_ROLES:
             raise ValidationError(_("Organizacijai gali būti suteikta tik tvarkytojo rolė"))
 
-        organization = self.object if self.object_model == Organization else getattr(self.object, "organization", None)
-
-        is_allowed = self.user.is_open_data_coordinator_for(self.object) or (
-            organization and self.user.is_open_data_coordinator_for(organization)
-        )
-
-        if role and role not in dict(Representative.OPEN_DATA_ROLES) and is_allowed:
+        if (
+            self.is_open_data_coordinator
+            and not self.is_resource_coordinator
+            and role not in dict(Representative.OPEN_DATA_ROLES)
+        ):
             self.add_error("role", _("Jūs neturite teisės priskirti šios rolės."))
 
         return self.cleaned_data
@@ -472,12 +476,16 @@ class RepresentativeCreateForm(ModelForm):
         self.object = kwargs.pop("object")
         super().__init__(*args, **kwargs)
 
-        organization = self.object if self.object_model == Organization else getattr(self.object, "organization", None)
+        self.is_resource_coordinator = self.user.is_coordinator_for(
+            self.object, roles=[Representative.RESOURCE_COORDINATOR]
+        )
+        self.is_open_data_coordinator = self.user.is_coordinator_for(
+            self.object, roles=[Representative.OPEN_DATA_COORDINATOR]
+        )
 
         self.fields["role"].choices = (
             Representative.OPEN_DATA_ROLES
-            if self.user.is_open_data_coordinator_for(self.object)
-            or (organization and self.user.is_open_data_coordinator_for(organization))
+            if self.is_open_data_coordinator and not self.is_resource_coordinator
             else Representative.ROLES
         )
 
@@ -512,13 +520,12 @@ class RepresentativeCreateForm(ModelForm):
         content_type = ContentType.objects.get_for_model(self.object_model)
         if Representative.objects.filter(content_type=content_type, object_id=self.object.id, email=email).exists():
             self.add_error("email", _("Narys su šiuo el. pašto adresu jau egzistuoja."))
-        organization = self.object if self.object_model == Organization else getattr(self.object, "organization", None)
 
-        is_allowed = self.user.is_open_data_coordinator_for(self.object) or (
-            organization and self.user.is_open_data_coordinator_for(organization)
-        )
-
-        if role and role not in dict(Representative.OPEN_DATA_ROLES) and is_allowed:
+        if (
+            self.is_open_data_coordinator
+            and not self.is_resource_coordinator
+            and role not in dict(Representative.OPEN_DATA_ROLES)
+        ):
             self.add_error("role", _("Jūs neturite teisės priskirti šios rolės."))
         return super().clean()
 

--- a/vitrina/orgs/forms.py
+++ b/vitrina/orgs/forms.py
@@ -364,7 +364,7 @@ class RepresentativeUpdateForm(ModelForm):
             self.object, roles=[Representative.OPEN_DATA_COORDINATOR]
         )
 
-        # If they are JUST an OD coordinator, restrict them.
+        # If they are JUST an Open data coordinator, restrict them.
         self.fields["role"].choices = (
             Representative.OPEN_DATA_ROLES
             if self.is_open_data_coordinator and not self.is_resource_coordinator

--- a/vitrina/orgs/forms.py
+++ b/vitrina/orgs/forms.py
@@ -357,6 +357,14 @@ class RepresentativeUpdateForm(ModelForm):
         self.object = kwargs.pop("object", None)
         super().__init__(*args, **kwargs)
 
+        organization = self.object if self.object_model == Organization else getattr(self.object, "organization", None)
+        self.fields["role"].choices = (
+            Representative.OPEN_DATA_ROLES
+            if self.user.is_open_data_coordinator_for(self.object)
+            or (organization and self.user.is_open_data_coordinator_for(organization))
+            else Representative.ROLES
+        )
+
         if self.object_model == Organization:
             if self.user.viisp_organization == self.object and self.user.is_resource_coordinator_for(self.object):
                 self.fields["can_make_agreements"].disabled = False
@@ -416,6 +424,15 @@ class RepresentativeUpdateForm(ModelForm):
 
         if self.instance.organization and role in Representative.COORDINATOR_ROLES:
             raise ValidationError(_("Organizacijai gali būti suteikta tik tvarkytojo rolė"))
+
+        organization = self.object if self.object_model == Organization else getattr(self.object, "organization", None)
+
+        is_allowed = self.user.is_open_data_coordinator_for(self.object) or (
+            organization and self.user.is_open_data_coordinator_for(organization)
+        )
+
+        if role and role not in dict(Representative.OPEN_DATA_ROLES) and is_allowed:
+            self.add_error("role", _("Jūs neturite teisės priskirti šios rolės."))
 
         return self.cleaned_data
 

--- a/vitrina/orgs/forms.py
+++ b/vitrina/orgs/forms.py
@@ -455,11 +455,9 @@ class RepresentativeCreateForm(ModelForm):
         self.object = kwargs.pop("object")
         super().__init__(*args, **kwargs)
 
-        content_type = ContentType.objects.get_for_model(self.object_model)
-
         self.fields["role"].choices = (
             Representative.OPEN_DATA_ROLES
-            if Representative.is_open_data_coordinator(self.user, content_type, self.object.pk)
+            if self.user.is_open_data_coordinator_for(self.object)
             else Representative.ROLES
         )
 
@@ -497,7 +495,7 @@ class RepresentativeCreateForm(ModelForm):
         if (
             role
             and role not in dict(Representative.OPEN_DATA_ROLES)
-            and Representative.is_open_data_coordinator(self.user, content_type, self.object.pk)
+            and self.user.is_open_data_coordinator_for(self.object)
         ):
             self.add_error("role", _("Jūs neturite teisės priskirti šios rolės."))
         return super().clean()

--- a/vitrina/orgs/forms.py
+++ b/vitrina/orgs/forms.py
@@ -455,9 +455,12 @@ class RepresentativeCreateForm(ModelForm):
         self.object = kwargs.pop("object")
         super().__init__(*args, **kwargs)
 
+        organization = self.object if self.object_model == Organization else getattr(self.object, "organization", None)
+
         self.fields["role"].choices = (
             Representative.OPEN_DATA_ROLES
             if self.user.is_open_data_coordinator_for(self.object)
+            or (organization and self.user.is_open_data_coordinator_for(organization))
             else Representative.ROLES
         )
 
@@ -492,11 +495,13 @@ class RepresentativeCreateForm(ModelForm):
         content_type = ContentType.objects.get_for_model(self.object_model)
         if Representative.objects.filter(content_type=content_type, object_id=self.object.id, email=email).exists():
             self.add_error("email", _("Narys su šiuo el. pašto adresu jau egzistuoja."))
-        if (
-            role
-            and role not in dict(Representative.OPEN_DATA_ROLES)
-            and self.user.is_open_data_coordinator_for(self.object)
-        ):
+        organization = self.object if self.object_model == Organization else getattr(self.object, "organization", None)
+
+        is_allowed = self.user.is_open_data_coordinator_for(self.object) or (
+            organization and self.user.is_open_data_coordinator_for(organization)
+        )
+
+        if role and role not in dict(Representative.OPEN_DATA_ROLES) and is_allowed:
             self.add_error("role", _("Jūs neturite teisės priskirti šios rolės."))
         return super().clean()
 

--- a/vitrina/orgs/models.py
+++ b/vitrina/orgs/models.py
@@ -248,15 +248,6 @@ class Representative(models.Model):
 
         return False
 
-    @classmethod
-    def is_open_data_coordinator(cls, user: "User", content_type: ContentType, object_id: int) -> bool:
-        return cls.objects.filter(
-            user=user,
-            content_type=content_type,
-            object_id=object_id,
-            role=cls.OPEN_DATA_COORDINATOR,
-        ).exists()
-
 
 class PublishedReport(models.Model):
     created = models.DateTimeField(blank=True, null=True, auto_now_add=True)

--- a/vitrina/orgs/models.py
+++ b/vitrina/orgs/models.py
@@ -233,7 +233,7 @@ class Representative(models.Model):
 
         object = self.content_object
 
-        if user.is_representative_for(
+        if user.is_coordinator_for(
             object,
             roles=[
                 Representative.RESOURCE_COORDINATOR,
@@ -246,8 +246,11 @@ class Representative(models.Model):
                 Representative.OPEN_DATA_MANAGER,
             )
 
-        if user.is_open_data_coordinator_for(
+        if user.is_coordinator_for(
             object,
+            roles=[
+                Representative.OPEN_DATA_COORDINATOR,
+            ],
         ):
             return self.role in Representative.OPEN_DATA_ROLE_KEYS
 

--- a/vitrina/orgs/models.py
+++ b/vitrina/orgs/models.py
@@ -231,20 +231,25 @@ class Representative(models.Model):
         if user.is_superuser or user.is_staff:
             return True
 
-        user_rep = user.representative_set.filter(organization=self.organization).first()
-        if not user_rep:
-            return False
+        object = self.content_object
 
-        if user_rep.role == Representative.OPEN_DATA_COORDINATOR:
-            return self.role in Representative.OPEN_DATA_ROLE_KEYS
-
-        if user_rep.role == Representative.RESOURCE_COORDINATOR:
+        if user.is_representative_for(
+            object,
+            roles=[
+                Representative.RESOURCE_COORDINATOR,
+            ],
+        ):
             return self.role in (
                 Representative.RESOURCE_COORDINATOR,
                 Representative.RESOURCE_MANAGER,
                 Representative.OPEN_DATA_COORDINATOR,
                 Representative.OPEN_DATA_MANAGER,
             )
+
+        if user.is_open_data_coordinator_for(
+            object,
+        ):
+            return self.role in Representative.OPEN_DATA_ROLE_KEYS
 
         return False
 

--- a/vitrina/orgs/services.py
+++ b/vitrina/orgs/services.py
@@ -553,10 +553,7 @@ def has_perm(
 
         if isinstance(obj, Type):
             model = obj
-            if parent:
-                nodes = get_parents(parent)
-            else:
-                nodes = []
+            nodes = get_parents(parent) if parent else []
         else:
             model = type(obj)
             nodes = get_parents(obj)

--- a/vitrina/structure/forms.py
+++ b/vitrina/structure/forms.py
@@ -211,10 +211,7 @@ class EnumForm(forms.ModelForm):
         property_metadata = prop.metadata.first() if prop else None
         organization = property_metadata.dataset.organization if property_metadata else None
         dataset = property_metadata.dataset if property_metadata else None
-        is_open_data_representative = self.user and (
-            self.user.is_open_data_representative_for(organization)
-            or self.user.is_open_data_representative_for(dataset)
-        )
+        is_open_data_representative = self.user and (self.user.is_open_data_representative_for(dataset or organization))
 
         if is_open_data_representative:
             self.fields["visibility"].choices = [
@@ -687,12 +684,7 @@ class ModelCreateForm(forms.ModelForm):
         self.initial["visibility"] = "None"
         self.initial["status"] = self.instance.status
 
-        organization = dataset.organization
-
-        is_open_data_representative = self.user and (
-            self.user.is_open_data_representative_for(organization)
-            or self.user.is_open_data_representative_for(dataset)
-        )
+        is_open_data_representative = self.user and (self.user.is_open_data_representative_for(dataset))
 
         if is_open_data_representative:
             self.fields["visibility"].choices = [
@@ -1189,11 +1181,7 @@ class PropertyForm(forms.ModelForm):
             if self.instance.object not in self.model.get_props_excluding_base():
                 self.fields["name"].widget.attrs["readonly"] = True
 
-        organization = model.dataset.organization
-        is_open_data_representative = self.user and (
-            self.user.is_open_data_representative_for(organization)
-            or self.user.is_open_data_representative_for(self.model.dataset)
-        )
+        is_open_data_representative = self.user and (self.user.is_open_data_representative_for(self.model.dataset))
 
         if is_open_data_representative:
             self.fields["visibility"].choices = [

--- a/vitrina/users/models.py
+++ b/vitrina/users/models.py
@@ -206,10 +206,15 @@ class User(AbstractUser):
         """
         if obj is None:
             return False
+        parents = obj.get_acl_parents()
 
-        for parent in obj.get_acl_parents():
+        # Check every node for a direct role.
+        for parent in parents:
             if self._has_direct_representative_role(parent, roles):
                 return True
+
+        # Check every node for organizational membership.
+        for parent in parents:
             if self._has_role_via_org_membership(parent, roles):
                 return True
 

--- a/vitrina/users/models.py
+++ b/vitrina/users/models.py
@@ -210,16 +210,13 @@ class User(AbstractUser):
         manager_equivalent_roles = [coordinator_to_manager.get(role, role) for role in open_data_roles]
 
         # Case 1: user directly holds an open data role on the object
-        if (
-            Representative.objects.filter(
-                content_type=content_type,
-                object_id=obj.pk,
-                role__in=open_data_roles,
-                user=self,
-            )
-            .exclude(deleted=True)
-            .exists()
-        ):
+        direct_representative = Representative.objects.filter(
+            content_type=content_type,
+            object_id=obj.pk,
+            role__in=open_data_roles,
+            user=self,
+        ).exclude(deleted=True)
+        if direct_representative.exists():
             return True
 
         # Case 2: access is resolved through the user's organizational membership.
@@ -234,7 +231,7 @@ class User(AbstractUser):
         )
 
         if user_organization_role_map:
-            for organization_id, organization_role in (
+            organization_representatives = (
                 Representative.objects.filter(
                     content_type=content_type,
                     object_id=obj.pk,
@@ -242,7 +239,9 @@ class User(AbstractUser):
                 )
                 .exclude(deleted=True)
                 .values_list("organization_id", "role")
-            ):
+            )
+
+            for organization_id, organization_role in organization_representatives:
                 user_role = coordinator_to_manager.get(
                     user_organization_role_map[organization_id], user_organization_role_map[organization_id]
                 )
@@ -259,6 +258,13 @@ class User(AbstractUser):
         return False
 
     def is_open_data_coordinator_for(self, obj: Union[Organization, "Dataset", None]) -> bool:
+        """
+        Check if this user is an Open Data Coordinator for the given object.
+
+        'Coordinator' is a specific role within the representative system.
+        Delegates to `is_open_data_representative_for` with the
+        `OPEN_DATA_COORDINATOR` role.
+        """
         return self.is_open_data_representative_for(obj, roles=[Representative.OPEN_DATA_COORDINATOR])
 
 

--- a/vitrina/users/models.py
+++ b/vitrina/users/models.py
@@ -240,7 +240,9 @@ class User(AbstractUser):
         obj: Union[Organization, "Dataset", None],
         roles: list[str] | None = None,
     ) -> bool:
-        """User personally holds one of the given roles on this object."""
+        """
+           Returns True if the user directly represents an object.
+        """
         content_type = ContentType.objects.get_for_model(obj)
         return (
             Representative.objects.filter(
@@ -259,8 +261,8 @@ class User(AbstractUser):
         roles: list[str] | None = None,
     ) -> bool:
         """
-        User belongs to an organization that holds a role on this object.
-        Effective permission = least privileged of (user's org role, org's role on object).
+            User belongs to an organization that holds a role on this object.
+            Effective permission = least privileged of (user's org role, org's role on object).
         """
         content_type = ContentType.objects.get_for_model(obj)
         coordinator_to_manager = dict(zip(Representative.COORDINATOR_ROLES, Representative.MANAGER_ROLES))

--- a/vitrina/users/models.py
+++ b/vitrina/users/models.py
@@ -232,10 +232,15 @@ class User(AbstractUser):
         """
         Returns True if the user is an Open Data representative for the object.
         This means the user has either Open Data Coordinator or Manager role.
+        We need to check if the user if not a Resource representative first, to not lower the role.
         """
-        open_data_roles = (
-            roles if roles is not None else [Representative.OPEN_DATA_COORDINATOR, Representative.OPEN_DATA_MANAGER]
-        )
+        if not obj or self.is_staff or self.is_superuser:
+            return False
+
+        if self.is_representative_for(obj, roles=list(Representative.RESOURCE_ROLE_KEYS)):
+            return False
+
+        open_data_roles = roles or [Representative.OPEN_DATA_COORDINATOR, Representative.OPEN_DATA_MANAGER]
         return self.is_representative_for(obj, roles=open_data_roles)
 
     def is_coordinator_for(self, obj: Union[Organization, "Dataset", None], roles: list[str]) -> bool:

--- a/vitrina/users/models.py
+++ b/vitrina/users/models.py
@@ -200,9 +200,9 @@ class User(AbstractUser):
         roles: list[str] | None = None,
     ) -> bool:
         """
-            Returns True if the user is a representative for the given object.
-            The user can have this role either directly or through an organization
-            they belong to. The check also includes parent objects in the ACL hierarchy.
+        Returns True if the user is a representative for the given object.
+        The user can have this role either directly or through an organization
+        they belong to. The check also includes parent objects in the ACL hierarchy.
         """
         if obj is None:
             return False
@@ -221,8 +221,8 @@ class User(AbstractUser):
         roles: list[str] | None = None,
     ) -> bool:
         """
-            Returns True if the user is an Open Data representative for the object.
-            This means the user has either Open Data Coordinator or Manager role.
+        Returns True if the user is an Open Data representative for the object.
+        This means the user has either Open Data Coordinator or Manager role.
         """
         open_data_roles = (
             roles if roles is not None else [Representative.OPEN_DATA_COORDINATOR, Representative.OPEN_DATA_MANAGER]
@@ -231,7 +231,7 @@ class User(AbstractUser):
 
     def is_open_data_coordinator_for(self, obj: Union[Organization, "Dataset", None]) -> bool:
         """
-            Returns True if the user is an Open Data Coordinator for the object.
+        Returns True if the user is an Open Data Coordinator for the object.
         """
         return self.is_open_data_representative_for(obj, roles=[Representative.OPEN_DATA_COORDINATOR])
 
@@ -241,7 +241,7 @@ class User(AbstractUser):
         roles: list[str] | None = None,
     ) -> bool:
         """
-           Returns True if the user directly represents an object.
+        Returns True if the user directly represents an object.
         """
         content_type = ContentType.objects.get_for_model(obj)
         return (
@@ -261,8 +261,8 @@ class User(AbstractUser):
         roles: list[str] | None = None,
     ) -> bool:
         """
-            User belongs to an organization that holds a role on this object.
-            Effective permission = least privileged of (user's org role, org's role on object).
+        User belongs to an organization that holds a role on this object.
+        Effective permission = least privileged of (user's org role, org's role on object).
         """
         content_type = ContentType.objects.get_for_model(obj)
         coordinator_to_manager = dict(zip(Representative.COORDINATOR_ROLES, Representative.MANAGER_ROLES))

--- a/vitrina/users/models.py
+++ b/vitrina/users/models.py
@@ -213,16 +213,11 @@ class User(AbstractUser):
         parents = obj.get_acl_parents()
 
         # Check every node for a direct role.
-        for parent in parents:
-            if self._has_direct_representative_role(parent, roles):
-                return True
+        if any(self._has_direct_representative_role(parent, roles) for parent in parents):
+            return True
 
         # Check every node for organizational membership.
-        for parent in parents:
-            if self._has_role_via_org_membership(parent, roles):
-                return True
-
-        return False
+        return any(self._has_role_via_org_membership(parent, roles) for parent in parents)
 
     def is_open_data_representative_for(
         self,
@@ -257,11 +252,7 @@ class User(AbstractUser):
 
         parents = obj.get_acl_parents()
 
-        for parent in parents:
-            if self._has_direct_representative_role(parent, roles=roles):
-                return True
-
-        return False
+        return any(self._has_direct_representative_role(parent, roles=roles) for parent in parents)
 
     def _has_direct_representative_role(
         self,
@@ -271,6 +262,8 @@ class User(AbstractUser):
         """
         Returns True if the user directly represents an object.
         """
+        if obj is None:
+            return False
         content_type = ContentType.objects.get_for_model(obj)
         return (
             Representative.objects.filter(
@@ -292,6 +285,9 @@ class User(AbstractUser):
         User belongs to an organization that holds a role on this object.
         Effective permission = least privileged of (user's org role, org's role on object).
         """
+        if obj is None:
+            return False
+
         content_type = ContentType.objects.get_for_model(obj)
         coordinator_to_manager = dict(zip(Representative.COORDINATOR_ROLES, Representative.MANAGER_ROLES))
         manager_equivalent_roles = [coordinator_to_manager.get(role, role) for role in roles]

--- a/vitrina/users/models.py
+++ b/vitrina/users/models.py
@@ -206,6 +206,10 @@ class User(AbstractUser):
         """
         if obj is None:
             return False
+
+        if self.is_staff or self.is_superuser:
+            return True
+
         parents = obj.get_acl_parents()
 
         # Check every node for a direct role.
@@ -234,11 +238,25 @@ class User(AbstractUser):
         )
         return self.is_representative_for(obj, roles=open_data_roles)
 
-    def is_open_data_coordinator_for(self, obj: Union[Organization, "Dataset", None]) -> bool:
+    def is_coordinator_for(self, obj: Union[Organization, "Dataset", None], roles: list[str]) -> bool:
         """
         Returns True if the user is an Open Data Coordinator for the object.
+        Only Direct Representative roles are checked because Organizational
+        representatives cannot hold Coordinator status.
         """
-        return self.is_open_data_representative_for(obj, roles=[Representative.OPEN_DATA_COORDINATOR])
+        if obj is None:
+            return False
+
+        if self.is_staff or self.is_superuser:
+            return True
+
+        parents = obj.get_acl_parents()
+
+        for parent in parents:
+            if self._has_direct_representative_role(parent, roles=roles):
+                return True
+
+        return False
 
     def _has_direct_representative_role(
         self,

--- a/vitrina/users/models.py
+++ b/vitrina/users/models.py
@@ -194,31 +194,46 @@ class User(AbstractUser):
             user=self, content_type=org_type, object_id=organization.pk, role=Representative.RESOURCE_COORDINATOR
         ).exists()
 
+    def is_representative_for(
+        self,
+        obj: Union[Organization, "Dataset", None],
+        roles: list[str] | None = None,
+    ) -> bool:
+        """
+            Returns True if the user is a representative for the given object.
+            The user can have this role either directly or through an organization
+            they belong to. The check also includes parent objects in the ACL hierarchy.
+        """
+        if obj is None:
+            return False
+
+        for parent in obj.get_acl_parents():
+            if self._has_direct_representative_role(parent, roles):
+                return True
+            if self._has_role_via_org_membership(parent, roles):
+                return True
+
+        return False
+
     def is_open_data_representative_for(
         self,
         obj: Union[Organization, "Dataset", None],
         roles: list[str] | None = None,
     ) -> bool:
-        if obj is None:
-            return False
-
+        """
+            Returns True if the user is an Open Data representative for the object.
+            This means the user has either Open Data Coordinator or Manager role.
+        """
         open_data_roles = (
             roles if roles is not None else [Representative.OPEN_DATA_COORDINATOR, Representative.OPEN_DATA_MANAGER]
         )
+        return self.is_representative_for(obj, roles=open_data_roles)
 
-        if self._has_direct_representative_role(obj, open_data_roles):
-            return True
-
-        if self._has_role_via_org_membership(obj, open_data_roles):
-            return True
-
-        # Case: check ancestors if the object supports it
-        if hasattr(obj, "get_ancestors"):
-            for ancestor in obj.get_ancestors():
-                if self.is_open_data_representative_for(ancestor, roles=roles):
-                    return True
-
-        return False
+    def is_open_data_coordinator_for(self, obj: Union[Organization, "Dataset", None]) -> bool:
+        """
+            Returns True if the user is an Open Data Coordinator for the object.
+        """
+        return self.is_open_data_representative_for(obj, roles=[Representative.OPEN_DATA_COORDINATOR])
 
     def _has_direct_representative_role(
         self,
@@ -278,16 +293,6 @@ class User(AbstractUser):
                 return True
 
         return False
-
-    def is_open_data_coordinator_for(self, obj: Union[Organization, "Dataset", None]) -> bool:
-        """
-        Check if this user is an Open Data Coordinator for the given object.
-
-        'Coordinator' is a specific role within the representative system.
-        Delegates to `is_open_data_representative_for` with the
-        `OPEN_DATA_COORDINATOR` role.
-        """
-        return self.is_open_data_representative_for(obj, roles=[Representative.OPEN_DATA_COORDINATOR])
 
 
 class UserTablePreferences(models.Model):

--- a/vitrina/users/models.py
+++ b/vitrina/users/models.py
@@ -197,63 +197,85 @@ class User(AbstractUser):
     def is_open_data_representative_for(
         self,
         obj: Union[Organization, "Dataset", None],
-        roles: list | None = None,
+        roles: list[str] | None = None,
     ) -> bool:
         if obj is None:
             return False
 
-        content_type = ContentType.objects.get_for_model(obj)
         open_data_roles = (
             roles if roles is not None else [Representative.OPEN_DATA_COORDINATOR, Representative.OPEN_DATA_MANAGER]
         )
-        coordinator_to_manager = dict(zip(Representative.COORDINATOR_ROLES, Representative.MANAGER_ROLES))
-        manager_equivalent_roles = [coordinator_to_manager.get(role, role) for role in open_data_roles]
 
-        # Case 1: user directly holds an open data role on the object
-        direct_representative = Representative.objects.filter(
-            content_type=content_type,
-            object_id=obj.pk,
-            role__in=open_data_roles,
-            user=self,
-        ).exclude(deleted=True)
-        if direct_representative.exists():
+        if self._has_direct_representative_role(obj, open_data_roles):
             return True
 
-        # Case 2: access is resolved through the user's organizational membership.
-        # Effective role is the least privileged of the user's role and the organization's role on the object.
-        user_organization_role_map = dict(
-            Representative.objects.filter(
-                user=self,
-                content_type=self.organization_content_type,
-            )
-            .exclude(deleted=True)
-            .values_list("object_id", "role")
-        )
+        if self._has_role_via_org_membership(obj, open_data_roles):
+            return True
 
-        if user_organization_role_map:
-            organization_representatives = (
-                Representative.objects.filter(
-                    content_type=content_type,
-                    object_id=obj.pk,
-                    organization_id__in=user_organization_role_map.keys(),
-                )
-                .exclude(deleted=True)
-                .values_list("organization_id", "role")
-            )
-
-            for organization_id, organization_role in organization_representatives:
-                user_role = coordinator_to_manager.get(
-                    user_organization_role_map[organization_id], user_organization_role_map[organization_id]
-                )
-                least_privileged_role = max(organization_role, user_role, key=Representative.MANAGER_ROLES.index)
-                if least_privileged_role in manager_equivalent_roles:
-                    return True
-
-        # Case 3: check ancestors if the object supports it
+        # Case: check ancestors if the object supports it
         if hasattr(obj, "get_ancestors"):
             for ancestor in obj.get_ancestors():
                 if self.is_open_data_representative_for(ancestor, roles=roles):
                     return True
+
+        return False
+
+    def _has_direct_representative_role(
+        self,
+        obj: Union[Organization, "Dataset", None],
+        roles: list[str] | None = None,
+    ) -> bool:
+        """User personally holds one of the given roles on this object."""
+        content_type = ContentType.objects.get_for_model(obj)
+        return (
+            Representative.objects.filter(
+                content_type=content_type,
+                object_id=obj.pk,
+                role__in=roles,
+                user=self,
+            )
+            .exclude(deleted=True)
+            .exists()
+        )
+
+    def _has_role_via_org_membership(
+        self,
+        obj: Union[Organization, "Dataset", None],
+        roles: list[str] | None = None,
+    ) -> bool:
+        """
+        User belongs to an organization that holds a role on this object.
+        Effective permission = least privileged of (user's org role, org's role on object).
+        """
+        content_type = ContentType.objects.get_for_model(obj)
+        coordinator_to_manager = dict(zip(Representative.COORDINATOR_ROLES, Representative.MANAGER_ROLES))
+        manager_equivalent_roles = [coordinator_to_manager.get(role, role) for role in roles]
+
+        user_organization_roles = dict(
+            Representative.objects.filter(user=self, content_type=self.organization_content_type)
+            .exclude(deleted=True)
+            .values_list("object_id", "role")
+        )
+        if not user_organization_roles:
+            return False
+
+        organization_representatives_on_obj = (
+            Representative.objects.filter(
+                content_type=content_type,
+                object_id=obj.pk,
+                organization_id__in=user_organization_roles.keys(),
+            )
+            .exclude(deleted=True)
+            .values_list("organization_id", "role")
+        )
+
+        for organization_id, organization_role in organization_representatives_on_obj:
+            user_role = coordinator_to_manager.get(
+                user_organization_roles[organization_id], user_organization_roles[organization_id]
+            )
+            effective_role = max(organization_role, user_role, key=Representative.MANAGER_ROLES.index)
+            if effective_role in manager_equivalent_roles:
+                return True
 
         return False
 

--- a/vitrina/users/models.py
+++ b/vitrina/users/models.py
@@ -194,13 +194,20 @@ class User(AbstractUser):
             user=self, content_type=org_type, object_id=organization.pk, role=Representative.RESOURCE_COORDINATOR
         ).exists()
 
-    def is_open_data_representative_for(self, obj: Union[Organization, "Dataset", None]) -> bool:
+    def is_open_data_representative_for(
+        self,
+        obj: Union[Organization, "Dataset", None],
+        roles: list | None = None,
+    ) -> bool:
         if obj is None:
             return False
 
         content_type = ContentType.objects.get_for_model(obj)
-        open_data_roles = [Representative.OPEN_DATA_COORDINATOR, Representative.OPEN_DATA_MANAGER]
+        open_data_roles = (
+            roles if roles is not None else [Representative.OPEN_DATA_COORDINATOR, Representative.OPEN_DATA_MANAGER]
+        )
         coordinator_to_manager = dict(zip(Representative.COORDINATOR_ROLES, Representative.MANAGER_ROLES))
+        manager_equivalent_roles = [coordinator_to_manager.get(role, role) for role in open_data_roles]
 
         # Case 1: user directly holds an open data role on the object
         if (
@@ -226,26 +233,33 @@ class User(AbstractUser):
             .values_list("object_id", "role")
         )
 
-        if not user_organization_role_map:
-            return False
+        if user_organization_role_map:
+            for organization_id, organization_role in (
+                Representative.objects.filter(
+                    content_type=content_type,
+                    object_id=obj.pk,
+                    organization_id__in=user_organization_role_map.keys(),
+                )
+                .exclude(deleted=True)
+                .values_list("organization_id", "role")
+            ):
+                user_role = coordinator_to_manager.get(
+                    user_organization_role_map[organization_id], user_organization_role_map[organization_id]
+                )
+                least_privileged_role = max(organization_role, user_role, key=Representative.MANAGER_ROLES.index)
+                if least_privileged_role in manager_equivalent_roles:
+                    return True
 
-        for organization_id, organization_role in (
-            Representative.objects.filter(
-                content_type=content_type,
-                object_id=obj.pk,
-                organization_id__in=user_organization_role_map.keys(),
-            )
-            .exclude(deleted=True)
-            .values_list("organization_id", "role")
-        ):
-            user_role = coordinator_to_manager.get(
-                user_organization_role_map[organization_id], user_organization_role_map[organization_id]
-            )
-            least_privileged_role = max(organization_role, user_role, key=Representative.MANAGER_ROLES.index)
-            if least_privileged_role in open_data_roles:
-                return True
+        # Case 3: check ancestors if the object supports it
+        if hasattr(obj, "get_ancestors"):
+            for ancestor in obj.get_ancestors():
+                if self.is_open_data_representative_for(ancestor, roles=roles):
+                    return True
 
         return False
+
+    def is_open_data_coordinator_for(self, obj: Union[Organization, "Dataset", None]) -> bool:
+        return self.is_open_data_representative_for(obj, roles=[Representative.OPEN_DATA_COORDINATOR])
 
 
 class UserTablePreferences(models.Model):


### PR DESCRIPTION
Summary:

- Updated is_open_data_representative_for function to add a optional parameter role to check coordinators explicitly.
- Updated is_open_data_representative_for function to check for objects which has get_ancestors functionality.

Ticket: https://github.com/atviriduomenys/dvms/issues/538

The branch has been renamed, because in drone the name was too long