### PR TITLE
Skip non manager roles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,9 @@ Improvements:
 Bug fixes:
 
 https://github.com/atviriduomenys/dvms/issues/549
+https://github.com/atviriduomenys/katalogas/issues/2558
 
+- Added an access check, which makes sure that given roles are from MANAGER_ROLES, else skips the iteration.
 - Removed `can_update_publishers` permission check from HTML forms and the corresponding view.
 - Removed the early return that was blocking non-superusers from updating Organizations as Representatives.
 

--- a/tests/orgs/test_services.py
+++ b/tests/orgs/test_services.py
@@ -2399,3 +2399,35 @@ class TestViispOrganizationPermissions:
 
         res = has_perm(user, Action.CREATE, Dataset, organization)
         assert res is True
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "org_role,user_role",
+    [
+        (Representative.OPEN_DATA_PUBLISHER, Representative.OPEN_DATA_MANAGER),
+        (Representative.OPEN_DATA_MANAGER, Representative.OPEN_DATA_PUBLISHER),
+    ],
+)
+def test_dataset_perm_via_org_chain_non_manager_role_does_not_crash(org_role: str, user_role: str):
+    dataset = DatasetFactory(is_public=False, access_rights=Dataset.NON_PUBLIC)
+    rep_org = OrganizationFactory()
+
+    RepresentativeFactory(
+        content_type=ContentType.objects.get_for_model(dataset),
+        object_id=dataset.pk,
+        role=org_role,
+        organization=rep_org,
+        user=None,
+    )
+
+    user = UserFactory()
+    RepresentativeFactory(
+        content_type=ContentType.objects.get_for_model(rep_org),
+        object_id=rep_org.pk,
+        role=user_role,
+        user=user,
+        organization=None,
+    )
+
+    assert has_perm(user, Action.VIEW, dataset) is False

--- a/vitrina/datasets/models.py
+++ b/vitrina/datasets/models.py
@@ -903,6 +903,8 @@ class Dataset(Resource):
 
         for org_id, org_role in org_roles:
             user_role = coordinator_to_manager.get(user_org_map[org_id], user_org_map[org_id])
+            if org_role not in Representative.MANAGER_ROLES or user_role not in Representative.MANAGER_ROLES:
+                continue
             # Use the more restrictive role between the organization's role and the user's role within that org.
             # e.g. org has RESOURCE_MANAGER, user has OPEN_DATA_MANAGER → effective role is OPEN_DATA_MANAGER
             effective_roles.append(max(org_role, user_role, key=Representative.MANAGER_ROLES.index))

--- a/vitrina/datasets/services.py
+++ b/vitrina/datasets/services.py
@@ -331,6 +331,8 @@ def filter_out_non_public_datasets_for_user(user: User, datasets: SearchQuerySet
             user_role = coordinator_to_manager.get(
                 user_organization_map[organization_id], user_organization_map[organization_id]
             )
+            if organization_role not in Representative.MANAGER_ROLES or user_role not in Representative.MANAGER_ROLES:
+                continue
             effective_role = max(organization_role, user_role, key=Representative.MANAGER_ROLES.index)
 
             if content_type_id == organization_ct.id:

--- a/vitrina/users/models.py
+++ b/vitrina/users/models.py
@@ -314,6 +314,8 @@ class User(AbstractUser):
             user_role = coordinator_to_manager.get(
                 user_organization_roles[organization_id], user_organization_roles[organization_id]
             )
+            if organization_role not in Representative.MANAGER_ROLES or user_role not in Representative.MANAGER_ROLES:
+                continue
             effective_role = max(organization_role, user_role, key=Representative.MANAGER_ROLES.index)
             if effective_role in manager_equivalent_roles:
                 return True


### PR DESCRIPTION
It seems the bug appears when either the user or org has roles assigned to it that are not in MANAGER_ROLES. Because of this, index(non_manager_role) fails. The bug was reproduced by using the test provided.

Introduced fix: 
If either role is not a manager role, it skips that iteration. 
If one role is a manager role and the other is not, it does not try to pass with one of the roles, because judging by the comments (and by the task comment), the goal is to always pick the role with the least access.