### PR TITLE
2607: Removing metadata_version return

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,8 +31,11 @@ Bug fixes:
 
 https://github.com/atviriduomenys/katalogas/issues/2620
 
- - Fixed an issue where base models were not exported as dependencies from another manifest, which also propagated to it not being displayed on UML diagarms.
+ - Fixed an issue where base models were not exported as dependencies from another manifest, which also propagated to it not being displayed on UML diagrams.
 
+https://github.com/atviriduomenys/katalogas/issues/2607
+
+ - Fixed an issue where importing a structure with name errors deletes the draft version.
 
 v 1.20.0 (2026-05-12)
 ==================

--- a/tests/structure/test_services.py
+++ b/tests/structure/test_services.py
@@ -2278,6 +2278,50 @@ def test_import_structure_with_wrong_datasets_name(app: DjangoTestApp):
 
 
 @pytest.mark.django_db
+def test_import_structure_with_errors_preserves_draft_metadata(app: DjangoTestApp):
+    valid_manifest = (
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/ivpk/adp/test,,,,,,,,,,,,,,,,,\n"
+    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=valid_manifest)))
+    structure.dataset.current_structure = structure
+    structure.dataset.save()
+    initial_version = create_structure_objects(structure)
+
+    ct = ContentType.objects.get_for_model(Dataset)
+    assert Metadata.objects.filter(
+        content_type=ct,
+        object_id=structure.dataset.pk,
+        metadata_version=initial_version,
+    ).exists()
+
+    broken_manifest = (
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/ivpk/adp/ššš,,,,,,,,,,,,,,,,,\n"
+    )
+    broken_structure = DatasetStructureFactory(
+        dataset=structure.dataset,
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=broken_manifest)),
+    )
+    broken_structure.dataset.current_structure = broken_structure
+    broken_structure.dataset.save()
+    create_structure_objects(broken_structure)
+
+    assert Metadata.objects.filter(
+        content_type=ct,
+        object_id=structure.dataset.pk,
+        metadata_version=initial_version,
+    ).exists()
+
+    comments = Comment.objects.filter(
+        content_type=ContentType.objects.get_for_model(broken_structure),
+        object_id=broken_structure.pk,
+    )
+    assert comments.count() == 1
+    assert "kodiniame pavadinime gali būti naudojamos tik lotyniškos raidės." in comments[0].body
+
+
+@pytest.mark.django_db
 def test_structure_resource__resource_title(app: DjangoTestApp):
     manifest = (
         "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"

--- a/vitrina/structure/services.py
+++ b/vitrina/structure/services.py
@@ -172,7 +172,7 @@ def create_structure_objects(structure: DatasetStructure, metadata_version: Vers
                         existing_comments=existing_structure_comments,
                     )
                     _load_prefixes(structure.dataset, state.manifest.prefixes, structure, metadata_version)
-                    metadata_version = _load_datasets(state, structure.dataset, metadata_version)
+                    _load_datasets(state, structure.dataset, metadata_version)
                     structure.dataset.update_level()
 
         for error in errors:
@@ -205,12 +205,8 @@ def create_or_get_uapi_format():
     return format_obj
 
 
-def _load_datasets(state: struct.State, dataset: Dataset, metadata_version: Version):
+def _load_datasets(state: struct.State, dataset: Dataset, metadata_version: Version) -> None:
     ct = ContentType.objects.get_for_model(dataset)
-    existing_metadata = list(
-        Metadata.objects.filter(content_type=ct, object_id=dataset.pk, metadata_version=metadata_version)
-    )
-    loaded_metadata = []
     _clean_errors(dataset.current_structure)
     existing_dataset_comments = list(
         Comment.objects.filter(
@@ -228,11 +224,9 @@ def _load_datasets(state: struct.State, dataset: Dataset, metadata_version: Vers
         else:
             message = _("Kodinis pavadinimas turi prasidėti nuo „%(expected)s“.") % {"expected": main_prefix}
         _create_errors([message], dataset.current_structure)
-        metadata_version.delete()
-        return metadata_version
+        return
 
     manifest_names = list({manifest.name for _, manifest in to_process if manifest.name})
-
     dataset_meta_uuid_by_name: dict[str, uuid.UUID] = {}
     if manifest_names:
         for metadata in Metadata.objects.filter(
@@ -276,16 +270,10 @@ def _load_datasets(state: struct.State, dataset: Dataset, metadata_version: Vers
             )
         if metadata:
             meta.errors.append(_(f'Duomenų išteklius "{meta.name}" jau egzistuoja.'))
-            loaded_metadata.append(metadata)
-            metadata_version.delete()
         elif not meta.name.isascii():
             meta.errors.append(_(f'"{meta.name}" kodiniame pavadinime gali būti naudojamos tik lotyniškos raidės.'))
-            loaded_metadata.append(metadata)
-            metadata_version.delete()
         elif any([ch.isupper() for ch in meta.name]):
             meta.errors.append(_(f'"{meta.name}" kodiniame pavadinime gali būti naudojamos tik mažosios raidės.'))
-            loaded_metadata.append(metadata)
-            metadata_version.delete()
         else:
             if not meta.id and (uid := dataset_meta_uuid_by_name.get(meta.name)):
                 meta.id = uid
@@ -312,16 +300,8 @@ def _load_datasets(state: struct.State, dataset: Dataset, metadata_version: Vers
             _load_models(meta, dataset, metadata_version, metadata_cache=metadata_cache)
             _link_distributions(meta, dataset, metadata_version, metadata_cache=metadata_cache)
             _link_models(dataset, meta, metadata_version, metadata_cache=metadata_cache)
-            loaded_metadata.append(metadata)
-
         if errors := meta.errors:
             _create_errors(errors, dataset.current_structure)
-
-    removed_metadata = list(set(existing_metadata) - set(loaded_metadata))
-    for meta in removed_metadata:
-        meta.delete()
-
-    return metadata_version
 
 
 def _get_manifest_datasets_to_process(state: struct.State, dataset: Dataset) -> list[tuple[int, struct.Dataset]]:

--- a/vitrina/structure/services.py
+++ b/vitrina/structure/services.py
@@ -211,6 +211,7 @@ def _load_datasets(state: struct.State, dataset: Dataset, metadata_version: Vers
         Metadata.objects.filter(content_type=ct, object_id=dataset.pk, metadata_version=metadata_version)
     )
     loaded_metadata = []
+    has_errors = False
     _clean_errors(dataset.current_structure)
     existing_dataset_comments = list(
         Comment.objects.filter(
@@ -274,13 +275,10 @@ def _load_datasets(state: struct.State, dataset: Dataset, metadata_version: Vers
             )
         if metadata:
             meta.errors.append(_(f'Duomenų išteklius "{meta.name}" jau egzistuoja.'))
-            loaded_metadata.append(metadata)
         elif not meta.name.isascii():
             meta.errors.append(_(f'"{meta.name}" kodiniame pavadinime gali būti naudojamos tik lotyniškos raidės.'))
-            loaded_metadata.append(metadata)
         elif any([ch.isupper() for ch in meta.name]):
             meta.errors.append(_(f'"{meta.name}" kodiniame pavadinime gali būti naudojamos tik mažosios raidės.'))
-            loaded_metadata.append(metadata)
         else:
             if not meta.id and (uid := dataset_meta_uuid_by_name.get(meta.name)):
                 meta.id = uid
@@ -311,7 +309,9 @@ def _load_datasets(state: struct.State, dataset: Dataset, metadata_version: Vers
 
         if errors := meta.errors:
             _create_errors(errors, dataset.current_structure)
+            has_errors = True
 
+    if not has_errors:
         removed_metadata = list(set(existing_metadata) - set(loaded_metadata))
         for meta in removed_metadata:
             meta.delete()

--- a/vitrina/structure/services.py
+++ b/vitrina/structure/services.py
@@ -207,6 +207,10 @@ def create_or_get_uapi_format():
 
 def _load_datasets(state: struct.State, dataset: Dataset, metadata_version: Version) -> None:
     ct = ContentType.objects.get_for_model(dataset)
+    existing_metadata = list(
+        Metadata.objects.filter(content_type=ct, object_id=dataset.pk, metadata_version=metadata_version)
+    )
+    loaded_metadata = []
     _clean_errors(dataset.current_structure)
     existing_dataset_comments = list(
         Comment.objects.filter(
@@ -270,10 +274,13 @@ def _load_datasets(state: struct.State, dataset: Dataset, metadata_version: Vers
             )
         if metadata:
             meta.errors.append(_(f'Duomenų išteklius "{meta.name}" jau egzistuoja.'))
+            loaded_metadata.append(metadata)
         elif not meta.name.isascii():
             meta.errors.append(_(f'"{meta.name}" kodiniame pavadinime gali būti naudojamos tik lotyniškos raidės.'))
+            loaded_metadata.append(metadata)
         elif any([ch.isupper() for ch in meta.name]):
             meta.errors.append(_(f'"{meta.name}" kodiniame pavadinime gali būti naudojamos tik mažosios raidės.'))
+            loaded_metadata.append(metadata)
         else:
             if not meta.id and (uid := dataset_meta_uuid_by_name.get(meta.name)):
                 meta.id = uid
@@ -300,8 +307,14 @@ def _load_datasets(state: struct.State, dataset: Dataset, metadata_version: Vers
             _load_models(meta, dataset, metadata_version, metadata_cache=metadata_cache)
             _link_distributions(meta, dataset, metadata_version, metadata_cache=metadata_cache)
             _link_models(dataset, meta, metadata_version, metadata_cache=metadata_cache)
+            loaded_metadata.append(metadata)
+
         if errors := meta.errors:
             _create_errors(errors, dataset.current_structure)
+
+        removed_metadata = list(set(existing_metadata) - set(loaded_metadata))
+        for meta in removed_metadata:
+            meta.delete()
 
 
 def _get_manifest_datasets_to_process(state: struct.State, dataset: Dataset) -> list[tuple[int, struct.Dataset]]:


### PR DESCRIPTION
Summary:
Fix: don't delete draft metadata when manifest import has errors
- Removed the loaded_metadata.append(metadata) calls from the name-validation error branches (they were appending None in some cases).
- Added an if not has_errors: guard on the cleanup — the draft is only pruned when the manifest is fully valid.

Ticket: https://github.com/atviriduomenys/katalogas/issues/2607