### PR TITLE
2485 one more fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,11 @@ https://github.com/atviriduomenys/katalogas/issues/2563
 - Add `DatasetStructureUMLView` with embedded and `?expanded` fullscreen variants.
 - Add `.mmd` (server-side) and `.svg` (client-side from the rendered SVG) download options.
 
+https://github.com/atviriduomenys/katalogas/issues/2485
+
+- Strip leading newline from DCAT-AP RDF response
+- Sanitize whitespace URIs in DCAT-AP RDF export
+
 v 1.20.0 (2026-05-12)
 ==================
 

--- a/tests/api/test_views.py
+++ b/tests/api/test_views.py
@@ -3106,6 +3106,17 @@ class EdpDcatApPublicRdfTests(TestCase):
 
 
 @pytest.mark.django_db
+def test_edp_dcat_ap_rdf_starts_with_xml_declaration(app: DjangoTestApp):
+    Dataset.objects.all().delete()
+    DatasetFactory(access_rights=Dataset.PUBLIC)
+
+    res = app.get("/edp/dcat-ap.rdf")
+
+    assert res.status_code == 200
+    assert res.text.startswith("<?xml")
+
+
+@pytest.mark.django_db
 def test_edp_dcat_ap_rdf_drops_whitespace_uris(app: DjangoTestApp):
     Dataset.objects.all().delete()
     bad = "https://www.migracija.lt, https://migracija.lrv.lt"

--- a/tests/api/test_views.py
+++ b/tests/api/test_views.py
@@ -3106,6 +3106,41 @@ class EdpDcatApPublicRdfTests(TestCase):
 
 
 @pytest.mark.django_db
+def test_edp_dcat_ap_rdf_drops_whitespace_uris(app: DjangoTestApp):
+    Dataset.objects.all().delete()
+    bad = "https://www.migracija.lt, https://migracija.lrv.lt"
+    DatasetFactory(
+        access_rights=Dataset.PUBLIC,
+        organization=OrganizationFactory(
+            title="Migracija",
+            email="info@example.com",
+            website=bad,
+        ),
+        landing_page=bad,
+        endpoint_url=bad,
+        endpoint_description=bad,
+    )
+
+    res = app.get("/edp/dcat-ap.rdf")
+
+    assert res.status_code == 200
+    # bad URI must never appear inside an rdf:resource/rdf:about attribute
+    assert bad not in res.text
+    # whitespace inside an attribute is the actual parser failure mode
+    for line in res.text.splitlines():
+        for attr in ("rdf:resource", "rdf:about"):
+            marker = f'{attr}="'
+            start = line.find(marker)
+            if start == -1:
+                continue
+            value_start = start + len(marker)
+            value_end = line.find('"', value_start)
+            assert value_end != -1
+            value = line[value_start:value_end]
+            assert not any(c.isspace() for c in value), f"whitespace in {attr}: {value!r}"
+
+
+@pytest.mark.django_db
 def test_edp_dcat_ap_rdf_hvd_dataset(app: DjangoTestApp):
     Dataset.objects.all().delete()
     hvd_group = DatasetGroupFactory(name="hvd")

--- a/tests/datasets/test_views.py
+++ b/tests/datasets/test_views.py
@@ -4472,12 +4472,6 @@ def test_dataset_rdf_download__dataset_with_spinta_data(app: DjangoTestApp):
                 <dct:license>
                     <dct:LicenseDocument rdf:about="http://publications.europa.eu/resource/authority/licence/CC_BY_4_0"/>
                 </dct:license>
-                <dcat:mediaType>
-                    <dct:MediaType rdf:about=""/>
-                </dcat:mediaType>
-                <dct:format>
-                    <dct:MediaTypeOrExtent rdf:about=""/>
-                </dct:format>
             </dcat:Distribution>
         </dcat:distribution>
         <dcat:distribution>

--- a/vitrina/api/helpers.py
+++ b/vitrina/api/helpers.py
@@ -1,3 +1,4 @@
+import re
 from typing import Optional
 
 from django.db.models import QuerySet
@@ -16,6 +17,27 @@ from vitrina.orgs.models import Organization
 
 
 DCAT_AP_RDF_TEMPLATE_NAME = "vitrina/api/edp/dcat_ap_rdf.html"
