### PR TITLE
fix enum.ref export, update enum import validation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,11 @@ Changes
 v 1.22.0 (current)
 ==================
 
+https://github.com/atviriduomenys/katalogas/issues/2629
 
+- Fix property-level enum `ref` export: structure export now always outputs an empty `ref` for enums declared at the property dimension.
+- Fix property-level enum creation via form: `Enum` objects created through the UI no longer inherit the property name as `enum.name`.
+- Add import validation: importing a CSV manifest with a non-empty `ref` on a property-level enum row now produces a structure error comment and silently sets the `ref` to an empty string.
 
 v 1.21.0 (2026-05-18)
 ==================

--- a/tests/structure/test_services.py
+++ b/tests/structure/test_services.py
@@ -787,7 +787,7 @@ def test_structure_with_enums(app: DjangoTestApp):
         "6,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
         "7,,,,,size,Size,,,,5,,,open,dct:size,,,,\n"
         "8,,,,,type,string,,,,5,,,open,dct:type,,,,\n"
-        '9,,,,,,enum,Type,,"""CREATED""",,,,,,,,,\n'
+        '9,,,,,,enum,,,"""CREATED""",,,,,,,,,\n'
         '10,,,,,,,,,"""MODIFIED""",,,,,,,,,\n'
     )
     structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
@@ -804,7 +804,7 @@ def test_structure_with_enums(app: DjangoTestApp):
     prop = Property.objects.get(metadata__uuid="8")
     prop_enum = Enum.objects.filter(content_type=ContentType.objects.get_for_model(prop), object_id=prop.pk)
     assert prop_enum.count() == 1
-    assert prop_enum[0].name == "Type"
+    assert prop_enum[0].name == ""
     assert list(prop_enum[0].enumitem_set.values_list("metadata__prepare", flat=True)) == ['"CREATED"', '"MODIFIED"']
 
 
@@ -816,7 +816,7 @@ def test_structure_with_enum_and_null_value(app: DjangoTestApp):
         ",,,,,,prefix,dct,,,,,,,http://www.purl.org/dc/terms/,,,,\n"
         ",,,,City,,,,,,,,,,,,,,\n"
         "1,,,,,type,string,,,,5,,,open,dct:type,,,,\n"
-        ',,,,,,enum,Type,,"""CREATED""",,,,,,,,,\n'
+        ',,,,,,enum,,,"""CREATED""",,,,,,,,,\n'
         ',,,,,,,,,"""null""",,,,,,,,,\n'
     )
     structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
@@ -827,7 +827,7 @@ def test_structure_with_enum_and_null_value(app: DjangoTestApp):
     prop = Property.objects.get(metadata__uuid="1")
     prop_enum = Enum.objects.filter(content_type=ContentType.objects.get_for_model(prop), object_id=prop.pk)
     assert prop_enum.count() == 1
-    assert prop_enum[0].name == "Type"
+    assert prop_enum[0].name == ""
     assert list(prop_enum[0].enumitem_set.values_list("metadata__prepare", flat=True)) == ['"CREATED"', '"null"']
 
 
@@ -866,7 +866,7 @@ def test_structure_with_enum_without_prepare_value_adds_comment_about_error(app:
         ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
         ",,,,City,,,,,,,,,,,,,,\n"
         "1,,,,,type,integer,,,,5,,,,,,,,\n"
-        ",,,,,,enum,Type,one,,,,,,,,,,\n"
+        ",,,,,,enum,,one,,,,,,,,,,\n"
     )
     structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
