### PR TITLE
Remove duplicated code and rename method

### DIFF
--- a/tests/datasets/test_helpers.py
+++ b/tests/datasets/test_helpers.py
@@ -1,94 +1,94 @@
 from django.contrib.contenttypes.models import ContentType
 
 from vitrina.datasets.factories import DatasetFactory
-from vitrina.datasets.helpers import validate_name_prefix
+from vitrina.datasets.helpers import get_name_prefixes
 from vitrina.orgs.factories import OrganizationFactory, RepresentativeFactory
 from vitrina.orgs.models import WhitelistedCodeName, Representative
 import pytest
 
 
 @pytest.mark.django_db
-def test_validate_name_prefix_matches_main_prefix():
+def test_get_name_prefixes_matches_main_prefix():
     org = OrganizationFactory(name="datasets/gov/test")
     WhitelistedCodeName.objects.filter(organization=org).delete()
-    matched, main, whitelisted = validate_name_prefix("datasets/gov/test/dataset", org)
+    matched, main, whitelisted = get_name_prefixes("datasets/gov/test/dataset", org)
     assert matched == "datasets/gov/test"
     assert main == "datasets/gov/test"
     assert whitelisted == []
 
 
 @pytest.mark.django_db
-def test_validate_name_prefix_matches_whitelisted_prefix():
+def test_get_name_prefixes_matches_whitelisted_prefix():
     org = OrganizationFactory(name="datasets/gov/test", whitelisted_names=["datasets/org/test"])
     WhitelistedCodeName.objects.filter(organization=org).exclude(code_name="datasets/org/test").delete()
-    matched, main, whitelisted = validate_name_prefix("datasets/org/test/dataset", org)
+    matched, main, whitelisted = get_name_prefixes("datasets/org/test/dataset", org)
     assert matched == "datasets/org/test"
 
 
 @pytest.mark.django_db
-def test_validate_name_prefix_matches_no_prefix():
+def test_get_name_prefixes_matches_no_prefix():
     org = OrganizationFactory(name="datasets/gov/test", whitelisted_names=["datasets/org/test"])
     WhitelistedCodeName.objects.filter(organization=org).exclude(code_name="datasets/org/test").delete()
-    matched, main, whitelisted = validate_name_prefix("datasets/other/test/dataset", org)
+    matched, main, whitelisted = get_name_prefixes("datasets/other/test/dataset", org)
     assert matched is None
 
 
 @pytest.mark.django_db
-def test_validate_name_prefix_resolves_org_from_dataset_instance():
+def test_get_name_prefixes_resolves_org_from_dataset_instance():
     org = OrganizationFactory(name="datasets/gov/test")
     WhitelistedCodeName.objects.filter(organization=org).delete()
     dataset = DatasetFactory(title="testt", organization=org)
-    matched, main, whitelisted = validate_name_prefix("datasets/gov/test/dataset", None, dataset)
+    matched, main, whitelisted = get_name_prefixes("datasets/gov/test/dataset", None, dataset)
     assert matched == "datasets/gov/test"
     assert main == "datasets/gov/test"
 
 
 @pytest.mark.django_db
-def test_validate_name_prefix_organization_takes_precedence_over_dataset():
+def test_get_name_prefixes_organization_takes_precedence_over_dataset():
     direct_org = OrganizationFactory(name="datasets/gov/test")
     WhitelistedCodeName.objects.filter(organization=direct_org).delete()
     dataset_org = OrganizationFactory(name="datasets/org/test")
     dataset = DatasetFactory(title="testt", organization=dataset_org)
-    matched, main, _ = validate_name_prefix("datasets/gov/test/dataset", direct_org, dataset)
+    matched, main, _ = get_name_prefixes("datasets/gov/test/dataset", direct_org, dataset)
     assert main == "datasets/gov/test"
 
 
 @pytest.mark.django_db
-def test_validate_name_prefix_returns_all_whitelisted_names():
+def test_get_name_prefixes_returns_all_whitelisted_names():
     org = OrganizationFactory(name="datasets/gov/test", whitelisted_names=["datasets/org/test", "datasets/org/other"])
     WhitelistedCodeName.objects.filter(organization=org).exclude(
         code_name__in=["datasets/org/test", "datasets/org/other"]
     ).delete()
-    _, _, whitelisted = validate_name_prefix("datasets/gov/test/dataset", org)
+    _, _, whitelisted = get_name_prefixes("datasets/gov/test/dataset", org)
     assert set(whitelisted) == {"datasets/org/test", "datasets/org/other"}
 
 
 @pytest.mark.django_db
-def test_validate_name_prefix_empty_whitelisted_names():
+def test_get_name_prefixes_empty_whitelisted_names():
     org = OrganizationFactory(name="datasets/gov/test", whitelisted_names=[])
     WhitelistedCodeName.objects.filter(organization=org).delete()
-    _, _, whitelisted = validate_name_prefix("datasets/gov/test/dataset", org)
+    _, _, whitelisted = get_name_prefixes("datasets/gov/test/dataset", org)
     assert whitelisted == []
 
 
-def test_validate_name_prefix_no_organization():
-    matched, main, whitelisted = validate_name_prefix("datasets/gov/test/dataset", None, None)
+def test_get_name_prefixes_no_organization():
+    matched, main, whitelisted = get_name_prefixes("datasets/gov/test/dataset", None, None)
     assert matched is None
     assert main == ""
     assert whitelisted == []
 
 
 @pytest.mark.django_db
