### PR TITLE
Add DCAT DatasetUpdateView

### DIFF
--- a/tests/dcat/test_views.py
+++ b/tests/dcat/test_views.py
@@ -1,7 +1,9 @@
 import uuid
+from unittest.mock import patch
 
 import pytest
 from django.conf import settings
+from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from django_webtest import DjangoTestApp
 
@@ -15,7 +17,8 @@ from vitrina.dcat.forms import (
     InformationSystemResourceForm,
     ServiceResourceForm,
 )
-from vitrina.identifiers.models import Identifier
+from vitrina.identifiers.factories import IdentifierFactory
+from vitrina.identifiers.models import Identifier, Agency
 from vitrina.orgs.factories import OrganizationFactory, RepresentativeFactory
 from vitrina.orgs.models import Representative
 from vitrina.structure.models import Metadata, Version
@@ -139,7 +142,7 @@ class TestDcatDatasetCreateView:
         assert response.status_code == 200
         assert type(response.context["form"]) is expected_form_class
 
-    def test_post_redirects_to_dcat_create_url(self, app: DjangoTestApp):
+    def test_post_redirects_to_dcat_update_url(self, app: DjangoTestApp):
         org = OrganizationFactory()
         subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
         importance_schema = ConceptSchema.objects.get(uri=Dataset.INFORMATION_SYSTEM_IMPORTANCE_SCHEMA_URI)
@@ -164,10 +167,13 @@ class TestDcatDatasetCreateView:
         form["information_system_creator"] = org.pk
         response = form.submit()
 
+        dataset = Dataset.objects.filter(translations__title="Test Redirect").first()
+        assert dataset is not None
+
         assert response.status_code == 302
         expected_url = reverse(
-            "dcat-dataset-create",
-            kwargs={"organization_id": org.pk, "subclass_uuid": str(subclass.pk)},
+            "dcat-dataset-update",
+            kwargs={"organization_id": org.pk, "dataset_id": dataset.id},
         )
         assert response.location == expected_url
 
@@ -375,3 +381,522 @@ class TestDcatDatasetCreateView:
         dataset = Dataset.objects.filter(translations__title="Test Dataset").first()
         assert dataset is not None
         assert dataset.get_parent() is None