@@ -876,11 +876,36 @@ def test_structure_with_enum_without_prepare_value_adds_comment_about_error(app:
     prop = Property.objects.get(metadata__uuid="1")
     prop_enum = Enum.objects.filter(content_type=ContentType.objects.get_for_model(prop), object_id=prop.pk)
     assert prop_enum.count() == 1
-    assert prop_enum[0].name == "Type"
+    assert prop_enum[0].name == ""
     assert not prop_enum[0].enumitem_set.exists()
     assert list(Comment.objects.filter(type=Comment.STRUCTURE_ERROR).values_list("body", flat=True)) == [
         'Reikšmė "" turi būti integer tipo.',
         'Duomenų reikšmė (source: "one") privalo turėti nurodytą "prepare" stulpelį.',
+    ]
+
+
+@pytest.mark.django_db
+def test_structure_with_property_enum_ref_value_adds_comment_about_error(app: DjangoTestApp):
+    manifest = (
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,City,,,,,,,,,,,,,,\n"
+        "1,,,,,type,integer,,,,5,,,,,,,,\n"
+        ",,,,,,enum,SomeName,,1,,,,,,,,,\n"
+        ",,,,,,,,,2,,,,,,,,,\n"
+    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure.dataset.current_structure = structure
+    structure.dataset.save()
+    create_structure_objects(structure)
+
+    prop = Property.objects.get(metadata__uuid="1")
+    prop_enum = Enum.objects.filter(content_type=ContentType.objects.get_for_model(prop), object_id=prop.pk)
+    assert prop_enum.count() == 1
+    assert prop_enum[0].name == ""
+    assert list(prop_enum[0].enumitem_set.values_list("metadata__prepare", flat=True)) == ["1", "2"]
+    assert list(Comment.objects.filter(type=Comment.STRUCTURE_ERROR).values_list("body", flat=True)) == [
+        'Reikšmių sąrašas "SomeName" negali turėtį pavadinimo (ref), kai yra deklaruojamas savybės dimensijoje.',
     ]
 
 
@@ -958,7 +983,7 @@ def test_structure_with_deleted_enums(app: DjangoTestApp):
         "10,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n"
         "11,,,,,size,Size,,,,5,,,open,dct:size,,,,\n"
         "12,,,,,type,string,,,,5,,,open,dct:type,,,,\n"
-        '13,,,,,,enum,Type,,"""CREATED""",,,,,,,,,\n'
+        '13,,,,,,enum,,,"""CREATED""",,,,,,,,,\n'
         '14,,,,,,,,,"""MODIFIED""",,,,,,,,,\n'
     )
     structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
@@ -966,7 +991,7 @@ def test_structure_with_deleted_enums(app: DjangoTestApp):
     structure.dataset.save()
     metadata_version = create_structure_objects(structure)
     assert Metadata.objects.filter(dataset=structure.dataset, metadata_version=metadata_version).count() == 15
-    assert list(Enum.objects.values_list("name", flat=True)) == ["Size", "Deprecated", "Type"]
+    assert list(Enum.objects.values_list("name", flat=True)) == ["Size", "Deprecated", ""]
     assert list(EnumItem.objects.filter(enum__name="Size").values_list("metadata__prepare", flat=True)) == [
         '"SMALL"',
         '"MEDIUM"',
@@ -977,7 +1002,7 @@ def test_structure_with_deleted_enums(app: DjangoTestApp):
         '"MEDIUM"',
         '"BIG"',
     ]
-    assert list(EnumItem.objects.filter(enum__name="Type").values_list("metadata__prepare", flat=True)) == [
+    assert list(EnumItem.objects.filter(enum__name="").values_list("metadata__prepare", flat=True)) == [
         '"CREATED"',
         '"MODIFIED"',
     ]
@@ -993,17 +1018,17 @@ def test_structure_with_deleted_enums(app: DjangoTestApp):
         "10,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n"
         "11,,,,,size,Size,,,,5,,,open,dct:size,,,,\n"
         "12,,,,,type,string,,,,5,,,open,dct:type,,,,\n"
-        '13,,,,,,enum,Type,,"""CREATED""",,,,,,,,,\n'
+        '13,,,,,,enum,,,"""CREATED""",,,,,,,,,\n'
     )
     structure.file = FilerFileFactory(file=FileField(filename="file.csv", data=new_manifest))
     metadata_version = create_structure_objects(structure, metadata_version)
     assert Metadata.objects.filter(dataset=structure.dataset, metadata_version=metadata_version).count() == 10
-    assert list(Enum.objects.values_list("name", flat=True)) == ["Size", "Type"]
+    assert list(Enum.objects.values_list("name", flat=True)) == ["Size", ""]
     assert list(EnumItem.objects.filter(enum__name="Size").values_list("metadata__prepare", flat=True)) == [
         '"SMALL"',
         '"BIG"',
     ]
-    assert list(EnumItem.objects.filter(enum__name="Type").values_list("metadata__prepare", flat=True)) == ['"CREATED"']
+    assert list(EnumItem.objects.filter(enum__name="").values_list("metadata__prepare", flat=True)) == ['"CREATED"']
 
 
 @pytest.mark.django_db
@@ -2161,7 +2186,7 @@ def test_structure_export__enums(app: DjangoTestApp, use_version):
         "8,,,,,id,integer,,,,,5,,,open,dct:identifier,,Identifikatorius,\n"
         "9,,,,,size,Size,,,,,5,,,open,dct:size,,,\n"
         "10,,,,,type,string,,,,,5,,,open,dct:type,,,\n"
-        "11,,,,,,enum,Type,,'''CREATED''',,,,,,,,,\n"
+        "11,,,,,,enum,,,'''CREATED''',,,,,,,,,\n"
         "12,,,,,,,,,'''MODIFIED''',,,,,,,,,\n"
     )
     structure = DatasetStructureFactory(
@@ -2185,7 +2210,7 @@ def test_structure_export__enums(app: DjangoTestApp, use_version):
         "8,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
         "9,,,,,size,Size,,,,,,,5,develop,,open,dct:size,,,\r\n"
         "10,,,,,type,string,,,,,,,5,develop,,open,dct:type,,,\r\n"
-        "11,,,,,,enum,Type,,,'''CREATED''',,,,develop,,,,,,\r\n"
+        "11,,,,,,enum,,,,'''CREATED''',,,,develop,,,,,,\r\n"
         "12,,,,,,,,,,'''MODIFIED''',,,,develop,,,,,,\r\n"
         ",,,,,,,,,,,,,,,,,,,,\r\n"
     )

