### PR TITLE
Add DCAT DatasetCreateView and forms

### DIFF
--- a/tests/dcat/test_forms.py
+++ b/tests/dcat/test_forms.py
@@ -1,0 +1,339 @@
+import pytest
+from django.utils.translation import override as translation_override
+from vitrina.classifiers.factories import ConceptFactory
+from vitrina.classifiers.models import Concept, ConceptSchema
+from vitrina.classifiers.factories import DocumentationFactory
+from vitrina.datasets.factories import ContactFactory, DatasetFactory
+from vitrina.datasets.models import Dataset
+from vitrina.dcat.forms import (
+    DatasetResourceForm,
+    InformationSystemResourceForm,
+    ServiceResourceForm,
+)
+from vitrina.orgs.factories import OrganizationFactory
+from vitrina.uapi.factories import AgentFactory
+
+pytestmark = pytest.mark.django_db
+
+
+class TestBaseResourceForm:
+    def test_parent_initial_value_set_when_parent_dataset_id_given(self):
+        organization = OrganizationFactory()
+        parent_dataset = DatasetFactory()
+
+        form = InformationSystemResourceForm(
+            organization=organization,
+            parent_dataset_id=parent_dataset.pk,
+        )
+
+        assert form.fields["parent"].initial == parent_dataset.pk
+
+    def test_parent_initial_not_set_when_no_parent_dataset_id(self):
+        organization = OrganizationFactory()
+
+        form = InformationSystemResourceForm(
+            organization=organization,
+            parent_dataset_id=None,
+        )
+
+        assert form.fields["parent"].initial is None
+
+    def test_parent_queryset_excludes_instance(self):
+        organization = OrganizationFactory()
+        dataset = DatasetFactory(organization=organization)
+        other_dataset = DatasetFactory()
+
+        form = InformationSystemResourceForm(
+            organization=organization,
+            parent_dataset_id=None,
+            instance=dataset,
+        )
+
+        assert dataset not in form.fields["parent"].queryset
+        assert other_dataset in form.fields["parent"].queryset
+
+    def test_description_not_required_when_language_is_en(self):
+        organization = OrganizationFactory()
+
+        with translation_override("en"):
+            form = InformationSystemResourceForm(
+                organization=organization,
+                parent_dataset_id=None,
+            )
+
+        assert form.fields["description"].required is False
+
+    def test_description_required_when_language_is_lt(self):
+        organization = OrganizationFactory()
+
+        with translation_override("lt"):
+            form = InformationSystemResourceForm(
+                organization=organization,
+                parent_dataset_id=None,
+            )
+
+        assert form.fields["description"].required is True
+
+    def test_name_with_non_ascii_raises_error(self):
+        organization = OrganizationFactory()
+
+        form = InformationSystemResourceForm(
+            organization=organization,
+            parent_dataset_id=None,
+            data={"name": f"{organization.name}ąčę"},
+        )
+        form.is_valid()
+
+        assert "name" in form.errors
+        assert "Kodiniame pavadinime gali būti naudojamos tik lotyniškos raidės." in form.errors["name"]
+
+
+class TestInformationSystemResourceForm:
+    def test_both_rights_fields_raises_error(self):
+        organization = OrganizationFactory()
+
+        form = InformationSystemResourceForm(
+            organization=organization,
+            parent_dataset_id=None,
+            data={
+                "rights_relation": "https://example.com",
+                "conditions": "Some conditions",
+            },
+        )
+        form.is_valid()
+
+        assert "rights_relation" in form.errors
+        assert "conditions" in form.errors
+        assert "Užpildykite tik vieną teisių deklaracijų lauką." in form.errors["rights_relation"]
+        assert "Užpildykite tik vieną teisių deklaracijų lauką." in form.errors["conditions"]
+
+    def test_invalid_identifier_raises_error(self):
+        organization = OrganizationFactory()
+        importance_schema = ConceptSchema.objects.get(uri=Dataset.INFORMATION_SYSTEM_IMPORTANCE_SCHEMA_URI)
+        importance = ConceptFactory(concept_schemas=[importance_schema])
+
+        form = InformationSystemResourceForm(
+            organization=organization,
+            parent_dataset_id=None,
+            data={
+                "title": "Test IS",
+                "description": "Test description",
+                "name": "testis",
+                "information_system_importance": importance.pk,
+                "information_system_publisher": organization.pk,
+                "information_system_creator": organization.pk,
+                "identifier": "not-four-digits",
+            },
+        )
+        form.is_valid()
+
+        assert "identifier" in form.errors
+        assert "Žymėjimas turi atitikti šabloną: ^\\d{4}$" in form.errors["identifier"]
+
+    def test_valid_identifier_passes(self):
+        organization = OrganizationFactory()
+        importance_schema = ConceptSchema.objects.get(uri=Dataset.INFORMATION_SYSTEM_IMPORTANCE_SCHEMA_URI)
+        importance = ConceptFactory(concept_schemas=[importance_schema])
+
+        form = InformationSystemResourceForm(
+            organization=organization,
+            parent_dataset_id=None,
+            data={
+                "title": "Test IS",
+                "description": "Test description",
+                "name": "testis",
+                "information_system_importance": importance.pk,
+                "information_system_publisher": organization.pk,
+                "information_system_creator": organization.pk,
+                "identifier": "1234",
+            },
+        )
+        form.is_valid()
+
+        assert "identifier" not in form.errors
+
+    def test_invalid_applicable_legislation_url_raises_error(self):
+        organization = OrganizationFactory()
+
+        form = InformationSystemResourceForm(
+            organization=organization,
+            parent_dataset_id=None,
+            data={"applicable_legislation": ["not-a-url"]},
+        )
+        form.is_valid()
+
+        assert "applicable_legislation" in form.errors
+
+
+class TestServiceResourceForm:
+    def test_no_agent_no_endpoint_url_raises_error(self):
+        organization = OrganizationFactory()
+        contact = ContactFactory(organization=organization)
+
+        form = ServiceResourceForm(
+            organization=organization,
+            parent_dataset_id=None,
+            data={
+                "title": "Test Service",
+                "name": "testservice",
+                "tags": "tag1",
+                "contact": contact.pk,
+            },
+        )
+        form.is_valid()
+
+        error_msg = "Pasirinkite agentą, arba nurodykite API adresą."
+        assert "agent" in form.errors
+        assert "endpoint_url" in form.errors
+        assert error_msg in form.errors["agent"]
+        assert error_msg in form.errors["endpoint_url"]
+
+    def test_no_endpoint_description_without_agent_raises_error(self):
+        organization = OrganizationFactory()
+        contact = ContactFactory(organization=organization)
+
+        form = ServiceResourceForm(
+            organization=organization,
+            parent_dataset_id=None,
+            data={
+                "title": "Test Service",
+                "name": "testservice",
+                "tags": "tag1",
+                "contact": contact.pk,
+                "endpoint_url": "http://example.com",
+            },
+        )
+        form.is_valid()
+
+        assert "endpoint_description" in form.errors
+        assert "Pasirinkite agentą, arba nurodykite API specifikaciją." in form.errors["endpoint_description"]
+
+    def test_agent_with_endpoint_url_raises_error(self):
+        organization = OrganizationFactory()
+        contact = ContactFactory(organization=organization)
+        agent = AgentFactory(organization=organization)
+
+        form = ServiceResourceForm(
+            organization=organization,
+            parent_dataset_id=None,
+            data={
+                "title": "Test Service",
+                "name": "testservice",
+                "tags": "tag1",
+                "contact": contact.pk,
+                "agent": agent.pk,
+                "endpoint_url": "http://example.com",
+            },
+        )
+        form.is_valid()
+
+        error_msg = "Pasirinkus agentą, šis laukas negali būti užpildytas."
+        assert "endpoint_url" in form.errors
+        assert error_msg in form.errors["endpoint_url"]
+
+    def test_agent_with_endpoint_description_raises_error(self):
+        organization = OrganizationFactory()
+        contact = ContactFactory(organization=organization)
+        agent = AgentFactory(organization=organization)
+
+        form = ServiceResourceForm(
+            organization=organization,
+            parent_dataset_id=None,
+            data={
+                "title": "Test Service",
+                "name": "testservice",
+                "tags": "tag1",
+                "contact": contact.pk,
+                "agent": agent.pk,
+                "endpoint_description": "http://example.com/spec",
+            },
+        )
+        form.is_valid()
+
+        error_msg = "Pasirinkus agentą, šis laukas negali būti užpildytas."
+        assert "endpoint_description" in form.errors
+        assert error_msg in form.errors["endpoint_description"]
+
+    def test_conforms_to_uapi_without_agent_raises_error(self):
+        organization = OrganizationFactory()
+        contact = ContactFactory(organization=organization)
+        uapi_concept = Concept.objects.get(code="UAPI")
+
+        form = ServiceResourceForm(
+            organization=organization,
+            parent_dataset_id=None,
+            data={
+                "title": "Test Service",
+                "name": "testservice",
+                "tags": "tag1",
+                "contact": contact.pk,
+                "conforms_to": uapi_concept.pk,
+                "endpoint_url": "http://example.com",
+                "endpoint_description": "http://example.com/spec",
+            },
+        )
+        form.is_valid()
+
+        assert "agent" in form.errors
+        assert "UDTS standartą atitinkančios paslaugos privalo būti susietos su agentu." in form.errors["agent"][0]
+
+
+class TestDatasetResourceForm:
+    def test_temporal_start_after_end_raises_error(self):
+        organization = OrganizationFactory()
+
+        form = DatasetResourceForm(
+            organization=organization,
+            parent_dataset_id=None,
+            data={
+                "temporal_start": "2025-08-20",
+                "temporal_end": "2025-08-10",
+            },
+        )
+        form.is_valid()
+
+        assert "temporal_start" in form.errors
+        assert "Laikotarpio pradžios data negali būti vėlesnė nei pabaigos data." in form.errors["temporal_start"]
+
+    def test_temporal_start_before_end_no_error(self):
+        organization = OrganizationFactory()
+
+        form = DatasetResourceForm(
+            organization=organization,
+            parent_dataset_id=None,
+            data={
+                "temporal_start": "2025-01-01",
+                "temporal_end": "2025-12-31",
+            },
+        )
+        form.is_valid()
+
+        assert "temporal_start" not in form.errors
+
+    def test_documentation_initial_populated_from_instance(self):
+        organization = OrganizationFactory()
+        dataset = DatasetFactory(organization=organization)
+        doc1 = DocumentationFactory(documentation_link="https://example.com/doc1")
+        doc2 = DocumentationFactory(documentation_link="https://example.com/doc2")
+        dataset.documentation.set([doc1, doc2])
+
+        form = DatasetResourceForm(
+            organization=organization,
+            parent_dataset_id=None,
+            instance=dataset,
+        )
+
+        assert set(form.initial["documentation"]) == {
+            "https://example.com/doc1",
+            "https://example.com/doc2",
+        }
+
+    def test_documentation_initial_empty_when_no_instance(self):
+        organization = OrganizationFactory()
+
+        form = DatasetResourceForm(
+            organization=organization,
+            parent_dataset_id=None,
+        )
+
+        assert "documentation" not in form.initial

