### PR TITLE
[549]: Allowing coordinators to create / update organizations as repr

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,12 @@ Improvements:
 - Adds variable `Agency.RISR_CODE = "risr"` and uses it throughout the code.
 - Moves some code from `Dataset` form and view to separate methods so that it can be reused. It's mostly copy-paste code
 
+Bug fixes:
+
+https://github.com/atviriduomenys/dvms/issues/549
+
+- Removed `can_update_publishers` permission check from HTML forms and the corresponding view.
+- Removed the early return that was blocking non-superusers from updating Organizations as Representatives.
 
 v 1.18.0 (2026-04-15)
 ==================

--- a/tests/orgs/test_views.py
+++ b/tests/orgs/test_views.py
@@ -390,7 +390,6 @@ def test_representative_create_organization_as_representative(app: DjangoTestApp
     ]
     form["email"] = organization1.email
     form["role"] = "resource_manager"
-    form.submit()
     response = form.submit()
     assert response.status_code == 200
     assert Representative.objects.filter(email="test_org1@test.com").count() == 1
@@ -411,7 +410,6 @@ def test_representative_create_organization_as_coordinator_role(
     ]
     form["email"] = organization1.email
     form["role"] = representative_role
-    form.submit()
     response = form.submit()
     assert response.status_code == 200
     assert "Organizacijai gali būti suteikta tik tvarkytojo rolė" in response.context["form"].errors["role"][0]