+
+
+class TestDcatDatasetUpdateView:
+    def test_unauthenticated_redirects_to_login(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
+        dataset = DatasetFactory(organization=org, subclass=subclass, is_public=False)
+
+        url = reverse(
+            "dcat-dataset-update",
+            kwargs={"organization_id": org.pk, "dataset_id": dataset.pk},
+        )
+        response = app.get(url)
+
+        assert response.status_code == 302
+        assert settings.LOGIN_URL in response.location
+
+    def test_no_permission_returns_403(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
+        dataset = DatasetFactory(organization=org, subclass=subclass, is_public=False)
+        user = UserFactory()
+        app.set_user(user)
+
+        url = reverse(
+            "dcat-dataset-update",
+            kwargs={"organization_id": org.pk, "dataset_id": dataset.pk},
+        )
+        response = app.get(url, expect_errors=True)
+
+        assert response.status_code == 403
+
+    def test_nonexistent_organization_returns_404(self, app: DjangoTestApp):
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
+        dataset = DatasetFactory(subclass=subclass, is_public=False)
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        url = reverse(
+            "dcat-dataset-update",
+            kwargs={"organization_id": 999999, "dataset_id": dataset.pk},
+        )
+        response = app.get(url, expect_errors=True)
+
+        assert response.status_code == 404
+
+    def test_nonexistent_dataset_returns_404(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        url = reverse(
+            "dcat-dataset-update",
+            kwargs={"organization_id": org.pk, "dataset_id": 999999},
+        )
+        response = app.get(url, expect_errors=True)
+
+        assert response.status_code == 404
+
+    def test_dataset_not_in_organization_returns_404(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        other_org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
+        dataset = DatasetFactory(organization=other_org, subclass=subclass, is_public=False)
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        url = reverse(
+            "dcat-dataset-update",
+            kwargs={"organization_id": org.pk, "dataset_id": dataset.pk},
+        )
+        response = app.get(url, expect_errors=True)
+
+        assert response.status_code == 404
+
+    def test_coordinator_of_different_org_returns_403(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        other_org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
+        dataset = DatasetFactory(organization=org, subclass=subclass, is_public=False)
+        user = UserFactory()
+        RepresentativeFactory(
+            content_type=ContentType.objects.get_for_model(other_org),
+            object_id=other_org.pk,
+            role=Representative.RESOURCE_COORDINATOR,
+            user=user,
+        )
+        app.set_user(user)
+
+        url = reverse(
+            "dcat-dataset-update",
+            kwargs={"organization_id": org.pk, "dataset_id": dataset.pk},
+        )
+        response = app.get(url, expect_errors=True)
+
+        assert response.status_code == 403
+
+    def test_public_dataset_redirects_with_warning(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
+        dataset = DatasetFactory(organization=org, subclass=subclass, is_public=True)
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        url = reverse(
+            "dcat-dataset-update",
+            kwargs={"organization_id": org.pk, "dataset_id": dataset.pk},
+        )
+        response = app.get(url)
+
+        assert response.status_code == 302
+        assert reverse("organization-detail", kwargs={"pk": org.pk}) in response.location
+
+    def test_invalid_subclass_redirects_with_warning(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        catalog_subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.CATALOG)
+        dataset = DatasetFactory(organization=org, subclass=catalog_subclass, is_public=False)
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        url = reverse(
+            "dcat-dataset-update",
+            kwargs={"organization_id": org.pk, "dataset_id": dataset.pk},
+        )
+        response = app.get(url)
+
+        assert response.status_code == 302
+        assert reverse("organization-detail", kwargs={"pk": org.pk}) in response.location
+
+    @pytest.mark.parametrize(
+        "subclass_name, expected_form_class",
+        [
+            (DCATResourceSubclass.INFORMATION_SYSTEM, InformationSystemResourceForm),
+            (DCATResourceSubclass.SERVICE, ServiceResourceForm),
+            (DCATResourceSubclass.DATASET, DatasetResourceForm),
+        ],
+    )
+    def test_get_uses_correct_form_per_subclass(self, app: DjangoTestApp, subclass_name: str, expected_form_class):
+        org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=subclass_name)
+        dataset = DatasetFactory(organization=org, subclass=subclass, is_public=False)
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        url = reverse(
+            "dcat-dataset-update",
+            kwargs={"organization_id": org.pk, "dataset_id": dataset.pk},
+        )
+        response = app.get(url)
+
+        assert response.status_code == 200
+        assert type(response.context["form"]) is expected_form_class
+
+    def test_post_redirects_to_dcat_update_url(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
+        importance_schema = ConceptSchema.objects.get(uri=Dataset.INFORMATION_SYSTEM_IMPORTANCE_SCHEMA_URI)
+        importance = ConceptFactory(concept_schemas=[importance_schema])
+        is_type_schema = ConceptSchema.objects.get(uri=Dataset.INFORMATION_SYSTEM_TYPE_SCHEMA_URI)
+        is_type = ConceptFactory(concept_schemas=[is_type_schema])
+        dataset = DatasetFactory(organization=org, subclass=subclass, is_public=False)
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        url = reverse(
+            "dcat-dataset-update",
+            kwargs={"organization_id": org.pk, "dataset_id": dataset.pk},
+        )
+        form = app.get(url).forms["dataset-form"]
+        form["title"] = "Redirect Test"
+        form["description"] = "Redirect description"
+        form["name"] = f"{org.name}redirect"
+        form["information_system_importance"] = importance.pk
+        form["information_system_type"] = is_type.pk
+        form["information_system_publisher"] = org.pk
+        form["information_system_creator"] = org.pk
+        response = form.submit()
+
+        assert response.status_code == 302
+        expected_url = reverse(
+            "dcat-dataset-update",
+            kwargs={"organization_id": org.pk, "dataset_id": dataset.pk},
+        )
+        assert response.location == expected_url
+
+    def test_post_information_system_updates_all_fields(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        publisher_org = OrganizationFactory()
+        creator_org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
+        importance_schema = ConceptSchema.objects.get(uri=Dataset.INFORMATION_SYSTEM_IMPORTANCE_SCHEMA_URI)
+        old_importance = ConceptFactory(concept_schemas=[importance_schema])
+        new_importance = ConceptFactory(concept_schemas=[importance_schema])
+        is_type_schema = ConceptSchema.objects.get(uri=Dataset.INFORMATION_SYSTEM_TYPE_SCHEMA_URI)
+        old_is_type = ConceptFactory(concept_schemas=[is_type_schema])
+        new_is_type = ConceptFactory(concept_schemas=[is_type_schema])
+        dataset = DatasetFactory(
+            organization=org,
+            subclass=subclass,
+            is_public=False,
+            information_system_importance=old_importance,
+            information_system_type=old_is_type,
+            information_system_publisher=org,
+            information_system_creator=org,
+        )
+        agency = Agency.objects.get(code=Agency.RISR_CODE)
+        IdentifierFactory(resource=dataset, scheme_agency=agency, notation="1111")
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        url = reverse(
+            "dcat-dataset-update",
+            kwargs={"organization_id": org.pk, "dataset_id": dataset.pk},
+        )
+        form = app.get(url).forms["dataset-form"]
+        form["title"] = "Updated IS Title"
+        form["description"] = "Updated IS description"
+        form["name"] = f"{org.name}updateis"
+        form["information_system_importance"] = new_importance.pk
+        form["information_system_type"] = new_is_type.pk
+        form["information_system_publisher"] = publisher_org.pk
+        form["information_system_creator"] = creator_org.pk
+        form["landing_page"] = "https://example.com/updated"
+        form["conditions"] = "Updated conditions"
+        form["tags"] = "updatedTag"
+        form["applicable_legislation"] = "https://example.com/law"
+        form["identifier"] = "9999"
+
+        with patch("vitrina.datasets.models.update_applicable_legislation_description"):
+            form.submit()
+
+        dataset.refresh_from_db()
+        assert dataset.title == "Updated IS Title"
+        assert dataset.description == "Updated IS description"
+        assert dataset.information_system_importance == new_importance
+        assert dataset.information_system_type == new_is_type
+        assert dataset.information_system_publisher == publisher_org
+        assert dataset.information_system_creator == creator_org
+        assert dataset.landing_page == "https://example.com/updated"
+        assert dataset.conditions == "Updated conditions"
+        assert set(dataset.tags.all().values_list("name", flat=True)) == {"updatedtag"}
+        assert dataset.applicable_legislation.filter(url="https://example.com/law").exists()
+        assert Identifier.objects.filter(resource=dataset).count() == 1
+        assert Identifier.objects.filter(resource=dataset, notation="9999").exists()
+
+    def test_post_service_updates_all_fields(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.SERVICE)
+        contact = ContactFactory(organization=org)
+        service_type_schema, _ = ConceptSchema.objects.get_or_create(uri=Dataset.SERVICE_TYPE_SCHEME_URI)
+        service_type_concept = ConceptFactory(concept_schemas=[service_type_schema])
+        dataset = DatasetFactory(organization=org, subclass=subclass, is_public=False, service=True)
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        url = reverse(
+            "dcat-dataset-update",
+            kwargs={"organization_id": org.pk, "dataset_id": dataset.pk},
+        )
+        form = app.get(url).forms["dataset-form"]
+        form["title"] = "Updated Service Title"
+        form["name"] = f"{org.name}updatesvc"
+        form["tags"] = "updatedSvcTag"
+        form["contact"] = contact.pk
+        form["endpoint_url"] = "https://api.updated.com"
+        form["endpoint_description"] = "https://api.updated.com/spec"
+        form["access_rights"] = Dataset.RESTRICTED
+        form["landing_page"] = "https://example.com/updated-svc"
+        form["service_type"] = [str(service_type_concept.pk)]
+        form.submit()
+
+        dataset.refresh_from_db()
+        assert dataset.title == "Updated Service Title"
+        assert dataset.endpoint_url == "https://api.updated.com"
+        assert dataset.endpoint_description == "https://api.updated.com/spec"
+        assert dataset.access_rights == Dataset.RESTRICTED
+        assert dataset.landing_page == "https://example.com/updated-svc"
+        assert dataset.contact == contact
+        assert set(dataset.tags.all().values_list("name", flat=True)) == {"updatedsvctag"}
+        assert dataset.service_type.filter(pk=service_type_concept.pk).exists()
+
+    def test_post_dataset_updates_all_fields(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.DATASET)
+        frequency = FrequencyFactory()
+        contact = ContactFactory(organization=org)
+        dataset = DatasetFactory(organization=org, subclass=subclass, is_public=False)
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        url = reverse(
+            "dcat-dataset-update",
+            kwargs={"organization_id": org.pk, "dataset_id": dataset.pk},
+        )
+        form = app.get(url).forms["dataset-form"]
+        form["title"] = "Updated Dataset Title"
+        form["description"] = "Updated dataset description"
+        form["name"] = f"{org.name}updateds"
+        form["access_rights"] = Dataset.RESTRICTED
+        form["frequency"] = frequency.pk
+        form["landing_page"] = "https://example.com/updated-ds"
+        form["temporal_start"] = "2025-01-01"
+        form["temporal_end"] = "2025-12-31"
+        form["spatial_resolution"] = "200"
+        form["temporal_resolution"] = "P1M"
+        form["contact"] = contact.pk
+        form["tags"] = "updatedDataTag"
+        form["documentation"] = "https://example.com/doc"
+        form["applicable_legislation"] = "https://example.com/law"
+        with patch("vitrina.datasets.models.update_applicable_legislation_description"):
+            form.submit()
+
+        dataset.refresh_from_db()
+        assert dataset.title == "Updated Dataset Title"
+        assert dataset.description == "Updated dataset description"
+        assert dataset.access_rights == Dataset.RESTRICTED
+        assert dataset.frequency == frequency
+        assert dataset.landing_page == "https://example.com/updated-ds"
+        assert str(dataset.temporal_start) == "2025-01-01"
+        assert str(dataset.temporal_end) == "2025-12-31"
+        assert dataset.spatial_resolution == "200"
+        assert dataset.temporal_resolution == "P1M"
+        assert dataset.contact == contact
+        assert set(dataset.tags.all().values_list("name", flat=True)) == {"updateddatatag"}
+        assert dataset.documentation.filter(documentation_link="https://example.com/doc").exists()
+        assert dataset.applicable_legislation.filter(url="https://example.com/law").exists()
+
+    def test_post_updates_metadata_title_and_name(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
+        importance_schema = ConceptSchema.objects.get(uri=Dataset.INFORMATION_SYSTEM_IMPORTANCE_SCHEMA_URI)
+        importance = ConceptFactory(concept_schemas=[importance_schema])
+        is_type_schema = ConceptSchema.objects.get(uri=Dataset.INFORMATION_SYSTEM_TYPE_SCHEMA_URI)
+        is_type = ConceptFactory(concept_schemas=[is_type_schema])
+        dataset = DatasetFactory(
+            organization=org,
+            subclass=subclass,
+            is_public=False,
+            information_system_importance=importance,
+            information_system_type=is_type,
+            information_system_publisher=org,
+            information_system_creator=org,
+        )
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        url = reverse(
+            "dcat-dataset-update",
+            kwargs={"organization_id": org.pk, "dataset_id": dataset.pk},
+        )
+        form = app.get(url).forms["dataset-form"]
+        form["title"] = "New Title"
+        form["description"] = "New description"
+        form["name"] = f"{org.name}newname"
+        form["information_system_importance"] = importance.pk
+        form["information_system_type"] = is_type.pk
+        form["information_system_publisher"] = org.pk
+        form["information_system_creator"] = org.pk
+        form.submit()
+
+        metadata = Metadata.objects.get(dataset=dataset)
+        assert metadata.title == "New Title"
+        assert metadata.description == "New description"
+        assert metadata.name == f"{org.name}newname"
+        assert metadata.draft is True
+
+    def test_post_changes_parent(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
+        importance_schema = ConceptSchema.objects.get(uri=Dataset.INFORMATION_SYSTEM_IMPORTANCE_SCHEMA_URI)
+        importance = ConceptFactory(concept_schemas=[importance_schema])
+        is_type_schema = ConceptSchema.objects.get(uri=Dataset.INFORMATION_SYSTEM_TYPE_SCHEMA_URI)
+        is_type = ConceptFactory(concept_schemas=[is_type_schema])
+        parent = DatasetFactory(organization=org, subclass=subclass, is_public=True)
+        dataset = DatasetFactory(organization=org, subclass=subclass, is_public=False)
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        url = reverse(
+            "dcat-dataset-update",
+            kwargs={"organization_id": org.pk, "dataset_id": dataset.pk},
+        )
+        form = app.get(url).forms["dataset-form"]
+        form["title"] = "IS Title"
+        form["description"] = "IS description"
+        form["name"] = f"{org.name}updateis"
+        form["information_system_importance"] = importance.pk
+        form["information_system_type"] = is_type.pk
+        form["information_system_publisher"] = org.pk
+        form["information_system_creator"] = org.pk
+        form["parent"] = parent.pk
+        form.submit()
+
+        dataset.refresh_from_db()
+        assert dataset.get_parent().pk == parent.pk
+
+    def test_post_removes_parent(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
+        importance_schema = ConceptSchema.objects.get(uri=Dataset.INFORMATION_SYSTEM_IMPORTANCE_SCHEMA_URI)
+        importance = ConceptFactory(concept_schemas=[importance_schema])
+        is_type_schema = ConceptSchema.objects.get(uri=Dataset.INFORMATION_SYSTEM_TYPE_SCHEMA_URI)
+        is_type = ConceptFactory(concept_schemas=[is_type_schema])
+        parent = DatasetFactory(organization=org, subclass=subclass, is_public=True)
+        dataset = DatasetFactory(organization=org, subclass=subclass, is_public=False)
+        dataset.move(parent, "sorted-child")
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        url = reverse(
+            "dcat-dataset-update",
+            kwargs={"organization_id": org.pk, "dataset_id": dataset.pk},
+        )
+        form = app.get(url).forms["dataset-form"]
+        form["title"] = "IS Title"
+        form["description"] = "IS description"
+        form["name"] = f"{org.name}updateis"
+        form["information_system_importance"] = importance.pk
+        form["information_system_type"] = is_type.pk
+        form["information_system_publisher"] = org.pk
+        form["information_system_creator"] = org.pk
+        form["parent"].force_value("")
+        form.submit()
+
+        dataset.refresh_from_db()
+        assert dataset.get_parent() is None
+
+    def test_post_sets_status_has_data_when_endpoint_url_changes_on_service(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.SERVICE)
+        contact = ContactFactory(organization=org)
+        dataset = DatasetFactory(
+            organization=org,
+            subclass=subclass,
+            is_public=False,
+            service=True,
+            status=Dataset.UNASSIGNED,
+        )
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        url = reverse(
+            "dcat-dataset-update",
+            kwargs={"organization_id": org.pk, "dataset_id": dataset.pk},
+        )
+        form = app.get(url).forms["dataset-form"]
+        form["title"] = "Service Title"
+        form["name"] = f"{org.name}updatesvc"
+        form["tags"] = "svcTag"
+        form["contact"] = contact.pk
+        form["endpoint_url"] = "https://api.new.com"
+        form["endpoint_description"] = "https://api.new.com/spec"
+        form.submit()
+
+        dataset.refresh_from_db()
+        assert dataset.status == Dataset.HAS_DATA
+
+    def test_post_sets_status_inventored_when_endpoint_url_changes_without_service_flag(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.SERVICE)
+        contact = ContactFactory(organization=org)
+        # service=False: endpoint_url change won't trigger HAS_DATA
+        dataset = DatasetFactory(
+            organization=org,
+            subclass=subclass,
+            is_public=False,
+            service=False,
+            status=Dataset.UNASSIGNED,
+        )
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        url = reverse(
+            "dcat-dataset-update",
+            kwargs={"organization_id": org.pk, "dataset_id": dataset.pk},
+        )
+        form = app.get(url).forms["dataset-form"]
+        form["title"] = "Service Title"
+        form["name"] = f"{org.name}updatesvc"
+        form["tags"] = "svcTag"
+        form["contact"] = contact.pk
+        form["endpoint_url"] = "https://api.new.com"
+        form["endpoint_description"] = "https://api.new.com/spec"
+        form.submit()
+
+        dataset.refresh_from_db()
+        assert dataset.status == Dataset.INVENTORED
+
+    def test_post_sets_status_unassigned_when_not_public_and_has_published_date(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
+        importance_schema = ConceptSchema.objects.get(uri=Dataset.INFORMATION_SYSTEM_IMPORTANCE_SCHEMA_URI)
+        importance = ConceptFactory(concept_schemas=[importance_schema])
+        is_type_schema = ConceptSchema.objects.get(uri=Dataset.INFORMATION_SYSTEM_TYPE_SCHEMA_URI)
+        is_type = ConceptFactory(concept_schemas=[is_type_schema])
+        # DatasetFactory sets published and status=HAS_DATA by default
+        dataset = DatasetFactory(organization=org, subclass=subclass, is_public=False)
+        assert dataset.published is not None
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        url = reverse(
+            "dcat-dataset-update",
+            kwargs={"organization_id": org.pk, "dataset_id": dataset.pk},
+        )
+        # IS form has no endpoint_url field, so endpoint_url won't be in changed_data
+        form = app.get(url).forms["dataset-form"]
+        form["title"] = "IS Title"
+        form["description"] = "IS description"
+        form["name"] = f"{org.name}updateis"
+        form["information_system_importance"] = importance.pk
+        form["information_system_type"] = is_type.pk
+        form["information_system_publisher"] = org.pk
+        form["information_system_creator"] = org.pk
+        form.submit()
+
+        dataset.refresh_from_db()
+        assert dataset.published is None
+        assert dataset.status == Dataset.UNASSIGNED

--- a/tests/dcat/test_views.py
+++ b/tests/dcat/test_views.py
@@ -413,6 +413,96 @@ class TestDcatDatasetUpdateView:
 
         assert response.status_code == 403
 
+    def test_user_with_different_organization_permissions_returns_403(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
+        dataset = DatasetFactory(organization=org, subclass=subclass, is_public=False)
+        new_organization = OrganizationFactory()
+        user = UserFactory(organization=new_organization)
+        RepresentativeFactory(
+            organization=new_organization,
+            content_type=ContentType.objects.get_for_model(new_organization),
+            object_id=new_organization.pk,
+            user=user,
+            role=Representative.RESOURCE_MANAGER,
+        )
+        app.set_user(user)
+
+        url = reverse(
+            "dcat-dataset-update",
+            kwargs={"organization_id": org.pk, "dataset_id": dataset.pk},
+        )
+        response = app.get(url, expect_errors=True)
+
+        assert response.status_code == 403
+
+    def test_user_with_different_dataset_permissions_returns_403(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
+        dataset = DatasetFactory(organization=org, subclass=subclass, is_public=False)
+        new_dataset = DatasetFactory(organization=org)
+        user = UserFactory(organization=org)
+        RepresentativeFactory(
+            organization=org,
+            content_type=ContentType.objects.get_for_model(new_dataset),
+            object_id=new_dataset.pk,
+            user=user,
+            role=Representative.RESOURCE_MANAGER,
+        )
+        app.set_user(user)
+
+        url = reverse(
+            "dcat-dataset-update",
+            kwargs={"organization_id": org.pk, "dataset_id": dataset.pk},
+        )
+        response = app.get(url, expect_errors=True)
+
+        assert response.status_code == 403
+
+    def test_user_with_correct_organization_permissions_returns_200(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
+        dataset = DatasetFactory(organization=org, subclass=subclass, is_public=False)
+        user = UserFactory(organization=org)
+        RepresentativeFactory(
+            organization=org,
+            content_type=ContentType.objects.get_for_model(org),
+            object_id=org.pk,
+            user=user,
+            role=Representative.RESOURCE_MANAGER,
+        )
+        app.set_user(user)
+
+        url = reverse(
+            "dcat-dataset-update",
+            kwargs={"organization_id": org.pk, "dataset_id": dataset.pk},
+        )
+        response = app.get(url)
+
+        assert response.status_code == 200
+
+    def test_user_with_correct_dataset_permissions_returns_200(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
+        dataset = DatasetFactory(organization=org, subclass=subclass, is_public=False)
+        user = UserFactory(organization=org)
+        RepresentativeFactory(
+            organization=org,
+            content_type=ContentType.objects.get_for_model(dataset),
+            object_id=dataset.pk,
+            user=user,
+            role=Representative.RESOURCE_MANAGER,
+        )
+        app.set_user(user)
+
+        url = reverse(
+            "dcat-dataset-update",
+            kwargs={"organization_id": org.pk, "dataset_id": dataset.pk},
+        )
+        response = app.get(url)
+
+        assert response.status_code == 200
+
     def test_nonexistent_organization_returns_404(self, app: DjangoTestApp):
         subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
         dataset = DatasetFactory(subclass=subclass, is_public=False)

--- a/vitrina/dcat/forms.py
+++ b/vitrina/dcat/forms.py
@@ -98,7 +98,7 @@ class BaseResourceForm(TranslatableModelForm):
         ],
     )
     parent = forms.ModelChoiceField(
-        Dataset.objects.all().order_by("translations__title").prefetch_related("translations"),
+        Dataset.objects.all().prefetch_related("translations"),
         label=_("Tėvinis išteklius"),
         widget=Select2Widget(),
         required=False,
@@ -128,11 +128,10 @@ class BaseResourceForm(TranslatableModelForm):
         elif instance:
             parent = instance.get_parent()
             self.fields["parent"].initial = parent
-            self.fields["parent"].queryset = Dataset.objects.exclude(pk=instance.pk)
+            self.fields["parent"].queryset = self.fields["parent"].queryset.exclude(pk=instance.pk)
 
-        if instance:
-            if instance.name:
-                self.initial["name"] = instance.name
+        if instance and instance.name:
+            self.initial["name"] = instance.name
 
     def clean_name(self) -> str | None:
         name = self.cleaned_data.get("name")

--- a/vitrina/dcat/templates/vitrina/dcat/dataset_form.html
+++ b/vitrina/dcat/templates/vitrina/dcat/dataset_form.html
@@ -13,23 +13,41 @@
 
 {% block head %}
     <style>
-        /* Match select width */
+        {# Match select width #}
         div.select, .select2.select2-container {
             width: 100% !important;
         }
-        /* Match select height and border color */
+        {# Match select height and border color #}
         .select2.select2-container .select2-selection--single {
             height: 2.5rem;
             padding: 6px 12px;
             border-color: #767676;
         }
-        /* Match select dropdown border color */
+        {# Match select dropdown border color #}
         .select2-container .select2-dropdown {
             border-color: #767676;
         }
-        /* Match select2 dropdown arrow */
+        {# Match select2 dropdown arrow #}
         .select2-selection__arrow {
             display: none;
+        }
+        {# Make selection choice delete button border span the full height choice #}
+        .select2-container .select2-selection--multiple .select2-selection__choice__remove {
+            height: 100%;
+        }
+        {# Fix search text leaking below the field border because of select2 version mismatch #}
+        {# Tag field uses select2 4.1.0 and other fields uses select2 4.0.13  #}
+        .select2-container .select2-selection--multiple .select2-selection__rendered {
+            overflow: visible !important;
+            white-space: normal !important;
+            display: inline !important;
+        }
+        .select2-container .select2-selection--multiple .select2-selection__choice {
+            float: none !important;
+            padding-left: 20px !important;  {# Fix choice remove button overlapping the tag text #}
+        }
+        .select2-container .select2-search--inline {
+            float: none !important;
         }
     </style>
 {% endblock %}

--- a/vitrina/dcat/urls.py
+++ b/vitrina/dcat/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from vitrina.dcat.views import DcatDatasetCreateView
+from vitrina.dcat.views import DcatDatasetCreateView, DcatDatasetUpdateView
 
 urlpatterns = [
     path(
@@ -12,5 +12,10 @@ urlpatterns = [
         "organization/<int:organization_id>/dcat/dataset/parent/<int:parent_id>/subclass/<uuid:subclass_uuid>/",
         DcatDatasetCreateView.as_view(),
         name="dcat-dataset-create-with-parent",
+    ),
+    path(
+        "organization/<int:organization_id>/dcat/dataset/<int:dataset_id>/update/",
+        DcatDatasetUpdateView.as_view(),
+        name="dcat-dataset-update",
     ),
 ]

--- a/vitrina/dcat/views.py
+++ b/vitrina/dcat/views.py
@@ -215,8 +215,8 @@ class DcatDatasetUpdateView(
     def subclass(self) -> DCATResourceSubclass:
         return self.get_object().subclass
 
-    def has_permission(self):
-        return has_perm(self.request.user, Action.UPDATE_WIZARD, Dataset, self.organization)
+    def has_permission(self) -> bool:
+        return has_perm(self.request.user, Action.UPDATE_WIZARD, self.get_object())
 
     def dispatch(self, request: WSGIRequest, *args, **kwargs) -> HttpResponseBase:
         obj = self.get_object()

--- a/vitrina/dcat/views.py
+++ b/vitrina/dcat/views.py
@@ -5,12 +5,13 @@ from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMix
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ImproperlyConfigured
 from django.core.handlers.wsgi import WSGIRequest
+from django.db.models import QuerySet
 from django.http import HttpResponseRedirect, HttpResponseBase
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.translation import get_language
-from parler.views import TranslatableCreateView, LanguageChoiceMixin
+from parler.views import TranslatableCreateView, LanguageChoiceMixin, TranslatableUpdateView
 from django.utils.translation import gettext_lazy as _
 
 from vitrina.catalogs.models import Catalog
@@ -20,6 +21,7 @@ from vitrina.datasets.models import Dataset, DCATResourceSubclass
 from vitrina.datasets.view_helpers import (
     create_tasks_and_notify_subscribers_about_dataset_creation,
     create_dataset_representative_and_attribution,
+    create_tasks_and_notify_subscribers_about_dataset_update,
 )
 from vitrina.dcat.forms import InformationSystemResourceForm, BaseResourceForm, ServiceResourceForm, DatasetResourceForm
 from vitrina.identifiers.models import Agency, Identifier
@@ -27,6 +29,7 @@ from vitrina.orgs.models import Organization
 from vitrina.orgs.services import Action, has_perm
 from vitrina.structure import VersionStatus
 from vitrina.structure.models import Version as _Version, Metadata
+from vitrina.structure.services import get_model_name
 
 
 DCAT_SUBCLASS_FORM_MAP = {
@@ -43,7 +46,6 @@ class DcatDatasetCreateView(
     LanguageChoiceMixin,
 ):
     model = Dataset
-    form_class = InformationSystemResourceForm
     template_name = "vitrina/dcat/dataset_form.html"
     context_object_name = "dataset"
 
@@ -79,7 +81,7 @@ class DcatDatasetCreateView(
 
         if not is_valid_subclass:
             messages.error(request, _("Vedlio negalima naudoti su šiuo duomenų ištekliaus poklasiu"))
-            return HttpResponseRedirect(reverse("organization-detail", kwargs={"pk": self.organization.id}))
+            return HttpResponseRedirect(reverse("organization-detail", kwargs={"pk": self.organization.pk}))
 
         return super().dispatch(request, *args, **kwargs)
 
@@ -185,10 +187,179 @@ class DcatDatasetCreateView(
 
         return HttpResponseRedirect(
             reverse(
-                "dcat-dataset-create",
+                "dcat-dataset-update",
                 kwargs={
+                    "dataset_id": self.object.pk,
                     "organization_id": self.organization.pk,
-                    "subclass_uuid": str(self.subclass.pk),
+                },
+            )
+        )
+
+
+class DcatDatasetUpdateView(
+    LoginRequiredMixin,
+    PermissionRequiredMixin,
+    TranslatableUpdateView,
+    LanguageChoiceMixin,
+):
+    model = Dataset
+    template_name = "vitrina/dcat/dataset_form.html"
+    context_object_name = "dataset"
+    pk_url_kwarg = "dataset_id"
+
+    @cached_property
+    def organization(self) -> Organization:
+        return get_object_or_404(Organization, pk=self.kwargs.get("organization_id"))
+
+    @cached_property
+    def subclass(self) -> DCATResourceSubclass:
+        return self.get_object().subclass
+
+    def has_permission(self):
+        return has_perm(self.request.user, Action.UPDATE_WIZARD, Dataset, self.organization)
+
+    def dispatch(self, request: WSGIRequest, *args, **kwargs) -> HttpResponseBase:
+        obj = self.get_object()
+        if obj.is_public:
+            messages.warning(request, _("Vedlio negalima naudoti su atvirais duomenų ištekliais"))
+            return HttpResponseRedirect(reverse("organization-detail", kwargs={"pk": self.organization.pk}))
+        if obj.subclass.name not in (
+            DCATResourceSubclass.INFORMATION_SYSTEM,
+            DCATResourceSubclass.SERVICE,
+            DCATResourceSubclass.DATASET,
+        ):
+            messages.warning(request, _("Vedlio negalima naudoti su šiuo duomenų ištekliaus poklasiu"))
+            return HttpResponseRedirect(reverse("organization-detail", kwargs={"pk": self.organization.pk}))
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_form_class(self) -> BaseResourceForm:
+        if (form_class := DCAT_SUBCLASS_FORM_MAP.get(self.subclass.name)) is None:
+            raise ImproperlyConfigured(_("Nurodytas duomenų ištekliaus poklasis neturi formos."))
+
+        return form_class
+
+    def get_context_data(self, **kwargs) -> dict:
+        context = super().get_context_data(**kwargs)
+        context.update(
+            {
+                "organization": self.organization,
+                "organization_id": self.organization.pk,
+                "current_title": _("Duomenų ištekliaus redagavimas"),
+                "form_title": self.subclass.translated_title,
+                "information_title": self.subclass.translated_title,
+                "information_description": self.subclass.translated_description,
+                "current_step": 2,
+                "current_percentage": 100,
+                "button": _("Redaguoti"),
+            }
+        )
+        return context
+
+    def get_queryset(self) -> QuerySet[Dataset]:
+        return super().get_queryset().filter(organization=self.organization)
+
+    def get_object(self, queryset: QuerySet[Dataset] | None = None) -> Dataset:
+        obj = super().get_object(queryset)
+        lang = self.request.GET.get("language", get_language())
+        obj.set_current_language(lang)
+
+        return obj
+
+    def get_form_kwargs(self) -> dict:
+        kwargs = super().get_form_kwargs()
+        kwargs["organization"] = self.organization
+        kwargs["parent_dataset_id"] = self.kwargs.get("parent_id")
+
+        return kwargs
+
+    def form_valid(self, form: BaseResourceForm) -> HttpResponseBase:
+        self.object = form.save(commit=False)
+        tags = form.cleaned_data["tags"]
+        self.object.tags.set(tags)
+
+        if "endpoint_url" in form.changed_data:
+            if self.object.datasetdistribution_set.exists() or (self.object.service and self.object.endpoint_url):
+                self.object.status = Dataset.HAS_DATA
+            elif self.object.plandataset_set.exists():
+                self.object.status = Dataset.PLANNED
+            else:
+                self.object.status = Dataset.INVENTORED
+        elif not self.object.is_public and self.object.published:
+            self.object.published = None
+            self.object.status = Dataset.UNASSIGNED
+
+        if self.object.subclass.name == DCATResourceSubclass.INFORMATION_SYSTEM and (
+            identifier := form.cleaned_data.get("identifier")
+        ):
+            agency = get_object_or_404(Agency, code=Agency.RISR_CODE)
+            Identifier.objects.update_or_create(
+                resource=self.object,
+                scheme_agency=agency,
+                defaults={
+                    "notation": identifier,
+                    "identifier_type": Identifier.IdentifierType.OTHER,
+                    "resource": self.object,
+                    "scheme_agency": agency,
+                },
+            )
+        if "applicable_legislation" in form.changed_data:
+            self.object.update_applicable_legislation(form.cleaned_data.get("applicable_legislation"))
+
+        if "documentation" in form.changed_data:
+            self.object.update_documentation(form.cleaned_data.get("documentation"))
+
+        if "service_type" in form.changed_data:
+            self.object.service_type.set(form.cleaned_data["service_type"])
+
+        self.object.save()
+
+        if metadata := self.object.metadata.first():
+            metadata.title = self.object.title
+            metadata.description = self.object.description
+            metadata.save()
+        else:
+            metadata = Metadata.objects.create(
+                uuid=str(uuid.uuid4()),
+                dataset=self.object,
+                content_type=ContentType.objects.get_for_model(self.object),
+                object_id=self.object.pk,
+                title=self.object.title,
+                description=self.object.description,
+                prepare_ast={},
+                version=1,
+            )
+        dataset_name = form.cleaned_data.get("name", "") or generate_unique_dataset_name(
+            self.object.organization, self.object
+        )
+        if not metadata.name or metadata.name != dataset_name:
+            metadata.name = dataset_name
+            metadata.draft = True
+            metadata.save()
+
+            # Update model names
+            for model in self.object.model_set.all():
+                if model_meta := model.metadata.first():
+                    model_meta.name = get_model_name(self.object, model.name)
+                    model_meta.save()
+
+        create_tasks_and_notify_subscribers_about_dataset_update(self.request, self.object)
+        self.object.save()
+
+        selected_parent = form.cleaned_data.get("parent")
+        if self.object.get_parent() != selected_parent:
+            if not selected_parent:
+                self.object.add_self_as_root()
+            else:
+                self.object.move(selected_parent, "sorted-child")
+
+        messages.success(self.request, _("Duomenų išteklius atnaujintas sėkmingai"))
+
+        return HttpResponseRedirect(
+            reverse(
+                "dcat-dataset-update",
+                kwargs={
+                    "dataset_id": self.object.pk,
+                    "organization_id": self.organization.pk,
                 },
             )
         )

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-24 11:32+0300\n"
+"POT-Creation-Date: 2026-04-24 11:51+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1972,6 +1972,12 @@ msgstr "Form creation tool cannot be used for this resource subclass"
 
 msgid "Nurodytas duomenų ištekliaus poklasis neturi formos."
 msgstr "Given resource subclass does not have a defined form."
+
+msgid "Vedlio negalima naudoti su atvirais duomenų ištekliais"
+msgstr "Form creation tool cannot be used with open data resources"
+
+msgid "Duomenų išteklius atnaujintas sėkmingai"
+msgstr "Resource updated successfully"
 
 msgid "Pasirinkti failą"
 msgstr "Select a file"


### PR DESCRIPTION
**Summary:**
 Adds `DcatDatasetUpdateView`  used for DCAT data update (non-open datasets).

This is part 2 of many PRs related to DCAT data creation. Additional views, forms and form fields will be added later.

DcatDatasetUpdateView is heavily inspired by DatasetUpdateView but used only for DCAT data update: information systems, services and datasets. It is impossible to update open data datasets using this view.

Most likely this will not be merged into devel right away. Most likely we will merge all DCAT related PRs to some dcat-devel branch until we will get green light to release it.