--- a/tests/dcat/test_forms.py
+++ b/tests/dcat/test_forms.py
@@ -82,8 +82,8 @@ class TestBaseResourceForm:
             parent_dataset_id=None,
             data={"name": f"{organization.name}ąčę"},
         )
-        form.is_valid()
 
+        assert not form.is_valid()
         assert "name" in form.errors
         assert "Kodiniame pavadinime gali būti naudojamos tik lotyniškos raidės." in form.errors["name"]
 
@@ -100,8 +100,8 @@ class TestInformationSystemResourceForm:
                 "conditions": "Some conditions",
             },
         )
-        form.is_valid()
 
+        assert not form.is_valid()
         assert "rights_relation" in form.errors
         assert "conditions" in form.errors
         assert "Užpildykite tik vieną teisių deklaracijų lauką." in form.errors["rights_relation"]
@@ -125,8 +125,8 @@ class TestInformationSystemResourceForm:
                 "identifier": "not-four-digits",
             },
         )
-        form.is_valid()
 
+        assert not form.is_valid()
         assert "identifier" in form.errors
         assert "Žymėjimas turi atitikti šabloną: ^\\d{4}$" in form.errors["identifier"]
 
@@ -148,8 +148,8 @@ class TestInformationSystemResourceForm:
                 "identifier": "1234",
             },
         )
-        form.is_valid()
 
+        assert not form.is_valid()
         assert "identifier" not in form.errors
 
     def test_invalid_applicable_legislation_url_raises_error(self):
@@ -160,8 +160,8 @@ class TestInformationSystemResourceForm:
             parent_dataset_id=None,
             data={"applicable_legislation": ["not-a-url"]},
         )
-        form.is_valid()
 
+        assert not form.is_valid()
         assert "applicable_legislation" in form.errors
 
 
@@ -180,9 +180,9 @@ class TestServiceResourceForm:
                 "contact": contact.pk,
             },
         )
-        form.is_valid()
 
         error_msg = "Pasirinkite agentą, arba nurodykite API adresą."
+        assert not form.is_valid()
         assert "agent" in form.errors
         assert "endpoint_url" in form.errors
         assert error_msg in form.errors["agent"]
@@ -203,8 +203,8 @@ class TestServiceResourceForm:
                 "endpoint_url": "http://example.com",
             },
         )
-        form.is_valid()
 
+        assert not form.is_valid()
         assert "endpoint_description" in form.errors
         assert "Pasirinkite agentą, arba nurodykite API specifikaciją." in form.errors["endpoint_description"]
 
@@ -225,9 +225,9 @@ class TestServiceResourceForm:
                 "endpoint_url": "http://example.com",
             },
         )
-        form.is_valid()
 
         error_msg = "Pasirinkus agentą, šis laukas negali būti užpildytas."
+        assert not form.is_valid()
         assert "endpoint_url" in form.errors
         assert error_msg in form.errors["endpoint_url"]
 
@@ -248,9 +248,9 @@ class TestServiceResourceForm:
                 "endpoint_description": "http://example.com/spec",
             },
         )
-        form.is_valid()
 
         error_msg = "Pasirinkus agentą, šis laukas negali būti užpildytas."
+        assert not form.is_valid()
         assert "endpoint_description" in form.errors
         assert error_msg in form.errors["endpoint_description"]
 
@@ -272,8 +272,8 @@ class TestServiceResourceForm:
                 "endpoint_description": "http://example.com/spec",
             },
         )
-        form.is_valid()
 
+        assert not form.is_valid()
         assert "agent" in form.errors
         assert "UDTS standartą atitinkančios paslaugos privalo būti susietos su agentu." in form.errors["agent"][0]
 
@@ -290,8 +290,8 @@ class TestDatasetResourceForm:
                 "temporal_end": "2025-08-10",
             },
         )
-        form.is_valid()
 
+        assert not form.is_valid()
         assert "temporal_start" in form.errors
         assert "Laikotarpio pradžios data negali būti vėlesnė nei pabaigos data." in form.errors["temporal_start"]
 
@@ -306,8 +306,8 @@ class TestDatasetResourceForm:
                 "temporal_end": "2025-12-31",
             },
         )
-        form.is_valid()
 
+        assert not form.is_valid()
         assert "temporal_start" not in form.errors
 
     def test_documentation_initial_populated_from_instance(self):

