### PR TITLE
Fix SPINTA data_last_updated to use :changes/-1 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,10 @@ https://github.com/atviriduomenys/katalogas/issues/2485
 - Strip leading newline from DCAT-AP RDF response
 - Sanitize whitespace URIs in DCAT-AP RDF export
 
+https://github.com/atviriduomenys/katalogas/issues/2260
+
+- Fix SPINTA data_last_updated to use :changes/-1 and aggregate all dataset models
+
 v 1.20.0 (2026-05-12)
 ==================
 

--- a/tests/resources/test_tasks.py
+++ b/tests/resources/test_tasks.py
@@ -1,12 +1,12 @@
 from datetime import timedelta
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from django.utils import timezone
 
 from vitrina.datasets.factories import DatasetFactory
 from vitrina.resources.factories import DatasetDistributionFactory
-from vitrina.resources.tasks import update_spinta_distribution_dates
+from vitrina.resources.tasks import _fetch_spinta_last_modified, update_spinta_distribution_dates
 
 
 @pytest.mark.django_db
@@ -56,3 +56,63 @@ def test_task_does_not_update_when_spinta_returns_older_date():
 
     distribution.refresh_from_db()
     assert distribution.data_last_updated == current_date
+
+
+def _mock_distribution_with_models(*full_names: str) -> MagicMock:
+    distribution = MagicMock()
+    distribution.pk = 42
+    models = [MagicMock(full_name=name) for name in full_names]
+    distribution.dataset.model_set.all.return_value.__iter__.return_value = iter(models)
+    distribution.dataset.model_set.all.return_value.exists.return_value = bool(models)
+    return distribution
+
+
+def test_fetch_uses_changes_last_row_endpoint():
+    # Regression: :changes silently ignores sort()/limit() and returns _cid ASC,
+    # so the task must use :changes/-1/ to read the latest change, not a sort+limit query.
+    distribution = _mock_distribution_with_models("gov/vmi/ja_nepriemokos/NepriemokosSuma")
+
+    with patch("vitrina.resources.tasks.get_data_from_spinta") as mock_get:
+        mock_get.return_value = {"_data": [{"_created": "2026-05-14T06:12:15.722841"}]}
+        _fetch_spinta_last_modified(distribution)
+
+    mock_get.assert_called_once()
+    args, _kwargs = mock_get.call_args
+    assert args[0] == "gov/vmi/ja_nepriemokos/NepriemokosSuma"
+    assert args[1] == ":changes/-1/"
+
+
+def test_fetch_returns_max_across_all_models():
+    # A dataset can have multiple models; data_last_updated should reflect the
+    # most recent change across all of them, not just the first model.
+    distribution = _mock_distribution_with_models("ns/ModelA", "ns/ModelB", "ns/ModelC")
+
+    responses = {
+        "ns/ModelA": {"_data": [{"_created": "2026-01-01T00:00:00"}]},
+        "ns/ModelB": {"_data": [{"_created": "2026-05-14T06:12:15"}]},  # newest
+        "ns/ModelC": {"_data": [{"_created": "2025-06-01T00:00:00"}]},
+    }
+
+    with patch("vitrina.resources.tasks.get_data_from_spinta") as mock_get:
+        mock_get.side_effect = lambda name, *a, **kw: responses[name]
+        result = _fetch_spinta_last_modified(distribution)
+
+    assert mock_get.call_count == 3
+    assert result.isoformat().startswith("2026-05-14T06:12:15")
+
+
+def test_fetch_tolerates_errors_from_individual_models():
+    # If one model's :changes query errors, the task should still use the
+    # newest timestamp from the models that did respond.
+    distribution = _mock_distribution_with_models("ns/Broken", "ns/Working")
+
+    responses = {
+        "ns/Broken": {"errors": ["some upstream failure"]},
+        "ns/Working": {"_data": [{"_created": "2026-05-14T06:12:15"}]},
+    }
+
+    with patch("vitrina.resources.tasks.get_data_from_spinta") as mock_get:
+        mock_get.side_effect = lambda name, *a, **kw: responses[name]
+        result = _fetch_spinta_last_modified(distribution)
+
+    assert result.isoformat().startswith("2026-05-14T06:12:15")

