### PR TITLE
2620 base model, as dependency, export bug

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,13 @@ https://github.com/atviriduomenys/katalogas/issues/2260
 
 - Fix SPINTA data_last_updated to use :changes/-1 and aggregate all dataset models
 
+Bug fixes:
+
+https://github.com/atviriduomenys/katalogas/issues/2620
+
+ - Fixed an issue where base models were not exported as dependencies from another manifest, which also propagated to it not being displayed on UML diagarms.
+
+
 v 1.20.0 (2026-05-12)
 ==================
 

--- a/tests/api/test_mixins.py
+++ b/tests/api/test_mixins.py
@@ -241,9 +241,9 @@ def test_check_dataset_access_raises_with_no_user_no_role(app: DjangoTestApp):
 @pytest.mark.parametrize(
     "organization_role, is_information_system, expected",
     [
-        (next(iter(Representative.OPEN_DATA_ROLE_KEYS)), True, False),
-        (next(iter(Representative.OPEN_DATA_ROLE_KEYS)), False, False),
-        (next(iter(Representative.RESOURCE_ROLE_KEYS)), True, False),
+        (Representative.OPEN_DATA_COORDINATOR, True, False),
+        (Representative.OPEN_DATA_COORDINATOR, False, False),
+        (Representative.RESOURCE_MANAGER, True, False),
         (None, True, False),
     ],
 )

--- a/tests/structure/test_services.py
+++ b/tests/structure/test_services.py
@@ -3248,3 +3248,114 @@ def test_generate_mermaid_model_click_links(app: DjangoTestApp):
         f"click `datasets/gov/ivpk/adp/Catalog` href "
         f'"{base_url}/datasets/{dataset_pk}/versions/{version_pk}/models/Catalog/"'
     ) in result