-def test_validate_name_prefix_empty_name():
+def test_get_name_prefixes_empty_name():
     org = OrganizationFactory(name="datasets/gov/test")
     WhitelistedCodeName.objects.filter(organization=org).delete()
-    matched, main, whitelisted = validate_name_prefix("", org)
+    matched, main, whitelisted = get_name_prefixes("", org)
     assert matched is None
     assert main == "datasets/gov/test"
 
 
 @pytest.mark.django_db
-def test_validate_name_prefix_with_publisher_role():
+def test_get_name_prefixes_with_publisher_role():
     publisher = OrganizationFactory(name="datasets/gov/publisher", whitelisted_names=[])
     org = OrganizationFactory(name="datasets/gov/test")
     RepresentativeFactory(
@@ -97,5 +97,5 @@ def test_validate_name_prefix_with_publisher_role():
         content_type=ContentType.objects.get_for_model(org),
         object_id=org.pk,
     )
-    _, _, whitelisted = validate_name_prefix("datasets/gov/test", publisher)
+    _, _, whitelisted = get_name_prefixes("datasets/gov/test", publisher)
     assert "datasets/gov/test" in whitelisted

--- a/vitrina/datasets/form_helpers.py
+++ b/vitrina/datasets/form_helpers.py
@@ -5,15 +5,14 @@ from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator
-from django.db.models import Q
 from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext_lazy as _
 
 from vitrina.classifiers.models import Concept
-from vitrina.datasets.helpers import validate_name_prefix
+from vitrina.datasets.helpers import get_name_prefixes
 from vitrina.datasets.models import Dataset, Contact
 from vitrina.identifiers.models import Agency
-from vitrina.orgs.models import Organization, Representative
+from vitrina.orgs.models import Organization
 from vitrina.resources.models import Format
 from vitrina.structure.models import Metadata
 from vitrina.uapi.models import Agent
@@ -38,33 +37,7 @@ def validate_dataset_name(name: str | None, dataset: Dataset | None, organizatio
         if any(ch.isupper() for ch in name):
             raise ValidationError(_("Kodiniame pavadinime gali būti naudojamos tik mažosios raidės."))
 
-        _matched, main_prefix, whitelisted = validate_name_prefix(name, organization, dataset)
-        allowed_prefixes = [main_prefix] + list(whitelisted)
-
-        representatives = Representative.objects.filter(
-            (Q(organization=organization) | Q(user__organization=organization))
-            & Q(role=Representative.OPEN_DATA_PUBLISHER)
-        )
-        dataset_ct = ContentType.objects.get_for_model(Dataset)
-        organization_ct = ContentType.objects.get_for_model(organization)
-        for rep in representatives:
-            if (
-                rep.content_type == dataset_ct
-                and rep.content_object.organization
-                and rep.content_object.organization.name
-                and rep.content_object.organization.name not in allowed_prefixes
-            ):
-                allowed_prefixes.append(rep.content_object.organization.name)
-                whitelisted.append(rep.content_object.organization.name)
-            elif (
-                rep.content_type == organization_ct
-                and rep.content_object.name
-                and rep.content_object.name not in allowed_prefixes
-            ):
-                allowed_prefixes.append(rep.content_object.name)
-                whitelisted.append(rep.content_object.name)
-
-        matched_prefix = next((prefix for prefix in allowed_prefixes if name.startswith(prefix)), None)
+        matched_prefix, main_prefix, whitelisted = get_name_prefixes(name, organization, dataset)
         if not matched_prefix:
             if whitelisted:
                 message = _(

--- a/vitrina/datasets/helpers.py
+++ b/vitrina/datasets/helpers.py
@@ -73,7 +73,7 @@ def generate_unique_dataset_name(organization: Organization, dataset: Dataset) -
     return f"{base_name}_{max_index}"
 
 
-def validate_name_prefix(
+def get_name_prefixes(
     name: str,
     organization: Organization | None,
     dataset_instance: Dataset | None = None,

--- a/vitrina/structure/services.py
+++ b/vitrina/structure/services.py
@@ -22,7 +22,7 @@ from django.utils.translation import gettext, gettext_lazy as _, get_language
 from vitrina import settings
 from vitrina.classifiers.models import Status
 from vitrina.comments.models import Comment
-from vitrina.datasets.helpers import validate_name_prefix
+from vitrina.datasets.helpers import get_name_prefixes
 from vitrina.datasets.models import DatasetStructure, Dataset
 from vitrina.datasets.structure import detect_read_errors, read
 from vitrina.helpers import none_to_string, get_encoding
@@ -365,7 +365,7 @@ def _get_manifest_datasets_to_import(
     main_prefix, whitelisted = "", []
     for order, meta in enumerate(datasets, 1):
         is_last = order == len(datasets)
-        matched_prefix, main_prefix, whitelisted = validate_name_prefix(meta.name, dataset.organization, dataset)
+        matched_prefix, main_prefix, whitelisted = get_name_prefixes(meta.name, dataset.organization, dataset)
         if meta.name == dataset.name or (matched_prefix and is_last):
             result.append((order, meta))
     return result, main_prefix, whitelisted


### PR DESCRIPTION
**Summary:**
- Renames `validate_name_prefix` to `get_name_prefixes`, since function does not validate anything
- Removes duplicated dataset name prefix checks for `OPEN_DATA_PUBLISHER` from `validate_dataset_name`. Same exact code already runs in `get_name_prefixes` function that is called.