### PR TITLE
[2546] Add support for ADOC format files in `PartnerRegisterForm`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,10 @@ https://github.com/atviriduomenys/katalogas/issues/2530
 
 - Remove Teritorija, Periodo pradžia, Periodo pabaiga columns from distribution table
 
+https://github.com/atviriduomenys/katalogas/issues/2546
+
+- Allow uploading ADOC files for `PartnerRegisterForm`.
+
 
 Bug fixes:
 

--- a/tests/orgs/test_forms.py
+++ b/tests/orgs/test_forms.py
@@ -1,11 +1,16 @@
+from pathlib import Path
+
 import pytest
 from django.contrib.contenttypes.models import ContentType
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 
+from tests.smart_contracts.conftest import AGREEMENT_ONE_SIGNER
 from vitrina.orgs.factories import OrganizationFactory, RepresentativeFactory
 from vitrina.orgs.forms import (
     OrganizationUpdateForm,
     OrganizationCreateForm,
+    PartnerRegisterForm,
     RepresentativeUpdateForm,
     RepresentativeCreateForm,
 )
@@ -270,3 +275,27 @@ class TestRepresentativeUpdateForm:
         )
 
         assert form.fields["can_make_agreements"].disabled is expected
+
+
+class TestPartnerRegisterForm:
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            AGREEMENT_ONE_SIGNER,
+            "test_form.pdf",
+        ],
+    )
+    def test_request_form_accepted_file_types(self, agreements_dir: Path, filename: str):
+        organization = OrganizationFactory()
+        with open(agreements_dir / filename, "rb") as file:
+            uploaded_file = SimpleUploadedFile(filename, file.read())
+
+        form = PartnerRegisterForm(
+            data={
+                "organization": organization.pk,
+                "coordinator_phone_number": "061234567",
+            },
+            files={"request_form": uploaded_file},
+        )
+
+        assert form.is_valid(), form.errors

--- a/tests/smart_contracts/files/test_contracts/test_form.pdf
+++ b/tests/smart_contracts/files/test_contracts/test_form.pdf
@@ -1,0 +1,21 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>
+endobj
+xref
+0 4
+0000000000 65535 f 
+0000000009 00000 n 
+0000000062 00000 n 
+0000000119 00000 n 
+trailer
+<< /Size 4 /Root 1 0 R >>
+startxref
+199
+%%EOF

--- a/vitrina/helpers.py
+++ b/vitrina/helpers.py
@@ -15,6 +15,7 @@ from operator import itemgetter
 
 import markdown
 from django.contrib.sites.models import Site
+from django.core.files import File
 from django.core.handlers.wsgi import WSGIRequest
 from django.core.handlers.wsgi import HttpRequest
 from django.core.mail import send_mail
@@ -700,7 +701,10 @@ def get_encoding(file_path):
             return "utf-8"
 
 
-def validate_file(file):
+def validate_file(file: File) -> None:
+    # Adding any additional types that are not in Python's built-in MIME type registry.
+    mimetypes.add_type("text/asciidoc", ".adoc")  # ADOC
+
     mime_type = mimetypes.guess_type(file.name)[0] or "application/octet-stream"
     validate_upload(
         file_name=file.name,


### PR DESCRIPTION
Add support for ADOC files by registering them explicitly to the MIME registry of python.


https://github.com/user-attachments/assets/baf93000-adee-45f3-a6fe-02081fe61aeb

