### PR TITLE
Fix DCAT form field ordering, limit some choices

### DIFF
--- a/tests/classifiers/test_managers.py
+++ b/tests/classifiers/test_managers.py
@@ -1,0 +1,75 @@
+import pytest
+from django.utils.translation import override as translation_override
+
+from vitrina.classifiers.factories import ConceptFactory
+from vitrina.classifiers.models import Concept
+
+pytestmark = pytest.mark.django_db
+
+
+def _set_label(concept, lang, label, description="desc"):
+    concept.set_current_language(lang)
+    concept.label = label
+    concept.description = description
+    concept.save()
+    return concept
+
+
+class TestConceptOrderedByLabelManager:
+    def test_concepts_ordered_alphabetically_by_translated_label(self):
+        c1 = _set_label(ConceptFactory(code="c_zebra"), "lt", "Zebra")
+        c2 = _set_label(ConceptFactory(code="c_apple"), "lt", "Apple")
+        c3 = _set_label(ConceptFactory(code="c_mango"), "lt", "Mango")
+
+        with translation_override("lt"):
+            ordered_ids = list(
+                Concept.ordered_by_label_objects.filter(pk__in=[c1.pk, c2.pk, c3.pk]).values_list("pk", flat=True)
+            )
+
+        assert ordered_ids == [c2.pk, c3.pk, c1.pk]
+
+    def test_falls_back_to_code_when_no_translation_for_current_language(self):
+        c_with_label = _set_label(ConceptFactory(code="zzz_code"), "lt", "Apple")
+        c_no_label = ConceptFactory(code="aaa_code")
+
+        with translation_override("lt"):
+            ordered_ids = list(
+                Concept.ordered_by_label_objects.filter(pk__in=[c_with_label.pk, c_no_label.pk]).values_list(
+                    "pk", flat=True
+                )
+            )
+
+        assert ordered_ids == [c_no_label.pk, c_with_label.pk]
+
+    def test_ordering_uses_current_language(self):
+        c1 = ConceptFactory(code="c_lang1")
+        c2 = ConceptFactory(code="c_lang2")
+        _set_label(c1, "lt", "Zebra")
+        _set_label(c2, "lt", "Apple")
+        _set_label(c1, "en", "Apple")
+        _set_label(c2, "en", "Zebra")
+
+        with translation_override("lt"):
+            lt_ids = list(Concept.ordered_by_label_objects.filter(pk__in=[c1.pk, c2.pk]).values_list("pk", flat=True))
+
+        with translation_override("en"):
+            en_ids = list(Concept.ordered_by_label_objects.filter(pk__in=[c1.pk, c2.pk]).values_list("pk", flat=True))
+
+        assert lt_ids == [c2.pk, c1.pk]
+        assert en_ids == [c1.pk, c2.pk]
+
+    def test_sort_label_annotation_is_code_when_no_translation(self):
+        concept = ConceptFactory(code="my_code")
+
+        with translation_override("lt"):
+            result = Concept.ordered_by_label_objects.filter(pk=concept.pk).values("_sort_label").first()
+
+        assert result["_sort_label"] == "my_code"
+
+    def test_sort_label_annotation_is_translated_label_when_translation_exists(self):
+        concept = _set_label(ConceptFactory(code="irrelevant_code"), "lt", "My Label")
+
+        with translation_override("lt"):
+            result = Concept.ordered_by_label_objects.filter(pk=concept.pk).values("_sort_label").first()
+
+        assert result["_sort_label"] == "My Label"

--- a/tests/classifiers/test_managers.py
+++ b/tests/classifiers/test_managers.py
@@ -7,7 +7,7 @@ from vitrina.classifiers.models import Concept
 pytestmark = pytest.mark.django_db
 
 
-def _set_label(concept, lang, label, description="desc"):
+def _set_label(concept: Concept, lang: str, label: str, description: str = "desc") -> Concept:
     concept.set_current_language(lang)
     concept.label = label
     concept.description = description
