### PR TITLE
Random UUID inclusion

### DIFF
--- a/vitrina/datasets/factories.py
+++ b/vitrina/datasets/factories.py
@@ -184,7 +184,7 @@ class DatasetGroupFactory(DjangoModelFactory):
         fake = faker.Faker()
         for lang in reversed(settings.LANGUAGES):
             group.set_current_language(lang[0])
-            group.title = fake.word() + fake.uuid4()
+            group.title = fake.uuid4()
         group.save()
         return group
 
@@ -210,7 +210,7 @@ class TypeFactory(DjangoModelFactory):
         fake = faker.Faker()
         for lang in reversed(settings.LANGUAGES):
             type.set_current_language(lang[0])
-            type.title = fake.word() + fake.uuid4()
+            type.title = fake.uuid4()
         type.save()
         return type
 
@@ -227,8 +227,8 @@ class RelationFactory(DjangoModelFactory):
         fake = faker.Faker()
         for lang in reversed(settings.LANGUAGES):
             relation.set_current_language(lang[0])
-            relation.title = fake.word() + fake.uuid4()
-            relation.inverse_title = fake.word() + fake.uuid4()
+            relation.title = fake.uuid4()
+            relation.inverse_title = fake.uuid4()
         relation.save()
         return relation
 

--- a/vitrina/datasets/factories.py
+++ b/vitrina/datasets/factories.py
@@ -184,7 +184,7 @@ class DatasetGroupFactory(DjangoModelFactory):
         fake = faker.Faker()
         for lang in reversed(settings.LANGUAGES):
             group.set_current_language(lang[0])
-            group.title = fake.word()
+            group.title = fake.word() + fake.uuid4()
         group.save()
         return group
 
@@ -210,7 +210,7 @@ class TypeFactory(DjangoModelFactory):
         fake = faker.Faker()
         for lang in reversed(settings.LANGUAGES):
             type.set_current_language(lang[0])
-            type.title = fake.word()
+            type.title = fake.word() + fake.uuid4()
         type.save()
         return type
 
@@ -227,8 +227,8 @@ class RelationFactory(DjangoModelFactory):
         fake = faker.Faker()
         for lang in reversed(settings.LANGUAGES):
             relation.set_current_language(lang[0])
-            relation.title = fake.word()
-            relation.inverse_title = fake.word()
+            relation.title = fake.word() + fake.uuid4()
+            relation.inverse_title = fake.word() + fake.uuid4()
         relation.save()
         return relation
 


### PR DESCRIPTION
Factory was used twice and generated the same word, breaking the unique constraint. Rerunning the tests makes it pass. Would not be that big of a problem, but the pipeline runs for 30 mins 😨 

Pipeline that broke - https://github.com/atviriduomenys/katalogas/actions/runs/26625074385/job/78459744042