### PR TITLE
2541 Add admin command to download Concepts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,6 +70,10 @@ https://github.com/atviriduomenys/katalogas/issues/2537
 
 - Fix Spinta download URL in Data tab to use `/:format/<fmt>` endpoint instead of query parameter format.
 
+https://github.com/atviriduomenys/katalogas/issues/2541
+
+- Added `ConceptSchema` admin action that downloads SKOS `Concept` objects from `ConceptSchema.uri`,
+  if uri is valid URI to EU Vocabulary Authority Tables. 
 
 v 1.17.1 (2026-03-30)
 ==================

--- a/tests/classifiers/test_schema_download.py
+++ b/tests/classifiers/test_schema_download.py
@@ -1,0 +1,503 @@
+from datetime import date
+from unittest.mock import patch, Mock
+
+import pytest
+import requests
+
+from vitrina.classifiers.factories import ConceptSchemaFactory, ConceptFactory
+from vitrina.classifiers.models import ConceptSchema, Concept
+from vitrina.classifiers.schema_download import RDFConceptDownloader
+
+
+pytestmark = pytest.mark.django_db
+
+
+def test_do_nothing_if_concept_schema_queryset_is_empty():
+    concept_downloader = RDFConceptDownloader()
+    success_uris, errors = concept_downloader.from_schemas(ConceptSchema.objects.none())
+
+    assert success_uris == []
+    assert errors == []
+
+
+def test_error_if_concept_schema_is_not_valid_url():
+    concept_schema = ConceptSchemaFactory(uri="test")
+    concept_schema_queryset = ConceptSchema.objects.filter(uri=concept_schema.uri)
+
+    concept_downloader = RDFConceptDownloader()
+    success_uris, errors = concept_downloader.from_schemas(concept_schema_queryset)
+
+    assert success_uris == []
+    assert errors == ["test nėra validus URI."]
+
+
+@patch("vitrina.classifiers.schema_download.requests.get")
+def test_error_if_request_to_concept_schema_uri_fails(request_mock: Mock):
+    response_mock = Mock()
+    response_mock.raise_for_status.side_effect = requests.exceptions.HTTPError("500 Server Error")
+    request_mock.return_value = response_mock
+
+    concept_schema = ConceptSchemaFactory(uri="https://www.foo.bar")
+    concept_schema_queryset = ConceptSchema.objects.filter(uri=concept_schema.uri)
+
+    concept_downloader = RDFConceptDownloader()
+    success_uris, errors = concept_downloader.from_schemas(concept_schema_queryset)
+
+    assert success_uris == []
+    assert errors == ["Nepavyko gauti uri: https://www.foo.bar. Klaida: 500 Server Error."]
+
+
+@patch("vitrina.classifiers.schema_download.requests.get")
+def test_error_if_request_to_concept_schema_uri_times_out(request_mock: Mock):
+    request_mock.side_effect = requests.exceptions.Timeout
+
+    concept_schema = ConceptSchemaFactory(uri="https://www.foo.bar")
+    concept_schema_queryset = ConceptSchema.objects.filter(uri=concept_schema.uri)
+
+    concept_downloader = RDFConceptDownloader()
+    success_uris, errors = concept_downloader.from_schemas(concept_schema_queryset)
+
+    assert success_uris == []
+    assert errors == ["Nepavyko gauti uri: https://www.foo.bar. Klaida: ."]
+
+
+@patch("vitrina.classifiers.schema_download.requests.get")
+def test_error_if_request_succeeds_but_is_empty(request_mock: Mock):
+    response_mock = Mock()
+    response_mock.content = ""
+    request_mock.return_value = response_mock
+
+    concept_schema = ConceptSchemaFactory(uri="https://www.foo.bar")
+    concept_schema_queryset = ConceptSchema.objects.filter(uri=concept_schema.uri)
+
+    concept_downloader = RDFConceptDownloader()
+    success_uris, errors = concept_downloader.from_schemas(concept_schema_queryset)
+
+    assert success_uris == []
+    assert errors == ["Nepavyko gauti uri: https://www.foo.bar. Uri atsakymas tuščias."]
+
+
+@patch("vitrina.classifiers.schema_download.requests.get")
+def test_error_if_response_data_is_not_rdf_data(request_mock: Mock):
+    response_mock = Mock()
+    response_mock.content = "test"
+    request_mock.return_value = response_mock
+
+    concept_schema = ConceptSchemaFactory(uri="https://www.foo.bar")
+    concept_schema_queryset = ConceptSchema.objects.filter(uri=concept_schema.uri)
+
+    concept_downloader = RDFConceptDownloader()
+    success_uris, errors = concept_downloader.from_schemas(concept_schema_queryset)
+
+    assert success_uris == []
+    assert errors == ["Nepavyko gauti uri: https://www.foo.bar. Gautas rezultatas nėra RDF formato."]
+
+
+@patch("vitrina.classifiers.schema_download.requests.get")
+def test_error_if_concept_schema_rdf_does_not_have_any_concept_uris(request_mock: Mock):
+    response_mock = Mock()
+    response_mock.content = "<rdf></rdf>"
+    request_mock.return_value = response_mock
+
+    concept_schema = ConceptSchemaFactory(uri="https://www.foo.bar")
+    concept_schema_queryset = ConceptSchema.objects.filter(uri=concept_schema.uri)
+
+    concept_downloader = RDFConceptDownloader()
+    success_uris, errors = concept_downloader.from_schemas(concept_schema_queryset)
+
+    assert success_uris == []
+    assert errors == [
+        'Sąvokų schemoje https://www.foo.bar nerasta jokių "http://www.w3.org/2004/02/skos/core#topConceptOf" elementų.'
+    ]
+
+
+@patch("vitrina.classifiers.schema_download.requests.get")
+def test_error_if_concept_is_not_uri(request_mock: Mock):
+    response_mock = Mock()
+    response_mock.content = """
+        <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+            <rdf:Description rdf:about="https://www.foo.bar">
+                <skos:hasTopConcept rdf:resource="test2" />
+            </rdf:Description>
+            <rdf:Description rdf:about="test2">
+                <skos:inScheme rdf:resource="https://www.foo.bar" />
+                <skos:topConceptOf rdf:resource="https://www.foo.bar" />
+            </rdf:Description>
+        </rdf:RDF>
+        """
+    request_mock.return_value = response_mock
+
+    concept_schema = ConceptSchemaFactory(uri="https://www.foo.bar")
+    concept_schema_queryset = ConceptSchema.objects.filter(uri=concept_schema.uri)
+
+    concept_downloader = RDFConceptDownloader()
+    success_uris, errors = concept_downloader.from_schemas(concept_schema_queryset)
+
+    assert success_uris == []
+    assert errors == ["test2 nėra validus URI."]
+
+
+@patch("vitrina.classifiers.schema_download.requests.get")
+def test_error_if_cannot_download_concept(request_mock: Mock):
+    mock_schema_response = Mock()
+    mock_schema_response.content = """
+        <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+            <rdf:Description rdf:about="https://www.foo.bar">
+                <skos:hasTopConcept rdf:resource="https://www.foo2.bar2" />
+            </rdf:Description>
+            <rdf:Description rdf:about="https://www.foo2.bar2">
+                <skos:inScheme rdf:resource="https://www.foo.bar" />
+                <skos:topConceptOf rdf:resource="https://www.foo.bar" />
+            </rdf:Description>
+        </rdf:RDF>
+        """
+    mock_concept_response = Mock()
+    mock_concept_response.raise_for_status.side_effect = requests.exceptions.HTTPError("500 Server Error")
+    request_mock.side_effect = [mock_schema_response, mock_concept_response]
+
+    concept_schema = ConceptSchemaFactory(uri="https://www.foo.bar")
+    concept_schema_queryset = ConceptSchema.objects.filter(uri=concept_schema.uri)
+
+    concept_downloader = RDFConceptDownloader()
+    success_uris, errors = concept_downloader.from_schemas(concept_schema_queryset)
+
+    assert success_uris == []
+    assert errors == ["https://www.foo2.bar2 nėra validus URI."]
+
+
+@patch("vitrina.classifiers.schema_download.requests.get")
+def test_error_if_concept_data_is_not_rdf_data(request_mock: Mock):
+    mock_schema_response = Mock()
+    mock_schema_response.content = """
+        <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+            <rdf:Description rdf:about="https://www.foo.bar">
+                <skos:hasTopConcept rdf:resource="https://www.foo2.bar" />
+            </rdf:Description>
+            <rdf:Description rdf:about="https://www.foo2.bar">
+                <skos:inScheme rdf:resource="https://www.foo.bar" />
+                <skos:topConceptOf rdf:resource="https://www.foo.bar" />
+            </rdf:Description>
+        </rdf:RDF>
+        """
+    mock_concept_response = Mock()
+    mock_concept_response.raise_for_status.side_effect = requests.exceptions.HTTPError("500 Server Error")
+    request_mock.side_effect = [mock_schema_response, mock_concept_response]
+
+    concept_schema = ConceptSchemaFactory(uri="https://www.foo.bar")
+    concept_schema_queryset = ConceptSchema.objects.filter(uri=concept_schema.uri)
+
+    concept_downloader = RDFConceptDownloader()
+    success_uris, errors = concept_downloader.from_schemas(concept_schema_queryset)
+
+    assert success_uris == []
+    assert errors == ["Nepavyko gauti uri: https://www.foo2.bar. Klaida: 500 Server Error."]
+
+
+@patch("vitrina.classifiers.schema_download.requests.get")
+def test_error_if_identifier_not_found_in_rdf_data(request_mock: Mock):
+    mock_schema_response = Mock()
+    mock_schema_response.content = """
+        <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+            <rdf:Description rdf:about="https://www.foo.bar">
+                <skos:hasTopConcept rdf:resource="https://www.foo2.bar" />
+            </rdf:Description>
+            <rdf:Description rdf:about="https://www.foo2.bar">
+                <skos:inScheme rdf:resource="https://www.foo.bar" />
+                <skos:topConceptOf rdf:resource="https://www.foo.bar" />
+            </rdf:Description>
+        </rdf:RDF>
+        """
+    mock_concept_response = Mock()
+    mock_concept_response.content = "<RDF></RDF>"
+    request_mock.side_effect = [mock_schema_response, mock_concept_response]
+
+    concept_schema = ConceptSchemaFactory(uri="https://www.foo.bar")
+    concept_schema_queryset = ConceptSchema.objects.filter(uri=concept_schema.uri)
+
+    concept_downloader = RDFConceptDownloader()
+    success_uris, errors = concept_downloader.from_schemas(concept_schema_queryset)
+
+    assert success_uris == []
+    assert errors == ['Sąvokoje https://www.foo2.bar nerastas "http://purl.org/dc/elements/1.1/identifier" elementas.']
+
+
+@patch("vitrina.classifiers.schema_download.requests.get")
+def test_error_if_start_date_not_found_in_rdf_data(request_mock: Mock):
+    mock_schema_response = Mock()
+    mock_schema_response.content = """
+        <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+            <rdf:Description rdf:about="https://www.foo.bar">
+                <skos:hasTopConcept rdf:resource="https://www.foo2.bar" />
+            </rdf:Description>
+            <rdf:Description rdf:about="https://www.foo2.bar">
+                <skos:inScheme rdf:resource="https://www.foo.bar" />
+                <skos:topConceptOf rdf:resource="https://www.foo.bar" />
+            </rdf:Description>
+        </rdf:RDF>
+        """
+    mock_concept_response = Mock()
+    mock_concept_response.content = """
+        <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dc="http://purl.org/dc/elements/1.1/">
+            <rdf:Description rdf:about="https://www.foo2.bar">
+                <dc:identifier>IDENTIFY</dc:identifier>
+            </rdf:Description>
+        </rdf:RDF>
+        """
+    request_mock.side_effect = [mock_schema_response, mock_concept_response]
+
+    concept_schema = ConceptSchemaFactory(uri="https://www.foo.bar")
+    concept_schema_queryset = ConceptSchema.objects.filter(uri=concept_schema.uri)
+
+    concept_downloader = RDFConceptDownloader()
+    success_uris, errors = concept_downloader.from_schemas(concept_schema_queryset)
+
+    assert success_uris == []
+    assert errors == [
+        'Sąvokoje https://www.foo2.bar nerastas "http://publications.europa.eu/ontology/euvoc#startDate" elementas.'
+    ]
+
+
+@patch("vitrina.classifiers.schema_download.requests.get")
+def test_creates_concept(request_mock: Mock):
+    mock_schema_response = Mock()
+    mock_schema_response.content = """
+        <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+            <rdf:Description rdf:about="https://www.foo.bar">
+                <skos:hasTopConcept rdf:resource="https://www.foo2.bar" />
+            </rdf:Description>
+            <rdf:Description rdf:about="https://www.foo2.bar">
+                <skos:inScheme rdf:resource="https://www.foo.bar" />
+                <skos:topConceptOf rdf:resource="https://www.foo.bar" />
+            </rdf:Description>
+        </rdf:RDF>
+        """
+    mock_concept_response = Mock()
+    mock_concept_response.content = """
+        <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ns6="http://publications.europa.eu/ontology/euvoc#">
+            <rdf:Description rdf:about="https://www.foo2.bar">
+                <dc:identifier>IDENTIFY</dc:identifier>
+                <ns6:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2015-10-23</ns6:startDate>
+                <skos:prefLabel xml:lang="en">test_label</skos:prefLabel>
+                <skos:definition xml:lang="en">Test description</skos:definition>
+                <skos:prefLabel xml:lang="lt">test_pavadinimas</skos:prefLabel>
+                <skos:definition xml:lang="lt">Test aprašymas</skos:definition>
+            </rdf:Description>
+        </rdf:RDF>
+        """
+    request_mock.side_effect = [mock_schema_response, mock_concept_response]
+
+    concept_schema = ConceptSchemaFactory(uri="https://www.foo.bar")
+    concept_schema_queryset = ConceptSchema.objects.filter(uri=concept_schema.uri)
+
+    concept_downloader = RDFConceptDownloader()
+    success_uris, errors = concept_downloader.from_schemas(concept_schema_queryset)
+
+    assert success_uris == ["https://www.foo2.bar"]
+    assert errors == []
+
+    concept = Concept.objects.filter(uri="https://www.foo2.bar").first()
+    assert concept is not None
+    assert concept.valid_since == date(2015, 10, 23)
+
+    concept.set_current_language("lt")
+    assert concept.label == "test_pavadinimas"
+    assert concept.description == "Test aprašymas"
+    concept.set_current_language("en")
+    assert concept.label == "test_label"
+    assert concept.description == "Test description"
+
+    assert concept_schema in concept.concept_schemas.all()
+
+
+@patch("vitrina.classifiers.schema_download.requests.get")
+def test_concept_lt_label_and_description_backfills_from_en_language(request_mock: Mock):
+    mock_schema_response = Mock()
+    mock_schema_response.content = """
+        <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+            <rdf:Description rdf:about="https://www.foo.bar">
+                <skos:hasTopConcept rdf:resource="https://www.foo2.bar" />
+            </rdf:Description>
+            <rdf:Description rdf:about="https://www.foo2.bar">
+                <skos:inScheme rdf:resource="https://www.foo.bar" />
+                <skos:topConceptOf rdf:resource="https://www.foo.bar" />
+            </rdf:Description>
+        </rdf:RDF>
+        """
+    mock_concept_response = Mock()
+    mock_concept_response.content = """
+        <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ns6="http://publications.europa.eu/ontology/euvoc#">
+            <rdf:Description rdf:about="https://www.foo2.bar">
+                <dc:identifier>IDENTIFY</dc:identifier>
+                <ns6:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2015-10-23</ns6:startDate>
+                <skos:prefLabel xml:lang="en">test_label</skos:prefLabel>
+                <skos:definition xml:lang="en">Test description</skos:definition>
+            </rdf:Description>
+        </rdf:RDF>
+        """
+    request_mock.side_effect = [mock_schema_response, mock_concept_response]
+
+    concept_schema = ConceptSchemaFactory(uri="https://www.foo.bar")
+    concept_schema_queryset = ConceptSchema.objects.filter(uri=concept_schema.uri)
+
+    concept_downloader = RDFConceptDownloader()
+    success_uris, errors = concept_downloader.from_schemas(concept_schema_queryset)
+
+    assert success_uris == ["https://www.foo2.bar"]
+    assert errors == []
+
+    concept = Concept.objects.filter(uri="https://www.foo2.bar").first()
+    assert concept is not None
+    concept.set_current_language("lt")
+    assert concept.label == "test_label"
+    assert concept.description == "Test description"
+    concept.set_current_language("en")
+    assert concept.label == "test_label"
+    assert concept.description == "Test description"
+
+
+@patch("vitrina.classifiers.schema_download.requests.get")
+def test_updates_existing_concept(request_mock: Mock):
+    mock_schema_response = Mock()
+    mock_schema_response.content = """
+        <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+            <rdf:Description rdf:about="https://www.foo.bar">
+                <skos:hasTopConcept rdf:resource="https://www.foo2.bar" />
+            </rdf:Description>
+            <rdf:Description rdf:about="https://www.foo2.bar">
+                <skos:inScheme rdf:resource="https://www.foo.bar" />
+                <skos:topConceptOf rdf:resource="https://www.foo.bar" />
+            </rdf:Description>
+        </rdf:RDF>
+        """
+    mock_concept_response = Mock()
+    mock_concept_response.content = """
+        <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ns6="http://publications.europa.eu/ontology/euvoc#">
+            <rdf:Description rdf:about="https://www.foo2.bar">
+                <dc:identifier>IDENTIFY</dc:identifier>
+                <ns6:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2015-10-23</ns6:startDate>
+                <skos:prefLabel xml:lang="en">test_label</skos:prefLabel>
+                <skos:definition xml:lang="en">Test description</skos:definition>
+            </rdf:Description>
+        </rdf:RDF>
+        """
+    request_mock.side_effect = [mock_schema_response, mock_concept_response]
+
+    concept_schema_old = ConceptSchemaFactory(uri="old-uri")
+    concept = ConceptFactory(code="IDENTIFY", concept_schemas=[concept_schema_old])
+
+    concept_schema_new = ConceptSchemaFactory(uri="https://www.foo.bar")
+    concept_schema_queryset = ConceptSchema.objects.filter(uri=concept_schema_new.uri)
+
+    concept_downloader = RDFConceptDownloader()
+    success_uris, errors = concept_downloader.from_schemas(concept_schema_queryset)
+
+    assert success_uris == ["https://www.foo2.bar"]
+    assert errors == []
+
+    concept.refresh_from_db()
+    assert concept.uri == "https://www.foo2.bar"
+    assert concept.valid_since == date(2015, 10, 23)
+
+    assert set(concept.concept_schemas.all().values_list("uri", flat=True)) == {
+        concept_schema_old.uri,
+        concept_schema_new.uri,
+    }
+
+
+@patch("vitrina.classifiers.schema_download.requests.get")
+def test_do_not_parse_same_concept_uri_twice(request_mock: Mock):
+    mock_schema_response1 = Mock()
+    mock_schema_response1.content = """
+        <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+            <rdf:Description rdf:about="https://www.foo.bar">
+                <skos:hasTopConcept rdf:resource="https://www.foo2.bar" />
+            </rdf:Description>
+            <rdf:Description rdf:about="https://www.foo2.bar">
+                <skos:inScheme rdf:resource="https://www.foo.bar" />
+                <skos:topConceptOf rdf:resource="https://www.foo.bar" />
+            </rdf:Description>
+        </rdf:RDF>
+        """
+    mock_concept_response = Mock()
+    mock_concept_response.content = """
+        <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ns6="http://publications.europa.eu/ontology/euvoc#">
+            <rdf:Description rdf:about="https://www.foo2.bar">
+                <dc:identifier>IDENTIFY</dc:identifier>
+                <ns6:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2015-10-23</ns6:startDate>
+                <skos:prefLabel xml:lang="en">test_label</skos:prefLabel>
+                <skos:definition xml:lang="en">Test description</skos:definition>
+            </rdf:Description>
+        </rdf:RDF>
+        """
+    mock_schema_response2 = Mock()
+    mock_schema_response2.content = """
+        <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+            <rdf:Description rdf:about="https://www.foo1-1.bar">
+                <skos:hasTopConcept rdf:resource="https://www.foo2.bar" />
+            </rdf:Description>
+            <rdf:Description rdf:about="https://www.foo2.bar">
+                <skos:inScheme rdf:resource="https://www.foo1-1.bar" />
+                <skos:topConceptOf rdf:resource="https://www.foo1-1.bar" />
+            </rdf:Description>
+        </rdf:RDF>
+        """
+    request_mock.side_effect = [mock_schema_response1, mock_concept_response, mock_schema_response2]
+
+    concept_schema1 = ConceptSchemaFactory(uri="https://www.foo.bar")
+    concept_schema2 = ConceptSchemaFactory(uri="https://www.foo1-1.bar")
+    concept_schema_queryset = ConceptSchema.objects.filter(uri__in=(concept_schema1.uri, concept_schema2.uri))
+
+    concept_downloader = RDFConceptDownloader()
+    success_uris, errors = concept_downloader.from_schemas(concept_schema_queryset)
+
+    assert success_uris == ["https://www.foo2.bar"]
+    assert errors == []
+
+    concept = Concept.objects.filter(uri="https://www.foo2.bar").first()
+    assert concept is not None
+    assert set(concept.concept_schemas.values_list("uri", flat=True)) == {
+        concept_schema1.uri,
+        concept_schema2.uri,
+    }
+
+    assert request_mock.call_count == 3
+
+
+@patch("vitrina.classifiers.schema_download.requests.get")
+def test_continue_download_on_error(request_mock: Mock):
+    mock_schema_response = Mock()
+    mock_schema_response.content = """
+        <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+            <rdf:Description rdf:about="https://www.foo.bar">
+                <skos:hasTopConcept rdf:resource="https://www.foo2.bar" />
+            </rdf:Description>
+            <rdf:Description rdf:about="https://www.foo2.bar">
+                <skos:inScheme rdf:resource="https://www.foo.bar" />
+                <skos:topConceptOf rdf:resource="https://www.foo.bar" />
+            </rdf:Description>
+        </rdf:RDF>
+        """
+    mock_concept_response = Mock()
+    mock_concept_response.content = """
+        <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ns6="http://publications.europa.eu/ontology/euvoc#">
+            <rdf:Description rdf:about="https://www.foo2.bar">
+                <dc:identifier>IDENTIFY</dc:identifier>
+                <ns6:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2015-10-23</ns6:startDate>
+                <skos:prefLabel xml:lang="en">test_label</skos:prefLabel>
+                <skos:definition xml:lang="en">Test description</skos:definition>
+                <skos:prefLabel xml:lang="lt">test_pavadinimas</skos:prefLabel>
+                <skos:definition xml:lang="lt">Test aprašymas</skos:definition>
+            </rdf:Description>
+        </rdf:RDF>
+        """
+    request_mock.side_effect = [mock_schema_response, mock_concept_response]
+
+    concept_schema1 = ConceptSchemaFactory(uri="not_url")
+    concept_schema2 = ConceptSchemaFactory(uri="https://www.foo.bar")
+    concept_schema_queryset = ConceptSchema.objects.filter(uri__in=(concept_schema1.uri, concept_schema2.uri))
+
+    concept_downloader = RDFConceptDownloader()
+    success_uris, errors = concept_downloader.from_schemas(concept_schema_queryset)
+
+    assert success_uris == ["https://www.foo2.bar"]
+    assert errors == ["not_url nėra validus URI."]

