### PR TITLE
2624 fix enum quotes for strings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,13 @@ https://github.com/atviriduomenys/katalogas/issues/2629
 - Fix property-level enum creation via form: `Enum` objects created through the UI no longer inherit the property name as `enum.name`.
 - Add import validation: importing a CSV manifest with a non-empty `ref` on a property-level enum row now produces a structure error comment and silently sets the `ref` to an empty string.
 
+https://github.com/atviriduomenys/katalogas/issues/2624
+
+- Remove auto-stripping of quotes from string enum values in the form's initial data
+- Remove auto-wrapping of unquoted string values in clean_value()
+- Remove synchronous type checking (TypeCheckerError) from clean_value()
+- Fix edge case in CSV import: when prepare is empty and source is also empty, no longer produces "" as a valid quoted value
+
 v 1.21.0 (2026-05-18)
 ==================
 

--- a/tests/datasets/test_structure.py
+++ b/tests/datasets/test_structure.py
@@ -317,15 +317,15 @@ def test_import_property_string_enum_without_prepare_uses_source_value():
     assert str_enum_property.type == "string"
     enum_item_1 = str_enum_property.enums[""][0]
     assert enum_item_1.source == "one"
-    assert enum_item_1.prepare == '"one"'
+    assert enum_item_1.prepare == ""
     assert enum_item_1.errors == []
     enum_item_2 = str_enum_property.enums[""][1]
     assert enum_item_2.source == "two"
-    assert enum_item_2.prepare == '"two"'
+    assert enum_item_2.prepare == ""
     assert enum_item_2.errors == []
 
 