--- a/tests/structure/test_services.py
+++ b/tests/structure/test_services.py
@@ -905,7 +905,7 @@ def test_structure_with_property_enum_ref_value_adds_comment_about_error(app: Dj
     assert prop_enum[0].name == ""
     assert list(prop_enum[0].enumitem_set.values_list("metadata__prepare", flat=True)) == ["1", "2"]
     assert list(Comment.objects.filter(type=Comment.STRUCTURE_ERROR).values_list("body", flat=True)) == [
-        'Reikšmių sąrašas "SomeName" negali turėtį pavadinimo (ref), kai yra deklaruojamas savybės dimensijoje.',
+        'Reikšmių sąrašas "SomeName" negali turėti pavadinimo (ref), kai yra deklaruojamas savybės dimensijoje.',
     ]
 
 

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -1615,6 +1615,48 @@ def test_property_enum_item_create__string(app: DjangoTestApp):
 
 
 @pytest.mark.django_db
+def test_property_enum_item_create__enum_name_is_empty(app: DjangoTestApp):
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+
+    version = VersionFactory()
+    model = ModelFactory(dataset=version.dataset, metadata_version=version)
+    dataset = version.dataset
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(model),
+        object_id=model.pk,
+        dataset=dataset,
+        name="test/dataset/TestModel",
+        metadata_version=version,
+    )
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(dataset),
+        object_id=dataset.pk,
+        dataset=dataset,
+        name="test/dataset",
+        metadata_version=version,
+    )
+    prop = PropertyFactory(model=model, metadata_version=version)
+    MetadataFactory(
+        content_type=ContentType.objects.get_for_model(prop),
+        object_id=prop.pk,
+        dataset=dataset,
+        name="prop",
+        type="string",
+        metadata_version=version,
+    )
+
+    form = app.get(reverse("enum-create", args=[dataset.pk, version.pk, model.name, prop.name])).forms["enum-form"]
+    form["value"] = "test"
+    form["source"] = "TEST"
+    form["access"] = Metadata.OPEN
+    form.submit()
+
+    enum = Enum.objects.get(content_type=ContentType.objects.get_for_model(prop), object_id=prop.pk)
+    assert enum.name == ""
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize("integer_value", [-1, 0, 1])
 def test_property_enum_item_create__integer(app: DjangoTestApp, integer_value: int):
     user = UserFactory(is_staff=True)