@@ -17,46 +17,52 @@ def _set_label(concept, lang, label, description="desc"):
 
 class TestConceptOrderedByLabelManager:
     def test_concepts_ordered_alphabetically_by_translated_label(self):
-        c1 = _set_label(ConceptFactory(code="c_zebra"), "lt", "Zebra")
-        c2 = _set_label(ConceptFactory(code="c_apple"), "lt", "Apple")
-        c3 = _set_label(ConceptFactory(code="c_mango"), "lt", "Mango")
+        concept1 = _set_label(ConceptFactory(code="c_zebra"), "lt", "Zebra")
+        concept2 = _set_label(ConceptFactory(code="c_apple"), "lt", "Apple")
+        concept3 = _set_label(ConceptFactory(code="c_mango"), "lt", "Mango")
 
         with translation_override("lt"):
             ordered_ids = list(
-                Concept.ordered_by_label_objects.filter(pk__in=[c1.pk, c2.pk, c3.pk]).values_list("pk", flat=True)
-            )
-
-        assert ordered_ids == [c2.pk, c3.pk, c1.pk]
-
-    def test_falls_back_to_code_when_no_translation_for_current_language(self):
-        c_with_label = _set_label(ConceptFactory(code="zzz_code"), "lt", "Apple")
-        c_no_label = ConceptFactory(code="aaa_code")
-
-        with translation_override("lt"):
-            ordered_ids = list(
-                Concept.ordered_by_label_objects.filter(pk__in=[c_with_label.pk, c_no_label.pk]).values_list(
+                Concept.ordered_by_label_objects.filter(pk__in=[concept1.pk, concept2.pk, concept3.pk]).values_list(
                     "pk", flat=True
                 )
             )
 
-        assert ordered_ids == [c_no_label.pk, c_with_label.pk]
+        assert ordered_ids == [concept2.pk, concept3.pk, concept1.pk]
 
-    def test_ordering_uses_current_language(self):
-        c1 = ConceptFactory(code="c_lang1")
-        c2 = ConceptFactory(code="c_lang2")
-        _set_label(c1, "lt", "Zebra")
-        _set_label(c2, "lt", "Apple")
-        _set_label(c1, "en", "Apple")
-        _set_label(c2, "en", "Zebra")
+    def test_falls_back_to_code_when_no_translation_for_current_language(self):
+        concept_with_label = _set_label(ConceptFactory(code="zzz_code"), "lt", "Apple")
+        concept_no_label = ConceptFactory(code="aaa_code")
 
         with translation_override("lt"):
-            lt_ids = list(Concept.ordered_by_label_objects.filter(pk__in=[c1.pk, c2.pk]).values_list("pk", flat=True))
+            ordered_ids = list(
+                Concept.ordered_by_label_objects.filter(
+                    pk__in=[concept_with_label.pk, concept_no_label.pk]
+                ).values_list("pk", flat=True)
+            )
+
+        assert ordered_ids == [concept_no_label.pk, concept_with_label.pk]
+
+    def test_ordering_uses_current_language(self):
+        concept1 = ConceptFactory(code="c_lang1")
+        concept2 = ConceptFactory(code="c_lang2")
+        _set_label(concept1, "lt", "Zebra")
+        _set_label(concept2, "lt", "Apple")
+        _set_label(concept1, "en", "Apple")
+        _set_label(concept2, "en", "Zebra")
+
+        with translation_override("lt"):
+            lt_ids = list(
+                Concept.ordered_by_label_objects.filter(pk__in=[concept1.pk, concept2.pk]).values_list("pk", flat=True)
+            )
 
         with translation_override("en"):
-            en_ids = list(Concept.ordered_by_label_objects.filter(pk__in=[c1.pk, c2.pk]).values_list("pk", flat=True))
+            en_ids = list(
+                Concept.ordered_by_label_objects.filter(pk__in=[concept1.pk, concept2.pk]).values_list("pk", flat=True)
+            )
 
-        assert lt_ids == [c2.pk, c1.pk]
-        assert en_ids == [c1.pk, c2.pk]
+        assert lt_ids == [concept2.pk, concept1.pk]
+        assert en_ids == [concept1.pk, concept2.pk]
 
     def test_sort_label_annotation_is_code_when_no_translation(self):
         concept = ConceptFactory(code="my_code")

--- a/tests/dcat/forms/test_dataset_forms.py
+++ b/tests/dcat/forms/test_dataset_forms.py
@@ -10,8 +10,8 @@ from vitrina.classifiers.models import (
     LANGUAGE_CONCEPT_SCHEMA_URI,
 )
 from vitrina.datasets.form_helpers import DATASET_STANDARD_URI
-from vitrina.datasets.factories import ContactFactory, DatasetFactory
-from vitrina.datasets.models import Dataset
+from vitrina.datasets.factories import ContactFactory, DatasetFactory, DCATResourceSubclassFactory
+from vitrina.datasets.models import Dataset, DCATResourceSubclass
 from vitrina.dcat.forms.dataset_forms import (
     DatasetResourceForm,
     InformationSystemResourceForm,
@@ -47,8 +47,9 @@ class TestBaseResourceForm:
 
     def test_parent_queryset_excludes_instance(self):
         organization = OrganizationFactory()
-        dataset = DatasetFactory(organization=organization)
-        other_dataset = DatasetFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
+        dataset = DatasetFactory(organization=organization, subclass=subclass, is_public=False)
+        other_dataset = DatasetFactory(organization=organization, subclass=subclass, is_public=False)
 
         form = InformationSystemResourceForm(
             organization=organization,
@@ -96,6 +97,43 @@ class TestBaseResourceForm:
 
 
 class TestInformationSystemResourceForm:
+    def test_parent_queryset_includes_is_dataset_from_same_org(self):
+        organization = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
+        matching_dataset = DatasetFactory(organization=organization, subclass=subclass, is_public=False)
+
+        form = InformationSystemResourceForm(organization=organization, parent_dataset_id=None)
+
+        assert matching_dataset in form.fields["parent"].queryset
+
+    def test_parent_queryset_excludes_dataset_from_different_org(self):
+        organization = OrganizationFactory()
+        other_organization = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
+        other_org_dataset = DatasetFactory(organization=other_organization, subclass=subclass, is_public=False)
+
+        form = InformationSystemResourceForm(organization=organization, parent_dataset_id=None)
+
+        assert other_org_dataset not in form.fields["parent"].queryset
+
+    def test_parent_queryset_excludes_dataset_with_service_subclass(self):
+        organization = OrganizationFactory()
+        service_subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.SERVICE)
+        service_dataset = DatasetFactory(organization=organization, subclass=service_subclass, is_public=False)
+
+        form = InformationSystemResourceForm(organization=organization, parent_dataset_id=None)
+
+        assert service_dataset not in form.fields["parent"].queryset
+
+    def test_parent_queryset_excludes_public_dataset(self):
+        organization = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
+        public_dataset = DatasetFactory(organization=organization, subclass=subclass, is_public=True)
+
+        form = InformationSystemResourceForm(organization=organization, parent_dataset_id=None)
+
+        assert public_dataset not in form.fields["parent"].queryset
+
     def test_both_rights_fields_raises_error(self):
         organization = OrganizationFactory()
 
@@ -229,6 +267,43 @@ class TestInformationSystemResourceForm:
 
 
 class TestServiceResourceForm:
+    def test_parent_queryset_includes_is_dataset_from_same_org(self):
+        organization = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
+        matching_dataset = DatasetFactory(organization=organization, subclass=subclass, is_public=False)
+
+        form = ServiceResourceForm(organization=organization, parent_dataset_id=None)
+
+        assert matching_dataset in form.fields["parent"].queryset
+
+    def test_parent_queryset_excludes_dataset_from_different_org(self):
+        organization = OrganizationFactory()
+        other_organization = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
+        other_org_dataset = DatasetFactory(organization=other_organization, subclass=subclass, is_public=False)
+
+        form = ServiceResourceForm(organization=organization, parent_dataset_id=None)
+
+        assert other_org_dataset not in form.fields["parent"].queryset
+
+    def test_parent_queryset_excludes_dataset_with_service_subclass(self):
+        organization = OrganizationFactory()
+        service_subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.SERVICE)
+        service_dataset = DatasetFactory(organization=organization, subclass=service_subclass, is_public=False)
+
+        form = ServiceResourceForm(organization=organization, parent_dataset_id=None)
+
+        assert service_dataset not in form.fields["parent"].queryset
+
+    def test_parent_queryset_excludes_public_dataset(self):
+        organization = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
+        public_dataset = DatasetFactory(organization=organization, subclass=subclass, is_public=True)
+
+        form = ServiceResourceForm(organization=organization, parent_dataset_id=None)
+
+        assert public_dataset not in form.fields["parent"].queryset
+
     def test_no_agent_no_endpoint_url_raises_error(self):
         organization = OrganizationFactory()
         contact = ContactFactory(organization=organization)
@@ -363,6 +438,43 @@ class TestServiceResourceForm:
 
 
 class TestDatasetResourceForm:
+    def test_parent_queryset_includes_service_dataset_from_same_org(self):
+        organization = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.SERVICE)
+        matching_dataset = DatasetFactory(organization=organization, subclass=subclass, is_public=False)
+
+        form = DatasetResourceForm(organization=organization, parent_dataset_id=None)
+
+        assert matching_dataset in form.fields["parent"].queryset
+
+    def test_parent_queryset_excludes_dataset_from_different_org(self):
+        organization = OrganizationFactory()
+        other_organization = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.SERVICE)
+        other_org_dataset = DatasetFactory(organization=other_organization, subclass=subclass, is_public=False)
+
+        form = DatasetResourceForm(organization=organization, parent_dataset_id=None)
+
+        assert other_org_dataset not in form.fields["parent"].queryset
+
+    def test_parent_queryset_excludes_dataset_with_is_subclass(self):
+        organization = OrganizationFactory()
+        is_subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
+        is_dataset = DatasetFactory(organization=organization, subclass=is_subclass, is_public=False)
+
+        form = DatasetResourceForm(organization=organization, parent_dataset_id=None)
+
+        assert is_dataset not in form.fields["parent"].queryset
+
+    def test_parent_queryset_excludes_public_dataset(self):
+        organization = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.SERVICE)
+        public_dataset = DatasetFactory(organization=organization, subclass=subclass, is_public=True)
+
+        form = DatasetResourceForm(organization=organization, parent_dataset_id=None)
+
+        assert public_dataset not in form.fields["parent"].queryset
+
     def test_temporal_start_after_end_raises_error(self):
         organization = OrganizationFactory()
 