+
+_URI_WHITESPACE_RE = re.compile(r"\s")
+
+
+def _safe_uri(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return None
+    value = str(value).strip()
+    if not value or _URI_WHITESPACE_RE.search(value):
+        return None
+    return value
+
+
+def _get_org_for_rdf(org: Optional[Organization]):
+    if org is None:
+        return None
+    return {
+        "title": org.title,
+        "email": _safe_uri(org.email),
+        "website": _safe_uri(org.website),
+    }
 
 
 def get_datasets_for_rdf(qs):
@@ -39,7 +61,7 @@ def get_datasets_for_rdf(qs):
             if dataset.is_part_of_dataservice():
                 dataset_resources = DynamicResourceService(dataset, None)
                 dynamic_distributions = dataset_resources.generate_resources(is_for_rdf_export=True)
-                distributions.extend(dynamic_distributions)
+                distributions.extend(_sanitize_dynamic_distribution(d) for d in dynamic_distributions)
 
         yield {
             "uri": dataset.get_absolute_url(),
@@ -61,16 +83,16 @@ def get_datasets_for_rdf(qs):
             "keywords": [k.name for k in dataset.tags.all()],
             "published": dataset.published,
             "modified": dataset.modified,
-            "organization": dataset.organization,
-            "creators": Organization.objects.filter(pk__in=dataset.get_creators()),
+            "organization": _get_org_for_rdf(dataset.organization),
+            "creators": [_get_org_for_rdf(o) for o in Organization.objects.filter(pk__in=dataset.get_creators())],
             "frequency": _get_frequency(dataset.frequency),
             "distributions": distributions,
-            "contact": _get_contact_email(dataset),
-            "landing_page": dataset.landing_page,
+            "contact": _safe_uri(_get_contact_email(dataset)),
+            "landing_page": _safe_uri(dataset.landing_page),
             "service": dataset.service,
-            "endpoint_url": dataset.endpoint_url,
+            "endpoint_url": _safe_uri(dataset.endpoint_url),
             "endpoint_type": _get_format(dataset.endpoint_type),
-            "endpoint_description": dataset.endpoint_description,
+            "endpoint_description": _safe_uri(dataset.endpoint_description),
             "endpoint_description_type": dataset.endpoint_description_type,
             "related_datasets": (
                 _get_rel_dataset(relation)
@@ -117,9 +139,9 @@ def _get_distribution(dataset: Dataset, dist: Distribution):
                 "description": dist.description,
             },
         ],
-        "download_url": dist.get_download_url(),
-        "access_url": dist.get_access_url(),
-        "access_service": dist.data_service.get_absolute_url() if dist.data_service else None,
+        "download_url": _safe_uri(dist.get_download_url()),
+        "access_url": _safe_uri(dist.get_access_url()),
+        "access_service": _safe_uri(dist.data_service.get_absolute_url()) if dist.data_service else None,
         "licence": _get_licence(dist.licence),
         "conditions": dist.conditions or "",
         "format": _get_format(dist.format),
@@ -146,7 +168,7 @@ def _get_categories(dataset):
 
 def _get_category(category: Category):
     return {
-        "uri": category.uri,
+        "uri": _safe_uri(category.uri),
         "translations": [
             {
                 "lang": "lt",
@@ -161,7 +183,7 @@ def _get_hvd_category(category: Category):
     if group_category_uri := category.datasetgroupcategoryuri_set.filter(group__name=DatasetGroup.HVD).first():
         uri = group_category_uri.uri
     return {
-        "uri": uri,
+        "uri": _safe_uri(uri),
         "translations": [
             {
                 "lang": "lt",
@@ -182,7 +204,7 @@ def _get_frequency(frequency: Optional[Frequency]):
         return
 
     return {
-        "uri": frequency.uri,
+        "uri": _safe_uri(frequency.uri),
         "translations": [
             {
                 "lang": "lt",
@@ -197,22 +219,32 @@ def _get_frequency(frequency: Optional[Frequency]):
 
 
 def _get_licence(licence: Optional[Licence]):
-    if licence and licence.url:
-        return {"uri": licence.url}
+    if licence and (uri := _safe_uri(licence.url)):
+        return {"uri": uri}
 
 
 def _get_format(format: Optional[Format]):
-    if format and format.uri:
-        return {
-            "uri": format.uri,
-        }
+    if format and (uri := _safe_uri(format.uri)):
+        return {"uri": uri}
 
 
 def _get_media_type(format: Optional[Format]):
-    if format and format.media_type_uri:
-        return {
-            "uri": format.media_type_uri,
-        }
+    if format and (uri := _safe_uri(format.media_type_uri)):
+        return {"uri": uri}
+
+
+def _sanitize_dynamic_distribution(dist: dict) -> dict:
+    cleaned = dict(dist)
+    for key in ("download_url", "access_url", "access_service"):
+        if key in cleaned:
+            cleaned[key] = _safe_uri(cleaned[key])
+    for key in ("licence", "format", "media_type", "compression_format", "packaging_format"):
+        nested = cleaned.get(key)
+        if nested and (uri := _safe_uri(nested.get("uri"))):
+            cleaned[key] = {**nested, "uri": uri}
+        elif nested is not None:
+            cleaned[key] = None
+    return cleaned
 
 
 def _get_contact_email(dataset: Dataset) -> str:

--- a/vitrina/api/helpers.py
+++ b/vitrina/api/helpers.py
@@ -114,7 +114,7 @@ def render_rdf_response(request: HttpRequest, datasets: QuerySet[Dataset]) -> Ht
         {"datasets": get_datasets_for_rdf(datasets)},
         request=request,
     )
-    content = _encode_xml_control_chars(content)
+    content = _encode_xml_control_chars(content).lstrip()
     return HttpResponse(content, content_type="application/rdf+xml")
 
 

--- a/vitrina/api/helpers.py
+++ b/vitrina/api/helpers.py
@@ -21,7 +21,7 @@ DCAT_AP_RDF_TEMPLATE_NAME = "vitrina/api/edp/dcat_ap_rdf.html"
 _URI_WHITESPACE_RE = re.compile(r"\s")
 
 
-def _safe_uri(value: Optional[str]) -> Optional[str]:
+def _safe_uri(value: str | None) -> str | None:
     if not value:
         return None
     value = str(value).strip()
@@ -30,7 +30,7 @@ def _safe_uri(value: Optional[str]) -> Optional[str]:
     return value
 
 
-def _get_org_for_rdf(org: Optional[Organization]):
+def _get_org_for_rdf(org: Organization | None) -> dict | None:
     if org is None:
         return None
     return {


### PR DESCRIPTION
```
riot --validate ~/dcat-ap.rdf
10:14:23 ERROR riot            :: [line: 287427, col: 99] {W002} <https://www.migracija.lt, https://migracija.lrv.lt> Code: 17/WHITESPACE in HOST: A single whitespace character. These match no grammar rules of URIs/IRIs.
```