@@ -5142,7 +5184,7 @@ def test_updating_metadata_in_not_draft_version_not_allowed(app: DjangoTestApp, 
         ",,,,,id,integer,,,,5,discont,,open,dct:identifier,,Identifikatorius,,\n"
         ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
         ",,,,,administration,string,,,,5,,,open,dct:title,,,,\n"
-        ",,,,,,enum,small,,'''SMALL''',,,,,,,,,\n"
+        ",,,,,,enum,,,'''SMALL''',,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
     )
     structure = DatasetStructureFactory(
@@ -5154,7 +5196,7 @@ def test_updating_metadata_in_not_draft_version_not_allowed(app: DjangoTestApp, 
     version = create_structure_objects(structure)
     version.status = status
     version.save()
-    enum_meta = Metadata.objects.filter(dataset=structure.dataset, name="small", metadata_version=version).first()
+    enum_meta = Metadata.objects.filter(dataset=structure.dataset, name="", metadata_version=version).first()
 
     enum = enum_meta.object
     enum_id = enum.id
@@ -5272,7 +5314,7 @@ def test_changed_metadata_keeps_status_after_publishing(app: DjangoTestApp):
         ",,,,,id,integer,,,,5,discont,,open,dct:identifier,,Identifikatorius,,\n"
         ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
         ",,,,,administration,string,,,,5,,,open,dct:title,,,,\n"
-        ",,,,,,enum,small,,'SMALL',,,,,,,,,\n"
+        ",,,,,,enum,,,'SMALL',,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
     )
     structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
@@ -5280,7 +5322,7 @@ def test_changed_metadata_keeps_status_after_publishing(app: DjangoTestApp):
     structure.dataset.save()
     version = create_structure_objects(structure)
 
-    enum_meta = Metadata.objects.filter(dataset=structure.dataset, name="small", metadata_version=version).first()
+    enum_meta = Metadata.objects.filter(dataset=structure.dataset, name="", metadata_version=version).first()
 
     enum = enum_meta.object
     enum_id = enum.id
@@ -5356,8 +5398,8 @@ def test_draft_metadata_defaults_to_develop_after_hard_change(app: DjangoTestApp
         ",,,,,id,integer,,,,5,discont,,open,dct:identifier,,Identifikatorius,,\n"
         ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
         ",,,,,administration,string,,,,5,,,open,dct:title,,,,\n"
-        ",,,,,,enum,small,,'''SMALL''',,,,,,,,,\n"
-        ",,,,,,,big,,BIG,,,,,,,,,\n"
+        ",,,,,,enum,,,'''SMALL''',,,,,,,,,\n"
+        ",,,,,,,,,BIG,,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
     )
     structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
@@ -5365,7 +5407,7 @@ def test_draft_metadata_defaults_to_develop_after_hard_change(app: DjangoTestApp
     structure.dataset.save()
     version = create_structure_objects(structure)
 
-    enum_meta = Metadata.objects.filter(dataset=structure.dataset, metadata_version=version, name="small").first()
+    enum_meta = Metadata.objects.filter(dataset=structure.dataset, metadata_version=version, name="").first()
 
     enum = enum_meta.object
     enum_id = enum.id
@@ -5418,8 +5460,8 @@ def test_changing_multiple_fields_in_draft_structure_respects_status(app: Django
         ",,,,,id,integer,,,,5,discont,,open,dct:identifier,,Identifikatorius,,\n"
         ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
         ",,,,,administration,string,,,,5,,,open,dct:title,,,,\n"
-        ",,,,,,enum,small,,'''SMALL''',,,,,,,,,\n"
-        ",,,,,,,big,,BIG,,,,,,,,,\n"
+        ",,,,,,enum,,,'''SMALL''',,,,,,,,,\n"
+        ",,,,,,,,,BIG,,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
     )
     structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
@@ -5427,7 +5469,7 @@ def test_changing_multiple_fields_in_draft_structure_respects_status(app: Django
     structure.dataset.save()
     version = create_structure_objects(structure)
 
-    enum_meta = Metadata.objects.filter(dataset=structure.dataset, metadata_version=version, name="small").first()
+    enum_meta = Metadata.objects.filter(dataset=structure.dataset, metadata_version=version, name="").first()
 
     enum = enum_meta.object
     enum_id = enum.id
@@ -5468,10 +5510,7 @@ def test_changing_multiple_fields_in_draft_structure_respects_status(app: Django
     prop = resp_props.context["prop"]
     for enum_item in prop.enums.first().enumitem_set.all():
         enum_metadata = enum_item.metadata.first()
-        if enum_metadata.name == new_enum_name:
-            assert enum_metadata.status.codename == "completed"
-        else:
-            assert enum_metadata.status.codename == "deprecated"
+        assert enum_metadata.status.codename == "deprecated"
 
 
 @pytest.mark.django_db
@@ -5486,8 +5525,8 @@ def test_draft_metadata_form_does_not_change_status_is_kept(app: DjangoTestApp):
         ",,,,,id,integer,,,,5,discont,,open,dct:identifier,,Identifikatorius,,\n"
         ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
         ",,,,,administration,string,,,,5,,,open,dct:title,,,,\n"
-        ",,,,,,enum,small,,'SMALL',,,,,,,,,\n"
-        ",,,,,,,big,,'''BIG''',,,,,,,,,\n"
+        ",,,,,,enum,,,'SMALL',,,,,,,,,\n"
+        ",,,,,,,,,'''BIG''',,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
     )
     structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
@@ -5495,7 +5534,7 @@ def test_draft_metadata_form_does_not_change_status_is_kept(app: DjangoTestApp):
     structure.dataset.save()
     version = create_structure_objects(structure)
 
-    enum_meta = Metadata.objects.filter(dataset=structure.dataset, metadata_version=version, name="small").first()
+    enum_meta = Metadata.objects.filter(dataset=structure.dataset, metadata_version=version, prepare="'SMALL'").first()
 
     enum = enum_meta.object
     enum_id = enum.id
@@ -5527,7 +5566,6 @@ def test_draft_metadata_form_does_not_change_status_is_kept(app: DjangoTestApp):
         reverse("property-structure", args=[structure.dataset.pk, version.pk, "Country", "administration"])
     )
     prop = resp_props.context["prop"]
-    # TODO the status of enum should also be completed but because of a bug the name of the enum is changed even though nothing is submited. Change after bug fix
     for enum_item in prop.enums.first().enumitem_set.all():
         enum_metadata = enum_item.metadata.first()
         assert enum_metadata.status.codename == "develop"
@@ -5970,7 +6008,7 @@ def test_publish_form_shows_all_metadata_rows_enum(app: DjangoTestApp):
         "7,,,,,id,integer,,,,,5,,,open,dct:identifier,,Identifikatorius,\n"
         "8,,,,,size,Size,,,,,5,,,open,dct:size,,,\n"
         "9,,,,,type,string,,,,,5,,,open,dct:type,,,\n"
-        "10,,,,,,enum,Type,,'''CREATED''',,,,,,,,,\n"
+        "10,,,,,,enum,,,'''CREATED''',,,,,,,,,\n"
         "11,,,,,,,,,'''MODIFIED''',,,,,,,,,\n"
     )
     structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
@@ -7787,6 +7825,67 @@ class TestStructure(BaseTestCreateManifest):
             "3,,,,,type,number required,,TypeID/text(),,,,,,develop,,,,,,",
             "4,,,,,,enum,,1.1,,1.2,,,,develop,,,,,,",
             "5,,,,,,,,1.3,,1.4,,,,develop,,,,,,",
+            ",,,,,,,,,,,,,,,,,,,,",
+        ]
+
+    @pytest.mark.django_db
+    def test_export__property_level_enum_ref_is_empty(self, app: DjangoTestApp):
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        manifest = (
+            "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description\n"
+            "1,datasets/gov/ivpk/dataset,,,,,,,,,,,,,,,,\n"
+            "2,,,,,,enum,DatasetEnum,,1,,,,,,,,\n"
+            "3,,,,,,,,,2,,,,,,,,\n"
+            "4,,,,Dataset,,,,,,1,,,,,,,\n"
+            "5,,,,,code,integer,,,,4,,,,,,,\n"
+            "6,,,,,,enum,,,10,,,,,,,,\n"
+            "7,,,,,,,,,20,,,,,,,,\n"
+        )
+        dataset = self._create_manifest(manifest, "Dataset", "Dataset")
+
+        response = app.get(reverse("dataset-structure-export-no-version", args=[dataset.pk]))
+
+        assert response.status_code == HTTPStatus.OK
+        assert response.text.splitlines() == [
+            "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
+            "1,datasets/gov/ivpk/dataset,,,,,,,,,,,,,,,,,,Dataset,Dataset",
+            "2,,,,,,enum,DatasetEnum,,,1,,,,develop,,,,,,",
+            "3,,,,,,,,,,2,,,,develop,,,,,,",
+            ",,,,,,,,,,,,,,,,,,,,",
+            "4,,,,Dataset,,,,,,,,,1,develop,,,,,,",
+            "5,,,,,code,integer,,,,,,,4,develop,,,,,,",
+            "6,,,,,,enum,,,,10,,,,develop,,,,,,",
+            "7,,,,,,,,,,20,,,,develop,,,,,,",
+            ",,,,,,,,,,,,,,,,,,,,",
+        ]
+
+    @pytest.mark.django_db
+    def test_export__property_level_enum_with_ref_on_import_exports_empty_ref(self, app: DjangoTestApp):
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        manifest = (
+            "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description\n"
+            "1,datasets/gov/ivpk/dataset,,,,,,,,,,,,,,,,\n"
+            "2,,,,Dataset,,,,,,1,,,,,,,\n"
+            "3,,,,,code,integer,,,,4,,,,,,,\n"
+            "4,,,,,,enum,SomeName,,10,,,,,,,,\n"
+            "5,,,,,,,,,20,,,,,,,,\n"
+        )
+        dataset = self._create_manifest(manifest, "Dataset", "Dataset")
+
+        response = app.get(reverse("dataset-structure-export-no-version", args=[dataset.pk]))
+
+        assert response.status_code == HTTPStatus.OK
+        assert response.text.splitlines() == [
+            "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
+            "1,datasets/gov/ivpk/dataset,,,,,,,,,,,,,,,,,,Dataset,Dataset",
+            "2,,,,Dataset,,,,,,,,,1,develop,,,,,,",
+            "3,,,,,code,integer,,,,,,,4,develop,,,,,,",
+            "4,,,,,,enum,,,,10,,,,develop,,,,,,",
+            "5,,,,,,,,,,20,,,,develop,,,,,,",
             ",,,,,,,,,,,,,,,,,,,,",
         ]
 

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -4860,7 +4860,7 @@ msgstr "UML diagram in mermaid syntax format."
 
 #, python-brace-format
 msgid ""