-def test_import_property_string_enum_without_quoted_prepare_adds_error():
+def test_import_property_string_enum_with_unquoted_prepare_imports_as_is():
     manifest = (
         "id,dataset,resource,base,model,property,type,ref,source,prepare,level,access,uri,title,description\n"
         ",example,,,,,,,,,,,,,\n"
@@ -345,7 +345,7 @@ def test_import_property_string_enum_without_quoted_prepare_adds_error():
     enum_item_1 = str_enum_property.enums[""][0]
     assert enum_item_1.source == "one"
     assert enum_item_1.prepare == "one"
-    assert enum_item_1.errors == ['Reikšmė "one" turi būti string tipo.']
+    assert enum_item_1.errors == []
 
 
 def test_import_property_not_string_enum_without_prepare_results_in_error():

--- a/tests/datasets/test_structure.py
+++ b/tests/datasets/test_structure.py
@@ -297,7 +297,7 @@ def test_import_property_enum_type_number():
     assert enum_item_2.prepare == "1.4"
 
 
-def test_import_property_string_enum_without_prepare_uses_source_value():
+def test_import_property_string_enum_without_prepare_adds_error():
     manifest = (
         "id,dataset,resource,base,model,property,type,ref,source,prepare,level,access,uri,title,description\n"
         ",example,,,,,,,,,,,,,\n"
@@ -317,12 +317,12 @@ def test_import_property_string_enum_without_prepare_uses_source_value():
     assert str_enum_property.type == "string"
     enum_item_1 = str_enum_property.enums[""][0]
     assert enum_item_1.source == "one"
-    assert enum_item_1.prepare == '"one"'
-    assert enum_item_1.errors == []
+    assert enum_item_1.prepare == ""
+    assert enum_item_1.errors == ['Duomenų reikšmė (source: "one") privalo turėti nurodytą "prepare" stulpelį.']
     enum_item_2 = str_enum_property.enums[""][1]
     assert enum_item_2.source == "two"
-    assert enum_item_2.prepare == '"two"'
-    assert enum_item_2.errors == []
+    assert enum_item_2.prepare == ""
+    assert enum_item_2.errors == ['Duomenų reikšmė (source: "two") privalo turėti nurodytą "prepare" stulpelį.']
 
 
 def test_import_property_string_enum_without_quoted_prepare_adds_error():
@@ -370,17 +370,11 @@ def test_import_property_not_string_enum_without_prepare_results_in_error():
     enum_item_1 = int_enum_property.enums[""][0]
     assert enum_item_1.source == "1"
     assert enum_item_1.prepare == ""
-    assert enum_item_1.errors == [
-        'Duomenų reikšmė (source: "1") privalo turėti nurodytą "prepare" stulpelį.',
-        'Reikšmė "" turi būti integer tipo.',
-    ]
+    assert enum_item_1.errors == ['Duomenų reikšmė (source: "1") privalo turėti nurodytą "prepare" stulpelį.']
     enum_item_2 = int_enum_property.enums[""][1]
     assert enum_item_2.source == "2"
     assert enum_item_2.prepare == ""
-    assert enum_item_2.errors == [
-        'Duomenų reikšmė (source: "2") privalo turėti nurodytą "prepare" stulpelį.',
-        'Reikšmė "" turi būti integer tipo.',
-    ]
+    assert enum_item_2.errors == ['Duomenų reikšmė (source: "2") privalo turėti nurodytą "prepare" stulpelį.']
 
 
 def test_import_enum_checks_uniqueness_based_on_source_and_prepare():

--- a/tests/datasets/test_structure.py
+++ b/tests/datasets/test_structure.py
@@ -297,7 +297,7 @@ def test_import_property_enum_type_number():
     assert enum_item_2.prepare == "1.4"
 
 
-def test_import_property_string_enum_without_prepare_adds_error():
+def test_import_property_string_enum_without_prepare_uses_source_value():
     manifest = (
         "id,dataset,resource,base,model,property,type,ref,source,prepare,level,access,uri,title,description\n"
         ",example,,,,,,,,,,,,,\n"
@@ -317,12 +317,12 @@ def test_import_property_string_enum_without_prepare_adds_error():
     assert str_enum_property.type == "string"
     enum_item_1 = str_enum_property.enums[""][0]
     assert enum_item_1.source == "one"
-    assert enum_item_1.prepare == ""
-    assert enum_item_1.errors == ['Duomenų reikšmė (source: "one") privalo turėti nurodytą "prepare" stulpelį.']
+    assert enum_item_1.prepare == '"one"'
+    assert enum_item_1.errors == []
     enum_item_2 = str_enum_property.enums[""][1]
     assert enum_item_2.source == "two"
-    assert enum_item_2.prepare == ""
-    assert enum_item_2.errors == ['Duomenų reikšmė (source: "two") privalo turėti nurodytą "prepare" stulpelį.']
+    assert enum_item_2.prepare == '"two"'
+    assert enum_item_2.errors == []
 
 
 def test_import_property_string_enum_without_quoted_prepare_adds_error():
@@ -370,11 +370,17 @@ def test_import_property_not_string_enum_without_prepare_results_in_error():
     enum_item_1 = int_enum_property.enums[""][0]
     assert enum_item_1.source == "1"
     assert enum_item_1.prepare == ""
-    assert enum_item_1.errors == ['Duomenų reikšmė (source: "1") privalo turėti nurodytą "prepare" stulpelį.']
+    assert enum_item_1.errors == [
+        'Duomenų reikšmė (source: "1") privalo turėti nurodytą "prepare" stulpelį.',
+        'Reikšmė "" turi būti integer tipo.',
+    ]
     enum_item_2 = int_enum_property.enums[""][1]
     assert enum_item_2.source == "2"
     assert enum_item_2.prepare == ""
-    assert enum_item_2.errors == ['Duomenų reikšmė (source: "2") privalo turėti nurodytą "prepare" stulpelį.']
+    assert enum_item_2.errors == [
+        'Duomenų reikšmė (source: "2") privalo turėti nurodytą "prepare" stulpelį.',
+        'Reikšmė "" turi būti integer tipo.',
+    ]
 
 
 def test_import_enum_checks_uniqueness_based_on_source_and_prepare():

--- a/tests/datasets/test_structure.py
+++ b/tests/datasets/test_structure.py
@@ -318,9 +318,11 @@ def test_import_property_string_enum_without_prepare_uses_source_value():
     enum_item_1 = str_enum_property.enums[""][0]
     assert enum_item_1.source == "one"
     assert enum_item_1.prepare == '"one"'
+    assert enum_item_1.errors == []
     enum_item_2 = str_enum_property.enums[""][1]
     assert enum_item_2.source == "two"
     assert enum_item_2.prepare == '"two"'
+    assert enum_item_2.errors == []
 
 
 def test_import_property_string_enum_without_quoted_prepare_adds_error():

--- a/tests/structure/test_forms.py
+++ b/tests/structure/test_forms.py
@@ -89,12 +89,11 @@ class TestEnumForm:
     @pytest.mark.parametrize(
         "given_value, saved_value",
         [
-            ("First", '"First"'),
             ("'First'", "'First'"),
             ('"First"', '"First"'),
         ],
     )
-    def test_creating_string_enum_automatically_adds_quotes_if_not_quoted(
+    def test_creating_string_enum_stores_quoted_value_as_is(
         self, app: DjangoTestApp, string_property: Property, given_value: str, saved_value: str
     ):
         user = UserFactory(is_staff=True)
@@ -153,7 +152,7 @@ class TestEnumForm:
         form = app.get(reverse("enum-create", args=[dataset.pk, version.pk, model.name, string_property.name])).forms[
             "enum-form"
         ]
-        form["value"] = "First"
+        form["value"] = '"First"'
         form["source"] = "TEST"
         form["access"] = Metadata.OPEN
         form["title"] = "Test value"
@@ -242,7 +241,7 @@ class TestEnumForm:
         form = app.get(
             reverse("enum-update", args=[dataset.pk, version.pk, model.name, string_property.name, enum_item.pk])
         ).forms["enum-form"]
-        form["value"] = "First2"
+        form["value"] = '"First2"'
         resp = form.submit()
 
         assert resp.url == string_property.get_absolute_url()
@@ -286,57 +285,3 @@ class TestEnumForm:
         resp = form.submit()
 
         assert resp.url == string_property.get_absolute_url()
-
-    @pytest.mark.parametrize("non_integer_value", ["abc", '"First"', "1.33", "1.0", 1.1])
-    def test_cannot_save_non_integer_item_values_for_integer_enum(
-        self, app: DjangoTestApp, integer_property: Property, non_integer_value: str | float
-    ):
-        user = UserFactory(is_staff=True)
-        app.set_user(user)
-
-        version = integer_property.metadata_version
-        model = integer_property.model
-        dataset = model.dataset
-
-        form = app.get(reverse("enum-create", args=[dataset.pk, version.pk, model.name, integer_property.name])).forms[
-            "enum-form"
-        ]
-        form["value"] = non_integer_value
-        form["source"] = "TEST"
-        form["access"] = Metadata.OPEN
-        form["title"] = "Test value"
-        form["description"] = "For testing"
-
-        resp = form.submit()
-
-        form = resp.context["form"]
-        assert not form.is_valid()
-        assert form.errors == {"value": [f'Reikšmė "{non_integer_value}" turi būti integer tipo.']}
-
-    @pytest.mark.parametrize("non_boolean_value", [True, False, 1, 0, "True", "False", "abc"])
-    def test_cannot_save_values_other_than_true_false_for_boolean_enum(
-        self, app: DjangoTestApp, boolean_property: Property, non_boolean_value: bool | str | int
-    ):
-        user = UserFactory(is_staff=True)
-        app.set_user(user)
-
-        version = boolean_property.metadata_version
-        model = boolean_property.model
-        dataset = model.dataset
-
-        form = app.get(reverse("enum-create", args=[dataset.pk, version.pk, model.name, boolean_property.name])).forms[
-            "enum-form"
-        ]
-        form["value"] = non_boolean_value
-        form["source"] = "TEST"
-        form["access"] = Metadata.OPEN
-        form["title"] = "Test value"
-        form["description"] = "For testing"
-
-        resp = form.submit()
-
-        form = resp.context["form"]
-        assert not form.is_valid()
-        assert form.errors == {
-            "value": [f'Reikšmė "{non_boolean_value}" turi būti boolean tipo. Viena iš: true, false']
-        }

--- a/tests/structure/test_services.py
+++ b/tests/structure/test_services.py
@@ -915,7 +915,7 @@ def test_structure_with_enum_with_wrong_type_prepare_adds_comment_about_error(ap
         ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
         ",,,,City,,,,,,,,,,,,,,\n"
         "1,,,,,type,integer,,,,5,,,,,,,,\n"
-        ',,,,,,enum,Type,one,hello,,,,,,,,,\n'
+        ",,,,,,enum,Type,one,hello,,,,,,,,,\n"
     )
     structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure

--- a/tests/structure/test_services.py
+++ b/tests/structure/test_services.py
@@ -879,6 +879,7 @@ def test_structure_with_enum_without_prepare_value_adds_comment_about_error(app:
     assert prop_enum[0].name == ""
     assert not prop_enum[0].enumitem_set.exists()
     assert list(Comment.objects.filter(type=Comment.STRUCTURE_ERROR).values_list("body", flat=True)) == [
+        'Reikšmė "" turi būti integer tipo.',
         'Duomenų reikšmė (source: "one") privalo turėti nurodytą "prepare" stulpelį.',
     ]
 

--- a/tests/structure/test_services.py
+++ b/tests/structure/test_services.py
@@ -916,18 +916,13 @@ def test_structure_with_enum_with_wrong_type_prepare_adds_comment_about_error(ap
         ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
         ",,,,City,,,,,,,,,,,,,,\n"
         "1,,,,,type,integer,,,,5,,,,,,,,\n"
-        ",,,,,,enum,Type,one,hello,,,,,,,,,\n"
+        ",,,,,,enum,,one,hello,,,,,,,,,\n"
     )
     structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
 
-    prop = Property.objects.get(metadata__uuid="1")
-    prop_enum = Enum.objects.filter(content_type=ContentType.objects.get_for_model(prop), object_id=prop.pk)
-    assert prop_enum.count() == 1
-    assert prop_enum[0].name == "Type"
-    assert not prop_enum[0].enumitem_set.exists()
     assert list(Comment.objects.filter(type=Comment.STRUCTURE_ERROR).values_list("body", flat=True)) == [
         'Reikšmė "hello" turi būti integer tipo.',
     ]

--- a/tests/structure/test_services.py
+++ b/tests/structure/test_services.py
@@ -879,7 +879,6 @@ def test_structure_with_enum_without_prepare_value_adds_comment_about_error(app:
     assert prop_enum[0].name == ""
     assert not prop_enum[0].enumitem_set.exists()
     assert list(Comment.objects.filter(type=Comment.STRUCTURE_ERROR).values_list("body", flat=True)) == [
-        'Reikšmė "" turi būti integer tipo.',
         'Duomenų reikšmė (source: "one") privalo turėti nurodytą "prepare" stulpelį.',
     ]
 
@@ -906,6 +905,30 @@ def test_structure_with_property_enum_ref_value_adds_comment_about_error(app: Dj
     assert list(prop_enum[0].enumitem_set.values_list("metadata__prepare", flat=True)) == ["1", "2"]
     assert list(Comment.objects.filter(type=Comment.STRUCTURE_ERROR).values_list("body", flat=True)) == [
         'Reikšmių sąrašas "SomeName" negali turėti pavadinimo (ref), kai yra deklaruojamas savybės dimensijoje.',
+    ]
+
+
+@pytest.mark.django_db
+def test_structure_with_enum_with_wrong_type_prepare_adds_comment_about_error(app: DjangoTestApp):
+    manifest = (
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,,,City,,,,,,,,,,,,,,\n"
+        "1,,,,,type,integer,,,,5,,,,,,,,\n"
+        ',,,,,,enum,Type,one,hello,,,,,,,,,\n'
+    )
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure.dataset.current_structure = structure
+    structure.dataset.save()
+    create_structure_objects(structure)
+
+    prop = Property.objects.get(metadata__uuid="1")
+    prop_enum = Enum.objects.filter(content_type=ContentType.objects.get_for_model(prop), object_id=prop.pk)
+    assert prop_enum.count() == 1
+    assert prop_enum[0].name == "Type"
+    assert not prop_enum[0].enumitem_set.exists()
+    assert list(Comment.objects.filter(type=Comment.STRUCTURE_ERROR).values_list("body", flat=True)) == [
+        'Reikšmė "hello" turi būti integer tipo.',
     ]
 
 

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -1607,7 +1607,7 @@ def test_property_enum_item_create__string(app: DjangoTestApp):
     ) == [
         {
             "metadata_version_id": version.pk,
-            "metadata__prepare": '"test"',
+            "metadata__prepare": "test",
             "metadata__source": "TEST",
             "metadata__access": Metadata.OPEN,
             "metadata__title": "Test value",

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -5500,7 +5500,6 @@ def test_changing_multiple_fields_in_draft_structure_respects_status(app: Django
         ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
         ",,,,,administration,string,,,,5,,,open,dct:title,,,,\n"
         ",,,,,,enum,,,'''SMALL''',,,,,,,,,\n"
-        ",,,,,,,,,BIG,,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
     )
     structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))

--- a/vitrina/datasets/structure.py
+++ b/vitrina/datasets/structure.py
@@ -836,17 +836,17 @@ def _read_enum(
 
     enum_type = getattr(enum.meta, "type")
 
-    # If string enum prepare is empty, use source as prepare value
-    if enum.prepare == "" and enum_type == "string" and enum.source:
-        enum.prepare = f'"{enum.source}"'
-
-    if enum.prepare == "":
+    if enum.prepare == "" and enum_type != "string":
         enum.errors.append(_(f'Duomenų reikšmė (source: "{enum.source}") privalo turėti nurodytą "prepare" stulpelį.'))
 
     _update_parent_visibility_from_enum(state, enum)
 
-    # Validate if enum item value matches enum type
-    if (type_checker := get_type_checker_for_type(enum_type)) and type(type_checker) is not NotImplementedTypeChecker:
+    # Validate if enum item value matches enum type (not applicable to string type)
+    if (
+        enum_type != "string"
+        and (type_checker := get_type_checker_for_type(enum_type))
+        and type(type_checker) is not NotImplementedTypeChecker
+    ):
         try:
             type_checker.check_enum_item_value(enum.prepare)
         except TypeCheckerError as e:

--- a/vitrina/datasets/structure.py
+++ b/vitrina/datasets/structure.py
@@ -837,7 +837,7 @@ def _read_enum(
     enum_type = getattr(enum.meta, "type")
 
     # If string enum prepare is empty, use source as prepare value
-    if enum.prepare == "" and enum_type == "string":
+    if enum.prepare == "" and enum_type == "string" and enum.source:
         enum.prepare = f'"{enum.source}"'
 
     if enum.prepare == "":

--- a/vitrina/datasets/structure.py
+++ b/vitrina/datasets/structure.py
@@ -836,21 +836,15 @@ def _read_enum(
 
     enum_type = getattr(enum.meta, "type")
 
-    # If string enum prepare is empty, use source as prepare value
-    if enum.prepare == "" and enum_type == "string" and enum.source:
-        enum.prepare = f'"{enum.source}"'
-
     if enum.prepare == "":
         enum.errors.append(_(f'Duomenų reikšmė (source: "{enum.source}") privalo turėti nurodytą "prepare" stulpelį.'))
-
-    _update_parent_visibility_from_enum(state, enum)
-
-    # Validate if enum item value matches enum type
-    if (type_checker := get_type_checker_for_type(enum_type)) and type(type_checker) is not NotImplementedTypeChecker:
+    elif (type_checker := get_type_checker_for_type(enum_type)) and type(type_checker) is not NotImplementedTypeChecker:
         try:
             type_checker.check_enum_item_value(enum.prepare)
         except TypeCheckerError as e:
             enum.errors.append(str(e))
+
+    _update_parent_visibility_from_enum(state, enum)
 
     # Validate enum item value uniqueness
     if enum.meta.enums.get(name):

--- a/vitrina/datasets/structure.py
+++ b/vitrina/datasets/structure.py
@@ -836,15 +836,21 @@ def _read_enum(
 
     enum_type = getattr(enum.meta, "type")
 
+    # If string enum prepare is empty, use source as prepare value
+    if enum.prepare == "" and enum_type == "string" and enum.source:
+        enum.prepare = f'"{enum.source}"'
+
     if enum.prepare == "":
         enum.errors.append(_(f'Duomenų reikšmė (source: "{enum.source}") privalo turėti nurodytą "prepare" stulpelį.'))
-    elif (type_checker := get_type_checker_for_type(enum_type)) and type(type_checker) is not NotImplementedTypeChecker:
+
+    _update_parent_visibility_from_enum(state, enum)
+
+    # Validate if enum item value matches enum type
+    if (type_checker := get_type_checker_for_type(enum_type)) and type(type_checker) is not NotImplementedTypeChecker:
         try:
             type_checker.check_enum_item_value(enum.prepare)
         except TypeCheckerError as e:
             enum.errors.append(str(e))
-
-    _update_parent_visibility_from_enum(state, enum)
 
     # Validate enum item value uniqueness
     if enum.meta.enums.get(name):

--- a/vitrina/structure/forms.py
+++ b/vitrina/structure/forms.py
@@ -20,7 +20,7 @@ from vitrina.classifiers.models import Status
 from vitrina.datasets.structure import Dataset
 from vitrina.resources.models import DatasetDistribution
 from vitrina.structure import spyna, AccessType
-from vitrina.structure.helpers import is_time_unit, is_si_unit, is_quoted
+from vitrina.structure.helpers import is_time_unit, is_si_unit
 from vitrina.structure.models import (
     EnumItem,
     Metadata,
@@ -32,7 +32,6 @@ from vitrina.structure.models import (
     VersionType,
     Enum,
 )
-from vitrina.structure.utils import TypeCheckerError
 from vitrina.users.models import User
 
 
@@ -193,11 +192,7 @@ class EnumForm(forms.ModelForm):
 
         if instance and instance.metadata.first():
             metadata = instance.metadata.first()
-            if self.prop.metadata.first() and self.prop.metadata.first().type == "string":
-                value = metadata.prepare.replace('"', "")
-            else:
-                value = metadata.prepare
-            self.initial["value"] = value
+            self.initial["value"] = metadata.prepare
             self.initial["source"] = metadata.source
             self.initial["access"] = metadata.access
             self.initial["title"] = metadata.title
@@ -241,16 +236,6 @@ class EnumForm(forms.ModelForm):
     def clean_value(self):
         if not (value := self.cleaned_data.get("value")):
             return value
-
-        if metadata := self.prop.metadata.first():
-            if metadata.type == "string" and not is_quoted(value):
-                value = f'"{value}"'
-
-            checker = metadata.get_type_checker()
-            try:
-                checker.check_enum_item_value(value)
-            except TypeCheckerError as e:
-                raise ValidationError(e)
 
         try:
             spyna.parse(value)

--- a/vitrina/structure/models.py
+++ b/vitrina/structure/models.py
@@ -18,8 +18,6 @@ from vitrina.structure.helpers import get_type_repr
 from vitrina.users.models import User
 from enum import Enum
 
-from vitrina.structure.utils import TypeChecker, get_type_checker_for_type
-
 
 class StatusCode(str, Enum):
     DEVELOP = "develop"
@@ -147,9 +145,6 @@ class Metadata(models.Model):
         if self.type:
             return get_type_repr(self)
         return ""
-
-    def get_type_checker(self) -> TypeChecker:
-        return get_type_checker_for_type(self.type)
 
 
 class Base(models.Model):


### PR DESCRIPTION
## Remove automatic enum quote handling in forms and fix empty-source edge case

Previously, the enum item form silently managed quotation marks on behalf
of the user: it stripped quotes before displaying a string enum value and
re-added them before saving. It also ran type validation
(string/integer/boolean) synchronously on form submit.

This PR removes that automatic behaviour so values are stored and displayed
exactly as entered. Type validation together with the rest of structure will be handled separately https://github.com/atviriduomenys/katalogas/issues/2370

## Changes

- Remove auto-stripping of quotes from string enum values in the form's
  initial data
- Remove auto-wrapping of unquoted string values in `clean_value()`
- Remove synchronous type checking (`TypeCheckerError`) from `clean_value()`
- Fix edge case in CSV import: when `prepare` is empty and `source` is also
  empty, no longer produces `""` as a valid quoted value
- Update tests accordingly