--- a/tests/dcat/forms/test_distribution_forms.py
+++ b/tests/dcat/forms/test_distribution_forms.py
@@ -5,6 +5,7 @@ from vitrina.classifiers.factories import ConceptFactory, DocumentationFactory, 
 from vitrina.classifiers.models import ConceptSchema
 from vitrina.datasets.factories import DatasetFactory, DatasetServiceFactory
 from vitrina.dcat.forms.distribution_forms import DatasetDistributionForm
+from vitrina.orgs.factories import OrganizationFactory
 from vitrina.resources.factories import DatasetDistributionFactory
 from vitrina.resources.models import DatasetDistribution, DISTRIBUTION_STANDARD_URI
 from vitrina.structure.factories import MetadataFactory
@@ -96,10 +97,11 @@ class TestDatasetDistributionForm:
         assert not form.initial.get("name")
 
     def test_data_service_queryset_includes_non_public_service_datasets(self):
-        dataset = DatasetFactory()
-        public_service_dataset = DatasetServiceFactory(is_public=True)
-        non_public_service_dataset = DatasetServiceFactory(is_public=False)
-        non_public_non_service_dataset = DatasetFactory(is_public=False)
+        organization = OrganizationFactory()
+        dataset = DatasetFactory(organization=organization)
+        public_service_dataset = DatasetServiceFactory(organization=organization, is_public=True)
+        non_public_service_dataset = DatasetServiceFactory(organization=organization, is_public=False)
+        non_public_non_service_dataset = DatasetFactory(organization=organization, is_public=False)
 
         form = DatasetDistributionForm(dataset)
 