-"Reikšmių sąrašas \"{0}\" negali turėtį pavadinimo (ref), kai yra "
+"Reikšmių sąrašas \"{0}\" negali turėti pavadinimo (ref), kai yra "
 "deklaruojamas savybės dimensijoje."
 msgstr ""
 "The enum list \"{0}\" cannot have a name (ref) when declared in the property "

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-14 14:55+0300\n"
+"POT-Creation-Date: 2026-05-21 19:04+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4857,6 +4857,14 @@ msgstr "UML diagrams"
 
 msgid "UML diagrama mermaid sintaksės formatu."
 msgstr "UML diagram in mermaid syntax format."
+
+#, python-brace-format
+msgid ""
+"Reikšmių sąrašas \"{0}\" negali turėtį pavadinimo (ref), kai yra "
+"deklaruojamas savybės dimensijoje."
+msgstr ""
+"The enum list \"{0}\" cannot have a name (ref) when declared in the property "
+"dimension."
 
 msgid ""
 "Įsitikinkite, kad jis egzistuoja ir turi patvirtintą (stabilią) versiją."

--- a/vitrina/structure/services.py
+++ b/vitrina/structure/services.py
@@ -440,7 +440,7 @@ def _load_enums(
             _create_errors(
                 [
                     _(
-                        'Reikšmių sąrašas "{0}" negali turėtį pavadinimo (ref), kai yra deklaruojamas savybės dimensijoje.'
+                        'Reikšmių sąrašas "{0}" negali turėti pavadinimo (ref), kai yra deklaruojamas savybės dimensijoje.'
                     ).format(name)
                 ],
                 obj,

--- a/vitrina/structure/services.py
+++ b/vitrina/structure/services.py
@@ -445,14 +445,14 @@ def _load_enums(
                 ],
                 obj,
             )
-            db_name = ""
+            enum_name = ""
         else:
-            db_name = name
+            enum_name = name
 
-        enum = existing_enum_map.get(db_name)
+        enum = existing_enum_map.get(enum_name)
         if not enum:
             enum = Enum.objects.create(
-                name=db_name, content_type=ct, object_id=obj.pk, metadata_version=metadata_version
+                name=enum_name, content_type=ct, object_id=obj.pk, metadata_version=metadata_version
             )
 
         existing_enum_items = list(

--- a/vitrina/structure/services.py
+++ b/vitrina/structure/services.py
@@ -436,9 +436,24 @@ def _load_enums(
     loaded_enums = []
 
     for name, enum_items in enums.items():
-        enum = existing_enum_map.get(name)
+        if isinstance(obj, Property) and name:
+            _create_errors(
+                [
+                    _(
+                        'Reikšmių sąrašas "{0}" negali turėtį pavadinimo (ref), kai yra deklaruojamas savybės dimensijoje.'
+                    ).format(name)
+                ],
+                obj,
+            )
+            db_name = ""
+        else:
+            db_name = name
+
+        enum = existing_enum_map.get(db_name)
         if not enum:
-            enum = Enum.objects.create(name=name, content_type=ct, object_id=obj.pk, metadata_version=metadata_version)
+            enum = Enum.objects.create(
+                name=db_name, content_type=ct, object_id=obj.pk, metadata_version=metadata_version
+            )
 
         existing_enum_items = list(
             EnumItem.objects.filter(enum=enum, metadata_version=metadata_version).prefetch_related("metadata")
@@ -2045,7 +2060,7 @@ def _enums_to_tabular(obj: models.Model, separator: bool = False, version: Versi
                     {
                         "id": meta.uuid,
                         "type": "enum" if first else "",
-                        "ref": enum.name if first else "",
+                        "ref": enum.name if (first and not isinstance(obj, Property)) else "",
                         "source": meta.source,
                         "prepare": meta.prepare,
                         "level": meta.level_given,

--- a/vitrina/structure/views.py
+++ b/vitrina/structure/views.py
@@ -1935,7 +1935,7 @@ class EnumCreateView(PermissionRequiredMixin, CreateView):
             self.object.enum = Enum.objects.create(
                 content_type=ContentType.objects.get_for_model(Property),
                 object_id=self.property.pk,
-                name=self.property.name,
+                name="",
                 metadata_version_id=self.metadata_version.pk,
             )
         self.object.save()


### PR DESCRIPTION
## Fix property-level enum `ref` handling in structure import/export

### Problem

Property-level enums had two related issues with the `ref` column:

1. **Export bug**: When exporting a structure, property-level enums were outputting a non-empty `ref` value (inherited from `Enum.name` in the DB), which is only meaningful for dataset-level enums.
2. **Form creation bug**: `EnumCreateView` was setting `Enum.name = property.name` when creating a new property-level enum group via the UI, causing the DB to store a false name.

### Changes

- **`vitrina/structure/views.py`**: Fix `EnumCreateView.form_valid` to create the `Enum` group with `name=""` instead of `name=self.property.name`.
- **`vitrina/structure/services.py`**:
  - In `_enums_to_tabular`: export guard — always output empty `ref` for property-level enums regardless of DB state (backwards compatibility for existing records).
  - In `_load_enums`: when importing a property-level enum with a non-empty `ref`, create a `STRUCTURE_ERROR` comment and silently discard the value — the enum group is created with `name=""` and all items are imported normally.
