### PR TITLE
2566 elasticsearch too many or clauses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,11 @@ https://github.com/atviriduomenys/katalogas/issues/2624
 - Remove synchronous type checking (TypeCheckerError) from clean_value()
 - Fix edge case in CSV import: when prepare is empty and source is also empty, no longer produces "" as a valid quoted value
 
+https://github.com/atviriduomenys/katalogas/issues/2566
+
+- Route per-user permission filtering and the manager-dataset list filter through Elasticsearch ``terms`` queries (via a custom Haystack backend) so large primary-key sets no longer expand into Lucene boolean OR clauses. Fixes intermittent ``too_many_clauses`` 400s on ``/datasets/manager`` and any authenticated dataset list whose user has many representations.
+
+
 v 1.21.0 (2026-05-18)
 ==================
 

--- a/tests/datasets/test_search_backends.py
+++ b/tests/datasets/test_search_backends.py
@@ -1,0 +1,123 @@
+import pytest
+from haystack.query import SearchQuerySet
+
+from vitrina.datasets.search_backends import (
+    ElasticsearchBackend,
+    ElasticSearchEngine,
+    ElasticsearchSearchQuery,
+)
+from vitrina.datasets.services import apply_terms_filter
+
+
+@pytest.fixture
+def backend():
+    return ElasticsearchBackend(
+        connection_alias="default",
+        URL="http://localhost:9200/",
+        INDEX_NAME="test",
+    )
+
+
+@pytest.mark.django_db
+def test_add_terms_filter_records_field_and_values():
+    query = ElasticsearchSearchQuery(using="default")
+    query.add_terms_filter("django_id", [1, 2, 3])
+    assert query._terms_filters == [("django_id", [1, 2, 3])]
+
+
+@pytest.mark.django_db
+def test_add_terms_filter_normalises_values_to_list():
+    query = ElasticsearchSearchQuery(using="default")
+    query.add_terms_filter("django_id", iter([1, 2, 3]))
+    assert query._terms_filters == [("django_id", [1, 2, 3])]
+
+
+@pytest.mark.django_db
+def test_clone_preserves_terms_filters_independently():
+    query = ElasticsearchSearchQuery(using="default")
+    query.add_terms_filter("django_id", [1, 2])
+    clone = query._clone()
+    clone.add_terms_filter("organization", [9])
+    assert query._terms_filters == [("django_id", [1, 2])]
+    assert clone._terms_filters == [("django_id", [1, 2]), ("organization", [9])]
+
+
+@pytest.mark.django_db
+def test_build_params_includes_terms_filters_when_present():
+    query = ElasticsearchSearchQuery(using="default")
+    query.add_terms_filter("django_id", [1, 2])
+    params = query.build_params()
+    assert params["terms_filters"] == [("django_id", [1, 2])]
+
+
+@pytest.mark.django_db
+def test_build_params_omits_key_when_no_terms_filters():
+    query = ElasticsearchSearchQuery(using="default")
+    params = query.build_params()
+    assert "terms_filters" not in params
+
+
+@pytest.mark.django_db
+def test_build_search_kwargs_appends_terms_filter(backend):
+    body = backend.build_search_kwargs(
+        "*:*",
+        terms_filters=[("django_id", ["1", "2", "3"])],
+    )
+
+    bool_clause = body["query"]["bool"]
+    flt = bool_clause["filter"]
+
+    if isinstance(flt, dict) and "terms" in flt:
+        assert flt["terms"] == {"django_id": ["1", "2", "3"]}
+    else:
+        terms_clauses = [f for f in flt["bool"]["must"] if "terms" in f and f["terms"].get("django_id")]
+        assert terms_clauses == [{"terms": {"django_id": ["1", "2", "3"]}}]
+
+
+@pytest.mark.django_db
+def test_build_search_kwargs_passes_through_when_no_terms_filters(backend):
+    body = backend.build_search_kwargs("*:*")
+
+    def _terms_field_names(node):
+        names = set()
+        if isinstance(node, dict):
+            if "terms" in node and isinstance(node["terms"], dict):
+                names.update(node["terms"].keys())
+            for value in node.values():
+                names.update(_terms_field_names(value))
+        elif isinstance(node, list):
+            for item in node:
+                names.update(_terms_field_names(item))
+        return names
+
+    field_names = _terms_field_names(body)
+    user_fields = {f for f in field_names if f != "django_ct"}
+    assert user_fields == set()
+
+
+@pytest.mark.django_db
+def test_build_search_kwargs_supports_multiple_terms_filters(backend):
+    body = backend.build_search_kwargs(
+        "*:*",
+        terms_filters=[("django_id", ["1", "2"]), ("organization", ["9"])],
+    )
+
+    flt = body["query"]["bool"]["filter"]
+    inner = flt["bool"]["must"] if "bool" in flt else [flt]
+    fields_seen = {next(iter(f["terms"])) for f in inner if "terms" in f}
+    assert {"django_id", "organization"}.issubset(fields_seen)
+
+
+@pytest.mark.django_db
+def test_engine_uses_custom_search_query():
+    assert ElasticSearchEngine.query is ElasticsearchSearchQuery
+
+
+@pytest.mark.django_db
+def test_apply_terms_filter_returns_clone_with_recorded_filter():
+    sqs = SearchQuerySet()
+    new_sqs = apply_terms_filter(sqs, "django_id", [1, 2, 3])
+
+    assert new_sqs is not sqs
+    assert getattr(sqs.query, "_terms_filters", []) == []
+    assert new_sqs.query._terms_filters == [("django_id", [1, 2, 3])]