--- a/tests/dcat/views/test_dataset_views.py
+++ b/tests/dcat/views/test_dataset_views.py
@@ -368,7 +368,7 @@ class TestDcatDatasetCreateView:
     def test_post_saves_dataset_with_parent(self, app: DjangoTestApp):
         org = OrganizationFactory()
         subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
-        parent = DatasetFactory(organization=org, subclass=subclass)
+        parent = DatasetFactory(organization=org, subclass=subclass, is_public=False)
         importance_schema = ConceptSchema.objects.get(uri=Dataset.INFORMATION_SYSTEM_IMPORTANCE_SCHEMA_URI)
         importance = ConceptFactory(concept_schemas=[importance_schema])
         is_type_schema = ConceptSchema.objects.get(uri=Dataset.INFORMATION_SYSTEM_TYPE_SCHEMA_URI)
@@ -926,7 +926,7 @@ class TestDcatDatasetUpdateView:
         importance = ConceptFactory(concept_schemas=[importance_schema])
         is_type_schema = ConceptSchema.objects.get(uri=Dataset.INFORMATION_SYSTEM_TYPE_SCHEMA_URI)
         is_type = ConceptFactory(concept_schemas=[is_type_schema])
-        parent = DatasetFactory(organization=org, subclass=subclass, is_public=True)
+        parent = DatasetFactory(organization=org, subclass=subclass, is_public=False)
         dataset = DatasetFactory(organization=org, subclass=subclass, is_public=False)
         user = UserFactory(is_staff=True)
         app.set_user(user)