+
+
+@pytest.mark.django_db
+def test_generate_mermaid_with_base_chain_across_datasets(app: DjangoTestApp):
+    grandparent_manifest = (
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n"
+        "40,datasets/gov/grand/dataset,,,,,,,,,,,,,,,,,\n"
+        "41,,,,GrandparentModel,,,id,,,,,,,,,,,\n"
+        "42,,,,,id,integer,,,,,,,,,,,,\n"
+    )
+    grandparent_structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=grandparent_manifest)),
+        dataset=DatasetFactory(
+            organization=OrganizationFactory(whitelisted_names=["datasets/gov/grand/"]),
+        ),
+    )
+    grandparent_structure.dataset.current_structure = grandparent_structure
+    grandparent_structure.dataset.save()
+    grandparent_version = create_structure_objects(grandparent_structure)
+    grandparent_version.status = VersionStatus.STABLE
+    grandparent_version.save()
+
+    parent_manifest = (
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n"
+        "30,datasets/gov/parent/dataset,,,,,,,,,,,,,,,,,\n"
+        "31,,,datasets/gov/grand/dataset/GrandparentModel,,,,,,,,,,,,,,,\n"
+        "32,,,,ParentModel,,,id,,,,,,,,,,,\n"
+        "33,,,,,id,integer,,,,,,,,,,,,\n"
+        ",,,/,,,,,,,,,,,,,,,\n"
+    )
+    parent_structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=parent_manifest)),
+        dataset=DatasetFactory(
+            organization=OrganizationFactory(whitelisted_names=["datasets/gov/parent/"]),
+        ),
+    )
+    parent_structure.dataset.current_structure = parent_structure
+    parent_structure.dataset.save()
+    parent_version = create_structure_objects(parent_structure)
+    parent_version.status = VersionStatus.STABLE
+    parent_version.save()
+
+    main_manifest = (
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,count,level,status,visibility,access,uri,eli,title,description\n"
+        "1,datasets/gov/main/dataset,,,,,,,,,,,,,,,,,\n"
+        "2,,,datasets/gov/parent/dataset/ParentModel,,,,,,,,,,,,,,,\n"
+        "3,,,,ChildModel,,,id,,,,,,,,,,,\n"
+        "4,,,,,id,integer,,,,,,,,,,,,\n"
+        ",,,/,,,,,,,,,,,,,,,\n"
+    )
+    main_structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=main_manifest)),
+        dataset=DatasetFactory(
+            title="Main",
+            description="Root",
+            organization=OrganizationFactory(whitelisted_names=["datasets/gov/main/"]),
+        ),
+    )
+    main_structure.dataset.current_structure = main_structure
+    main_structure.dataset.save()
+    main_version = create_structure_objects(main_structure)
+
+    mermaid = generate_mermaid_diagram(main_structure.dataset, main_version)
+
+    assert (
+        """
+classDiagram
+namespace `datasets/gov/grand/dataset` {
+class `datasets/gov/grand/dataset/GrandparentModel`["GrandparentModel"]:::Entity {
+«optional»
+id : integer [0..1]
+}
+}
+namespace `datasets/gov/parent/dataset` {
+class `datasets/gov/parent/dataset/ParentModel`["ParentModel"]:::Entity {
+«optional»
+id : integer [0..1]
+}
+}
+namespace `datasets/gov/main/dataset` {
+class `datasets/gov/main/dataset/ChildModel`["ChildModel"]:::Entity {
+«optional»
+id : integer [0..1]
+}
+}
+`datasets/gov/main/dataset/ChildModel` --|> `datasets/gov/parent/dataset/ParentModel`
+`datasets/gov/parent/dataset/ParentModel` --|> `datasets/gov/grand/dataset/GrandparentModel`
+"""
+        in mermaid
+    )
+
+    base_url = f"{settings.META_SITE_PROTOCOL}://{settings.META_SITE_DOMAIN}"
+    child_url = reverse(
+        "model-structure",
+        kwargs={"pk": main_structure.dataset.pk, "version_id": main_version.pk, "model": "ChildModel"},
+    )
+    parent_url = reverse(
+        "model-structure",
+        kwargs={"pk": parent_structure.dataset.pk, "version_id": parent_version.pk, "model": "ParentModel"},
+    )
+    grandparent_url = reverse(
+        "model-structure",
+        kwargs={
+            "pk": grandparent_structure.dataset.pk,
+            "version_id": grandparent_version.pk,
+            "model": "GrandparentModel",
+        },
+    )
+    assert f'click `datasets/gov/main/dataset/ChildModel` href "{base_url}{child_url}"' in mermaid
+    assert f'click `datasets/gov/parent/dataset/ParentModel` href "{base_url}{parent_url}"' in mermaid
+    assert f'click `datasets/gov/grand/dataset/GrandparentModel` href "{base_url}{grandparent_url}"' in mermaid

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -61,7 +61,7 @@ from vitrina.utils import RevisionComment, RevisionSource
 class BaseTestCreateManifest:
     def _create_manifest(
         self, manifest: str, title: str = "", description: str = "", whitelisted_names: list[str] | None = None
-    ):
+    ) -> Dataset:
         dataset = DatasetFactory(
             title=title,
             description=description,
@@ -8152,6 +8152,125 @@ class TestStructureExportDependentModels(BaseTestCreateManifest):
         lines = resp.text.split("\r\n")
         no_pk_model_line = [line for line in lines if "NoPkModel" in line][0]
         assert no_pk_model_line == "11,,,,NoPkModel,,,,,,,,,,develop,,,,,,"
+
+    @pytest.mark.django_db
+    def test_structure_export_dependent_models__base_then_pk_ref(self, app: DjangoTestApp):
+        """Recursion must continue from a base hop: our model -> base in DS2 -> DS2 model
+        has a PK property referencing DS3 -> DS3 model is also exported as a dependency."""
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        leaf_manifest = (
+            "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+            "30,datasets/gov/leaf/dataset,,,,,,,,,,,,,,,,,\n"
+            "31,,,,LeafModel,,,id,,,,,,,,,,,\n"
+            "32,,,,,id,integer,,,,5,,,open,dct:identifier,,,,\n"
+        )
+        leaf_dataset = self._create_manifest(
+            leaf_manifest,
+            "Leaf Dataset",
+            "Reached transitively via base + PK ref",
+            whitelisted_names=["datasets/gov/leaf/"],
+        )
+        leaf_version = leaf_dataset.latest_version()
+        leaf_version.status = VersionStatus.STABLE
+        leaf_version.save()
+
+        base_manifest = (
+            "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+            "20,datasets/gov/base/dataset,,,,,,,,,,,,,,,,,\n"
+            '21,,,,BaseModel,,,"id, leaf",,,,,,,,,,,\n'
+            "22,,,,,id,integer,,,,5,,,open,dct:identifier,,,,\n"
+            "23,,,,,leaf,ref,/datasets/gov/leaf/dataset/LeafModel,,,5,,,open,dct:leaf,,,,\n"
+        )
+        base_dataset = self._create_manifest(
+            base_manifest,
+            "Base Dataset",
+            "Used as base by main dataset's model",
+            whitelisted_names=["datasets/gov/base/"],
+        )
+        base_version = base_dataset.latest_version()
+        base_version.status = VersionStatus.STABLE
+        base_version.save()
+
+        main_manifest = (
+            "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+            "1,datasets/gov/main/dataset,,,,,,,,,,,,,,,,,\n"
+            "2,,,datasets/gov/base/dataset/BaseModel,,,,,,,,,,,,,,,\n"
+            "3,,,,MainModel,,,id,,,,,,,,,,,\n"
+            "4,,,,,id,integer,,,,5,,,open,dct:identifier,,,,\n"
+            ",,,/,,,,,,,,,,,,,,,\n"
+        )
+        main_dataset = self._create_manifest(
+            main_manifest, "Main Dataset", "Root", whitelisted_names=["datasets/gov/main/"]
+        )
+
+        resp = app.get(reverse("dataset-structure-export", args=[main_dataset.pk, main_dataset.latest_version().pk]))
+
+        assert "datasets/gov/base/dataset" in resp.text
+        assert "BaseModel" in resp.text
+        assert "datasets/gov/leaf/dataset" in resp.text
+        assert "LeafModel" in resp.text
+
+    @pytest.mark.django_db
+    def test_structure_export_dependent_models__base_of_a_base(self, app: DjangoTestApp):
+        """Two base hops compose: our model -> base in DS2 -> that DS2 model has its own
+        base in DS3 -> DS3 model is exported as a transitive dependency."""
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        grandparent_manifest = (
+            "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+            "40,datasets/gov/grand/dataset,,,,,,,,,,,,,,,,,\n"
+            "41,,,,GrandparentModel,,,id,,,,,,,,,,,\n"
+            "42,,,,,id,integer,,,,5,,,open,dct:identifier,,,,\n"
+        )
+        grandparent_dataset = self._create_manifest(
+            grandparent_manifest,
+            "Grandparent Dataset",
+            "Base of the base; must still appear",
+            whitelisted_names=["datasets/gov/grand/"],
+        )
+        grandparent_version = grandparent_dataset.latest_version()
+        grandparent_version.status = VersionStatus.STABLE
+        grandparent_version.save()
+
+        parent_manifest = (
+            "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+            "30,datasets/gov/parent/dataset,,,,,,,,,,,,,,,,,\n"
+            "31,,,datasets/gov/grand/dataset/GrandparentModel,,,,,,,,,,,,,,,\n"
+            "32,,,,ParentModel,,,id,,,,,,,,,,,\n"
+            "33,,,,,id,integer,,,,5,,,open,dct:identifier,,,,\n"
+            ",,,/,,,,,,,,,,,,,,,\n"
+        )
+        parent_dataset = self._create_manifest(
+            parent_manifest,
+            "Parent Dataset",
+            "Used as base by main dataset's model",
+            whitelisted_names=["datasets/gov/parent/"],
+        )
+        parent_version = parent_dataset.latest_version()
+        parent_version.status = VersionStatus.STABLE
+        parent_version.save()
+
+        main_manifest = (
+            "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+            "1,datasets/gov/main/dataset,,,,,,,,,,,,,,,,,\n"
+            "2,,,datasets/gov/parent/dataset/ParentModel,,,,,,,,,,,,,,,\n"
+            "3,,,,ChildModel,,,id,,,,,,,,,,,\n"
+            "4,,,,,id,integer,,,,5,,,open,dct:identifier,,,,\n"
+            ",,,/,,,,,,,,,,,,,,,\n"
+        )
+        main_dataset = self._create_manifest(
+            main_manifest, "Main Dataset", "Root", whitelisted_names=["datasets/gov/main/"]
+        )
+
+        resp = app.get(reverse("dataset-structure-export", args=[main_dataset.pk, main_dataset.latest_version().pk]))
+
+        assert "datasets/gov/parent/dataset" in resp.text
+        assert "ParentModel" in resp.text
+        assert "datasets/gov/grand/dataset" in resp.text
+        assert "GrandparentModel" in resp.text
 
 
 @pytest.mark.django_db

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -7616,6 +7616,8 @@ class TestStructure(BaseTestCreateManifest):
         assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
+            "1,datasets/gov/ivpk/example,,,,,,,,,,,,,,,,,,Model Dataset,Dataset that defines base model.",
+            "2,,,,Animal,,,,,,,,,0,completed,public,,,,,",
             "1,datasets/gov/test/example2,,,,,,,,,,,,,,,,,,Base Dataset,Dataset that references model with base",
             "2,,,datasets/gov/ivpk/example/Animal,,,,,,,,,,,,,,,,,",
             "3,,,,Dog,,,,,,,,,0,completed,public,,,,,",

--- a/vitrina/datasets/form_helpers.py
+++ b/vitrina/datasets/form_helpers.py
@@ -1,7 +1,6 @@
 import re
 from typing import Any
 
-from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator
@@ -19,9 +18,7 @@ from vitrina.uapi.models import Agent
 from vitrina.users.models import User
 
 
-DATA_SERVICE_STANDARD_URI = (
-    f"{settings.META_SITE_PROTOCOL}://{settings.META_SITE_DOMAIN}/id/non-standard/DataServiceStandard"
-)
+DATA_SERVICE_STANDARD_URI = "https://data.gov.lt/id/non-standard/DataServiceStandard"
 UAPI_CONCEPT_CODE = "UAPI"
 JSON_FORMAT = "JSON"
 OPENAPI_FORMAT = "OpenAPI"

--- a/vitrina/structure/migrations/0018_extend_model_dependencies_with_base.py
+++ b/vitrina/structure/migrations/0018_extend_model_dependencies_with_base.py
@@ -1,0 +1,167 @@
+from django.db import migrations
+
+
+REVERSE_SQL = """
+CREATE OR REPLACE VIEW dsa_model_dependencies AS
+WITH RECURSIVE dependencies AS (
+SELECT
+    mod.id root_id,
+    mod.metadata_version_id root_version_id,
+    mod.dataset_id root_dataset_id,
+    mod.id current_id,
+    ARRAY[mod.id]::bigint[] path,
+    0 depth
+FROM model mod
+UNION ALL
+SELECT
+    dep.root_id root_id,
+    dep.root_version_id root_version_id,
+    dep.root_dataset_id root_dataset_id,
+    prp.ref_model_id current_id,
+    dep.path || prp.ref_model_id path,
+    dep.depth + 1 depth
+FROM dependencies dep
+JOIN model cur
+    ON cur.id = dep.current_id
+JOIN django_content_type model_ct
+    ON model_ct.app_label = 'vitrina_structure'
+    AND model_ct.model = 'model'
+JOIN django_content_type prop_ct
+    ON prop_ct.app_label = 'vitrina_structure'
+    AND prop_ct.model = 'property'
+JOIN metadata cur_meta
+    ON cur_meta.content_type_id = model_ct.id
+    AND cur_meta.object_id = cur.id
+    AND cur_meta.metadata_version_id = cur.metadata_version_id
+JOIN property prp
+    ON prp.model_id = dep.current_id
+JOIN metadata prop_meta
+    ON prop_meta.content_type_id = prop_ct.id
+    AND prop_meta.object_id = prp.id
+    AND prop_meta.metadata_version_id = prp.metadata_version_id
+WHERE
+    dep.depth < 20
+    AND prp.given IS TRUE
+    AND prp.ref_model_id IS NOT NULL
+    AND NOT prp.ref_model_id = ANY(dep.path)
+    AND (
+        cur.dataset_id = dep.root_dataset_id
+        OR (
+            cur.dataset_id != dep.root_dataset_id
+            AND cur_meta.ref IS NOT NULL
+            AND prop_meta.name = ANY(
+                string_to_array(regexp_replace(cur_meta.ref, '\s+', '', 'g'), ',')
+            )
+        )
+    )
+)
+SELECT DISTINCT
+dep.root_id root_model_id,
+dep.root_version_id root_version_id,
+dep.current_id child_model_id,
+array_to_string(dep.path, '->') path,
+dep.depth,
+dep.root_dataset_id root_dataset_id
+FROM
+dependencies dep
+JOIN model mod ON mod.id = dep.current_id
+WHERE
+dep.depth > 0
+AND mod.dataset_id != dep.root_dataset_id
+ORDER BY
+    dep.root_id, dep.depth DESC, dep.current_id;
+"""
+
+
+FORWARD_SQL = """
+CREATE OR REPLACE VIEW dsa_model_dependencies AS
+WITH RECURSIVE dependencies AS (
+SELECT
+    mod.id root_id,
+    mod.metadata_version_id root_version_id,
+    mod.dataset_id root_dataset_id,
+    mod.id current_id,
+    ARRAY[mod.id]::bigint[] path,
+    0 depth
+FROM model mod
+UNION ALL
+SELECT
+    dep.root_id root_id,
+    dep.root_version_id root_version_id,
+    dep.root_dataset_id root_dataset_id,
+    next_step.next_id current_id,
+    dep.path || next_step.next_id path,
+    dep.depth + 1 depth
+FROM dependencies dep
+JOIN model cur
+    ON cur.id = dep.current_id
+CROSS JOIN LATERAL (
+    SELECT prp.ref_model_id AS next_id
+    FROM property prp
+    JOIN django_content_type model_ct
+        ON model_ct.app_label = 'vitrina_structure'
+        AND model_ct.model = 'model'
+    JOIN django_content_type prop_ct
+        ON prop_ct.app_label = 'vitrina_structure'
+        AND prop_ct.model = 'property'
+    JOIN metadata cur_meta
+        ON cur_meta.content_type_id = model_ct.id
+        AND cur_meta.object_id = cur.id
+        AND cur_meta.metadata_version_id = cur.metadata_version_id
+    JOIN metadata prop_meta
+        ON prop_meta.content_type_id = prop_ct.id
+        AND prop_meta.object_id = prp.id
+        AND prop_meta.metadata_version_id = prp.metadata_version_id
+    WHERE prp.model_id = cur.id
+        AND prp.given IS TRUE
+        AND prp.ref_model_id IS NOT NULL
+        AND (
+            cur.dataset_id = dep.root_dataset_id
+            OR (
+                cur.dataset_id != dep.root_dataset_id
+                AND cur_meta.ref IS NOT NULL
+                AND prop_meta.name = ANY(
+                    string_to_array(regexp_replace(cur_meta.ref, '\\s+', '', 'g'), ',')
+                )
+            )
+        )
+    UNION ALL
+    SELECT b.model_id AS next_id
+    FROM base b
+    WHERE b.id = cur.base_id
+        AND b.model_id IS NOT NULL
+) AS next_step
+WHERE
+    dep.depth < 20
+    AND NOT next_step.next_id = ANY(dep.path)
+)
+SELECT DISTINCT
+dep.root_id root_model_id,
+dep.root_version_id root_version_id,
+dep.current_id child_model_id,
+array_to_string(dep.path, '->') path,
+dep.depth,
+dep.root_dataset_id root_dataset_id
+FROM
+dependencies dep
+JOIN model mod ON mod.id = dep.current_id
+WHERE
+dep.depth > 0
+AND mod.dataset_id != dep.root_dataset_id
+ORDER BY
+    dep.root_id, dep.depth DESC, dep.current_id;
+"""
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("vitrina_structure", "0017_umldiagram"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql=FORWARD_SQL,
+            reverse_sql=REVERSE_SQL,
+        ),
+    ]