--- a/vitrina/resources/tasks.py
+++ b/vitrina/resources/tasks.py
@@ -92,34 +92,44 @@ def _fetch_spinta_last_modified(distribution: DatasetDistribution) -> datetime |
         logger.debug("Distribution %d dataset has no models, skipping.", distribution.pk)
         return None
 
-    model = models.first()
-    data = get_data_from_spinta(
-        f"{model.full_name}/:changes/:format/json",
-        query="select(_created)&sort(-_created)&limit(1)",
-        timeout=15,
-    )
+    latest: datetime | None = None
+    for model in models:
+        model_latest = _fetch_model_last_modified(model.full_name, distribution.pk)
+        if model_latest and (latest is None or model_latest > latest):
+            latest = model_latest
+    return latest
+
+
+def _fetch_model_last_modified(model_full_name: str, distribution_pk: int) -> datetime | None:
+    data = get_data_from_spinta(model_full_name, ":changes/-1/", timeout=15)
 
     if not data:
         return None
 
     if "errors" in data:
         logger.warning(
-            "SPINTA returned errors for distribution %d: %s",
-            distribution.pk,
+            "SPINTA returned errors for distribution %d model %s: %s",
+            distribution_pk,
+            model_full_name,
             data["errors"],
         )
         return None
 
     items = data.get("_data", [])
     if not items:
-        logger.debug("Distribution %d SPINTA response has no _data items, skipping.", distribution.pk)
+        logger.debug(
+            "Distribution %d model %s SPINTA response has no _data items, skipping.",
+            distribution_pk,
+            model_full_name,
+        )
         return None
 
     serializer = SpintaChangeSerializer(data=items[0])
     if not serializer.is_valid():
         logger.warning(
-            "Invalid SPINTA change entry for distribution %d: %s",
-            distribution.pk,
+            "Invalid SPINTA change entry for distribution %d model %s: %s",
+            distribution_pk,
+            model_full_name,
             serializer.errors,
         )
         return None

--- a/vitrina/resources/tasks.py
+++ b/vitrina/resources/tasks.py
@@ -94,9 +94,9 @@ def _fetch_spinta_last_modified(distribution: DatasetDistribution) -> datetime |
 
     latest: datetime | None = None
     for model in models:
-        model_latest = _fetch_model_last_modified(model.full_name, distribution.pk)
-        if model_latest and (latest is None or model_latest > latest):
-            latest = model_latest
+        latest_model_datetime = _fetch_model_last_modified(model.full_name, distribution.pk)
+        if latest_model_datetime and (latest is None or latest_model_datetime > latest):
+            latest = latest_model_datetime
     return latest
 
 


### PR DESCRIPTION
Celery task queried `:changes/:format/json?select(_created)&sort(-_created)&limit(1)`, but the `:changes` endpoint silently ignores `sort()` and `select()` and always returns rows in `_cid` ascending order - so `limit(1)` returned the oldest change (verified on `NepriemokosSuma`: query returns `_cid=1, _created=2024-11-18`, while `:changes/-1/` returns `_cid=2709025, _created=2026-05-14`). 

The fix switches to `:changes/-1/` (Spinta's "last row" syntax, already used in `vitrina/datasets/admin.py`) and aggregates across all models in the dataset, so distributions with multiple models reflect the newest change from any of them.

```
https://get.data.gov.lt/datasets/gov/vmi/ja_nepriemokos/NepriemokosSuma/:changes/?select(_created)&sort(-_created)&limit(1)
```
vs
```
https://get.data.gov.lt/datasets/gov/vmi/ja_nepriemokos/NepriemokosSuma/:changes/-1
```