--- a/tests/dcat/views/test_distribution_views.py
+++ b/tests/dcat/views/test_distribution_views.py
@@ -1,5 +1,7 @@
 import pytest
 from django.conf import settings
+
+from vitrina.datasets.models import DCATResourceSubclass
 from vitrina.structure import VersionStatus
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
@@ -7,7 +9,7 @@ from django_webtest import DjangoTestApp
 
 from vitrina.classifiers.factories import ConceptFactory, LicenceFactory
 from vitrina.classifiers.models import ConceptSchema, LANGUAGE_CONCEPT_SCHEMA_URI
-from vitrina.datasets.factories import DatasetFactory, DatasetServiceFactory
+from vitrina.datasets.factories import DatasetFactory, DatasetServiceFactory, DCATResourceSubclassFactory
 from vitrina.orgs.factories import OrganizationFactory, RepresentativeFactory
 from vitrina.orgs.models import Representative
 from vitrina.resources.factories import (
@@ -229,7 +231,8 @@ class TestDcatDistributionCreateView:
     def test_post_saves_all_fields(self, app: DjangoTestApp):
         org = OrganizationFactory()
         dataset = DatasetFactory(organization=org, is_public=False)
-        data_service = DatasetServiceFactory(is_public=False)
+        data_service_subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.SERVICE)
+        data_service = DatasetServiceFactory(organization=org, subclass=data_service_subclass, is_public=False)
         licence = LicenceFactory()
         file_format = FileFormat()
         compression_format = CompressionFormatFactory()
@@ -562,7 +565,8 @@ class TestDcatDistributionUpdateView:
         org = OrganizationFactory()
         dataset = DatasetFactory(organization=org, is_public=False)
         distribution = DatasetDistributionFactory(dataset=dataset)
-        data_service = DatasetServiceFactory(is_public=False)
+        data_service_subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.SERVICE)
+        data_service = DatasetServiceFactory(organization=org, subclass=data_service_subclass, is_public=False)
         licence = LicenceFactory()
         fmt = FileFormat()
         compression_fmt = CompressionFormatFactory()