--- a/tests/datasets/test_views.py
+++ b/tests/datasets/test_views.py
@@ -13,6 +13,7 @@ from filer.models import File
 from reversion.models import Version
 from webtest import Upload
 from unittest.mock import patch
+from elasticsearch.client import Elasticsearch
 
 from vitrina.catalogs.factories import CatalogFactory
 from vitrina.classifiers.factories import (
@@ -624,6 +625,52 @@ class TestDatasetListView:
         resp = app.get(reverse("dataset-list"))
         resp = resp.click(linkid="manager-dataset-url")
         assert sorted([int(obj.pk) for obj in resp.context["object_list"]]) == sorted([dataset.pk, dataset2.pk])
+
+    def test_manager_dataset_list_uses_terms_query_not_or_expansion(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        dataset_ct = ContentType.objects.get_for_model(Dataset)
+        user = User.objects.create_user(email="manyreps@test.com", password="test123")
+        datasets = [DatasetFactory(organization=org) for _ in range(5)]
+        for dataset in datasets:
+            RepresentativeFactory(
+                content_type=dataset_ct,
+                object_id=dataset.pk,
+                role=Representative.RESOURCE_MANAGER,
+                user=user,
+            )
+
+        captured_bodies: list[dict] = []
+        original_search = Elasticsearch.search
+
+        def _capture_search(self_, *args, **kwargs):
+            captured_bodies.append(kwargs.get("body") or (args[0] if args else None))
+            return original_search(self_, *args, **kwargs)
+
+        app.set_user(user)
+        with patch.object(Elasticsearch, "search", _capture_search):
+            resp = app.get(reverse("manager-dataset-list"))
+
+        assert resp.status_code == 200
+
+        def _terms_field_names(node):
+            names = set()
+            if isinstance(node, dict):
+                if "terms" in node and isinstance(node["terms"], dict):
+                    names.update(node["terms"].keys())
+                for value in node.values():
+                    names.update(_terms_field_names(value))
+            elif isinstance(node, list):
+                for item in node:
+                    names.update(_terms_field_names(item))
+            return names
+
+        django_id_terms_seen = any("django_id" in _terms_field_names(body) for body in captured_bodies if body)
+        assert django_id_terms_seen, "Expected a terms clause on django_id; found OR-expansion or none"
+
+        body_dump = repr(captured_bodies)
+
+        assert "django_id:(" not in body_dump
+        assert "id:(" not in body_dump
 
     def test_search_without_query(self, app: DjangoTestApp, search_datasets: list[Dataset]):
         resp = app.get(reverse("dataset-list"))

--- a/vitrina/datasets/search_backends.py
+++ b/vitrina/datasets/search_backends.py
@@ -1,3 +1,5 @@
+from typing import Any, Iterable
+
 from haystack.backends.elasticsearch7_backend import (
     Elasticsearch7SearchBackend,
     Elasticsearch7SearchEngine,
@@ -7,19 +9,19 @@ from haystack.constants import DEFAULT_ALIAS
 
 
 class ElasticsearchSearchQuery(Elasticsearch7SearchQuery):
-    def __init__(self, using=DEFAULT_ALIAS):
+    def __init__(self, using: str = DEFAULT_ALIAS) -> None:
         super().__init__(using=using)
-        self._terms_filters: list[tuple[str, list]] = []
+        self._terms_filters: list[tuple[str, list[Any]]] = []
 
-    def add_terms_filter(self, field: str, values) -> None:
+    def add_terms_filter(self, field: str, values: Iterable[Any]) -> None:
         self._terms_filters.append((field, list(values)))
 
-    def _clone(self, klass=None, using=None):
+    def _clone(self, klass: type | None = None, using: str | None = None) -> "ElasticsearchSearchQuery":
         clone = super()._clone(klass=klass, using=using)
         clone._terms_filters = list(self._terms_filters)
         return clone
 
-    def build_params(self, spelling_query=None, **kwargs):
+    def build_params(self, spelling_query: str | None = None, **kwargs: Any) -> dict[str, Any]:
         params = super().build_params(spelling_query=spelling_query, **kwargs)
         if self._terms_filters:
             params["terms_filters"] = [(field, list(values)) for field, values in self._terms_filters]
@@ -88,7 +90,7 @@ class ElasticsearchBackend(Elasticsearch7SearchBackend):
         "integer": {"type": "long"},
     }
 
-    def build_search_kwargs(self, query_string, **kwargs):
+    def build_search_kwargs(self, query_string: str, **kwargs: Any) -> dict[str, Any]:
         terms_filters = kwargs.pop("terms_filters", None)
         search_kwargs = super().build_search_kwargs(query_string, **kwargs)
         if not terms_filters:

--- a/vitrina/datasets/search_backends.py
+++ b/vitrina/datasets/search_backends.py
@@ -1,7 +1,29 @@
 from haystack.backends.elasticsearch7_backend import (
     Elasticsearch7SearchBackend,
     Elasticsearch7SearchEngine,
+    Elasticsearch7SearchQuery,
 )
+from haystack.constants import DEFAULT_ALIAS
+
+
+class ElasticsearchSearchQuery(Elasticsearch7SearchQuery):
+    def __init__(self, using=DEFAULT_ALIAS):
+        super().__init__(using=using)
+        self._terms_filters: list[tuple[str, list]] = []
+
+    def add_terms_filter(self, field: str, values) -> None:
+        self._terms_filters.append((field, list(values)))
+
+    def _clone(self, klass=None, using=None):
+        clone = super()._clone(klass=klass, using=using)
+        clone._terms_filters = list(self._terms_filters)
+        return clone
+
+    def build_params(self, spelling_query=None, **kwargs):
+        params = super().build_params(spelling_query=spelling_query, **kwargs)
+        if self._terms_filters:
+            params["terms_filters"] = [(field, list(values)) for field, values in self._terms_filters]
+        return params
 
 
 class ElasticsearchBackend(Elasticsearch7SearchBackend):
@@ -66,6 +88,38 @@ class ElasticsearchBackend(Elasticsearch7SearchBackend):
         "integer": {"type": "long"},
     }
 
+    def build_search_kwargs(self, query_string, **kwargs):
+        terms_filters = kwargs.pop("terms_filters", None)
+        search_kwargs = super().build_search_kwargs(query_string, **kwargs)
+        if not terms_filters:
+            return search_kwargs
+
+        new_filters = [{"terms": {field: list(values)}} for field, values in terms_filters]
+
+        query = search_kwargs.get("query", {})
+        bool_clause = query.get("bool")
+
+        if bool_clause and "filter" in bool_clause:
+            existing = bool_clause["filter"]
+            if isinstance(existing, dict) and "bool" in existing and "must" in existing["bool"]:
+                existing["bool"]["must"].extend(new_filters)
+            elif isinstance(existing, list):
+                existing.extend(new_filters)
+            else:
+                bool_clause["filter"] = {"bool": {"must": [existing, *new_filters]}}
+        else:
+            current_query = search_kwargs.pop("query")
+            wrapped_filter = new_filters[0] if len(new_filters) == 1 else {"bool": {"must": new_filters}}
+            search_kwargs["query"] = {
+                "bool": {
+                    "must": current_query,
+                    "filter": wrapped_filter,
+                }
+            }
+
+        return search_kwargs
+
 
 class ElasticSearchEngine(Elasticsearch7SearchEngine):
     backend = ElasticsearchBackend
+    query = ElasticsearchSearchQuery

--- a/vitrina/datasets/services.py
+++ b/vitrina/datasets/services.py
@@ -271,8 +271,6 @@ def filter_out_non_public_datasets_for_user(user: User, datasets: SearchQuerySet
     if user.is_staff or user.is_superuser:
         return datasets
 
-    combined_filter = public_filter
-
     organization_ct = ContentType.objects.get_for_model(Organization)
     dataset_ct = ContentType.objects.get_for_model(Dataset)
 
@@ -345,6 +343,8 @@ def filter_out_non_public_datasets_for_user(user: User, datasets: SearchQuerySet
                     resource_dataset_ids.add(object_id)
                 elif effective_role in open_data_roles:
                     open_data_dataset_ids.add(object_id)
+
+    combined_filter = public_filter
 
     if resource_org_ids:
         combined_filter |= SQ(organization__in=resource_org_ids)

--- a/vitrina/datasets/services.py
+++ b/vitrina/datasets/services.py
@@ -304,7 +304,6 @@ def filter_out_non_public_datasets_for_user(user: User, datasets: SearchQuerySet
             elif role in open_data_roles:
                 open_data_dataset_ids.add(object_id)
 
-    # Get user's org memberships with their roles, to restrict effective role
     user_organization_map = dict(
         Representative.objects.filter(
             user=user,
@@ -344,28 +343,50 @@ def filter_out_non_public_datasets_for_user(user: User, datasets: SearchQuerySet
                 elif effective_role in open_data_roles:
                     open_data_dataset_ids.add(object_id)
 
-    combined_filter = public_filter
+    has_role_branches = (
+        bool(resource_org_ids)
+        or bool(resource_dataset_ids)
+        or bool(open_data_org_ids)
+        or bool(open_data_dataset_ids)
+        or user.is_gov_organization_resource_manager
+    )
+    if not has_role_branches:
+        return datasets.filter(public_filter)
+
+    permission_filter = Q(is_public=True, access_rights__in=(Dataset.PUBLIC, Dataset.RESTRICTED))
 
     if resource_org_ids:
-        combined_filter |= SQ(organization__in=resource_org_ids)
+        permission_filter |= Q(organization_id__in=resource_org_ids)
 
     if resource_dataset_ids:
-        combined_filter |= SQ(id__in=resource_dataset_ids)
+        permission_filter |= Q(pk__in=resource_dataset_ids)
 
     if open_data_org_ids:
-        combined_filter |= SQ(
-            organization__in=open_data_org_ids, access_rights__in=(Dataset.PUBLIC, Dataset.RESTRICTED)
+        permission_filter |= Q(
+            organization_id__in=open_data_org_ids,
+            access_rights__in=(Dataset.PUBLIC, Dataset.RESTRICTED),
         )
 
     if open_data_dataset_ids:
-        combined_filter |= SQ(id__in=open_data_dataset_ids, access_rights__in=(Dataset.PUBLIC, Dataset.RESTRICTED))
-
-    if user.is_gov_organization_resource_manager:
-        combined_filter |= SQ(
-            is_public="true", access_rights__in=(Dataset.PUBLIC, Dataset.RESTRICTED, Dataset.NON_PUBLIC)
+        permission_filter |= Q(
+            pk__in=open_data_dataset_ids,
+            access_rights__in=(Dataset.PUBLIC, Dataset.RESTRICTED),
         )
 
-    return datasets.filter(combined_filter)
+    if user.is_gov_organization_resource_manager:
+        permission_filter |= Q(
+            is_public=True,
+            access_rights__in=(Dataset.PUBLIC, Dataset.RESTRICTED, Dataset.NON_PUBLIC),
+        )
+
+    allowed_dataset_pks = list(Dataset.objects.filter(permission_filter).values_list("pk", flat=True).distinct())
+    return apply_terms_filter(datasets, "django_id", allowed_dataset_pks)
+
+
+def apply_terms_filter(searchqueryset: SearchQuerySet, field: str, values) -> SearchQuerySet:
+    clone = searchqueryset._clone()
+    clone.query.add_terms_filter(field, values)
+    return clone
 
 
 def create_subscription(user, dataset):

--- a/vitrina/datasets/services.py
+++ b/vitrina/datasets/services.py
@@ -1,6 +1,6 @@
 import secrets
 from collections import OrderedDict
-from typing import List, Any, Dict, Type
+from typing import List, Any, Dict, Iterable, Type
 
 import numpy as np
 from django.db import transaction
@@ -383,7 +383,7 @@ def filter_out_non_public_datasets_for_user(user: User, datasets: SearchQuerySet
     return apply_terms_filter(datasets, "django_id", allowed_dataset_pks)
 
 
-def apply_terms_filter(searchqueryset: SearchQuerySet, field: str, values) -> SearchQuerySet:
+def apply_terms_filter(searchqueryset: SearchQuerySet, field: str, values: Iterable[Any]) -> SearchQuerySet:
     clone = searchqueryset._clone()
     clone.query.add_terms_filter(field, values)
     return clone

--- a/vitrina/datasets/views.py
+++ b/vitrina/datasets/views.py
@@ -31,7 +31,6 @@ from django.utils.translation import gettext_lazy as _
 from django.views import View
 from django.views.generic import DetailView, ListView, TemplateView
 from django.views.generic.edit import CreateView, UpdateView, DeleteView
-from haystack.backends import SQ
 from haystack.generic_views import FacetedSearchView
 from haystack.query import SearchQuerySet
 from itsdangerous import URLSafeSerializer
@@ -207,25 +206,17 @@ class DatasetListView(PermissionRequiredMixin, PlanMixin, FacetedSearchView):
             queryset = queryset.facet(field, **options)
 
         if is_manager_dataset_list(self.request):
-            # Get dataset IDs where user is a direct representative
-            dataset_ids = [
-                rep.object_id
-                for rep in self.request.user.representative_set.filter(role__in=Representative.MANAGER_ROLES)
-            ]
-
-            # Get organization IDs where user is a representative
-            org_ids = [
-                rep.object_id
-                for rep in self.request.user.representative_set.filter(role__in=Representative.MANAGER_ROLES)
-            ]
-
-            query = SQ()
-            for dataset_id in dataset_ids:
-                query |= SQ(id=dataset_id)
-            for org_id in org_ids:
-                query |= SQ(organization=org_id)
-
-            queryset = queryset.filter(query)
+            dataset_ct = ContentType.objects.get_for_model(Dataset)
+            organization_ct = ContentType.objects.get_for_model(Organization)
+            manager_reps = self.request.user.representative_set.filter(role__in=Representative.MANAGER_ROLES)
+            direct_dataset_ids = manager_reps.filter(content_type=dataset_ct).values_list("object_id", flat=True)
+            managed_org_ids = manager_reps.filter(content_type=organization_ct).values_list("object_id", flat=True)
+            allowed_dataset_pks = list(
+                Dataset.objects.filter(Q(pk__in=direct_dataset_ids) | Q(organization_id__in=managed_org_ids))
+                .values_list("pk", flat=True)
+                .distinct()
+            )
+            queryset = queryset.filter(django_id__in=allowed_dataset_pks)
 
         if is_org_dataset_list(self.request):
             queryset = queryset.filter(organization=self.organization.pk)

--- a/vitrina/datasets/views.py
+++ b/vitrina/datasets/views.py
@@ -82,6 +82,7 @@ from vitrina.uapi.models import Agent
 from vitrina.views import HistoryView, HistoryMixin, PlanMixin
 from vitrina.datasets.mixins import DatasetBreadcrumbsMixin, Crumb
 from vitrina.datasets.services import (
+    apply_terms_filter,
     update_facet_data,
     get_frequency_and_format,
     get_requests,
@@ -216,7 +217,7 @@ class DatasetListView(PermissionRequiredMixin, PlanMixin, FacetedSearchView):
                 .values_list("pk", flat=True)
                 .distinct()
             )
-            queryset = queryset.filter(django_id__in=allowed_dataset_pks)
+            queryset = apply_terms_filter(queryset, "django_id", allowed_dataset_pks)
 
         if is_org_dataset_list(self.request):
             queryset = queryset.filter(organization=self.organization.pk)


### PR DESCRIPTION
Haystack renders `SearchQuerySet.filter(field__in=[...])` as a Lucene boolean expansion - one OR clause per value - and two call sites (`is_manager_dataset_list` in `views.py` and `filter_out_non_public_datasets_for_user` in `services.py`) feed it large PK sets that blow past `max_clause_count` (prod has it bumped to 8192). Elasticsearch's terms query does the same job as a single clause regardless of array length, but Haystack doesn't expose it, so this PR adds a custom backend that does, plus an `apply_terms_filter` helper. Both call sites now resolve allowed dataset PKs in Postgres and apply them as one terms clause, while anonymous / no-role users keep the cheap public-filter path.