--- a/vitrina/classifiers/admin.py
+++ b/vitrina/classifiers/admin.py
@@ -1,5 +1,7 @@
 from typing import Any
-from django.contrib import admin
+
+from django.contrib import admin, messages
+from django.core.handlers.wsgi import WSGIRequest
 from django.db.models import QuerySet
 from django.http import HttpRequest
 from django.utils.safestring import mark_safe
@@ -9,6 +11,7 @@ from parler.admin import TranslatableAdmin
 from treebeard.admin import TreeAdmin
 from treebeard.forms import movenodeform_factory
 
+from vitrina.classifiers.schema_download import RDFConceptDownloader
 from vitrina.classifiers.forms import AreaOfManagementAdminForm
 from vitrina.classifiers.models import (
     Category,
@@ -231,7 +234,31 @@ class StatusAdmin(TranslatableAdmin, RevisionCommentVersionAdmin):
 
 @admin.register(ConceptSchema)
 class ConceptSchemaAdmin(TranslatableAdmin, RevisionCommentVersionAdmin):
+    actions = ["download_concepts"]
     list_display = ("label", "uri", "description")
+
+    @admin.action(description=_("Atnaujinti pasirinktų sąvokų schemų sąvokas"))
+    def download_concepts(self, request: WSGIRequest, queryset: QuerySet[ConceptSchema]):
+        concept_downloader = RDFConceptDownloader()
+        processed_concept_uris, errors = concept_downloader.from_schemas(queryset)
+
+        if processed_concept_uris:
+            messages.success(
+                request,
+                mark_safe(
+                    _(
+                        "Sėkmingai atnaujintos {} sąvokų schemų sąvokos. Pilnas sąrašas: <br>{}".format(
+                            len(processed_concept_uris), "<br>".join(processed_concept_uris)
+                        )
+                    )
+                ),
+            )
+
+        if errors:
+            messages.error(
+                request,
+                mark_safe(_("Nepavyko atsisiųsti dalies sąvokų. Pilnas sąrašas: <br>{}".format("<br>".join(errors)))),
+            )
 
 
 @admin.register(Concept)

--- a/vitrina/classifiers/models.py
+++ b/vitrina/classifiers/models.py
@@ -245,7 +245,7 @@ class Concept(TranslatableModel, UUIDBaseModel):
         verbose_name_plural = _("Sąvokos")
 
     def __str__(self) -> str:
-        return self.label
+        return self.translated_label
 
     @property
     def translated_label(self) -> str:

--- a/vitrina/classifiers/schema_download.py
+++ b/vitrina/classifiers/schema_download.py
@@ -14,7 +14,7 @@ EUVOC_START_DATE = URIRef("http://publications.europa.eu/ontology/euvoc#startDat
 
 DOWNLOAD_LANGUAGES = ("lt", "en")
 
-ErrorType = str | None
+SKOS_RDF_REQUEST_TIMEOUT = 2
 
 
 class RDFConceptDownloader:
@@ -31,16 +31,17 @@ class RDFConceptDownloader:
 
     @staticmethod
     def _is_downloadable(uri: str) -> bool:
+        validator = URLValidator()
         try:
-            validator = URLValidator()
             validator(uri)
-            return True
         except ValidationError:
             return False
 
+        return True
+
     def _download_rdf(self, uri: str) -> bytes | None:
         try:
-            response = requests.get(uri, headers={"Accept": "application/rdf+xml"}, timeout=3)
+            response = requests.get(uri, headers={"Accept": "application/rdf+xml"}, timeout=SKOS_RDF_REQUEST_TIMEOUT)
             response.raise_for_status()
         except requests.RequestException as err:
             self.__errors[uri] = _("Nepavyko gauti uri: {}. Klaida: {}.").format(uri, str(err))
@@ -54,9 +55,8 @@ class RDFConceptDownloader:
             return None
 
         if (rdf_data := self._download_rdf(uri)) is None:
-            # self.__errors[uri] = _("Nepavyko gauti uri: {}. Uri atsakymas tuščias.").format(uri)
             return None
-        elif rdf_data == "":
+        elif not rdf_data:
             self.__errors[uri] = _("Nepavyko gauti uri: {}. Uri atsakymas tuščias.").format(uri)
             return None
 
@@ -97,18 +97,16 @@ class RDFConceptDownloader:
         labels = {}
         descriptions = {}
 
-        if (concept_graph := self._create_graph(concept_uri, concept_rdf_data)) is None:
+        if not (concept_graph := self._create_graph(concept_uri, concept_rdf_data)):
             return
 
-        code = next(concept_graph.objects(concept_uri, DC.identifier), None)
-        if not code:
+        if not (code := next(concept_graph.objects(concept_uri, DC.identifier), None)):
             self.__errors[str(concept_uri)] = _('Sąvokoje {} nerastas "{}" elementas.').format(
                 str(concept_uri), DC.identifier
             )
             return
 
-        valid_since = next(concept_graph.objects(concept_uri, EUVOC_START_DATE), None)
-        if not valid_since:
+        if not (valid_since := next(concept_graph.objects(concept_uri, EUVOC_START_DATE), None)):
             self.__errors[str(concept_uri)] = _('Sąvokoje {} nerastas "{}" elementas.').format(
                 str(concept_uri), EUVOC_START_DATE
             )

--- a/vitrina/classifiers/schema_download.py
+++ b/vitrina/classifiers/schema_download.py
@@ -1,0 +1,177 @@
+from xml.sax import SAXParseException
+
+import requests
+from django.core.exceptions import ValidationError
+from django.core.validators import URLValidator
+from django.db.models import QuerySet
+
+from django.utils.translation import gettext_lazy as _
+from rdflib import Graph, URIRef, SKOS, Node, DC
+
+from vitrina.classifiers.models import ConceptSchema, Concept
+
+EUVOC_START_DATE = URIRef("http://publications.europa.eu/ontology/euvoc#startDate")
+
+DOWNLOAD_LANGUAGES = ("lt", "en")
+
+ErrorType = str | None
+
+
+class RDFConceptDownloader:
+    __processed_concepts: dict
+    __errors: dict
+
+    def __init__(self) -> None:
+        self.__processed_concepts = {}
+        self.__errors = {}
+
+    def __reset_results(self) -> None:
+        self.__processed_concepts = {}
+        self.__errors = {}
+
+    @staticmethod
+    def _is_downloadable(uri: str) -> bool:
+        try:
+            validator = URLValidator()
+            validator(uri)
+            return True
+        except ValidationError:
+            return False
+
+    def _download_rdf(self, uri: str) -> bytes | None:
+        try:
+            response = requests.get(uri, headers={"Accept": "application/rdf+xml"}, timeout=3)
+            response.raise_for_status()
+        except requests.RequestException as err:
+            self.__errors[uri] = _("Nepavyko gauti uri: {}. Klaida: {}.").format(uri, str(err))
+            return None
+
+        return response.content
+
+    def _check_and_download_uri(self, uri: str) -> bytes | None:
+        if not self._is_downloadable(uri):
+            self.__errors[uri] = _("{} nėra validus URI.").format(uri)
+            return None
+
+        if (rdf_data := self._download_rdf(uri)) is None:
+            # self.__errors[uri] = _("Nepavyko gauti uri: {}. Uri atsakymas tuščias.").format(uri)
+            return None
+        elif rdf_data == "":
+            self.__errors[uri] = _("Nepavyko gauti uri: {}. Uri atsakymas tuščias.").format(uri)
+            return None
+
+        return rdf_data
+
+    def _create_graph(self, uri: str, rdf_data: bytes) -> Graph | None:
+        try:
+            graph = Graph()
+            graph.parse(data=rdf_data, format="xml")
+        except SAXParseException:
+            self.__errors[uri] = _("Nepavyko gauti uri: {}. Gautas rezultatas nėra RDF formato.").format(uri)
+            return None
+
+        return graph
+
+    def _parse_concept_schema_uri(self, schema_uri: str, schema_rdf_data: bytes) -> set[Node] | None:
+        """
+        Get all concept uri from RDF. Concept URIs have SKOS.hasTopConcept or SKOS.topConceptOf namespace
+        """
+
+        if (schema_graph := self._create_graph(schema_uri, schema_rdf_data)) is None:
+            return None
+
+        schema_uri_ref = URIRef(schema_uri)
+        if not (concept_uris := set(schema_graph.objects(schema_uri_ref, SKOS.hasTopConcept))):
+            # Some RDFs might have the relation reversed
+            concept_uris = set(schema_graph.subjects(SKOS.topConceptOf, schema_uri_ref))
+
+        if not concept_uris:
+            self.__errors[schema_uri] = _('Sąvokų schemoje {} nerasta jokių "{}" elementų.').format(
+                schema_uri, SKOS.topConceptOf
+            )
+            return None
+
+        return concept_uris
+
+    def _parse_concept_uri(self, concept_uri: URIRef, concept_rdf_data: bytes, concept_schema: ConceptSchema) -> None:
+        labels = {}
+        descriptions = {}
+
+        if (concept_graph := self._create_graph(concept_uri, concept_rdf_data)) is None:
+            return
+
+        code = next(concept_graph.objects(concept_uri, DC.identifier), None)
+        if not code:
+            self.__errors[str(concept_uri)] = _('Sąvokoje {} nerastas "{}" elementas.').format(
+                str(concept_uri), DC.identifier
+            )
+            return
+
+        valid_since = next(concept_graph.objects(concept_uri, EUVOC_START_DATE), None)
+        if not valid_since:
+            self.__errors[str(concept_uri)] = _('Sąvokoje {} nerastas "{}" elementas.').format(
+                str(concept_uri), EUVOC_START_DATE
+            )
+            return
+
+        for label in concept_graph.objects(concept_uri, SKOS.prefLabel):
+            if label.language in DOWNLOAD_LANGUAGES:
+                labels[label.language] = str(label)
+
+        for description in concept_graph.objects(concept_uri, SKOS.definition):
+            if description.language in DOWNLOAD_LANGUAGES:
+                descriptions[description.language] = str(description)
+
+        # Fallback: if en exists but lt does not, copy en to lt
+        if "en" in labels and "lt" not in labels:
+            labels["lt"] = labels["en"]
+        if "en" in descriptions and "lt" not in descriptions:
+            descriptions["lt"] = descriptions["en"]
+
+        concept_obj, created = Concept.objects.update_or_create(
+            code=str(code),
+            defaults={
+                "uri": str(concept_uri),
+                "valid_since": valid_since.toPython(),
+            },
+        )
+
+        for lang in DOWNLOAD_LANGUAGES:
+            if lang in labels or lang in descriptions:
+                concept_obj.set_current_language(lang)
+                if lang in labels:
+                    concept_obj.label = labels[lang]
+                if lang in descriptions:
+                    concept_obj.description = descriptions.get(lang, "")
+
+        concept_obj.save()
+        concept_obj.concept_schemas.add(concept_schema)
+
+        self.__processed_concepts[str(concept_uri)] = concept_obj
+
+    def from_schemas(self, concept_schema_queryset: QuerySet[ConceptSchema]) -> tuple[list, list]:
+        self.__reset_results()
+
+        for concept_schema in concept_schema_queryset.filter(uri__isnull=False):
+            if (rdf_data := self._check_and_download_uri(concept_schema.uri)) is None:
+                continue
+
+            if (concept_uris := self._parse_concept_schema_uri(concept_schema.uri, rdf_data)) is None:
+                continue
+
+            for concept_uri in concept_uris:
+                if not isinstance(concept_uri, URIRef):
+                    continue
+
+                uri_str = str(concept_uri)
+                if uri_str in self.__processed_concepts:
+                    concept_obj = self.__processed_concepts[uri_str]
+                    concept_obj.concept_schemas.add(concept_schema)
+                    continue
+
+                if (rdf_data := self._check_and_download_uri(uri_str)) is None:
+                    continue
+
+                self._parse_concept_uri(concept_uri, rdf_data, concept_schema)
+
+        return list(self.__processed_concepts.keys()), list(self.__errors.values())

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -4005,7 +4005,7 @@ msgid "Nurodoma organizacija, kuriai priskirtas šablonas."
 msgstr "Specifies the organization to which the template is assigned."
 
 msgid "Duomenis teikianti organizacija"
-msgstr "Data-providing organisation"
+msgstr "Data-providing organization"
 
 msgid "Duomenų teikėjo atstovas"
 msgstr "Data provider representative"

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-27 13:45+0200\n"
+"POT-Creation-Date: 2026-04-10 09:50+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,6 +17,12 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "Organizacija"
+msgstr "Organization"
+
+msgid "Duomenų skelbėjas"
+msgstr "Data publisher"
 
 msgid "Versijos duomenys"
 msgstr "Version data"
@@ -52,9 +58,6 @@ msgstr "API key"
 
 msgid "Taikymo sritis"
 msgstr "Application area"
-
-msgid "Organizacija"
-msgstr "Organization"
 
 msgid "Duomenų išteklius"
 msgstr "Resource"
@@ -107,6 +110,15 @@ msgstr "Add management area"
 
 msgid "Kategorijos"
 msgstr "Categories"
+
+msgid "Atnaujinti pasirinktų sąvokų schemų sąvokas"
+msgstr "Update selected concept scheme concepts"
+
+msgid "Sėkmingai atnaujintos {} sąvokų schemų sąvokos. Pilnas sąrašas: <br>{}"
+msgstr "Successfully updated {} concept scheme concepts. Full list: <br>{}"
+
+msgid "Nepavyko atsisiųsti dalies sąvokų. Pilnas sąrašas: <br>{}"
+msgstr "Failed to download some concepts. Full list: <br>{}"
 
 msgid "Klasifikatoriai"
 msgstr "Classificators"
@@ -214,6 +226,24 @@ msgstr "Applicable legislation"
 
 msgid "Teisiniai pagrindai"
 msgstr "Applicable legislation"
+
+msgid "Nepavyko gauti uri: {}. Klaida: {}."
+msgstr "Failed to get uri: {}. Error: {}."
+
+msgid "{} nėra validus URI."
+msgstr "{} is not valid URI."
+
+msgid "Nepavyko gauti uri: {}. Uri atsakymas tuščias."
+msgstr "Failed to get uri: {}. Uri response is empty."
+
+msgid "Nepavyko gauti uri: {}. Gautas rezultatas nėra RDF formato."
+msgstr "Failed to get uri: {}. Response is not in RDF format."
+
+msgid "Sąvokų schemoje {} nerasta jokių \"{}\" elementų."
+msgstr "Concept scheme {} does not have any \"{}\" elements."
+
+msgid "Sąvokoje {} nerastas \"{}\" elementas."
+msgstr "Concept {} does not have \"{}\" element."
 
 msgid "Pranešimas (lietuvių kalba)"
 msgstr "Message (in Lithuanian)"
@@ -650,14 +680,6 @@ msgstr ""
 "Contact information that can be used for sending comments about the "
 "resource. Corresponds to dcat:contactPoint"
 
-msgid "Institucija teikianti duomenis"
-msgstr "The institution providing the data"
-
-msgid ""
-"Subjektas, atsakingas už duomenų rinkinio parengimą. Atitinka dct:creator."
-msgstr ""
-"An entity responsible for producing the resource. Corresponds to dct:creator"
-
 msgid "Paslaugų teikėjas"
 msgstr "Service provider"
 
@@ -667,13 +689,6 @@ msgid ""
 msgstr ""
 "This property indicates the entity (organization) responsible for providing "
 "access to the resource. Corresponds to dct:publisher"
-
-msgid ""
-"Ar jūsų atstovaujama institucija yra atsakinga už šio duomenų rinkinio "
-"atvėrimą?"
-msgstr ""
-"Is the institution you are representing responsible for opening the data to "
-"the public?"
 
 msgid ""
 "Teisės aktas, kurio pagrindu yra valdomas ir tvarkomas duomenų rinkinys."
@@ -1592,12 +1607,6 @@ msgstr "Delete"
 msgid "Atsisiuntimo formatas"
 msgstr "Download format"
 
-msgid "Duomenis teikianti organizacija"
-msgstr "Data-providing organisation"
-
-msgid "Institucija, atsakinga už duomenų atvėrimą"
-msgstr "The institution responsible for opening the data to the public"
-
 msgid "Kontaktinė informacija"
 msgstr "Contact information"
 
@@ -1727,6 +1736,9 @@ msgstr "Use case list"
 msgid "Pridėti panaudojimo atvejį"
 msgstr "Add use case"
 
+msgid "Laukia patvirtinimo"
+msgstr "Waiting for confirmation"
+
 msgid ""
 "Šio duomenų rinkinio duomenys nėra naudojami nei viename panaudojimo "
 "atvejyje."
@@ -1832,6 +1844,9 @@ msgstr "History"
 
 msgid "Duomenų ištekliaus būsena"
 msgstr "Resource status"
+
+msgid "Duomenų rengėjas"
+msgstr "Data creator"
 
 msgid "Žymė"
 msgstr "Tag"
@@ -2452,11 +2467,11 @@ msgstr ""
 "Can't remove coordinator role from the user, since he is the only user of "
 "the coordinator role left."
 
-msgid "Narys su šiuo el. pašto adresu jau egzistuoja."
-msgstr "User with this e-mail already exists"
-
 msgid "Jūs neturite teisės priskirti šios rolės."
 msgstr "You don't have permission to assign this representative role."
+
+msgid "Narys su šiuo el. pašto adresu jau egzistuoja."
+msgstr "User with this e-mail already exists"
 
 msgid "Prašymas"
 msgstr "Request"
@@ -2648,6 +2663,9 @@ msgstr "Open data coordinator"
 
 msgid "Atvirų duomenų tvarkytojas"
 msgstr "Open data manager"
+
+msgid "Atvirų duomenų skelbėjas"
+msgstr "Open data publisher"
 
 msgid "Ataskaita"
 msgstr "Report"
@@ -3252,12 +3270,6 @@ msgstr ""
 
 msgid "Pateikti naują panaudojimo atvejį"
 msgstr "Submit a new use case"
-
-msgid "naujas"
-msgstr "new"
-
-msgid "atmestas"
-msgstr "rejected"
 
 msgid "Nėra panaudojimo atvejo"
 msgstr "No use case"
@@ -3991,6 +4003,9 @@ msgstr "File must be in Markdown format (.md)."
 
 msgid "Nurodoma organizacija, kuriai priskirtas šablonas."
 msgstr "Specifies the organization to which the template is assigned."
+
+msgid "Duomenis teikianti organizacija"
+msgstr "Data-providing organisation"
 
 msgid "Duomenų teikėjo atstovas"
 msgstr "Data provider representative"
@@ -4992,6 +5007,7 @@ msgstr "Enum item \"{value}\" must be string type."
 msgid "Reikšmė \"{value}\" turi būti integer tipo."
 msgstr "Enum item \"{value}\" must be integer type."
 
+#, python-brace-format
 msgid "Reikšmė \"{value}\" turi būti number tipo."
 msgstr "Enum item \"{value}\" must be number type."
 


### PR DESCRIPTION
**Summary:**
Add Django admin command to download SKOS data from https://op.europa.eu/en/web/eu-vocabularies/authority-tables

Each `ConceptScheme` URI has a set of `skos:hasTopConcept` URIs. From these URIs we import `Concept` objects.

**Ticket:**
https://github.com/atviriduomenys/katalogas/issues/2541