--- a/tests/dcat/test_views.py
+++ b/tests/dcat/test_views.py
@@ -1,0 +1,377 @@
+import uuid
+
+import pytest
+from django.conf import settings
+from django.urls import reverse
+from django_webtest import DjangoTestApp
+
+from vitrina.catalogs.models import Catalog
+from vitrina.classifiers.factories import ConceptFactory, FrequencyFactory
+from vitrina.classifiers.models import ConceptSchema
+from vitrina.datasets.factories import ContactFactory, DatasetFactory, DCATResourceSubclassFactory
+from vitrina.datasets.models import Dataset, DCATResourceSubclass
+from vitrina.dcat.forms import (
+    DatasetResourceForm,
+    InformationSystemResourceForm,
+    ServiceResourceForm,
+)
+from vitrina.identifiers.models import Identifier
+from vitrina.orgs.factories import OrganizationFactory, RepresentativeFactory
+from vitrina.orgs.models import Representative
+from vitrina.structure.models import Metadata, Version
+from vitrina.users.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+class TestDcatDatasetCreateView:
+    def test_unauthenticated_redirects_to_login(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
+
+        url = reverse(
+            "dcat-dataset-create",
+            kwargs={"organization_id": org.pk, "subclass_uuid": subclass.pk},
+        )
+        response = app.get(url)
+
+        assert response.status_code == 302
+        assert settings.LOGIN_URL in response.location
+
+    def test_no_permission_returns_403(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
+        user = UserFactory()
+        app.set_user(user)
+
+        url = reverse(
+            "dcat-dataset-create",
+            kwargs={"organization_id": org.pk, "subclass_uuid": subclass.pk},
+        )
+        response = app.get(url, expect_errors=True)
+
+        assert response.status_code == 403
+
+    def test_nonexistent_organization_returns_404(self, app: DjangoTestApp):
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        url = reverse(
+            "dcat-dataset-create",
+            kwargs={"organization_id": 999999, "subclass_uuid": subclass.pk},
+        )
+        response = app.get(url, expect_errors=True)
+
+        assert response.status_code == 404
+
+    def test_nonexistent_subclass_returns_404(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        url = reverse(
+            "dcat-dataset-create",
+            kwargs={"organization_id": org.pk, "subclass_uuid": uuid.uuid4()},
+        )
+        response = app.get(url, expect_errors=True)
+
+        assert response.status_code == 404
+
+    def test_coordinator_of_different_org_returns_403(self, app: DjangoTestApp):
+        from django.contrib.contenttypes.models import ContentType
+
+        org = OrganizationFactory()
+        other_org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
+        user = UserFactory()
+        RepresentativeFactory(
+            content_type=ContentType.objects.get_for_model(other_org),
+            object_id=other_org.pk,
+            role=Representative.RESOURCE_COORDINATOR,
+            user=user,
+        )
+        app.set_user(user)
+
+        url = reverse(
+            "dcat-dataset-create",
+            kwargs={"organization_id": org.pk, "subclass_uuid": subclass.pk},
+        )
+        response = app.get(url, expect_errors=True)
+
+        assert response.status_code == 403
+
+    def test_invalid_subclass_redirects_with_error(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        catalog_subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.CATALOG)
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        url = reverse(
+            "dcat-dataset-create",
+            kwargs={"organization_id": org.pk, "subclass_uuid": catalog_subclass.pk},
+        )
+        response = app.get(url)
+
+        assert response.status_code == 302
+        assert reverse("organization-detail", kwargs={"pk": org.pk}) in response.location
+
+    @pytest.mark.parametrize(
+        "subclass_name, expected_form_class",
+        [
+            (DCATResourceSubclass.INFORMATION_SYSTEM, InformationSystemResourceForm),
+            (DCATResourceSubclass.SERVICE, ServiceResourceForm),
+            (DCATResourceSubclass.DATASET, DatasetResourceForm),
+        ],
+    )
+    def test_get_uses_correct_form_per_subclass(self, app: DjangoTestApp, subclass_name: str, expected_form_class):
+        org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=subclass_name)
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        url = reverse(
+            "dcat-dataset-create",
+            kwargs={"organization_id": org.pk, "subclass_uuid": subclass.pk},
+        )
+        response = app.get(url)
+
+        assert response.status_code == 200
+        assert type(response.context["form"]) is expected_form_class
+
+    def test_post_redirects_to_dcat_create_url(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
+        importance_schema = ConceptSchema.objects.get(uri=Dataset.INFORMATION_SYSTEM_IMPORTANCE_SCHEMA_URI)
+        importance = ConceptFactory(concept_schemas=[importance_schema])
+        is_type_schema = ConceptSchema.objects.get(uri=Dataset.INFORMATION_SYSTEM_TYPE_SCHEMA_URI)
+        is_type = ConceptFactory(concept_schemas=[is_type_schema])
+        FrequencyFactory(title="Nežinomas")
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        url = reverse(
+            "dcat-dataset-create",
+            kwargs={"organization_id": org.pk, "subclass_uuid": subclass.pk},
+        )
+        form = app.get(url).forms["dataset-form"]
+        form["title"] = "Test Redirect"
+        form["description"] = "Test redirect description"
+        form["name"] = f"{org.name}testredirect"
+        form["information_system_importance"] = importance.pk
+        form["information_system_type"] = is_type.pk
+        form["information_system_publisher"] = org.pk
+        form["information_system_creator"] = org.pk
+        response = form.submit()
+
+        assert response.status_code == 302
+        expected_url = reverse(
+            "dcat-dataset-create",
+            kwargs={"organization_id": org.pk, "subclass_uuid": str(subclass.pk)},
+        )
+        assert response.location == expected_url
+
+    def test_post_information_system_saves_all_fields(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        publisher_org = OrganizationFactory()
+        creator_org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
+        importance_schema = ConceptSchema.objects.get(uri=Dataset.INFORMATION_SYSTEM_IMPORTANCE_SCHEMA_URI)
+        importance = ConceptFactory(concept_schemas=[importance_schema])
+        is_type_schema = ConceptSchema.objects.get(uri=Dataset.INFORMATION_SYSTEM_TYPE_SCHEMA_URI)
+        is_type = ConceptFactory(concept_schemas=[is_type_schema])
+        FrequencyFactory(title="Nežinomas")
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        url = reverse(
+            "dcat-dataset-create",
+            kwargs={"organization_id": org.pk, "subclass_uuid": subclass.pk},
+        )
+        form = app.get(url).forms["dataset-form"]
+        form["title"] = "IS All Fields"
+        form["description"] = "IS description"
+        form["name"] = f"{org.name}isallfields"
+        form["information_system_importance"] = importance.pk
+        form["information_system_type"] = is_type.pk
+        form["information_system_publisher"] = publisher_org.pk
+        form["information_system_creator"] = creator_org.pk
+        form["landing_page"] = "https://example.com/landing"
+        form["conditions"] = "Some conditions text"
+        form["tags"] = "tagA, tagB"
+        form["identifier"] = "5678"
+        form.submit()
+
+        dataset = Dataset.objects.filter(translations__title="IS All Fields").first()
+        assert dataset is not None
+
+        # Automatically set fields
+        assert dataset.organization == org
+        assert dataset.subclass == subclass
+        assert dataset.is_public is False
+        assert dataset.access_rights == Dataset.CONFIDENTIAL
+        assert dataset.catalog == Catalog.objects.get(identifier=Catalog.IDENTIFIER_ISRIS)
+
+        # Form set fields
+        assert dataset.title == "IS All Fields"
+        assert dataset.description == "IS description"
+        assert dataset.information_system_importance == importance
+        assert dataset.information_system_type == is_type
+        assert dataset.information_system_publisher == publisher_org
+        assert dataset.information_system_creator == creator_org
+        assert dataset.landing_page == "https://example.com/landing"
+        assert dataset.conditions == "Some conditions text"
+        assert set(dataset.tags.all().values_list("name", flat=True)) == {"taga", "tagb"}
+        assert Identifier.objects.filter(resource=dataset, notation="5678").exists()
+        assert Metadata.objects.get(dataset=dataset).name == f"{org.name}isallfields"
+        assert Version.objects.filter(dataset=dataset).count() == 1
+
+    def test_post_service_saves_all_fields(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.SERVICE)
+        contact = ContactFactory(organization=org)
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        url = reverse(
+            "dcat-dataset-create",
+            kwargs={"organization_id": org.pk, "subclass_uuid": subclass.pk},
+        )
+        form = app.get(url).forms["dataset-form"]
+        form["title"] = "Service All Fields"
+        form["name"] = f"{org.name}serviceallfields"
+        form["tags"] = "svcTag"
+        form["contact"] = contact.pk
+        form["endpoint_url"] = "https://api.example.com"
+        form["endpoint_description"] = "https://api.example.com/spec"
+        form["access_rights"] = Dataset.RESTRICTED
+        form["landing_page"] = "https://example.com/service"
+        form.submit()
+
+        dataset = Dataset.objects.filter(translations__title="Service All Fields").first()
+        assert dataset is not None
+
+        # Automatically set fields
+        assert dataset.organization == org
+        assert dataset.subclass == subclass
+        assert dataset.is_public is False
+        assert dataset.service is True
+        assert dataset.catalog == Catalog.objects.get(identifier=Catalog.IDENTIFIER_ISRIS)
+
+        # Form set fields
+        assert dataset.title == "Service All Fields"
+        assert dataset.endpoint_url == "https://api.example.com"
+        assert dataset.endpoint_description == "https://api.example.com/spec"
+        assert dataset.access_rights == Dataset.RESTRICTED
+        assert dataset.landing_page == "https://example.com/service"
+        assert dataset.contact == contact
+        assert set(dataset.tags.all().values_list("name", flat=True)) == {"svctag"}
+
+    def test_post_dataset_saves_all_fields(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.DATASET)
+        frequency = FrequencyFactory()
+        contact = ContactFactory(organization=org)
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        url = reverse(
+            "dcat-dataset-create",
+            kwargs={"organization_id": org.pk, "subclass_uuid": subclass.pk},
+        )
+        form = app.get(url).forms["dataset-form"]
+        form["title"] = "Dataset All Fields"
+        form["description"] = "Dataset description"
+        form["name"] = f"{org.name}datasetallfields"
+        form["access_rights"] = Dataset.RESTRICTED
+        form["frequency"] = frequency.pk
+        form["landing_page"] = "https://example.com/dataset"
+        form["temporal_start"] = "2024-01-01"
+        form["temporal_end"] = "2024-12-31"
+        form["spatial_resolution"] = "100"
+        form["temporal_resolution"] = "P1D"
+        form["contact"] = contact.pk
+        form["tags"] = "dataTag"
+        form.submit()
+
+        dataset = Dataset.objects.filter(translations__title="Dataset All Fields").first()
+        assert dataset is not None
+
+        # Automatically set fields
+        assert dataset.organization == org
+        assert dataset.subclass == subclass
+        assert dataset.is_public is False
+        assert dataset.catalog == Catalog.objects.get(identifier=Catalog.IDENTIFIER_ISRIS)
+
+        # Form set fields
+        assert dataset.title == "Dataset All Fields"
+        assert dataset.description == "Dataset description"
+        assert dataset.access_rights == Dataset.RESTRICTED
+        assert dataset.frequency == frequency
+        assert dataset.landing_page == "https://example.com/dataset"
+        assert str(dataset.temporal_start) == "2024-01-01"
+        assert str(dataset.temporal_end) == "2024-12-31"
+        assert dataset.spatial_resolution == "100"
+        assert dataset.temporal_resolution == "P1D"
+        assert dataset.contact == contact
+        assert set(dataset.tags.all().values_list("name", flat=True)) == {"datatag"}
+        assert Metadata.objects.get(dataset=dataset).name == f"{org.name}datasetallfields"
+
+    def test_post_saves_dataset_with_parent(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
+        parent = DatasetFactory(organization=org, subclass=subclass)
+        importance_schema = ConceptSchema.objects.get(uri=Dataset.INFORMATION_SYSTEM_IMPORTANCE_SCHEMA_URI)
+        importance = ConceptFactory(concept_schemas=[importance_schema])
+        is_type_schema = ConceptSchema.objects.get(uri=Dataset.INFORMATION_SYSTEM_TYPE_SCHEMA_URI)
+        is_type = ConceptFactory(concept_schemas=[is_type_schema])
+        FrequencyFactory(title="Nežinomas")
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        url = reverse(
+            "dcat-dataset-create-with-parent",
+            kwargs={"organization_id": org.pk, "parent_id": parent.pk, "subclass_uuid": subclass.pk},
+        )
+        form = app.get(url).forms["dataset-form"]
+        form["title"] = "Child Dataset"
+        form["description"] = "Child description"
+        form["name"] = f"{org.name}child"
+        form["information_system_importance"] = importance.pk
+        form["information_system_type"] = is_type.pk
+        form["information_system_publisher"] = org.pk
+        form["information_system_creator"] = org.pk
+        form.submit()
+
+        child = Dataset.objects.filter(translations__title="Child Dataset").first()
+        assert child is not None
+        assert child.get_parent().pk == parent.pk
+
+    def test_post_saves_dataset_without_parent(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
+        importance_schema = ConceptSchema.objects.get(uri=Dataset.INFORMATION_SYSTEM_IMPORTANCE_SCHEMA_URI)
+        importance = ConceptFactory(concept_schemas=[importance_schema])
+        is_type_schema = ConceptSchema.objects.get(uri=Dataset.INFORMATION_SYSTEM_TYPE_SCHEMA_URI)
+        is_type = ConceptFactory(concept_schemas=[is_type_schema])
+        FrequencyFactory(title="Nežinomas")
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        url = reverse(
+            "dcat-dataset-create",
+            kwargs={"organization_id": org.pk, "subclass_uuid": subclass.pk},
+        )
+        form = app.get(url).forms["dataset-form"]
+        form["title"] = "Test Dataset"
+        form["description"] = "Dataset description"
+        form["name"] = f"{org.name}dataset"
+        form["information_system_importance"] = importance.pk
+        form["information_system_type"] = is_type.pk
+        form["information_system_publisher"] = org.pk
+        form["information_system_creator"] = org.pk
+        form.submit()
+
+        dataset = Dataset.objects.filter(translations__title="Test Dataset").first()
+        assert dataset is not None
+        assert dataset.get_parent() is None

--- a/tests/orgs/test_services.py
+++ b/tests/orgs/test_services.py
@@ -2102,6 +2102,83 @@ def test_dataset_distribution_edit_permission_organization_publisher_via_org_rep
     assert res is expected
 
 
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "role,expected",
+    [
+        (Representative.RESOURCE_COORDINATOR, True),
+        (Representative.RESOURCE_MANAGER, True),
+        (Representative.OPEN_DATA_COORDINATOR, False),
+        (Representative.OPEN_DATA_MANAGER, False),
+    ],
+)
+def test_dataset_create_wizard_permission_organization(role: str, expected: bool):
+    organization = OrganizationFactory()
+    ct = ContentType.objects.get_for_model(organization)
+    representative = RepresentativeFactory(content_type=ct, object_id=organization.pk, role=role)
+    res = has_perm(representative.user, Action.CREATE_WIZARD, Dataset, organization)
+    assert res is expected
+
+
+@pytest.mark.django_db
+def test_dataset_create_wizard_permission_global_manager():
+    organization = OrganizationFactory()
+    user = UserFactory(is_staff=True)
+    res = has_perm(user, Action.CREATE_WIZARD, Dataset, organization)
+    assert res is True
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "access_rights,role,expected",
+    [
+        (Dataset.PUBLIC, Representative.RESOURCE_COORDINATOR, True),
+        (Dataset.RESTRICTED, Representative.RESOURCE_COORDINATOR, True),
+        (Dataset.NON_PUBLIC, Representative.RESOURCE_COORDINATOR, True),
+        (Dataset.CONFIDENTIAL, Representative.RESOURCE_COORDINATOR, True),
+        (Dataset.PUBLIC, Representative.RESOURCE_MANAGER, True),
+        (Dataset.RESTRICTED, Representative.RESOURCE_MANAGER, True),
+        (Dataset.NON_PUBLIC, Representative.RESOURCE_MANAGER, True),
+        (Dataset.CONFIDENTIAL, Representative.RESOURCE_MANAGER, True),
+        (Dataset.PUBLIC, Representative.OPEN_DATA_COORDINATOR, False),
+        (Dataset.PUBLIC, Representative.OPEN_DATA_MANAGER, False),
+    ],
+)
+def test_dataset_update_wizard_permission_non_public_dataset(access_rights: str, role: str, expected: bool):
+    dataset = DatasetFactory(is_public=False, access_rights=access_rights)
+    ct = ContentType.objects.get_for_model(dataset)
+    rep = RepresentativeFactory(content_type=ct, object_id=dataset.pk, role=role)
+    res = has_perm(rep.user, Action.UPDATE_WIZARD, dataset)
+    assert res is expected
+
+
+@pytest.mark.django_db
+def test_dataset_update_wizard_permission_global_manager():
+    dataset = DatasetFactory(is_public=False)
+    user = UserFactory(is_staff=True)
+    res = has_perm(user, Action.UPDATE_WIZARD, dataset)
+    assert res is True
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "role",
+    [
+        Representative.RESOURCE_COORDINATOR,
+        Representative.RESOURCE_MANAGER,
+        Representative.OPEN_DATA_COORDINATOR,
+        Representative.OPEN_DATA_MANAGER,
+    ],
+)
+def test_dataset_update_wizard_not_allowed_for_public_is(role: str):
+    # UPDATE_WIZARD has no ACL entry for is_public=True datasets
+    dataset = DatasetFactory(is_public=True, access_rights=Dataset.PUBLIC)
+    ct = ContentType.objects.get_for_model(dataset)
+    rep = RepresentativeFactory(content_type=ct, object_id=dataset.pk, role=role)
+    res = has_perm(rep.user, Action.UPDATE_WIZARD, dataset)
+    assert res is False
+
+
 class TestHasDatasetPerm:
     @pytest.mark.parametrize("access_rights", [Dataset.PUBLIC, Dataset.RESTRICTED])
     def test_permissions_with_dataset_open_data_representative(self, access_rights: str):

--- a/vitrina/catalogs/models.py
+++ b/vitrina/catalogs/models.py
@@ -5,6 +5,8 @@ from vitrina.classifiers.models import Licence
 
 
 class Catalog(models.Model):
+    IDENTIFIER_ISRIS = "isris"
+
     # TODO: https://github.com/atviriduomenys/katalogas/issues/59
     created = models.DateTimeField(blank=True, null=True, auto_now_add=True)
     modified = models.DateTimeField(blank=True, null=True, auto_now=True)

--- a/vitrina/classifiers/models.py
+++ b/vitrina/classifiers/models.py
@@ -74,6 +74,8 @@ class Licence(models.Model):
 
 
 class Frequency(models.Model):
+    CODE_UNKNOWN = "UNKNOWN"
+
     created = models.DateTimeField(blank=True, null=True, auto_now_add=True)
     modified = models.DateTimeField(blank=True, null=True, auto_now=True)
     version = models.IntegerField(default=1)

--- a/vitrina/datasets/form_helpers.py
+++ b/vitrina/datasets/form_helpers.py
@@ -143,12 +143,12 @@ def set_default_agent_endpoint_fields(cleaned_data: dict[str, Any]) -> dict[str,
 
     if not cleaned_data.get("endpoint_description_type"):
         if not (openapi_format := Format.objects.filter(title=OPENAPI_FORMAT).first()):
-            raise ValidationError(error_template.format(JSON_FORMAT))
+            raise ValidationError(error_template.format(OPENAPI_FORMAT))
         cleaned_data["endpoint_description_type"] = openapi_format
 
     if not cleaned_data.get("conforms_to"):
         if not (uapi_concept := Concept.objects.filter(code=UAPI_CONCEPT_CODE).first()):
-            raise ValidationError(error_template.format(JSON_FORMAT))
+            raise ValidationError(error_template.format(UAPI_CONCEPT_CODE))
         cleaned_data["conforms_to"] = uapi_concept
 
     return cleaned_data

--- a/vitrina/dcat/forms.py
+++ b/vitrina/dcat/forms.py
@@ -1,0 +1,377 @@
+from typing import Any
+
+from crispy_forms.helper import FormHelper
+from crispy_forms.layout import Layout, Field
+from django import forms
+from django.core.exceptions import ValidationError
+from django.core.validators import RegexValidator
+from django_select2.forms import Select2Widget, Select2MultipleWidget
+from parler.forms import TranslatableModelForm, TranslatedField
+from django.utils.translation import gettext_lazy as _
+
+from vitrina.classifiers.models import Concept
+from vitrina.datasets.form_helpers import (
+    validate_dataset_name,
+    validate_applicable_legislation,
+    validate_identifier,
+    get_contact_form_choices,
+    set_default_agent_endpoint_fields,
+    validate_agent_endpoint_fields,
+    DATA_SERVICE_STANDARD_URI,
+)
+from vitrina.datasets.models import Dataset, Contact
+from vitrina.fields import StringListField
+from vitrina.helpers import inline_fields
+from vitrina.orgs.models import Organization
+from vitrina.uapi.models import Agent
+
+
+class ApplicableLegislationFormMixin(forms.Form):
+    applicable_legislation = StringListField(
+        label=_("Teisinis pagrindas"),
+        help_text=_(
+            "Teisės aktas, kurio pagrindu yra valdomas ir tvarkomas duomenų rinkinys.<br>"
+            "Norint nurodyti konkrečią vietą teisės akto dokumente, po „#“ pateikite konkrečią nuorodą, "
+            "pvz., „#17.2“.<br>"
+            "Tais atvejais, kai yra keli dokumentai su priedais: „#priedas1/17.2“, „17.2/17.2.5“, "
+            "kur „priedas1“ yra dokumento failo pavadinimas.<br>"
+            "Atitinka dcatap:applicableLegislation."
+        ),
+        required=False,
+        unique=True,
+    )
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        instance: Dataset | None = self.instance if self.instance and self.instance.pk else None
+
+        if instance:
+            self.initial["applicable_legislation"] = list(instance.applicable_legislation.values_list("url", flat=True))
+
+    def clean_applicable_legislation(self) -> list[str]:
+        urls = self.cleaned_data.get("applicable_legislation", []) or []
+
+        item_errors = validate_applicable_legislation(urls)
+
+        if any(item_errors):
+            self.fields["applicable_legislation"].widget.validation_errors = item_errors
+            raise ValidationError(_("Yra klaidų sąraše."))
+
+        return [url for url in urls if url]  # Remove empty URL rows
+
+
+class ContactFormMixin(forms.Form):
+    contact = forms.ChoiceField(
+        label=_("Kontaktinis asmuo ar organizacija"),
+        help_text=_(
+            "Kontaktinė informacija, kurią galima naudoti siunčiant pastabas apie duomenų išteklių. Atitinka dcat:contactPoint."
+        ),
+        required=False,
+        widget=Select2Widget,
+    )
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._populate_contact_choices()
+
+    def clean_contact(self) -> Contact | None:
+        if contact := self.cleaned_data.get("contact"):
+            return Contact.objects.get(pk=contact)
+        return None
+
+    def _populate_contact_choices(self) -> None:
+        """Populate contact choices grouped by organization."""
+        self.fields["contact"].choices = [("", "---------")] + get_contact_form_choices(self.organization)
+        self.fields["contact"].initial = self.instance.contact.content_object.id if self.instance.contact else None
+
+
+class BaseResourceForm(TranslatableModelForm):
+    name = forms.CharField(
+        label=_("Kodinis pavadinimas"),
+        help_text=_("Duomenų ištekliaus identifikatorius. Atitinka dct:identifier."),
+        required=True,
+        validators=[
+            RegexValidator(
+                "([a-z]+\/?)+",
+                message="Kodinis pavadinimas turi būti sudarytas iš mažųjų raidžių ir (arba) gali turėti pasvirųjų brūkšnių",
+            )
+        ],
+    )
+    parent = forms.ModelChoiceField(
+        Dataset.objects.all().order_by("translations__title").prefetch_related("translations"),
+        label=_("Tėvinis išteklius"),
+        widget=Select2Widget(),
+        required=False,
+        help_text=_("Ši savybė nurodo susijusį resursą. Atitinka dct:relation."),
+    )
+    description = TranslatedField(required=True)
+    title = TranslatedField(
+        form_class=forms.CharField,
+        required=True,
+        widget=forms.TextInput(),
+    )
+
+    def __init__(self, organization: Organization, parent_dataset_id: int | None, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        instance: Dataset | None = self.instance if self.instance and self.instance.pk else None
+        self.helper = FormHelper()
+        self.helper.attrs["novalidate"] = ""
+        self.helper.form_id = "dataset-form"
+        self.helper.form_tag = False
+        self.organization = organization
+
+        if self.language_code == "en":
+            self.fields["description"].required = False
+
+        if parent_dataset_id:
+            self.fields["parent"].initial = parent_dataset_id
+        elif instance:
+            parent = instance.get_parent()
+            self.fields["parent"].initial = parent
+            self.fields["parent"].queryset = Dataset.objects.exclude(pk=instance.pk)
+
+        if instance:
+            if instance.name:
+                self.initial["name"] = instance.name
+
+    def clean_name(self) -> str | None:
+        name = self.cleaned_data.get("name")
+        validate_dataset_name(
+            name=name,
+            dataset=self.instance,
+            organization=self.organization,
+        )
+
+        return name
+
+
+class InformationSystemResourceForm(ApplicableLegislationFormMixin, BaseResourceForm):
+    identifier = forms.CharField(label=_("Identifikatorius"), required=False)
+
+    class Meta:
+        model = Dataset
+        fields = (
+            "parent",
+            "name",
+            "information_system_importance",
+            "information_system_type",
+            "description",
+            "identifier",
+            "information_system_publisher",
+            "information_system_creator",
+            "title",
+            "landing_page",
+            "applicable_legislation",
+            "conditions",
+            "rights_relation",
+            "tags",
+        )
+        widgets = {
+            "information_system_importance": Select2Widget,
+            "information_system_type": Select2Widget,
+            "information_system_publisher": Select2Widget,
+            "information_system_creator": Select2Widget,
+        }
+
+    def __init__(self, organization: Organization, parent_dataset_id: int | None, *args, **kwargs) -> None:
+        super().__init__(organization, parent_dataset_id, *args, **kwargs)
+        instance = self.instance if self.instance and self.instance.pk else None
+        if instance:
+            self.fields["identifier"].initial = instance.identifier if instance.identifier else ""
+
+        self.fields["landing_page"].label = _("Tinklalapis")
+        self.fields["landing_page"].help_text = _(
+            "Ši savybė nurodo tinklalapį, kuris yra pagrindinis katalogo puslapis. Atitinka foaf:homepage."
+        )
+
+        organization_qs = Organization.objects.all()
+        self.fields["information_system_publisher"].queryset = organization_qs
+        self.fields["information_system_publisher"].required = True
+        self.fields["information_system_publisher"].help_text = _(
+            "Ši savybė nurodo subjektą (organizaciją), atsakingą už IS prieinamumą. Atitinka dct:publisher"
+        )
+        self.fields["information_system_creator"].queryset = organization_qs
+        self.fields["information_system_creator"].required = True
+        self.fields["information_system_creator"].help_text = _(
+            "Subjektas, atsakingas už IS parengimą. Atitinka dct:creator"
+        )
+
+        self.fields["information_system_type"].queryset = Concept.objects.filter(
+            concept_schemas__uri=Dataset.INFORMATION_SYSTEM_TYPE_SCHEMA_URI
+        ).prefetch_related("translations")
+        self.fields["information_system_type"].label_from_instance = lambda obj: str(obj.translated_label)
+
+        self.fields["information_system_importance"].required = True
+        self.fields["information_system_importance"].queryset = Concept.objects.filter(
+            concept_schemas__uri=Dataset.INFORMATION_SYSTEM_IMPORTANCE_SCHEMA_URI
+        ).prefetch_related("translations")
+        self.fields["information_system_importance"].label_from_instance = lambda obj: str(obj.translated_label)
+
+    def clean(self) -> None:
+        rights_relation = self.cleaned_data.get("rights_relation")
+        conditions = self.cleaned_data.get("conditions")
+        if rights_relation and conditions:
+            self.add_error("conditions", _("Užpildykite tik vieną teisių deklaracijų lauką."))
+            self.add_error("rights_relation", _("Užpildykite tik vieną teisių deklaracijų lauką."))
+
+    def clean_identifier(self) -> str:
+        identifier = self.cleaned_data.get("identifier")
+        validate_identifier(identifier)
+
+        return identifier
+
+
+class ServiceResourceForm(ContactFormMixin, BaseResourceForm):
+    endpoint_url = forms.CharField(
+        label=_("API adresas"),
+        required=False,
+        help_text=_("Laisvu tekstu pateikiamas duomenų paslaugos galinio taško URL. Atitinka dcat:endpointURL."),
+    )
+    endpoint_description = forms.CharField(
+        label=_("API specifikacija"),
+        required=False,
+        help_text=_(
+            "Šioje savybėje pateikiamas paslaugų, prieinamų per galinius taškus, aprašymas. "
+            "Įskaitant jų operacijas, parametrus ir t. t. Atitinka dcat:endpointDescription."
+        ),
+    )
+    conforms_to = forms.ModelChoiceField(
+        Concept.objects.filter(concept_schemas__uri=DATA_SERVICE_STANDARD_URI).prefetch_related("translations"),
+        label=_("Atitinka"),
+        required=False,
+        help_text=_("Nurodo kokį standartą atitinka paslauga. Atitinka dct:conformsTo."),
+        widget=Select2Widget,
+    )
+
+    class Meta:
+        model = Dataset
+        fields = (
+            "parent",
+            "name",
+            "title",
+            "agent",  # Either "agent" or "endpoint_url" is required
+            "endpoint_url",
+            "endpoint_type",  # Not in DCAT. Maybe make non-required?
+            "contact",
+            "endpoint_description",
+            "endpoint_description_type",  # Not in DCAT. Maybe make non-required?
+            "tags",
+            "access_rights",
+            "conforms_to",
+            "description",
+            "landing_page",
+            "service_type",
+        )
+
+        widgets = {
+            "agent": Select2Widget,
+            "endpoint_type": Select2Widget,
+            "endpoint_description_type": Select2Widget,
+            "access_rights": Select2Widget,
+            "service_type": Select2MultipleWidget,
+        }
+
+    def __init__(self, organization: Organization, parent_dataset_id: int | None, *args, **kwargs) -> None:
+        super().__init__(organization, parent_dataset_id, *args, **kwargs)
+
+        self.fields["service_type"].queryset = (
+            Concept.objects.filter(concept_schemas__uri=Dataset.SERVICE_TYPE_SCHEME_URI)
+            .prefetch_related("translations")
+            .distinct()
+        )
+        self.fields["service_type"].label_from_instance = lambda obj: obj.safe_translation_getter(
+            "label", any_language=True
+        )
+        self.fields["description"].required = False
+        self.fields["tags"].required = True
+        self.fields["agent"].queryset = Agent.objects.not_archived().filter(organization=self.organization)
+        self.fields["contact"].required = True
+
+    def clean(self) -> dict[str, Any]:
+        cleaned_data = super().clean()
+
+        cleaned_data = set_default_agent_endpoint_fields(cleaned_data)
+
+        errors = validate_agent_endpoint_fields(
+            agent=cleaned_data.get("agent"),
+            conforms_to=cleaned_data.get("conforms_to"),
+            endpoint_url=cleaned_data.get("endpoint_url"),
+            endpoint_type=cleaned_data.get("endpoint_type"),
+            endpoint_description=cleaned_data.get("endpoint_description"),
+            endpoint_description_type=cleaned_data.get("endpoint_description_type"),
+        )
+        for field_name, error_message in errors:
+            self.add_error(field_name, error_message)
+
+        return cleaned_data
+
+
+class DatasetResourceForm(ApplicableLegislationFormMixin, ContactFormMixin, BaseResourceForm):
+    documentation = StringListField(
+        label=_("Dokumentacija"),
+        help_text=_("Ši savybė nurodo puslapį apie šį duomenų rinkinį. Atitinka foaf:page."),
+        required=False,
+        unique=True,
+    )
+
+    class Meta:
+        model = Dataset
+        fields = (
+            "parent",
+            "name",
+            "description",
+            "title",
+            "tags",
+            "temporal_start",
+            "temporal_end",
+            "access_rights",
+            "documentation",
+            "frequency",
+            "landing_page",
+            "contact",
+            "spatial_resolution",
+            "temporal_resolution",
+            "applicable_legislation",
+        )
+        widgets = {
+            "access_rights": Select2Widget,
+            "frequency": Select2Widget,
+            "temporal_start": forms.TextInput(attrs={"type": "date"}),
+            "temporal_end": forms.TextInput(attrs={"type": "date"}),
+        }
+
+    def __init__(self, organization: Organization, parent_dataset_id: int | None, *args, **kwargs) -> None:
+        super().__init__(organization, parent_dataset_id, *args, **kwargs)
+
+        instance: Dataset | None = self.instance if self.instance and self.instance.pk else None
+        if instance:
+            self.initial["documentation"] = list(instance.documentation.values_list("documentation_link", flat=True))
+
+        self.helper.layout = Layout(
+            Field("parent"),
+            Field("name"),
+            Field("description"),
+            Field("title"),
+            Field("tags"),
+            inline_fields(
+                Field("temporal_start"),
+                Field("temporal_end"),
+            ),
+            Field("access_rights"),
+            Field("documentation"),
+            Field("frequency"),
+            Field("landing_page"),
+            Field("contact"),
+            Field("spatial_resolution"),
+            Field("temporal_resolution"),
+            Field("applicable_legislation"),
+        )
+
+    def clean(self) -> None:
+        start = self.cleaned_data.get("temporal_start")
+        end = self.cleaned_data.get("temporal_end")
+        if start and end and start > end:
+            self.add_error(
+                "temporal_start",
+                _("Laikotarpio pradžios data negali būti vėlesnė nei pabaigos data."),
+            )

--- a/vitrina/dcat/templates/vitrina/dcat/dataset_form.html
+++ b/vitrina/dcat/templates/vitrina/dcat/dataset_form.html
@@ -1,0 +1,47 @@
+{% extends "base_form.html" %}
+{% load i18n parler_tags %}
+{% load crispy_forms_tags %}
+
+{% block before_render_css %}{% include "component/before_comment.html" %}{% endblock %}
+{% block after_render_css %}{% include "component/after_comment.html" %}{% endblock %}
+
+{% block before_cms_toolbar %}{% include "component/before_comment.html" %}{% endblock %}
+{% block after_cms_toolbar %}{% include "component/after_comment.html" %}{% endblock %}
+
+{% block before_render_js %}{% include "component/before_comment.html" %}{% endblock %}
+{% block after_render_js %}{% include "component/after_comment.html" %}{% endblock %}
+
+{% block head %}
+    <style>
+        /* Match select width */
+        div.select, .select2.select2-container {
+            width: 100% !important;
+        }
+        /* Match select height and border color */
+        .select2.select2-container .select2-selection--single {
+            height: 2.5rem;
+            padding: 6px 12px;
+            border-color: #767676;
+        }
+        /* Match select dropdown border color */
+        .select2-container .select2-dropdown {
+            border-color: #767676;
+        }
+        /* Match select2 dropdown arrow */
+        .select2-selection__arrow {
+            display: none;
+        }
+    </style>
+{% endblock %}
+
+{% block content %}
+    {% include 'vitrina/datasets/resource_information.html' %}
+    <form method="post" id="dataset-form" enctype="multipart/form-data" novalidate>
+        {% csrf_token %}
+
+        <div class="column is-half">
+            {% crispy form %}
+        </div>
+        {% include 'vitrina/datasets/resource_form_buttons.html' %}
+    </form>
+{% endblock %}

--- a/vitrina/dcat/urls.py
+++ b/vitrina/dcat/urls.py
@@ -1,1 +1,16 @@
-urlpatterns = []
+from django.urls import path
+
+from vitrina.dcat.views import DcatDatasetCreateView
+
+urlpatterns = [
+    path(
+        "organization/<int:organization_id>/dcat/dataset/subclass/<uuid:subclass_uuid>/",
+        DcatDatasetCreateView.as_view(),
+        name="dcat-dataset-create",
+    ),
+    path(
+        "organization/<int:organization_id>/dcat/dataset/parent/<int:parent_id>/subclass/<uuid:subclass_uuid>/",
+        DcatDatasetCreateView.as_view(),
+        name="dcat-dataset-create-with-parent",
+    ),
+]

--- a/vitrina/dcat/views.py
+++ b/vitrina/dcat/views.py
@@ -29,6 +29,13 @@ from vitrina.structure import VersionStatus
 from vitrina.structure.models import Version as _Version, Metadata
 
 
+DCAT_SUBCLASS_FORM_MAP = {
+    DCATResourceSubclass.INFORMATION_SYSTEM: InformationSystemResourceForm,
+    DCATResourceSubclass.SERVICE: ServiceResourceForm,
+    DCATResourceSubclass.DATASET: DatasetResourceForm,
+}
+
+
 class DcatDatasetCreateView(
     LoginRequiredMixin,
     PermissionRequiredMixin,
@@ -42,7 +49,7 @@ class DcatDatasetCreateView(
 
     @cached_property
     def organization(self) -> Organization:
-        return get_object_or_404(Organization, id=self.kwargs.get("organization_id"))
+        return get_object_or_404(Organization, pk=self.kwargs.get("organization_id"))
 
     @cached_property
     def subclass(self) -> DCATResourceSubclass:
@@ -60,7 +67,7 @@ class DcatDatasetCreateView(
         )
         return isris_catalog
 
-    def has_permission(self):
+    def has_permission(self) -> bool:
         return has_perm(self.request.user, Action.CREATE_WIZARD, Dataset, self.organization)
 
     def dispatch(self, request: WSGIRequest, *args, **kwargs) -> HttpResponseBase:
@@ -77,16 +84,12 @@ class DcatDatasetCreateView(
         return super().dispatch(request, *args, **kwargs)
 
     def get_form_class(self) -> BaseResourceForm:
-        if self.subclass.name == DCATResourceSubclass.INFORMATION_SYSTEM:
-            return InformationSystemResourceForm
-        if self.subclass.name == DCATResourceSubclass.SERVICE:
-            return ServiceResourceForm
-        if self.subclass.name == DCATResourceSubclass.DATASET:
-            return DatasetResourceForm
+        if (form_class := DCAT_SUBCLASS_FORM_MAP.get(self.subclass.name)) is None:
+            raise ImproperlyConfigured(_("Nurodytas duomenų ištekliaus poklasis neturi formos."))
 
-        raise ImproperlyConfigured(_("Nurodytas duomenų ištekliaus poklasis neturi formos."))
+        return form_class
 
-    def get_context_data(self, **kwargs):
+    def get_context_data(self, **kwargs) -> dict:
         context = super().get_context_data(**kwargs)
         context.update(
             {
@@ -103,7 +106,7 @@ class DcatDatasetCreateView(
         )
         return context
 
-    def get_form_kwargs(self):
+    def get_form_kwargs(self) -> dict:
         kwargs = super().get_form_kwargs()
         kwargs["organization"] = self.organization
         kwargs["parent_dataset_id"] = self.kwargs.get("parent_id")
@@ -140,9 +143,6 @@ class DcatDatasetCreateView(
 
         if self.subclass.name == DCATResourceSubclass.SERVICE:
             self.object.service = True
-
-        if self.subclass.name == DCATResourceSubclass.DATASET:
-            pass
 
         self.object.save()
         tags = form.cleaned_data.get("tags")

--- a/vitrina/dcat/views.py
+++ b/vitrina/dcat/views.py
@@ -1,0 +1,194 @@
+import uuid
+
+from django.contrib import messages
+from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
+from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ImproperlyConfigured
+from django.core.handlers.wsgi import WSGIRequest
+from django.http import HttpResponseRedirect, HttpResponseBase
+from django.shortcuts import get_object_or_404
+from django.urls import reverse
+from django.utils.functional import cached_property
+from django.utils.translation import get_language
+from parler.views import TranslatableCreateView, LanguageChoiceMixin
+from django.utils.translation import gettext_lazy as _
+
+from vitrina.catalogs.models import Catalog
+from vitrina.classifiers.models import Frequency
+from vitrina.datasets.helpers import generate_unique_dataset_name
+from vitrina.datasets.models import Dataset, DCATResourceSubclass
+from vitrina.datasets.view_helpers import (
+    create_tasks_and_notify_subscribers_about_dataset_creation,
+    create_dataset_representative_and_attribution,
+)
+from vitrina.dcat.forms import InformationSystemResourceForm, BaseResourceForm, ServiceResourceForm, DatasetResourceForm
+from vitrina.identifiers.models import Agency, Identifier
+from vitrina.orgs.models import Organization
+from vitrina.orgs.services import Action, has_perm
+from vitrina.structure import VersionStatus
+from vitrina.structure.models import Version as _Version, Metadata
+
+
+class DcatDatasetCreateView(
+    LoginRequiredMixin,
+    PermissionRequiredMixin,
+    TranslatableCreateView,
+    LanguageChoiceMixin,
+):
+    model = Dataset
+    form_class = InformationSystemResourceForm
+    template_name = "vitrina/dcat/dataset_form.html"
+    context_object_name = "dataset"
+
+    @cached_property
+    def organization(self) -> Organization:
+        return get_object_or_404(Organization, id=self.kwargs.get("organization_id"))
+
+    @cached_property
+    def subclass(self) -> DCATResourceSubclass:
+        return get_object_or_404(DCATResourceSubclass, pk=self.kwargs.get("subclass_uuid"))
+
+    @cached_property
+    def catalog(self) -> Catalog:
+        isris_catalog, created = Catalog.objects.get_or_create(
+            identifier=Catalog.IDENTIFIER_ISRIS,
+            defaults={
+                "title": "ISRIS",
+                "description": "ISRIS - Informacinių sistemų ir Registrų katalogas",
+                "version": "1",
+            },
+        )
+        return isris_catalog
+
+    def has_permission(self):
+        return has_perm(self.request.user, Action.CREATE_WIZARD, Dataset, self.organization)
+
+    def dispatch(self, request: WSGIRequest, *args, **kwargs) -> HttpResponseBase:
+        is_valid_subclass = self.subclass.name in [
+            DCATResourceSubclass.INFORMATION_SYSTEM,
+            DCATResourceSubclass.SERVICE,
+            DCATResourceSubclass.DATASET,
+        ]
+
+        if not is_valid_subclass:
+            messages.error(request, _("Vedlio negalima naudoti su šiuo duomenų ištekliaus poklasiu"))
+            return HttpResponseRedirect(reverse("organization-detail", kwargs={"pk": self.organization.id}))
+
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_form_class(self) -> BaseResourceForm:
+        if self.subclass.name == DCATResourceSubclass.INFORMATION_SYSTEM:
+            return InformationSystemResourceForm
+        if self.subclass.name == DCATResourceSubclass.SERVICE:
+            return ServiceResourceForm
+        if self.subclass.name == DCATResourceSubclass.DATASET:
+            return DatasetResourceForm
+
+        raise ImproperlyConfigured(_("Nurodytas duomenų ištekliaus poklasis neturi formos."))
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context.update(
+            {
+                "organization": self.organization,
+                "organization_id": self.organization.pk,
+                "current_title": _("Pridėti duomenų išteklių"),
+                "form_title": self.subclass.translated_title,
+                "information_title": self.subclass.translated_title,
+                "information_description": self.subclass.translated_description,
+                "current_step": 2,
+                "current_percentage": 100,
+                "button": _("Sukurti"),
+            }
+        )
+        return context
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["organization"] = self.organization
+        kwargs["parent_dataset_id"] = self.kwargs.get("parent_id")
+
+        return kwargs
+
+    def form_valid(self, form: BaseResourceForm) -> HttpResponseBase:
+        language = self.request.GET.get("language", get_language())
+
+        self.object = form.save(commit=False)
+        self.object.set_current_language(language)
+        self.object.organization = self.organization
+        self.object.subclass = self.subclass
+        self.object.is_public = False
+        self.object.catalog = self.catalog
+
+        parent: Dataset | None = form.cleaned_data.get("parent", None)
+        if parent:
+            parent.add_child(instance=self.object)
+        else:
+            Dataset.add_root(instance=self.object)
+
+        if self.subclass.name == DCATResourceSubclass.INFORMATION_SYSTEM:
+            self.object.access_rights = Dataset.CONFIDENTIAL
+            self.object.frequency = Frequency.objects.filter(code=Frequency.CODE_UNKNOWN).first()
+            if identifier := form.cleaned_data.get("identifier"):
+                agency = get_object_or_404(Agency, code=Agency.RISR_CODE)
+                Identifier.objects.create(
+                    resource=self.object,
+                    notation=identifier,
+                    scheme_agency=agency,
+                    identifier_type=Identifier.IdentifierType.OTHER,
+                )
+
+        if self.subclass.name == DCATResourceSubclass.SERVICE:
+            self.object.service = True
+
+        if self.subclass.name == DCATResourceSubclass.DATASET:
+            pass
+
+        self.object.save()
+        tags = form.cleaned_data.get("tags")
+        self.object.tags.set(tags)
+
+        dataset_name = form.cleaned_data.get("name", "") or generate_unique_dataset_name(
+            self.object.organization, self.object
+        )
+        draft_metadata_version = _Version.objects.create(
+            dataset=self.object,
+            version=1,
+            status=VersionStatus.DRAFT,
+        )
+        Metadata.objects.create(
+            uuid=str(uuid.uuid4()),
+            dataset=self.object,
+            content_type=ContentType.objects.get_for_model(self.object),
+            object_id=self.object.pk,
+            name=dataset_name,
+            title=self.object.title,
+            description=self.object.description,
+            prepare_ast={},
+            version=1,
+            metadata_version=draft_metadata_version,
+        )
+
+        create_tasks_and_notify_subscribers_about_dataset_creation(self.request, self.object)
+        create_dataset_representative_and_attribution(self.object)
+
+        if applicable_legislation_urls := form.cleaned_data.get("applicable_legislation"):
+            self.object.update_applicable_legislation(applicable_legislation_urls)
+
+        if documentation_urls := form.cleaned_data.get("documentation"):
+            self.object.update_documentation(documentation_urls)
+
+        if "service_type" in form.changed_data:
+            self.object.service_type.set(form.cleaned_data["service_type"])
+
+        messages.success(self.request, _("Duomenų išteklius sukurtas sėkmingai"))
+
+        return HttpResponseRedirect(
+            reverse(
+                "dcat-dataset-create",
+                kwargs={
+                    "organization_id": self.organization.pk,
+                    "subclass_uuid": str(self.subclass.pk),
+                },
+            )
+        )

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-22 11:16+0300\n"
+"POT-Creation-Date: 2026-04-22 11:53+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -684,7 +684,8 @@ msgstr "The notation must match the pattern: %(pattern)s"
 
 #, python-brace-format
 msgid "Nepavyko rasti `{0}` pasirinkimų sąraše. Susisiekite su administracija."
-msgstr "Could not find {0} in the list of choices. Please contact the administration."
+msgstr ""
+"Could not find {0} in the list of choices. Please contact the administration."
 
 msgid "Pasirinkite agentą, arba nurodykite API adresą."
 msgstr "Select an agent or specify an API address."
@@ -1965,6 +1966,12 @@ msgstr "Organizations"
 
 msgid "vaikiniai duomenų ištekliai"
 msgstr "child resources"
+
+msgid "Vedlio negalima naudoti su šiuo duomenų ištekliaus poklasiu"
+msgstr "Form creation tool cannot be used for this resource subclass"
+
+msgid "Nurodytas duomenų ištekliaus poklasis neturi formos."
+msgstr "Given resource subclass does not have defined form."
 
 msgid "Pasirinkti failą"
 msgstr "Select a file"

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-22 11:53+0300\n"
+"POT-Creation-Date: 2026-04-24 11:32+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -659,24 +659,24 @@ msgid ""
 "Kodinis pavadinimas turi prasidėti nuo „%(expected)s“ arba vieno iš "
 "leidžiamų kodinio pavadinimo pradžių: „%(whitelisted)s“."
 msgstr ""
-"The code name must begin with „%(expected)s“ or one of the following "
-"whitelisted code name prefixes: „%(whitelisted)s“."
+"The codename must begin with „%(expected)s“ or one of the following "
+"whitelisted codename prefixes: „%(whitelisted)s“."
 
 #, python-format
 msgid "Kodinis pavadinimas turi prasidėti nuo „%(expected)s“."
-msgstr "The code name must begin with „%(expected)s“."
+msgstr "The codename must begin with „%(expected)s“."
 
 #, python-format
 msgid "Po „%(prefix)s“ turi būti bent vienas simbolis."
 msgstr "There must be at least one character after „%(prefix)s“."
 
 msgid "Duomenų rinkinys su šiuo kodiniu pavadinimu jau egzistuoja."
-msgstr "Dataset with this code name already exists."
+msgstr "Dataset with this codename already exists."
 
 msgid ""
 "Kodinis pavadinimas yra privalomas, jei duomenų rinkinys jau turi kodinį "
 "pavadinimą."
-msgstr "A code name is required if the dataset already has a code name."
+msgstr "A codename is required if the dataset already has a codename."
 
 #, python-format
 msgid "Žymėjimas turi atitikti šabloną: %(pattern)s"
@@ -686,6 +686,20 @@ msgstr "The notation must match the pattern: %(pattern)s"
 msgid "Nepavyko rasti `{0}` pasirinkimų sąraše. Susisiekite su administracija."
 msgstr ""
 "Could not find {0} in the list of choices. Please contact the administration."
+
+msgid "Pasirinkus agentą, šis laukas negali būti užpildytas."
+msgstr "If agent is selected, this field must be left empty."
+
+#, python-brace-format
+msgid "Pasirinkus agentą, API formatas privalo būti '{0}'"
+msgstr "If an agent is selected, the API format must be '{0}'."
+
+#, python-brace-format
+msgid "Pasirinkus agentą, API specifikacijos formatas privalo būti '{0}'"
+msgstr "If an agent is selected, the API specification format must be '{0}'."
+
+msgid "Su agentu susietos paslaugos privalo atitikti UDTS standartą."
+msgstr "Services associated with an agent must comply with the UAPI standard."
 
 msgid "Pasirinkite agentą, arba nurodykite API adresą."
 msgstr "Select an agent or specify an API address."
@@ -700,20 +714,6 @@ msgstr ""
 "Services that comply with the UAPI standard must be associated with an "
 "agent. Select an agent or choose a different value for the 'Conforms to' "
 "field."
-
-msgid "Pasirinkus agentą, šis laukas negali būti užpildytas."
-msgstr "If agent is selected, this field must be left emtpy."
-
-#, python-brace-format
-msgid "Pasirinkus agentą, API formatas privalo būti '{0}'"
-msgstr "If an agent is selected, the API format must be '{0}'."
-
-#, python-brace-format
-msgid "Pasirinkus agentą, API specifikacijos formatas privalo būti '{0}'"
-msgstr "If an agent is selected, the API specification format must be '{0}'."
-
-msgid "Su agentu susietos paslaugos privalo atitikti UDTS standartą."
-msgstr "Services associated with an agent must comply with the UAPI standard."
 
 msgid "Duomenų ištekliaus rūšis"
 msgstr "Resource subclass"
@@ -820,7 +820,7 @@ msgid "Ar duomenys vieši?"
 msgstr "Is the data public?"
 
 msgid "Duomenų rinkinio kodinis pavadinimas"
-msgstr "Dataset code name"
+msgstr "Dataset codename"
 
 msgid "Detalus duomenų rinkinio aprašas"
 msgstr "Detailed description of the dataset"
@@ -832,7 +832,7 @@ msgid "Metaduomenų katalogo pavadinimas"
 msgstr "Metadata catalog title"
 
 msgid "Metaduomenų katalogo kodinis pavadinimas"
-msgstr "Metadata catalog code name"
+msgstr "Metadata catalog codename"
 
 msgid "Detalus metaduomenų katalogo aprašas"
 msgstr "Detailed description of the metadata catalog"
@@ -1334,7 +1334,7 @@ msgstr "The user has been sent an email for registration"
 msgid ""
 "Modelio kodiniame pavadinime gali būti didžiosos/mažosios raidės ir "
 "skaičiai, "
-msgstr "Model code name can contain uppercase/lowercase letters and numbers. "
+msgstr "Model codename can contain uppercase/lowercase letters and numbers. "
 
 msgid ""
 "Pavadinime gali būti mažosios raidės ir skaičiai, žodžiai gali būti atskirti "
@@ -1971,7 +1971,7 @@ msgid "Vedlio negalima naudoti su šiuo duomenų ištekliaus poklasiu"
 msgstr "Form creation tool cannot be used for this resource subclass"
 
 msgid "Nurodytas duomenų ištekliaus poklasis neturi formos."
-msgstr "Given resource subclass does not have defined form."
+msgstr "Given resource subclass does not have a defined form."
 
 msgid "Pasirinkti failą"
 msgstr "Select a file"
@@ -2335,10 +2335,10 @@ msgid "organizacija"
 msgstr "organization"
 
 msgid "Leistinas kodinis pavadinimas"
-msgstr "Allowed code name"
+msgstr "Allowed codename"
 
 msgid "Leistini kodiniai pavadinimai"
-msgstr "Allowed code names"
+msgstr "Allowed codenames"
 
 msgid ""
 "Pasirinktoms organizacijoms sėkmingai pašalintas, duomenų atvėrimo paslaugos "
@@ -2414,7 +2414,7 @@ msgid "Logotipas"
 msgstr "Logo"
 
 msgid "Pirmas kodinio pavadinimo simbolis turi būti mažoji raidė."
-msgstr "First symbol of code name must be lowercase letter."
+msgstr "First symbol of codename must be lowercase letter."
 
 msgid ""
 "Pavadinime gali būti didžiosos/mažosios raidės ir skaičiai, žodžiai gali "
@@ -2604,7 +2604,7 @@ msgid "Organizacijai negali būti nurodytos pareigos."
 msgstr "A position cannot be specified for an organization"
 
 msgid "Toks Organizacijos kodinis pavadinimas jau egzistuoja."
-msgstr "This code name for the Organization already exists."
+msgstr "This codename for the Organization already exists."
 
 msgid "Neteisingas objekto tipas. Turi būti AreaOfManagement arba int"
 msgstr "Incorrect object type. It must be AreaOfManagement or int."
@@ -4471,7 +4471,7 @@ msgstr ""
 "changing parts or filters."
 
 msgid "Pirmas kodinio pavadinimo simbolis turi būti didžioji raidė."
-msgstr "First symbol of code name must be capital letter."
+msgstr "First symbol of codename must be capital letter."
 
 msgid ""
 "Pavadinime gali būti didžiosos/mažosios raidės ir skaičiai, jokie kiti "
@@ -4481,7 +4481,7 @@ msgstr ""
 "symbols are not allowed."
 
 msgid "Modelis su tokiu kodiniu pavadinimu jau egzistuoja."
-msgstr "Model with this code name already exists."
+msgstr "Model with this codename already exists."
 
 msgid ""
 "Stulpelis 'Klasė' turi būti užpildytas pasirenkant šį metaduomenų matomumo "
@@ -4611,7 +4611,7 @@ msgid ""
 "Duomenų lauko kodinis pavadinimas. Galimi simboliai: lotyniškos mažosios "
 "raidės, skaičiai ir apatinio pabraukimo (`_`) simbolis."
 msgstr ""
-"The code name of the data field. Allowed characters: Latin lower case "
+"The codename of the data field. Allowed characters: Latin lower case "
 "letters, digits, and the underscore (`_`) character."
 
 msgid ""
@@ -4651,7 +4651,7 @@ msgid ""
 msgstr ""
 "Data field name. This name is intended for human readability and will be "
 "displayed in data field lists and headers. If not provided, the property "
-"code name will be used."
+"codename will be used."
 
 msgid "Duomenų lauko aprašymas."
 msgstr "Data field description."

--- a/vitrina/orgs/services.py
+++ b/vitrina/orgs/services.py
@@ -46,6 +46,8 @@ class Action(Enum):
     MANAGE_KEYS = "manage_keys"
     MANAGE_PROJECT_KEYS = "manage_project_keys"
     ASSIGN = "assign"
+    CREATE_WIZARD = "create_wizard"
+    UPDATE_WIZARD = "update_wizard"
 
 
 class Role(Enum):
@@ -73,6 +75,8 @@ WRITE_ACTIONS: set[Action] = {
     Action.ASSIGN,
     Action.INFORMATION_SYSTEM_UPDATE,
     Action.INFORMATION_SYSTEM_REPRESENTATIVE_CREATE,
+    Action.CREATE_WIZARD,
+    Action.UPDATE_WIZARD,
 }
 DATASET_RELATED_OBJECTS: set[Type[Model]] = {
     Dataset,
@@ -128,7 +132,7 @@ def inherit_structure_acl(
     return new_acl
 
 
-_dataset_update_acl: ACL = {
+_dataset_base_update_acl: ACL = {
     (Dataset, DATASET_IS_PUBLIC, Dataset.PUBLIC, Action.UPDATE): {
         Role.GLOBAL_MANAGER,
         Role.RESOURCE_COORDINATOR,
@@ -178,7 +182,29 @@ _dataset_update_acl: ACL = {
         Role.RESOURCE_MANAGER,
     },
 }
-_dataset_view_acl: ACL = inherit_acl(_dataset_update_acl, new_action=Action.VIEW) | {
+_dataset_update_acl: ACL = inherit_acl(_dataset_base_update_acl) | {
+    (Dataset, not DATASET_IS_PUBLIC, Dataset.PUBLIC, Action.UPDATE_WIZARD): {
+        Role.RESOURCE_COORDINATOR,
+        Role.RESOURCE_MANAGER,
+        Role.GLOBAL_MANAGER,
+    },
+    (Dataset, not DATASET_IS_PUBLIC, Dataset.RESTRICTED, Action.UPDATE_WIZARD): {
+        Role.RESOURCE_COORDINATOR,
+        Role.RESOURCE_MANAGER,
+        Role.GLOBAL_MANAGER,
+    },
+    (Dataset, not DATASET_IS_PUBLIC, Dataset.NON_PUBLIC, Action.UPDATE_WIZARD): {
+        Role.RESOURCE_COORDINATOR,
+        Role.RESOURCE_MANAGER,
+        Role.GLOBAL_MANAGER,
+    },
+    (Dataset, not DATASET_IS_PUBLIC, Dataset.CONFIDENTIAL, Action.UPDATE_WIZARD): {
+        Role.RESOURCE_COORDINATOR,
+        Role.RESOURCE_MANAGER,
+        Role.GLOBAL_MANAGER,
+    },
+}
+_dataset_view_acl: ACL = inherit_acl(_dataset_base_update_acl, new_action=Action.VIEW) | {
     (Dataset, DATASET_IS_PUBLIC, Dataset.PUBLIC, Action.VIEW): {
         Role.AUTHENTICATED,
         Role.VISITOR,
@@ -214,7 +240,12 @@ _dataset_create_acl: ACL = {
         Role.GLOBAL_MANAGER,
         Role.OPEN_DATA_COORDINATOR,
         Role.OPEN_DATA_MANAGER,
-    )
+    ),
+    (Dataset, Action.CREATE_WIZARD): (
+        Role.RESOURCE_COORDINATOR,
+        Role.RESOURCE_MANAGER,
+        Role.GLOBAL_MANAGER,
+    ),
 }
 _information_system_update_acl: ACL = inherit_acl(
     _dataset_update_acl,


### PR DESCRIPTION
**Summary:**
Adds `DcatDatasetCreateView` and forms used for DCAT data creation (non-open datasets).

This is **part 1** of many PRs related to DCAT data creation. Additional views, forms and form fields will be added later.

`DcatDatasetCreateView` is heavily inspired by `DatasetCreateView` but used only for DCAT data creation: information systems, services and datasets. It is impossible to create open data datasets using this view.

Most likely this will not be merged into `devel` right away. Most likely we will merge all DCAT related PRs to some `dcat-devel` branch until we will get green light to release it.