### PR DESCRIPTION
## Summary

Fixes a bug where models inherited as a base in another dataset were silently missing from the dataset structure export. Same bug also caused those external base models to be absent from the generated Mermaid UML diagram.

### Root cause

`Dataset.get_dependent_models()` queries the `dsa_model_dependencies` recursive SQL view, whose recursion only walked `property.ref_model_id`. The `model.base → base.model` relationship was never followed, so when dataset's model extended a base in another dataset, that base's model was excluded from the dependency set.

Both the structure CSV export (`_dependent_models_to_tabular`) and the Mermaid click-link generator (`_generate_mermaid_model_click_links`) consume `get_dependent_models()`, so both were affected.

### Fix

New migration `0018_extend_model_dependencies_with_base` rewrites the recursive CTE. The recursive term now uses a `CROSS JOIN LATERAL` that produces the next-step model id from the union of:
- the existing property branch (PK-only when crossing into a foreign dataset), and
- a new base branch (`base.model_id` where `base.id = cur.base_id`).

### Drive-by fixes

A couple of unrelated issues surfaced while testing this branch — each is its own commit:

- **`hardcode DATA_SERVICE_STANDARD_URI`** (_vitrina/datasets/form_helpers.py_) — the form field for `conforms_to` was building its filter URI from `META_SITE_PROTOCOL` / `META_SITE_DOMAIN`, but the underlying `ConceptSchema` is created by a migration with the URI hardcoded to `https://data.gov.lt/...`. Any environment using non-default settings (local dev, staging) silently had an empty queryset, breaking the form's `ServiceResourceForm` validation. Switched the form constant to match the migration.
- **`fix flaky test`** (_tests/api/test_mixins.py_) — `test_is_restricted_information_system` was parametrized with `next(iter(Representative.OPEN_DATA_ROLE_KEYS))`, but `OPEN_DATA_ROLE_KEYS` is a `set` and Python's set iteration order is hash-randomized per process. Test IDs differed between discovery and execution, breaking VS Code's test UI and any tool that caches IDs (CI retries, `--lf`, xdist). Replaced with explicit role constants.