--- a/vitrina/classifiers/managers.py
+++ b/vitrina/classifiers/managers.py
@@ -1,0 +1,15 @@
+from django.db.models import OuterRef, Subquery, QuerySet
+from django.db.models.functions import Coalesce
+from django.utils.translation import get_language
+from parler.managers import TranslatableManager
+
+
+class ConceptOrderedByLabelManager(TranslatableManager):
+    def get_queryset(self) -> QuerySet:
+        queryset = super().get_queryset()
+        language = get_language()
+        translation_model = queryset.model._parler_meta.root_model
+        label_subquery = Subquery(
+            translation_model.objects.filter(master_id=OuterRef("pk"), language_code=language).values("label")[:1]
+        )
+        return queryset.annotate(_sort_label=Coalesce(label_subquery, "code")).order_by("_sort_label")

--- a/vitrina/classifiers/models.py
+++ b/vitrina/classifiers/models.py
@@ -1,9 +1,11 @@
 from django.db import models
 from django.utils.translation import gettext_lazy as _, get_language
+from parler.managers import TranslatableManager
 
 from parler.models import TranslatableModel, TranslatedFields
 from treebeard.mp_tree import MP_Node, MP_NodeManager
 
+from vitrina.classifiers.managers import ConceptOrderedByLabelManager
 from vitrina.models import UUIDBaseModel
 
 LANGUAGE_CONCEPT_SCHEMA_URI = "http://publications.europa.eu/resource/authority/language"
@@ -243,6 +245,9 @@ class Concept(TranslatableModel, UUIDBaseModel):
         label=models.CharField(max_length=255, verbose_name=_("Pavadinimas")),
         description=models.TextField(verbose_name=_("Aprašymas")),
     )
+
+    objects = TranslatableManager()
+    ordered_by_label_objects = ConceptOrderedByLabelManager()
 
     class Meta:
         verbose_name = _("Sąvoka")

--- a/vitrina/dcat/forms/dataset_forms.py
+++ b/vitrina/dcat/forms/dataset_forms.py
@@ -20,7 +20,7 @@ from vitrina.datasets.form_helpers import (
     DATA_SERVICE_STANDARD_URI,
     DATASET_STANDARD_URI,
 )
-from vitrina.datasets.models import Dataset, Contact
+from vitrina.datasets.models import Dataset, Contact, DCATResourceSubclass
 from vitrina.fields import StringListField
 from vitrina.helpers import inline_fields
 from vitrina.orgs.models import Organization