--- a/tests/orgs/test_views.py
+++ b/tests/orgs/test_views.py
@@ -391,8 +391,11 @@ def test_representative_create_organization_as_representative(app: DjangoTestApp
     form["email"] = organization1.email
     form["role"] = "resource_manager"
     response = form.submit()
-    assert response.status_code == 200
-    assert Representative.objects.filter(email="test_org1@test.com").count() == 1
+    assert response.status_code == 302
+    representative_qs = Representative.objects.filter(email="test_org1@test.com")
+    assert representative_qs.count() == 1
+    assert representative_qs.first().role == "resource_manager"
+    assert representative_qs.first().organization == organization1
 
 
 @pytest.mark.parametrize(

--- a/tests/orgs/test_views.py
+++ b/tests/orgs/test_views.py
@@ -262,6 +262,7 @@ def representative_data():
         "open_data_representative_coordinator": open_data_representative_coordinator,
         "resource_representative_coordinator": resource_representative_coordinator,
         "representative_viisp_coordinator": representative_viisp_coordinator,
+        "content_type": content_type,
     }
 
 
@@ -380,6 +381,56 @@ def test_representative_create_without_user_for_two_organizations(app: DjangoTes
     assert mail.outbox[0].to == ["new@gmail.com"]
 
 
+def test_representative_create_organization_as_representative(app: DjangoTestApp, representative_data):
+    app.set_user(representative_data["resource_coordinator"])
+    organization1 = OrganizationFactory(email="test_org1@test.com")
+
+    form = app.get(reverse("representative-create", kwargs={"pk": representative_data["organization"].pk})).forms[
+        "representative-form"
+    ]
+    form["email"] = organization1.email
+    form["role"] = "resource_manager"
+    form.submit()
+    response = form.submit()
+    assert response.status_code == 200
+    assert Representative.objects.filter(email="test_org1@test.com").count() == 1
+
+
+@pytest.mark.parametrize(
+    "representative_role",
+    ["resource_coordinator", "open_data_coordinator"],
+)
+def test_representative_create_organization_as_coordinator_role(
+    app: DjangoTestApp, representative_data, representative_role
+):
+    app.set_user(representative_data[representative_role])
+    organization1 = OrganizationFactory(email="test_org1@test.com")
+
+    form = app.get(reverse("representative-create", kwargs={"pk": representative_data["organization"].pk})).forms[
+        "representative-form"
+    ]
+    form["email"] = organization1.email
+    form["role"] = representative_role
+    form.submit()
+    response = form.submit()
+    assert response.status_code == 200
+    assert "Organizacijai gali būti suteikta tik tvarkytojo rolė" in response.context["form"].errors["role"][0]
+    assert Representative.objects.filter(email="test_org1@test.com").count() == 0
+
+
+@pytest.mark.parametrize("restricted_role", ["resource_manager", "resource_coordinator"])
+def test_open_data_coordinator_cannot_see_restricted_roles(app: DjangoTestApp, representative_data, restricted_role):
+    app.set_user(representative_data["open_data_coordinator"])
+
+    form = app.get(reverse("representative-create", kwargs={"pk": representative_data["organization"].pk})).forms[
+        "representative-form"
+    ]
+
+    available_roles = [value for value, _, _ in form["role"].options]
+
+    assert restricted_role not in available_roles
+
+
 def test_representative_create_invalid_phone(app: DjangoTestApp, representative_data):
     app.set_user(representative_data["open_data_coordinator"])
     form = app.get(reverse("representative-create", kwargs={"pk": representative_data["organization"].pk})).forms[
@@ -440,6 +491,34 @@ def test_representative_update_phone(app: DjangoTestApp, representative_data):
     assert resp.status_code == 302
     representative_data["open_data_representative_manager"].refresh_from_db()
     assert representative_data["open_data_representative_manager"].phone == "061234567"
+
+
+def test_representative_update_organization_as_representative(app: DjangoTestApp, representative_data):
+    organization_representative = OrganizationFactory(email="test_org1@test.com")
+    organization_representative = RepresentativeFactory(
+        role="resource_manager",
+        content_type=representative_data["content_type"],
+        object_id=representative_data["organization"].pk,
+        organization=organization_representative,
+    )
+    organization_representative.save()
+    app.set_user(representative_data["resource_coordinator"])
+    form = app.get(
+        reverse(
+            "representative-update",
+            kwargs={
+                "pk": representative_data["organization"].pk,
+                "representative_id": organization_representative.pk,
+            },
+        )
+    ).forms["representative-form"]
+    form["phone"] = "061234567"
+    form["role"] = "open_data_manager"
+    resp = form.submit()
+    assert resp.status_code == 302
+    organization_representative.refresh_from_db()
+    assert organization_representative.phone == "061234567"
+    assert organization_representative.role == "open_data_manager"
 
 
 def test_representative_subscription(app: DjangoTestApp, representative_data):

--- a/vitrina/datasets/services.py
+++ b/vitrina/datasets/services.py
@@ -639,9 +639,6 @@ class DatasetRepresentativeService:
         self._manage_user_subscription(form, user)
 
     def _handle_organization_representative(self, representative: Representative, organization: Organization) -> None:
-        if not self.request.user.is_superuser:
-            return
-
         if not organization.publisher:
             return
 

--- a/vitrina/datasets/templates/vitrina/datasets/members_list.html
+++ b/vitrina/datasets/templates/vitrina/datasets/members_list.html
@@ -77,9 +77,6 @@
                 {% if has_permission %}
                     <td>
                         <div class="buttons is-right">
-                            {% if m.organization and not can_delete_publishers %}
-                            <a></a>
-                            {% else %}
                                 {% can_update_representative m request.user as can_update %}
                                 {% if can_update %}
                                     <a id="update-member-{{ m.pk }}-btn" class="button is-primary is-small"
@@ -87,10 +84,6 @@
                                         {% translate "Redaguoti" %}
                                     </a>
                                 {% endif %}
-                            {% endif %}
-                            {% if m.organization and not can_delete_publishers %}
-                            <a></a>
-                            {% else %}
                                 {% can_update_representative m request.user as can_update %}
                                 {% if can_update %}
                                     <a id="delete-member-{{ m.pk }}-btn"  class="button is-link is-small"
@@ -98,7 +91,6 @@
                                         {% translate "Pašalinti" %}
                                     </a>
                                 {% endif %}
-                            {% endif %}
                         </div>
                     </td>
                 {% endif %}

--- a/vitrina/datasets/views.py
+++ b/vitrina/datasets/views.py
@@ -1415,7 +1415,6 @@ class DatasetMembersView(
             Representative,
             self.object,
         )
-        context["can_delete_publishers"] = self.request.user.is_superuser
         return context
 
 

--- a/vitrina/orgs/models.py
+++ b/vitrina/orgs/models.py
@@ -239,12 +239,7 @@ class Representative(models.Model):
                 Representative.RESOURCE_COORDINATOR,
             ],
         ):
-            return self.role in (
-                Representative.RESOURCE_COORDINATOR,
-                Representative.RESOURCE_MANAGER,
-                Representative.OPEN_DATA_COORDINATOR,
-                Representative.OPEN_DATA_MANAGER,
-            )
+            return self.role in Representative.RESOURCE_ROLE_KEYS | Representative.OPEN_DATA_ROLE_KEYS
 
         if user.is_coordinator_for(
             object,

--- a/vitrina/orgs/templates/vitrina/orgs/members.html
+++ b/vitrina/orgs/templates/vitrina/orgs/members.html
@@ -68,9 +68,6 @@
                     {% endif %}
                     <td>{{ m.get_role_display|default:"-" }}</td>
                     {% if has_permission %}
-                        {% if m.organization and not can_delete_publishers %}
-                        <td></td>
-                        {% else %}
                             {% can_update_representative m request.user as can_update %}
                             {% if can_update %}
                                 <td>
@@ -79,12 +76,8 @@
                                     </a>
                                 </td>
                             {% endif %}
-                        {% endif %}
 
 
-                        {% if m.organization and not can_delete_publishers %}
-                        <td></td>
-                        {% else %}
                             {% can_update_representative m request.user as can_delete %}
                             {% if can_delete %}
                                 <td>
@@ -93,7 +86,6 @@
                                     </a>
                                 </td>
                             {% endif %}
-                        {% endif %}
                     {% endif %}
                 </tr>
             {% endfor %}

--- a/vitrina/orgs/views.py
+++ b/vitrina/orgs/views.py
@@ -1115,7 +1115,7 @@ class RepresentativeCreateView(
                 reverse("organization-detail", kwargs={"pk": self.object.object_id}),
             )
             manage_subscriptions_for_representative(subscribe, user, self.organization, link)
-        elif organization and self.request.user.is_superuser:
+        elif organization:
             if self.object.role in Representative.COORDINATOR_ROLES:
                 form.add_error("role", _("Organizacijai gali būti suteikta tik tvarkytojo rolė"))
                 return self.form_invalid(form)

--- a/vitrina/orgs/views.py
+++ b/vitrina/orgs/views.py
@@ -548,7 +548,6 @@ class OrganizationMembersView(
             Representative,
             self.organization,
         )
-        context_data["can_delete_publishers"] = self.request.user.is_superuser
         context_data["parent_links"].update({None: _("Tvarkytojai")})
         return context_data
 

--- a/vitrina/users/models.py
+++ b/vitrina/users/models.py
@@ -197,7 +197,7 @@ class User(AbstractUser):
     def is_representative_for(
         self,
         obj: Union[Organization, "Dataset", None],
-        roles: list[str] | None = None,
+        roles: list[str],
     ) -> bool:
         """
         Returns True if the user is a representative for the given object.


### PR DESCRIPTION
Summary:

- Removed can_update_publishers permission check from HTML forms and the corresponding view
- Removed the early return that was blocking non-superusers
- Removed the superuser-only restriction when updating an organization

Ticket: https://github.com/atviriduomenys/dvms/issues/549