### PR TITLE
[2652] Adjust HTML form to display edit/delete buttons

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,10 @@ https://github.com/atviriduomenys/katalogas/issues/2588
 - Add database indexes on ``dataset_statistic.dataset_id`` and ``model_download_statistic.model``.
 - Raise the Haystack Elasticsearch iterator batch size (env-configurable via ``HAYSTACK_ITERATOR_LOAD_PER_QUERY``) to cut Elasticsearch round-trips when loading statistics pages.
 
+https://github.com/atviriduomenys/katalogas/issues/2652
+
+- Adjust HTML form to display the edit/delete buttons for enum values even if the `enum.prepare` is not set.
+
 v 1.21.0 (2026-05-18)
 ==================
 

--- a/vitrina/structure/forms.py
+++ b/vitrina/structure/forms.py
@@ -100,7 +100,7 @@ VISIBILITY_LEVEL_CHOICES = (
 
 
 class EnumForm(forms.ModelForm):
-    value = forms.CharField(label=_("Reikšmė"), help_text=_("Fiksuotos reikšmės vertė."))
+    value = forms.CharField(label=_("Reikšmė"), help_text=_("Fiksuotos reikšmės vertė."), required=False)
     source = forms.CharField(
         label=_("Reikšmė šaltinyje"),
         required=False,

--- a/vitrina/structure/templates/vitrina/structure/property_structure.html
+++ b/vitrina/structure/templates/vitrina/structure/property_structure.html
@@ -309,8 +309,7 @@
                             {% endif %}
                             </div>
                             <div class="column is-2">
-                                {% if enum_meta.prepare or enum_meta.title %}
-                                    {% if prop.name and model.name and can_manage_structure %}
+                                {% if prop.name and model.name and can_manage_structure %}
                                     {% if not is_disabled %}
                                         <a href="{% url 'enum-update' dataset.pk version_id.pk model.name prop.name enum_item.pk %}"
                                            class="button is-primary is-small">
@@ -333,7 +332,6 @@
                                            aria-disabled="true">
                                             {% translate "Ištrinti" %}
                                         </a>
-                                    {% endif %}
                                     {% endif %}
                                 {% endif %}
                             </div>


### PR DESCRIPTION
If a manifest file is uploaded to Katalogas without a `enum.prepare` the `edit` and `delete` buttons would be hidden; Adjust and display the buttons even when the `enum.prepare` is not given.


<img width="835" height="205" alt="image" src="https://github.com/user-attachments/assets/7df61051-3331-4149-bd2f-7bf32f698188" />