@@ -190,12 +190,16 @@ class InformationSystemResourceForm(ApplicableLegislationFormMixin, BaseResource
         if instance:
             self.fields["identifier"].initial = instance.identifier if instance.identifier else ""
 
+        self.fields["parent"].queryset = self.fields["parent"].queryset.filter(
+            organization=self.organization, subclass__name=DCATResourceSubclass.INFORMATION_SYSTEM, is_public=False
+        )
+
         self.fields["landing_page"].label = _("Tinklalapis")
         self.fields["landing_page"].help_text = _(
             "Ši savybė nurodo tinklalapį, kuris yra pagrindinis katalogo puslapis. Atitinka foaf:homepage."
         )
 
-        organization_qs = Organization.objects.all()
+        organization_qs = Organization.objects.all().order_by("title")
         self.fields["information_system_publisher"].queryset = organization_qs
         self.fields["information_system_publisher"].required = True
         self.fields["information_system_publisher"].help_text = _(
@@ -207,20 +211,20 @@ class InformationSystemResourceForm(ApplicableLegislationFormMixin, BaseResource
             "Subjektas, atsakingas už IS parengimą. Atitinka dct:creator"
         )
 
-        self.fields["information_system_type"].queryset = Concept.objects.filter(
+        self.fields["information_system_type"].queryset = Concept.ordered_by_label_objects.filter(
             concept_schemas__uri=Dataset.INFORMATION_SYSTEM_TYPE_SCHEMA_URI
         ).prefetch_related("translations")
         self.fields["information_system_type"].label_from_instance = lambda obj: str(obj.translated_label)
 
         self.fields["information_system_importance"].required = True
-        self.fields["information_system_importance"].queryset = Concept.objects.filter(
+        self.fields["information_system_importance"].queryset = Concept.ordered_by_label_objects.filter(
             concept_schemas__uri=Dataset.INFORMATION_SYSTEM_IMPORTANCE_SCHEMA_URI
         ).prefetch_related("translations")
         self.fields["information_system_importance"].label_from_instance = lambda obj: str(obj.translated_label)
 
         self.fields["information_system_assessment_url"].required = True
 
-        self.fields["languages"].queryset = Concept.objects.filter(
+        self.fields["languages"].queryset = Concept.ordered_by_label_objects.filter(
             concept_schemas__uri=LANGUAGE_CONCEPT_SCHEMA_URI
         ).prefetch_related("translations")
         self.fields["languages"].label_from_instance = lambda obj: str(obj.translated_label)
@@ -254,7 +258,9 @@ class ServiceResourceForm(ContactFormMixin, BaseResourceForm):
         ),
     )
     conforms_to = forms.ModelChoiceField(
-        Concept.objects.filter(concept_schemas__uri=DATA_SERVICE_STANDARD_URI).prefetch_related("translations"),
+        Concept.ordered_by_label_objects.filter(concept_schemas__uri=DATA_SERVICE_STANDARD_URI).prefetch_related(
+            "translations"
+        ),
         label=_("Atitinka"),
         required=False,
         help_text=_("Nurodo kokį standartą atitinka paslauga. Atitinka dct:conformsTo."),
@@ -303,8 +309,12 @@ class ServiceResourceForm(ContactFormMixin, BaseResourceForm):
     def __init__(self, organization: Organization, parent_dataset_id: int | None, *args, **kwargs) -> None:
         super().__init__(organization, parent_dataset_id, *args, **kwargs)
 
+        self.fields["parent"].queryset = self.fields["parent"].queryset.filter(
+            organization=self.organization, subclass__name=DCATResourceSubclass.INFORMATION_SYSTEM, is_public=False
+        )
+
         self.fields["service_type"].queryset = (
-            Concept.objects.filter(concept_schemas__uri=Dataset.SERVICE_TYPE_SCHEME_URI)
+            Concept.ordered_by_label_objects.filter(concept_schemas__uri=Dataset.SERVICE_TYPE_SCHEME_URI)
             .prefetch_related("translations")
             .distinct()
         )
@@ -343,7 +353,9 @@ class DatasetResourceForm(ApplicableLegislationFormMixin, ContactFormMixin, Base
         unique=True,
     )
     conforms_to = forms.ModelChoiceField(
-        Concept.objects.filter(concept_schemas__uri=DATASET_STANDARD_URI).prefetch_related("translations"),
+        Concept.ordered_by_label_objects.filter(concept_schemas__uri=DATASET_STANDARD_URI).prefetch_related(
+            "translations"
+        ),
         label=_("Atitinka"),
         required=False,
         help_text=_("Nurodo kokį standartą atitinka duomenų rinkinys. Atitinka dct:conformsTo."),
@@ -392,15 +404,18 @@ class DatasetResourceForm(ApplicableLegislationFormMixin, ContactFormMixin, Base
         if instance:
             self.initial["documentation"] = list(instance.documentation.values_list("documentation_link", flat=True))
 
+        self.fields["parent"].queryset = self.fields["parent"].queryset.filter(
+            organization=self.organization, subclass__name=DCATResourceSubclass.SERVICE, is_public=False
+        )
         self.fields["dataset_type"].queryset = (
-            Concept.objects.filter(concept_schemas__uri=Dataset.DATASET_TYPE_SCHEME_URI)
+            Concept.ordered_by_label_objects.filter(concept_schemas__uri=Dataset.DATASET_TYPE_SCHEME_URI)
             .prefetch_related("translations")
             .distinct()
         )
         self.fields["dataset_type"].label_from_instance = lambda obj: obj.safe_translation_getter(
             "label", any_language=True
         )
-        self.fields["languages"].queryset = Concept.objects.filter(
+        self.fields["languages"].queryset = Concept.ordered_by_label_objects.filter(
             concept_schemas__uri=LANGUAGE_CONCEPT_SCHEMA_URI
         ).prefetch_related("translations")
         self.fields["languages"].label_from_instance = lambda obj: obj.safe_translation_getter(

--- a/vitrina/dcat/forms/distribution_forms.py
+++ b/vitrina/dcat/forms/distribution_forms.py
@@ -2,7 +2,6 @@ from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Submit
 from django import forms
 from django.core.exceptions import ValidationError
-from django.db.models import Case, When, IntegerField
 from django.forms.widgets import URLInput
 from django_select2.forms import Select2Widget, Select2MultipleWidget
 from parler.forms import TranslatableModelForm
@@ -11,8 +10,11 @@ from vitrina.classifiers.models import Concept, Licence
 from vitrina.datasets.form_helpers import validate_urls
 from vitrina.datasets.models import Dataset, DCATResourceSubclass
 from vitrina.fields import StringListField
-from vitrina.resources.forms import CODE_ORDER
-from vitrina.resources.models import DatasetDistribution, DISTRIBUTION_STANDARD_URI
+from vitrina.resources.models import (
+    DatasetDistribution,
+    DISTRIBUTION_STANDARD_URI,
+    DISTRIBUTION_AVAILABILITY_SCHEMA_URI,
+)
 
 from django.utils.translation import gettext_lazy as _
 
@@ -87,11 +89,20 @@ class DatasetDistributionForm(TranslatableModelForm):
 
         self.fields["access_url"].required = True
         self.fields["availability"].required = True
+        self.fields["availability"].queryset = Concept.ordered_by_label_objects.filter(
+            concept_schemas__uri=DISTRIBUTION_AVAILABILITY_SCHEMA_URI
+        ).prefetch_related("translations")
+        self.fields["availability"].label_from_instance = lambda obj: obj.safe_translation_getter(
+            "label", any_language=True
+        )
+
         self.fields["title"].required = True
         self.fields["description"].required = True
 
         self.fields["data_service"].queryset = Dataset.objects.filter(
-            is_public=False, subclass__name=DCATResourceSubclass.SERVICE
+            organization=self.dataset.organization,
+            subclass__name=DCATResourceSubclass.SERVICE,
+            is_public=False,
         ).prefetch_related("translations")
         self.fields["data_service"].required = False
         self.fields["licence"].queryset = self.fields["licence"].queryset.order_by("title")
@@ -99,21 +110,12 @@ class DatasetDistributionForm(TranslatableModelForm):
         self.fields["format"].required = False
         self.fields["compression_format"].queryset = self.fields["compression_format"].queryset.order_by("title")
         self.fields["packaging_format"].queryset = self.fields["packaging_format"].queryset.order_by("title")
-        self.fields["conforms_to"].queryset = Concept.objects.filter(
+        self.fields["conforms_to"].queryset = Concept.ordered_by_label_objects.filter(
             concept_schemas__uri=DISTRIBUTION_STANDARD_URI
         ).prefetch_related("translations")
-        self.fields["status"].queryset = (
-            Concept.objects.filter(concept_schemas__uri=DatasetDistribution.DISTRIBUTION_STATUS_URI)
-            .prefetch_related("translations")
-            .distinct()
-            .order_by(
-                Case(
-                    *[When(code=code, then=pos) for pos, code in enumerate(CODE_ORDER)],
-                    default=len(CODE_ORDER),
-                    output_field=IntegerField(),
-                )
-            )
-        )
+        self.fields["status"].queryset = Concept.ordered_by_label_objects.filter(
+            concept_schemas__uri=DatasetDistribution.DISTRIBUTION_STATUS_URI
+        ).prefetch_related("translations")
         self.fields["status"].label_from_instance = lambda obj: obj.safe_translation_getter("label", any_language=True)
 
         if not self.resource and (default_licence := Licence.objects.filter(is_default=True).first()):


### PR DESCRIPTION
**Summary:**
- Add `ConceptOrderedByLabelManager` that orders queryset by `Concept.label` of currently used language. 
- Limit choices of DCAT dataset form `parent` field:
    - `InformationSystem` parent can only be another `InformationSystem` from same organization
    -  `Service` parent can only be `InformationSystem` from same organization
    -  `Dataset` parent can only be `Service` from same organization