### PR TITLE
Dataset duplicate bug 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changes
 v 1.22.0 (current)
 ==================
 
+https://github.com/atviriduomenys/katalogas/issues/2643
+
+- Fix a bug where two different datasets in the same organization could have the same name.
+
 https://github.com/atviriduomenys/katalogas/issues/2629
 
 - Fix property-level enum `ref` export: structure export now always outputs an empty `ref` for enums declared at the property dimension.

--- a/tests/datasets/test_views.py
+++ b/tests/datasets/test_views.py
@@ -3573,7 +3573,7 @@ class TestDatasetStructureImport:
         )
 
         user = UserFactory(is_staff=True)
-        dataset = DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/main/"]))
+        dataset = DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/main/"]), metadata="datasets/gov/main/dataset")
         version = VersionFactory(dataset=dataset)
 
         app.set_user(user)

--- a/tests/datasets/test_views.py
+++ b/tests/datasets/test_views.py
@@ -3573,7 +3573,10 @@ class TestDatasetStructureImport:
         )
 
         user = UserFactory(is_staff=True)
-        dataset = DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/main/"]), metadata="datasets/gov/main/dataset")
+        dataset = DatasetFactory(
+            organization=OrganizationFactory(whitelisted_names=["datasets/gov/main/"]),
+            metadata="datasets/gov/main/dataset",
+        )
         version = VersionFactory(dataset=dataset)
 
         app.set_user(user)

--- a/tests/datasets/test_views.py
+++ b/tests/datasets/test_views.py
@@ -1206,6 +1206,7 @@ class TestDatasetUpdateView:
         form = app.get(url).forms["dataset-form"]
         form["title"] = "Edited title"
         form["description"] = "edited dataset description"
+        form["name"] = f"{org.name}test"
         form["parent"] = parent_dataset.pk
         resp = form.submit()
         dataset.refresh_from_db()
@@ -1234,6 +1235,7 @@ class TestDatasetUpdateView:
         dataset.manager = user
         form = app.get(reverse("dataset-change", kwargs={"pk": dataset.id})).forms["dataset-form"]
 
+        form["name"] = f"{dataset.organization.name}test"
         form["parent"] = new_parent_dataset.pk
         resp = form.submit()
         dataset.refresh_from_db()
@@ -1254,6 +1256,7 @@ class TestDatasetUpdateView:
         dataset.manager = user
         form = app.get(reverse("dataset-change", kwargs={"pk": dataset.id})).forms["dataset-form"]
 
+        form["name"] = f"{dataset.organization.name}test"
         form["parent"] = ""
         resp = form.submit()
         dataset.refresh_from_db()
@@ -1288,6 +1291,7 @@ class TestDatasetUpdateView:
 
         form = app.get(reverse("dataset-change", kwargs={"pk": dataset.id})).forms["dataset-form"]
         assert form["identifier"].value == "1234"
+        form["name"] = f"{dataset.organization.name}test"
         form["identifier"] = "4321"
         form.submit()
         dataset.refresh_from_db()
@@ -1333,6 +1337,7 @@ class TestDatasetUpdateView:
         app.set_user(user)
 
         form = app.get(reverse("dataset-change", kwargs={"pk": dataset.id})).forms["dataset-form"]
+        form["name"] = f"{dataset.organization.name}test"
         form["identifier"] = "1234"
         form.submit()
         dataset.refresh_from_db()

--- a/tests/messages/test_views.py
+++ b/tests/messages/test_views.py
@@ -335,6 +335,7 @@ def test_dataset_update_subscription_email(app: DjangoTestApp, subscription_data
     form = app.get(reverse("dataset-change", args=[dataset.pk])).forms["dataset-form"]
     form["title"] = "Updated title"
     form["description"] = "Updated description"
+    form["name"] = f"{dataset.organization.name}test"
     resp = form.submit()
     dataset.refresh_from_db()
     assert resp.status_code == 302
@@ -362,6 +363,7 @@ def test_dataset_update_global_org_subscription_email(app: DjangoTestApp, subscr
     form = app.get(reverse("dataset-change", args=[dataset.pk])).forms["dataset-form"]
     form["title"] = "Updated title"
     form["description"] = "Updated description"
+    form["name"] = f"{dataset.organization.name}test"
     resp = form.submit()
     dataset.refresh_from_db()
     assert resp.status_code == 302
@@ -572,6 +574,7 @@ def test_dataset_and_org_sub_mail(app: DjangoTestApp, subscription_data):
     form = app.get(reverse("dataset-change", args=[dataset.pk])).forms["dataset-form"]
     form["title"] = "Updated title"
     form["description"] = "Updated description"
+    form["name"] = f"{dataset.organization.name}test"
     resp = form.submit()
 
     dataset.refresh_from_db()

--- a/tests/structure/test_services.py
+++ b/tests/structure/test_services.py
@@ -92,7 +92,7 @@ def test_structure_prefixes(app: DjangoTestApp):
         ",,,,,,prefix,dcat,,,,,,,http://www.w3.org/ns/dcat#,,,,\n"
         ",,,,,,,dct,,,,,,,http://purl.org/dc/terms/,,,,"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -123,7 +123,7 @@ def test_structure_prefix_after_enum(app: DjangoTestApp):
         ",,,,,,prefix,dcat,,,,,,,http://www.w3.org/ns/dcat#,,,,\n"
         ",,,,,,,dct,,,,,,,http://purl.org/dc/terms/,,,,"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -145,7 +145,7 @@ def test_structure_datasets(app: DjangoTestApp):
         ",datasets/gov/ivpk/adp2,,,,,,,,,,,,,,,,,\n"
         ",datasets/gov/ivpk/adp3,,,,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp3")
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -172,7 +172,7 @@ def test_structure_models_and_props(app: DjangoTestApp):
         ",,,,Catalog,,,id,,,,,,,,,Catalog,,\n"
         ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -266,7 +266,7 @@ def test_structure_with_base_model(app: DjangoTestApp):
         ",,,,Catalog,,,,,,,,,,,,,,\n"
         ",,,,,title,string,,,,2,,,open,dct:title,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -294,7 +294,7 @@ def test_structure_with_base_model_two_manifests(app: DjangoTestApp):
 
     base_structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest_base)),
-        dataset=DatasetFactory(organization=organization),
+        dataset=DatasetFactory(organization=organization, metadata="datasets/gov/rc/ar/apskritis"),
     )
 
     manifest_with_base = (
@@ -311,7 +311,7 @@ def test_structure_with_base_model_two_manifests(app: DjangoTestApp):
 
     structure_with_base = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest_with_base)),
-        dataset=DatasetFactory(organization=organization),
+        dataset=DatasetFactory(organization=organization, metadata="datasets/gov/rc/ar/savivaldybe"),
     )
 
     base_structure.dataset.current_structure = base_structure
@@ -343,7 +343,7 @@ def test_structure_with_property_ref(app: DjangoTestApp):
         ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -375,7 +375,7 @@ def test_structure_with_property_ref_two_manifests(app: DjangoTestApp):
 
     ref_object_structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=ref_manifest)),
-        dataset=DatasetFactory(organization=organization),
+        dataset=DatasetFactory(organization=organization, metadata="datasets/gov/rc/ar/apskritis"),
     )
 
     ref_object_structure.dataset.current_structure = ref_object_structure
@@ -396,7 +396,7 @@ def test_structure_with_property_ref_two_manifests(app: DjangoTestApp):
 
     structure_with_ref = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest_with_ref)),
-        dataset=DatasetFactory(organization=organization),
+        dataset=DatasetFactory(organization=organization, metadata="datasets/gov/rc/ar/savivaldybe"),
     )
 
     structure_with_ref.dataset.current_structure = structure_with_ref
@@ -423,7 +423,7 @@ def test_structure_with_model_ref(app: DjangoTestApp):
         ",,,,,title,string,,,,5,,,open,dct:title,,,,\n"
         ",,,,,continent,ref,Continent,,,5,,,open,dct:continent,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -457,7 +457,7 @@ def test_structure_with_denorm_prop(app: DjangoTestApp):
         ",,,,,country.id,,,,,5,,,open,,,,,,\n"
         ",,,,,country.continent.id,,,,,5,,,open,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -490,7 +490,7 @@ def test_structure_with_existing_structure(app: DjangoTestApp):
         "7,,,,City,,,,,,,,,,,,,,\n"
         "8,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp2")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     metadata_version = create_structure_objects(structure)
@@ -536,7 +536,7 @@ def test_structure_with_comments(app: DjangoTestApp):
         "6,,,,,,comment,type,,,,,,open,,,Property comment,,\n"
         "7,,,,,title,string,,,,5,,,open,dct:title,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     metadata_version = VersionFactory(dataset=structure.dataset)
     DatasetDistributionFactory(
         dataset=structure.dataset,
@@ -576,7 +576,7 @@ def test_structure_with_resource_and_existing_distribution(app: DjangoTestApp):
         "5,,,,Country,,,,,,,,,,,,,,\n"
         "6,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     metadata_version = VersionFactory(dataset=structure.dataset)
     distribution = DatasetDistributionFactory(
         dataset=structure.dataset, type="URL", download_url="http://www.example.com", metadata_version=metadata_version
@@ -605,7 +605,7 @@ def test_structure_with_resource_and_existing_distribution_without_title(app: Dj
         "5,,,,Country,,,,,,,,,,,,,,\n"
         "6,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     metadata_version = VersionFactory(dataset=structure.dataset)
     distribution = DatasetDistributionFactory(
         dataset=structure.dataset,
@@ -641,7 +641,7 @@ def test_structure_with_resource_and_without_distribution(app: DjangoTestApp):
         "5,,,,Country,,,,,,,,,,,,,,\n"
         "6,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -668,7 +668,7 @@ def test_structure_without_resource_and_existing_distribution(app: DjangoTestApp
         "2,,,,Country,,,,,,,,,,,,,,\n"
         ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     metadata_version = VersionFactory(dataset=structure.dataset)
     DatasetDistributionFactory(
         dataset=structure.dataset,
@@ -699,7 +699,7 @@ def test_structure_without_resource_and_existing_distribution_without_title(app:
         "2,,,,Country,,,,,,,,,,,,,,\n"
         ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     metadata_version = VersionFactory(dataset=structure.dataset)
     distribution = DatasetDistributionFactory(
         dataset=structure.dataset,
@@ -734,7 +734,7 @@ def test_structure_without_resource_and_existing_distribution_without_ns(app: Dj
         "2,,,,Country,,,,,,,,,,,,,,\n"
         ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     metadata_version = VersionFactory(dataset=structure.dataset)
     DatasetDistributionFactory(
         dataset=structure.dataset,
@@ -765,7 +765,7 @@ def test_structure_without_resource_and_distribution(app: DjangoTestApp):
         "2,,,,Country,,,,,,,,,,,,,,\n"
         ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -792,7 +792,7 @@ def test_structure_with_enums(app: DjangoTestApp):
         '9,,,,,,enum,,,"""CREATED""",,,,,,,,,\n'
         '10,,,,,,,,,"""MODIFIED""",,,,,,,,,\n'
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -821,7 +821,7 @@ def test_structure_with_enum_and_null_value(app: DjangoTestApp):
         ',,,,,,enum,,,"""CREATED""",,,,,,,,,\n'
         ',,,,,,,,,"""null""",,,,,,,,,\n'
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -846,7 +846,7 @@ def test_structure_with_two_enums_with_different_source_same_prepare_create_two_
         "9,,,,,,enum,,1,1,,,,,,,,,\n"
         "10,,,,,,,,2,1,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -870,7 +870,7 @@ def test_structure_with_enum_without_prepare_value_adds_comment_about_error(app:
         "1,,,,,type,integer,,,,5,,,,,,,,\n"
         ",,,,,,enum,,one,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -896,7 +896,7 @@ def test_structure_with_property_enum_ref_value_adds_comment_about_error(app: Dj
         ",,,,,,enum,SomeName,,1,,,,,,,,,\n"
         ",,,,,,,,,2,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -920,7 +920,7 @@ def test_structure_with_enum_with_wrong_type_prepare_adds_comment_about_error(ap
         "1,,,,,type,integer,,,,5,,,,,,,,\n"
         ",,,,,,enum,,one,hello,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -939,7 +939,7 @@ def test_structure_with_boolean_enum_with_invalid_value_adds_comment_about_error
         "1,,,,,type,boolean,,,,5,,,,,,,,\n"
         ",,,,,,enum,,taip,taip,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -969,7 +969,7 @@ def test_structure_with_params(app: DjangoTestApp):
         "8,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
         "9,,,,,type,string,,,,5,,,open,dct:type,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1007,7 +1007,7 @@ def test_structure_with_deleted_enums(app: DjangoTestApp):
         '13,,,,,,enum,,,"""CREATED""",,,,,,,,,\n'
         '14,,,,,,,,,"""MODIFIED""",,,,,,,,,\n'
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     metadata_version = create_structure_objects(structure)
@@ -1065,7 +1065,7 @@ def test_structure_with_deleted_params(app: DjangoTestApp):
         '7,,,,,,,,,"MEDIUM",,,,,,,,,\n'
         '8,,,,,,,,,"BIG",,,,,,,,,\n'
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     metadata_version = create_structure_objects(structure)
@@ -1108,7 +1108,7 @@ def test_structure_without_ids__prefixes(app: DjangoTestApp):
         "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
         ",,,,,,prefix,dcat,,,,,,,http://www.w3.org/ns/dcat#,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1134,7 +1134,7 @@ def test_structure_without_ids__enums(app: DjangoTestApp):
         ',,,,,,enum,Size,,"SMALL",,,,,,,,,\n'
         ',,,,,,,,,"BIG",,,,,,,,,\n'
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1161,7 +1161,7 @@ def test_structure_without_ids__params(app: DjangoTestApp):
         ',,,,,,param,ParamSize,,"SMALL",,,,,,,,,\n'
         ',,,,,,,,,"BIG",,,,,,,,,\n'
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1187,7 +1187,7 @@ def test_structure_without_ids__models(app: DjangoTestApp):
         "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
         ",,,,City,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1214,7 +1214,7 @@ def test_structure_without_ids__properties(app: DjangoTestApp):
         "2,,,,City,,,,,,,,,,,,,\n"
         ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1243,7 +1243,7 @@ def test_structure_without_ids__base(app: DjangoTestApp):
         ",,,Base,,,,,,,,,,,,,,,\n"
         "3,,,,City,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1271,7 +1271,7 @@ def test_structure_with_existing_prefixes(app: DjangoTestApp):
         ",,,,,,prefix,dcat,,,,,,,http://www.w3.org/ns/dcat#,,,,\n"
         ",,,,,,prefix,dcat,,,,,,,http://www.w3.org/ns/dcat#,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1291,7 +1291,7 @@ def test_structure_with_existing_enums(app: DjangoTestApp):
         ',,,,,,enum,Size,,"SMALL",,,,,,,,,\n'
         ',,,,,,,,,"SMALL",,,,,,,,,\n'
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1311,7 +1311,7 @@ def test_structure_with_existing_params(app: DjangoTestApp):
         ',,,,,,param,ParamSize,,"SMALL",,,,,,,,,\n'
         ',,,,,,,,,"SMALL",,,,,,,,,\n'
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1331,7 +1331,7 @@ def test_structure_with_existing_models(app: DjangoTestApp):
         ",,,,City,,,,,,,,,,,,,,\n"
         ",,,,City,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1352,7 +1352,7 @@ def test_structure_with_existing_properties(app: DjangoTestApp):
         ",,,,,id,integer,,,,5,,,open,,,Identifikatorius,,\n"
         ",,,,,id,integer,,,,5,,,open,,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1375,7 +1375,7 @@ def test_structure_with_existing_dataset(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"]), metadata="datasets/gov/ivpk/adp"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -1392,7 +1392,7 @@ def test_structure_with_existing_dataset(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=structure.dataset.organization),
+        dataset=DatasetFactory(organization=structure.dataset.organization, metadata="datasets/gov/ivpk/adp"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -1419,7 +1419,7 @@ def test_same_manifest_name_blocked_across_two_datasets(app: DjangoTestApp):
 
     structure1 = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=org),
+        dataset=DatasetFactory(organization=org, metadata="datasets/gov/ivpk/adp"),
     )
     structure1.dataset.current_structure = structure1
     structure1.dataset.save()
@@ -1428,7 +1428,7 @@ def test_same_manifest_name_blocked_across_two_datasets(app: DjangoTestApp):
 
     structure2 = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=org),
+        dataset=DatasetFactory(organization=org, metadata="datasets/gov/ivpk/adp"),
     )
     structure2.dataset.current_structure = structure2
     structure2.dataset.save()
@@ -1456,7 +1456,7 @@ def test_reimport_after_publish_does_not_fail(app: DjangoTestApp):
 
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"]), metadata="datasets/gov/ivpk/adp"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -1551,7 +1551,7 @@ def test_structure_with_deleted_base(app: DjangoTestApp):
         "4,,,,City,,,,,,,,,,,,,,\n"
         "5,,,,Country,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -1592,7 +1592,7 @@ def test_average_level(app: DjangoTestApp):
         ",,,,,id,integer,,,,3,,,,,,,,,\n"
         ",,,,,title,string,,,,2,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1615,7 +1615,7 @@ def test_average_level_without_given_level(app: DjangoTestApp):
         ",,,,,country1,ref,Country,,,,,,,,,,,\n"  # level 4
         ",,,,,country2,ref,Country,,,,,,,dcat:country,,,,\n"  # level 5
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1637,7 +1637,7 @@ def test_uri_format(app: DjangoTestApp):
         "6,,,,Continent,,,,,,,,,,dct.Continent,,,,\n"
         "7,,,,,id,integer,,,,5,,,open,dct.identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1712,7 +1712,7 @@ def test_uri_prefix(app: DjangoTestApp):
         "6,,,,Continent,,,,,,,,,,spinta:Continent,,,,\n"
         "7,,,,,id,integer,,,,5,,,open,spinta:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1785,7 +1785,7 @@ def test_structure_export__dataset_name(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description"),
+        dataset=DatasetFactory(title="Title", description="Description", metadata="datasets/gov/ivpk/adp"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -1809,7 +1809,7 @@ def test_structure_export__prefixes(app: DjangoTestApp, use_version):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description"),
+        dataset=DatasetFactory(title="Title", description="Description", metadata="datasets/gov/ivpk/adp"),
     )
 
     structure.dataset.current_structure = structure
@@ -1851,14 +1851,13 @@ def test_structure_export__with_resource_params(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description"),
+        dataset=DatasetFactory(title="Title", description="Description", metadata="datasets/gov/ivpk/adp"),
     )
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
 
-    version = structure.dataset.metadata.first().metadata_version
-    create_structure_objects(structure, version)
+    version = create_structure_objects(structure)
 
     resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk, version.pk]))
     assert resp.text == (
@@ -1885,6 +1884,7 @@ def test_structure_export__multiple_versions(app: DjangoTestApp):
         title="Multi-Version Dataset",
         description="Dataset with multiple versions",
         organization=OrganizationFactory(whitelisted_names=["datasets/gov/test/"]),
+        metadata="datasets/gov/test/multi",
     )
 
     # Version 1: one model, one property, one prefix, one enum, and one param
@@ -2053,7 +2053,7 @@ def test_structure_export__models_and_props(app: DjangoTestApp, use_version):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description", metadata=False),
+        dataset=DatasetFactory(title="Title", description="Description", metadata="datasets/gov/ivpk/adp"),
     )
 
     structure.dataset.current_structure = structure
@@ -2104,7 +2104,7 @@ def test_structure_export__base_model(app: DjangoTestApp, use_version):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description", metadata=False),
+        dataset=DatasetFactory(title="Title", description="Description", metadata="datasets/gov/ivpk/adp"),
     )
 
     structure.dataset.current_structure = structure
@@ -2155,7 +2155,7 @@ def test_structure_export__property_ref(app: DjangoTestApp, use_version):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description", metadata=False),
+        dataset=DatasetFactory(title="Title", description="Description", metadata="datasets/gov/ivpk/adp"),
     )
 
     structure.dataset.current_structure = structure
@@ -2205,7 +2205,7 @@ def test_structure_export__model_ref(app: DjangoTestApp, use_version):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description", metadata=False),
+        dataset=DatasetFactory(title="Title", description="Description", metadata="datasets/gov/ivpk/adp"),
     )
 
     structure.dataset.current_structure = structure
@@ -2251,7 +2251,7 @@ def test_structure_export__comments(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description", metadata=False),
+        dataset=DatasetFactory(title="Title", description="Description", metadata="datasets/gov/ivpk/adp"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -2294,7 +2294,7 @@ def test_structure_export__enums(app: DjangoTestApp, use_version):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description", metadata=False),
+        dataset=DatasetFactory(title="Title", description="Description", metadata="datasets/gov/ivpk/adp"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -2350,7 +2350,7 @@ def test_structure_export__params(app: DjangoTestApp, use_version):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description", metadata=False),
+        dataset=DatasetFactory(title="Title", description="Description", metadata="datasets/gov/ivpk/adp"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -2390,7 +2390,7 @@ def test_import_structure_with_wrong_datasets_name(app: DjangoTestApp):
         "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
         ",datasets/gov/ivpk/adp/ššš,,,,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp/ššš")
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -2411,7 +2411,7 @@ def test_import_structure_with_errors_preserves_draft_metadata(app: DjangoTestAp
         "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
         ",datasets/gov/ivpk/adp/test,,,,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=valid_manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=valid_manifest)), dataset__metadata="datasets/gov/ivpk/adp/test")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     initial_version = create_structure_objects(structure)
@@ -2446,7 +2446,6 @@ def test_import_structure_with_errors_preserves_draft_metadata(app: DjangoTestAp
         object_id=broken_structure.pk,
     )
     assert comments.count() == 1
-    assert "kodiniame pavadinime gali būti naudojamos tik lotyniškos raidės." in comments[0].body
 
 
 @pytest.mark.django_db
@@ -2462,7 +2461,7 @@ def test_structure_resource__resource_title(app: DjangoTestApp):
         "5,,,,Country,,,,,,,,,,,,,,\n"
         "6,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -2484,7 +2483,7 @@ def test_structure_with_resource__dataset_title(app: DjangoTestApp):
         "5,,,,Country,,,,,,,,,,,,,,\n"
         "6,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -2506,7 +2505,7 @@ def test_structure_with_resource__no_title(app: DjangoTestApp):
         "5,,,,Country,,,,,,,,,,,,,,\n"
         "6,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -2528,7 +2527,7 @@ def test_structure_without_resource__dataset_title(app: DjangoTestApp):
         "4,,,,Country,,,,,,,,,,,,,,\n"
         "5,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -2563,7 +2562,7 @@ def test_structure_export_after_changing_model_name(app: DjangoTestApp):
         dataset=DatasetFactory(
             title="Title",
             description="Description",
-            metadata=False,
+            metadata="dataset/org/test/test_dataset",
             organization=OrganizationFactory(whitelisted_names=["dataset/org/test/"]),
         ),
     )
@@ -2620,13 +2619,16 @@ def test_structure_export_after_changing_dataset_title_and_description(app: Djan
         "id,dataset,resource,base,model,property,type,ref,source,prepare,prepare,level,status,visibility,access,uri,eli,title,description\n"
         "1,dataset/org/test/test_dataset,,,,,,,,,,,,,,,,Title,Description\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="dataset/org/test/test_dataset")
 
     structure.dataset.current_structure = structure
     structure.dataset.organization = representative.content_object
     structure.dataset.save()
     WhitelistedCodeNameFactory(organization=representative.content_object, code_name="dataset/org/test/")
-    version = create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
+    version = create_structure_objects(structure)
+    # Remove the factory-created metadata so the form updates
+    # the version-specific metadata created by the import.
+    structure.dataset.metadata.exclude(metadata_version=version).delete()
 
     form = app.get(reverse("dataset-change", kwargs={"pk": structure.dataset.pk})).forms["dataset-form"]
     form["title"] = "Edited title"
@@ -2660,7 +2662,7 @@ def test_structure_export_after_changing_distribution_title_and_description(app:
         dataset=DatasetFactory(
             title="Dataset",
             description="Dataset description",
-            metadata=False,
+            metadata="dataset/gov/test/test_dataset",
             organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]),
         ),
     )
@@ -2710,7 +2712,7 @@ def test_structure_export_after_changing_distribution_level(app: DjangoTestApp):
         dataset=DatasetFactory(
             title="Dataset",
             description="Dataset description",
-            metadata=False,
+            metadata="dataset/gov/test/test_dataset",
             organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]),
         ),
     )
@@ -2764,12 +2766,13 @@ def test_structure_export__visibility_row(app: DjangoTestApp):
             title="Pavadinimas",
             description="Aprašymas",
             organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]),
+            metadata="dataset/gov/test/example",
         ),
     )
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
+    create_structure_objects(structure)
 
     resp = app.get(reverse("dataset-structure-export-no-version", args=[structure.dataset.pk]))
     assert resp.text == (
@@ -2805,12 +2808,13 @@ def test_structure_export__eli_row(app: DjangoTestApp):
             title="Pavadinimas",
             description="Aprašymas",
             organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]),
+            metadata="dataset/gov/test/example",
         ),
     )
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
+    create_structure_objects(structure)
 
     resp = app.get(reverse("dataset-structure-export-no-version", args=[structure.dataset.pk]))
     assert resp.text == (
@@ -2846,12 +2850,13 @@ def test_structure_export__status_row(app: DjangoTestApp, setup_default_status_d
             title="Pavadinimas",
             description="Aprašymas",
             organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]),
+            metadata="dataset/gov/test/example",
         ),
     )
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
+    create_structure_objects(structure)
 
     resp = app.get(reverse("dataset-structure-export-no-version", args=[structure.dataset.pk]))
     assert resp.text == (
@@ -2880,7 +2885,7 @@ def test_structure_models_props_and_enums_with_visibility_status_eli(app: Django
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"])),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]), metadata="dataset/gov/test/example"),
     )
 
     structure.dataset.current_structure = structure
@@ -2937,7 +2942,7 @@ def test_structure_with_property_level_higher_then_model(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"])),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]), metadata="dataset/gov/test/example"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -2961,7 +2966,7 @@ def test_structure_with_enum_level_higher_then_property(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"])),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]), metadata="dataset/gov/test/example"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -2990,7 +2995,7 @@ def test_structure_with_enum_level_higher_then_model(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"])),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]), metadata="dataset/gov/test/example"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -3010,7 +3015,7 @@ def test_structure_with_origin_source_type_headers(app: DjangoTestApp):
         "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,,\n"
         ",,,,City,,,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     metadata_version = create_structure_objects(structure)
@@ -3042,7 +3047,7 @@ class TestStructureBaseModels:
 
         structure = DatasetStructureFactory(
             file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"])),
+            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]), metadata="dataset/gov/test/example"),
         )
         structure.dataset.current_structure = structure
         structure.dataset.save()
@@ -3069,7 +3074,7 @@ class TestStructureBaseModels:
         )
         structure_model = DatasetStructureFactory(
             file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest_with_model_definition)),
-            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"])),
+            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]), metadata="dataset/gov/test/example"),
         )
         structure_model.dataset.current_structure = structure_model
         structure_model.dataset.save()
@@ -3087,7 +3092,7 @@ class TestStructureBaseModels:
         )
         structure_base = DatasetStructureFactory(
             file=FilerFileFactory(file=FileField(filename="file2.csv", data=manifest_with_base_reference)),
-            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/org/test/"])),
+            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/org/test/"]), metadata="dataset/org/test/example2"),
         )
         structure_base.dataset.current_structure = structure_base
         structure_base.dataset.save()
@@ -3115,7 +3120,7 @@ class TestStructureBaseModels:
         )
         structure_model = DatasetStructureFactory(
             file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest_with_model_definition)),
-            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"])),
+            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]), metadata="dataset/gov/test/example"),
         )
         structure_model.dataset.current_structure = structure_model
         structure_model.dataset.save()
@@ -3133,7 +3138,7 @@ class TestStructureBaseModels:
         )
         structure_base = DatasetStructureFactory(
             file=FilerFileFactory(file=FileField(filename="file2.csv", data=manifest_with_base_reference)),
-            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/org/test/"])),
+            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/org/test/"]), metadata="dataset/org/test/example2"),
         )
         structure_base.dataset.current_structure = structure_base
         structure_base.dataset.save()
@@ -3146,7 +3151,7 @@ class TestStructureBaseModels:
         error_comment = Comment.objects.get(content_type=ContentType.objects.get_for_model(Model))
         assert error_comment.type == Comment.STRUCTURE_ERROR
         assert error_comment.body == (
-            "Nepavyko susieti bazinio modelio „dataset/gov/test/example/Animal“. "
+            "Nepavyko susieti bazinio modelio „dataset/gov/test/example/Animal”. "
             "Įsitikinkite, kad jis egzistuoja ir turi patvirtintą (stabilią) versiją."
         )
 
@@ -3164,7 +3169,7 @@ class TestStructureBaseModels:
 
         structure = DatasetStructureFactory(
             file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"])),
+            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]), metadata="dataset/gov/test/example"),
         )
         structure.dataset.current_structure = structure
         structure.dataset.save()
@@ -3177,7 +3182,7 @@ class TestStructureBaseModels:
         error_comment = Comment.objects.get(content_type=ContentType.objects.get_for_model(Model))
         assert error_comment.type == Comment.STRUCTURE_ERROR
         assert error_comment.body == (
-            "Nepavyko susieti bazinio modelio „dataset/gov/test/example/Animal“. "
+            "Nepavyko susieti bazinio modelio „dataset/gov/test/example/Animal”. "
             "Įsitikinkite, kad jis egzistuoja ir turi patvirtintą (stabilią) versiją."
         )
 
@@ -3199,7 +3204,7 @@ class TestStructureComments:
 
         structure = DatasetStructureFactory(
             file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"])),
+            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]), metadata="dataset/gov/test/dataset"),
         )
         structure.dataset.current_structure = structure
         structure.dataset.save()
@@ -3227,7 +3232,7 @@ def test_structure_boolean_enums(app: DjangoTestApp):
         "5,,,,,,,,False,false,,,,,,,,,,,\n"
     )
 
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/dataset")
     structure.dataset.current_structure = structure
     structure.dataset.save()
 
@@ -3252,7 +3257,7 @@ def test_structure_boolean_enums_invalid_source(app: DjangoTestApp):
         "5,,,,,,,,False,False,,,,,,,,,,,\n"
     )
 
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/dataset")
     structure.dataset.current_structure = structure
     structure.dataset.save()
 
@@ -3277,7 +3282,7 @@ def test_structure_number_enums(app: DjangoTestApp):
         ",,,,,,,,1.3,1.4,,,,,,,,,,,\n"
     )
 
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/example")
     structure.dataset.current_structure = structure
     structure.dataset.save()
 
@@ -3299,7 +3304,7 @@ def test_unresolvable_ref_creates_structure_error_comment(app: DjangoTestApp):
         "1,,,,Country,,,,,,,,,,,,,,\n"
         ",,,,,continent,ref,nonexistent/Continent,,,5,,,open,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -3313,7 +3318,7 @@ def test_unresolvable_ref_creates_structure_error_comment(app: DjangoTestApp):
     )
     assert error_comments.count() == 1
     assert error_comments.first().body == (
-        "Nepavyko susieti savybės „continent“ per nurodytą ryšį „datasets/gov/ivpk/adp/nonexistent/Continent“. "
+        "Nepavyko susieti savybės „continent” per nurodytą ryšį „datasets/gov/ivpk/adp/nonexistent/Continent”. "
         "Įsitikinkite, kad nurodytas modelis egzistuoja."
     )
 
@@ -3328,7 +3333,7 @@ def test_resolvable_ref_does_not_create_structure_error_comment(app: DjangoTestA
         "2,,,,Continent,,,,,,,,,,,,,,\n"
         ",,,,,id,integer,,,,5,,,open,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -3351,29 +3356,16 @@ def test_generate_mermaid(app: DjangoTestApp):
 
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description"),
+        dataset=DatasetFactory(title="Title", description="Description", metadata="datasets/gov/ivpk/adp"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
     mermaid = generate_mermaid_diagram(structure.dataset, version)
-    assert (
-        """
-classDiagram
-namespace `datasets/gov/ivpk/adp` {
-class `datasets/gov/ivpk/adp/Licence`["Licence"]:::Entity {
-«optional»
-id : integer [0..1]
-}
-class `datasets/gov/ivpk/adp/Catalog`["Catalog"]:::Entity {
-«optional»
-id : integer [0..1]
-}
-}
-`datasets/gov/ivpk/adp/Licence` --> "[0..1]" `datasets/gov/ivpk/adp/Catalog` : catalog<br/>«optional»
-"""
-        in mermaid
-    )
+    assert "classDiagram" in mermaid
+    assert "class Licence" in mermaid
+    assert "class Catalog" in mermaid
+    assert 'Licence --> "[0..1]" Catalog : catalog' in mermaid
 
     base_url = f"{settings.META_SITE_PROTOCOL}://{settings.META_SITE_DOMAIN}"
     dataset_pk = structure.dataset.pk
@@ -3401,7 +3393,7 @@ def test_generate_mermaid_model_click_links(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(),
+        dataset=DatasetFactory(metadata="datasets/gov/ivpk/adp"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -3434,6 +3426,7 @@ def test_generate_mermaid_with_base_chain_across_datasets(app: DjangoTestApp):
         file=FilerFileFactory(file=FileField(filename="file.csv", data=grandparent_manifest)),
         dataset=DatasetFactory(
             organization=OrganizationFactory(whitelisted_names=["datasets/gov/grand/"]),
+            metadata="datasets/gov/grand/dataset",
         ),
     )
     grandparent_structure.dataset.current_structure = grandparent_structure
@@ -3454,6 +3447,7 @@ def test_generate_mermaid_with_base_chain_across_datasets(app: DjangoTestApp):
         file=FilerFileFactory(file=FileField(filename="file.csv", data=parent_manifest)),
         dataset=DatasetFactory(
             organization=OrganizationFactory(whitelisted_names=["datasets/gov/parent/"]),
+            metadata="datasets/gov/parent/dataset",
         ),
     )
     parent_structure.dataset.current_structure = parent_structure
@@ -3476,6 +3470,7 @@ def test_generate_mermaid_with_base_chain_across_datasets(app: DjangoTestApp):
             title="Main",
             description="Root",
             organization=OrganizationFactory(whitelisted_names=["datasets/gov/main/"]),
+            metadata="datasets/gov/main/dataset",
         ),
     )
     main_structure.dataset.current_structure = main_structure
@@ -3484,32 +3479,12 @@ def test_generate_mermaid_with_base_chain_across_datasets(app: DjangoTestApp):
 
     mermaid = generate_mermaid_diagram(main_structure.dataset, main_version)
 
-    assert (
-        """
-classDiagram
-namespace `datasets/gov/grand/dataset` {
-class `datasets/gov/grand/dataset/GrandparentModel`["GrandparentModel"]:::Entity {
-«optional»
-id : integer [0..1]
-}
-}
-namespace `datasets/gov/parent/dataset` {
-class `datasets/gov/parent/dataset/ParentModel`["ParentModel"]:::Entity {
-«optional»
-id : integer [0..1]
-}
-}
-namespace `datasets/gov/main/dataset` {
-class `datasets/gov/main/dataset/ChildModel`["ChildModel"]:::Entity {
-«optional»
-id : integer [0..1]
-}
-}
-`datasets/gov/main/dataset/ChildModel` --|> `datasets/gov/parent/dataset/ParentModel`
-`datasets/gov/parent/dataset/ParentModel` --|> `datasets/gov/grand/dataset/GrandparentModel`
-"""
-        in mermaid
-    )
+    assert "classDiagram" in mermaid
+    assert "GrandparentModel" in mermaid
+    assert "ParentModel" in mermaid
+    assert "ChildModel" in mermaid
+    assert "ChildModel --|> ParentModel" in mermaid
+    assert "ParentModel --|> GrandparentModel" in mermaid
 
     base_url = f"{settings.META_SITE_PROTOCOL}://{settings.META_SITE_DOMAIN}"
     child_url = reverse(
@@ -3547,7 +3522,7 @@ def test_structure_export__scopes(app: DjangoTestApp, use_version):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description", metadata=False),
+        dataset=DatasetFactory(title="Title", description="Description", metadata="datasets/gov/ivpk/adp"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()

--- a/tests/structure/test_services.py
+++ b/tests/structure/test_services.py
@@ -1,3 +1,5 @@
+import datetime
+
 import pytest
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
@@ -1394,14 +1396,96 @@ def test_structure_with_existing_dataset(app: DjangoTestApp):
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure, version)
+    version2 = create_structure_objects(structure)
     assert list(
         Comment.objects.filter(
             type=Comment.STRUCTURE_ERROR,
             content_type=ContentType.objects.get_for_model(structure),
         ).values_list("body", flat=True)
     ) == ['Duomenų išteklius "datasets/gov/ivpk/adp" jau egzistuoja.']
-    assert Metadata.objects.filter(dataset=structure.dataset, metadata_version=version).count() == 0
+    assert Metadata.objects.filter(dataset=structure.dataset, metadata_version=version2).count() == 0
+
+
+@pytest.mark.django_db
+def test_same_manifest_name_blocked_across_two_datasets(app: DjangoTestApp):
+    manifest = (
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,resource1,,,,,,,,,,,,,,,,\n"
+        ",,,,City,,,,,,,,,,,\n"
+        ",,,,,id,integer,,,,5,,,open,,,Identifikatorius,,,\n"
+    )
+    org = OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])
+
+    structure1 = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=DatasetFactory(organization=org),
+    )
+    structure1.dataset.current_structure = structure1
+    structure1.dataset.save()
+    create_structure_objects(structure1)
+    assert Comment.objects.filter(type=Comment.STRUCTURE_ERROR).count() == 0
+
+    structure2 = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=DatasetFactory(organization=org),
+    )
+    structure2.dataset.current_structure = structure2
+    structure2.dataset.save()
+    version2 = create_structure_objects(structure2)
+    assert list(
+        Comment.objects.filter(
+            type=Comment.STRUCTURE_ERROR,
+            content_type=ContentType.objects.get_for_model(structure2),
+        ).values_list("body", flat=True)
+    ) == ['Duomenų išteklius "datasets/gov/ivpk/adp" jau egzistuoja.']
+    assert Metadata.objects.filter(dataset=structure2.dataset, metadata_version=version2).count() == 0
+
+
+@pytest.mark.django_db
+def test_reimport_after_publish_does_not_fail(app: DjangoTestApp):
+    manifest = (
+        "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",,resource1,,,,,,,,,,,,,,,,\n"
+        ",,,,City,,,,,,,,,,,\n"
+        ",,,,,id,integer,,,,5,,,open,,,Identifikatorius,,,\n"
+    )
+    user = UserFactory(is_staff=True)
+    app.set_user(user)
+
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
+    )
+    structure.dataset.current_structure = structure
+    structure.dataset.save()
+    draft_version = create_structure_objects(structure)
+    assert Comment.objects.filter(type=Comment.STRUCTURE_ERROR).count() == 0
+
+    metadata_ids = list(
+        Metadata.objects.filter(dataset=structure.dataset, metadata_version=draft_version).values_list("pk", flat=True)
+    )
+    form = app.get(reverse("version-create", args=[structure.dataset.pk, draft_version.pk])).forms["version-form"]
+    form["released"] = datetime.date.today() + datetime.timedelta(days=15)
+    form["version_type"] = "MAJOR"
+    form["metadata"] = metadata_ids
+    form.submit()
+
+    structure2 = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
+        dataset=structure.dataset,
+    )
+    structure.dataset.current_structure = structure2
+    structure.dataset.save()
+    create_structure_objects(structure2)
+    assert (
+        Comment.objects.filter(
+            type=Comment.STRUCTURE_ERROR,
+            content_type=ContentType.objects.get_for_model(structure2),
+        ).count()
+        == 0
+    )
 
 
 @pytest.mark.django_db
@@ -1420,13 +1504,14 @@ def test_structure_with_invalid_prefix_no_whitelist(app: DjangoTestApp):
     WhitelistedCodeName.objects.filter(organization=structure.dataset.organization).delete()
     structure.dataset.current_structure = structure
     structure.dataset.save()
+    dataset_name = structure.dataset.name
     create_structure_objects(structure)
     assert list(
         Comment.objects.filter(
             type=Comment.STRUCTURE_ERROR,
             content_type=ContentType.objects.get_for_model(structure),
         ).values_list("body", flat=True)
-    ) == ["Kodinis pavadinimas turi prasidėti nuo „datasets/gov/other“."]
+    ) == [f"Kodinis pavadinimas (datasets/gov/test/adp) nesutampa su rinkinio kodiniu pavadinimu {dataset_name}."]
 
 
 @pytest.mark.django_db
@@ -1446,15 +1531,14 @@ def test_structure_with_invalid_prefix_with_whitelist(app: DjangoTestApp):
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
+    dataset_name = structure.dataset.name
     create_structure_objects(structure)
     assert list(
         Comment.objects.filter(
             type=Comment.STRUCTURE_ERROR,
             content_type=ContentType.objects.get_for_model(structure),
         ).values_list("body", flat=True)
-    ) == [
-        "Kodinis pavadinimas turi prasidėti nuo „datasets/gov/other“ arba vieno iš leidžiamų kodinio pavadinimo pradžių: „datasets/gov/allowed/“."
-    ]
+    ) == [f"Kodinis pavadinimas (datasets/gov/test/adp) nesutampa su rinkinio kodiniu pavadinimu {dataset_name}."]
 
 
 @pytest.mark.django_db

--- a/tests/structure/test_services.py
+++ b/tests/structure/test_services.py
@@ -3406,7 +3406,7 @@ def test_generate_mermaid(app: DjangoTestApp):
 
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description"),
+        dataset=DatasetFactory(title="Title", description="Description", metadata="datasets/gov/ivpk/adp"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -3489,6 +3489,7 @@ def test_generate_mermaid_with_base_chain_across_datasets(app: DjangoTestApp):
         file=FilerFileFactory(file=FileField(filename="file.csv", data=grandparent_manifest)),
         dataset=DatasetFactory(
             organization=OrganizationFactory(whitelisted_names=["datasets/gov/grand/"]),
+            metadata="datasets/gov/grand/dataset",
         ),
     )
     grandparent_structure.dataset.current_structure = grandparent_structure

--- a/tests/structure/test_services.py
+++ b/tests/structure/test_services.py
@@ -92,7 +92,7 @@ def test_structure_prefixes(app: DjangoTestApp):
         ",,,,,,prefix,dcat,,,,,,,http://www.w3.org/ns/dcat#,,,,\n"
         ",,,,,,,dct,,,,,,,http://purl.org/dc/terms/,,,,"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -123,7 +123,7 @@ def test_structure_prefix_after_enum(app: DjangoTestApp):
         ",,,,,,prefix,dcat,,,,,,,http://www.w3.org/ns/dcat#,,,,\n"
         ",,,,,,,dct,,,,,,,http://purl.org/dc/terms/,,,,"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -145,7 +145,7 @@ def test_structure_datasets(app: DjangoTestApp):
         ",datasets/gov/ivpk/adp2,,,,,,,,,,,,,,,,,\n"
         ",datasets/gov/ivpk/adp3,,,,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp3")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -172,7 +172,7 @@ def test_structure_models_and_props(app: DjangoTestApp):
         ",,,,Catalog,,,id,,,,,,,,,Catalog,,\n"
         ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -266,7 +266,7 @@ def test_structure_with_base_model(app: DjangoTestApp):
         ",,,,Catalog,,,,,,,,,,,,,,\n"
         ",,,,,title,string,,,,2,,,open,dct:title,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -294,7 +294,7 @@ def test_structure_with_base_model_two_manifests(app: DjangoTestApp):
 
     base_structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest_base)),
-        dataset=DatasetFactory(organization=organization, metadata="datasets/gov/rc/ar/apskritis"),
+        dataset=DatasetFactory(organization=organization),
     )
 
     manifest_with_base = (
@@ -311,7 +311,7 @@ def test_structure_with_base_model_two_manifests(app: DjangoTestApp):
 
     structure_with_base = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest_with_base)),
-        dataset=DatasetFactory(organization=organization, metadata="datasets/gov/rc/ar/savivaldybe"),
+        dataset=DatasetFactory(organization=organization),
     )
 
     base_structure.dataset.current_structure = base_structure
@@ -343,7 +343,7 @@ def test_structure_with_property_ref(app: DjangoTestApp):
         ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -375,7 +375,7 @@ def test_structure_with_property_ref_two_manifests(app: DjangoTestApp):
 
     ref_object_structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=ref_manifest)),
-        dataset=DatasetFactory(organization=organization, metadata="datasets/gov/rc/ar/apskritis"),
+        dataset=DatasetFactory(organization=organization),
     )
 
     ref_object_structure.dataset.current_structure = ref_object_structure
@@ -396,7 +396,7 @@ def test_structure_with_property_ref_two_manifests(app: DjangoTestApp):
 
     structure_with_ref = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest_with_ref)),
-        dataset=DatasetFactory(organization=organization, metadata="datasets/gov/rc/ar/savivaldybe"),
+        dataset=DatasetFactory(organization=organization),
     )
 
     structure_with_ref.dataset.current_structure = structure_with_ref
@@ -423,7 +423,7 @@ def test_structure_with_model_ref(app: DjangoTestApp):
         ",,,,,title,string,,,,5,,,open,dct:title,,,,\n"
         ",,,,,continent,ref,Continent,,,5,,,open,dct:continent,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -457,7 +457,7 @@ def test_structure_with_denorm_prop(app: DjangoTestApp):
         ",,,,,country.id,,,,,5,,,open,,,,,,\n"
         ",,,,,country.continent.id,,,,,5,,,open,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -490,7 +490,7 @@ def test_structure_with_existing_structure(app: DjangoTestApp):
         "7,,,,City,,,,,,,,,,,,,,\n"
         "8,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp2")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     metadata_version = create_structure_objects(structure)
@@ -536,7 +536,7 @@ def test_structure_with_comments(app: DjangoTestApp):
         "6,,,,,,comment,type,,,,,,open,,,Property comment,,\n"
         "7,,,,,title,string,,,,5,,,open,dct:title,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     metadata_version = VersionFactory(dataset=structure.dataset)
     DatasetDistributionFactory(
         dataset=structure.dataset,
@@ -576,7 +576,7 @@ def test_structure_with_resource_and_existing_distribution(app: DjangoTestApp):
         "5,,,,Country,,,,,,,,,,,,,,\n"
         "6,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     metadata_version = VersionFactory(dataset=structure.dataset)
     distribution = DatasetDistributionFactory(
         dataset=structure.dataset, type="URL", download_url="http://www.example.com", metadata_version=metadata_version
@@ -605,7 +605,7 @@ def test_structure_with_resource_and_existing_distribution_without_title(app: Dj
         "5,,,,Country,,,,,,,,,,,,,,\n"
         "6,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     metadata_version = VersionFactory(dataset=structure.dataset)
     distribution = DatasetDistributionFactory(
         dataset=structure.dataset,
@@ -641,7 +641,7 @@ def test_structure_with_resource_and_without_distribution(app: DjangoTestApp):
         "5,,,,Country,,,,,,,,,,,,,,\n"
         "6,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -668,7 +668,7 @@ def test_structure_without_resource_and_existing_distribution(app: DjangoTestApp
         "2,,,,Country,,,,,,,,,,,,,,\n"
         ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     metadata_version = VersionFactory(dataset=structure.dataset)
     DatasetDistributionFactory(
         dataset=structure.dataset,
@@ -699,7 +699,7 @@ def test_structure_without_resource_and_existing_distribution_without_title(app:
         "2,,,,Country,,,,,,,,,,,,,,\n"
         ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     metadata_version = VersionFactory(dataset=structure.dataset)
     distribution = DatasetDistributionFactory(
         dataset=structure.dataset,
@@ -734,7 +734,7 @@ def test_structure_without_resource_and_existing_distribution_without_ns(app: Dj
         "2,,,,Country,,,,,,,,,,,,,,\n"
         ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     metadata_version = VersionFactory(dataset=structure.dataset)
     DatasetDistributionFactory(
         dataset=structure.dataset,
@@ -765,7 +765,7 @@ def test_structure_without_resource_and_distribution(app: DjangoTestApp):
         "2,,,,Country,,,,,,,,,,,,,,\n"
         ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -792,7 +792,7 @@ def test_structure_with_enums(app: DjangoTestApp):
         '9,,,,,,enum,,,"""CREATED""",,,,,,,,,\n'
         '10,,,,,,,,,"""MODIFIED""",,,,,,,,,\n'
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -821,7 +821,7 @@ def test_structure_with_enum_and_null_value(app: DjangoTestApp):
         ',,,,,,enum,,,"""CREATED""",,,,,,,,,\n'
         ',,,,,,,,,"""null""",,,,,,,,,\n'
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -846,7 +846,7 @@ def test_structure_with_two_enums_with_different_source_same_prepare_create_two_
         "9,,,,,,enum,,1,1,,,,,,,,,\n"
         "10,,,,,,,,2,1,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -870,7 +870,7 @@ def test_structure_with_enum_without_prepare_value_adds_comment_about_error(app:
         "1,,,,,type,integer,,,,5,,,,,,,,\n"
         ",,,,,,enum,,one,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -896,7 +896,7 @@ def test_structure_with_property_enum_ref_value_adds_comment_about_error(app: Dj
         ",,,,,,enum,SomeName,,1,,,,,,,,,\n"
         ",,,,,,,,,2,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -920,7 +920,7 @@ def test_structure_with_enum_with_wrong_type_prepare_adds_comment_about_error(ap
         "1,,,,,type,integer,,,,5,,,,,,,,\n"
         ",,,,,,enum,,one,hello,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -939,7 +939,7 @@ def test_structure_with_boolean_enum_with_invalid_value_adds_comment_about_error
         "1,,,,,type,boolean,,,,5,,,,,,,,\n"
         ",,,,,,enum,,taip,taip,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -969,7 +969,7 @@ def test_structure_with_params(app: DjangoTestApp):
         "8,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
         "9,,,,,type,string,,,,5,,,open,dct:type,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1007,7 +1007,7 @@ def test_structure_with_deleted_enums(app: DjangoTestApp):
         '13,,,,,,enum,,,"""CREATED""",,,,,,,,,\n'
         '14,,,,,,,,,"""MODIFIED""",,,,,,,,,\n'
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     metadata_version = create_structure_objects(structure)
@@ -1065,7 +1065,7 @@ def test_structure_with_deleted_params(app: DjangoTestApp):
         '7,,,,,,,,,"MEDIUM",,,,,,,,,\n'
         '8,,,,,,,,,"BIG",,,,,,,,,\n'
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     metadata_version = create_structure_objects(structure)
@@ -1108,7 +1108,7 @@ def test_structure_without_ids__prefixes(app: DjangoTestApp):
         "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
         ",,,,,,prefix,dcat,,,,,,,http://www.w3.org/ns/dcat#,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1134,7 +1134,7 @@ def test_structure_without_ids__enums(app: DjangoTestApp):
         ',,,,,,enum,Size,,"SMALL",,,,,,,,,\n'
         ',,,,,,,,,"BIG",,,,,,,,,\n'
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1161,7 +1161,7 @@ def test_structure_without_ids__params(app: DjangoTestApp):
         ',,,,,,param,ParamSize,,"SMALL",,,,,,,,,\n'
         ',,,,,,,,,"BIG",,,,,,,,,\n'
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1187,7 +1187,7 @@ def test_structure_without_ids__models(app: DjangoTestApp):
         "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
         ",,,,City,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1214,7 +1214,7 @@ def test_structure_without_ids__properties(app: DjangoTestApp):
         "2,,,,City,,,,,,,,,,,,,\n"
         ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1243,7 +1243,7 @@ def test_structure_without_ids__base(app: DjangoTestApp):
         ",,,Base,,,,,,,,,,,,,,,\n"
         "3,,,,City,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1271,7 +1271,7 @@ def test_structure_with_existing_prefixes(app: DjangoTestApp):
         ",,,,,,prefix,dcat,,,,,,,http://www.w3.org/ns/dcat#,,,,\n"
         ",,,,,,prefix,dcat,,,,,,,http://www.w3.org/ns/dcat#,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1291,7 +1291,7 @@ def test_structure_with_existing_enums(app: DjangoTestApp):
         ',,,,,,enum,Size,,"SMALL",,,,,,,,,\n'
         ',,,,,,,,,"SMALL",,,,,,,,,\n'
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1311,7 +1311,7 @@ def test_structure_with_existing_params(app: DjangoTestApp):
         ',,,,,,param,ParamSize,,"SMALL",,,,,,,,,\n'
         ',,,,,,,,,"SMALL",,,,,,,,,\n'
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1331,7 +1331,7 @@ def test_structure_with_existing_models(app: DjangoTestApp):
         ",,,,City,,,,,,,,,,,,,,\n"
         ",,,,City,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1352,7 +1352,7 @@ def test_structure_with_existing_properties(app: DjangoTestApp):
         ",,,,,id,integer,,,,5,,,open,,,Identifikatorius,,\n"
         ",,,,,id,integer,,,,5,,,open,,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1375,7 +1375,7 @@ def test_structure_with_existing_dataset(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"]), metadata="datasets/gov/ivpk/adp"),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -1392,7 +1392,7 @@ def test_structure_with_existing_dataset(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=structure.dataset.organization, metadata="datasets/gov/ivpk/adp"),
+        dataset=DatasetFactory(organization=structure.dataset.organization),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -1419,7 +1419,7 @@ def test_same_manifest_name_blocked_across_two_datasets(app: DjangoTestApp):
 
     structure1 = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=org, metadata="datasets/gov/ivpk/adp"),
+        dataset=DatasetFactory(organization=org),
     )
     structure1.dataset.current_structure = structure1
     structure1.dataset.save()
@@ -1428,7 +1428,7 @@ def test_same_manifest_name_blocked_across_two_datasets(app: DjangoTestApp):
 
     structure2 = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=org, metadata="datasets/gov/ivpk/adp"),
+        dataset=DatasetFactory(organization=org),
     )
     structure2.dataset.current_structure = structure2
     structure2.dataset.save()
@@ -1456,7 +1456,7 @@ def test_reimport_after_publish_does_not_fail(app: DjangoTestApp):
 
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"]), metadata="datasets/gov/ivpk/adp"),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -1551,7 +1551,7 @@ def test_structure_with_deleted_base(app: DjangoTestApp):
         "4,,,,City,,,,,,,,,,,,,,\n"
         "5,,,,Country,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -1592,7 +1592,7 @@ def test_average_level(app: DjangoTestApp):
         ",,,,,id,integer,,,,3,,,,,,,,,\n"
         ",,,,,title,string,,,,2,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1615,7 +1615,7 @@ def test_average_level_without_given_level(app: DjangoTestApp):
         ",,,,,country1,ref,Country,,,,,,,,,,,\n"  # level 4
         ",,,,,country2,ref,Country,,,,,,,dcat:country,,,,\n"  # level 5
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1637,7 +1637,7 @@ def test_uri_format(app: DjangoTestApp):
         "6,,,,Continent,,,,,,,,,,dct.Continent,,,,\n"
         "7,,,,,id,integer,,,,5,,,open,dct.identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1712,7 +1712,7 @@ def test_uri_prefix(app: DjangoTestApp):
         "6,,,,Continent,,,,,,,,,,spinta:Continent,,,,\n"
         "7,,,,,id,integer,,,,5,,,open,spinta:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -1785,7 +1785,7 @@ def test_structure_export__dataset_name(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description", metadata="datasets/gov/ivpk/adp"),
+        dataset=DatasetFactory(title="Title", description="Description"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -1809,7 +1809,7 @@ def test_structure_export__prefixes(app: DjangoTestApp, use_version):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description", metadata="datasets/gov/ivpk/adp"),
+        dataset=DatasetFactory(title="Title", description="Description"),
     )
 
     structure.dataset.current_structure = structure
@@ -1851,13 +1851,14 @@ def test_structure_export__with_resource_params(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description", metadata="datasets/gov/ivpk/adp"),
+        dataset=DatasetFactory(title="Title", description="Description"),
     )
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
 
-    version = create_structure_objects(structure)
+    version = structure.dataset.metadata.first().metadata_version
+    create_structure_objects(structure, version)
 
     resp = app.get(reverse("dataset-structure-export", args=[structure.dataset.pk, version.pk]))
     assert resp.text == (
@@ -1884,7 +1885,6 @@ def test_structure_export__multiple_versions(app: DjangoTestApp):
         title="Multi-Version Dataset",
         description="Dataset with multiple versions",
         organization=OrganizationFactory(whitelisted_names=["datasets/gov/test/"]),
-        metadata="datasets/gov/test/multi",
     )
 
     # Version 1: one model, one property, one prefix, one enum, and one param
@@ -2053,7 +2053,7 @@ def test_structure_export__models_and_props(app: DjangoTestApp, use_version):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description", metadata="datasets/gov/ivpk/adp"),
+        dataset=DatasetFactory(title="Title", description="Description", metadata=False),
     )
 
     structure.dataset.current_structure = structure
@@ -2104,7 +2104,7 @@ def test_structure_export__base_model(app: DjangoTestApp, use_version):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description", metadata="datasets/gov/ivpk/adp"),
+        dataset=DatasetFactory(title="Title", description="Description", metadata=False),
     )
 
     structure.dataset.current_structure = structure
@@ -2155,7 +2155,7 @@ def test_structure_export__property_ref(app: DjangoTestApp, use_version):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description", metadata="datasets/gov/ivpk/adp"),
+        dataset=DatasetFactory(title="Title", description="Description", metadata=False),
     )
 
     structure.dataset.current_structure = structure
@@ -2205,7 +2205,7 @@ def test_structure_export__model_ref(app: DjangoTestApp, use_version):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description", metadata="datasets/gov/ivpk/adp"),
+        dataset=DatasetFactory(title="Title", description="Description", metadata=False),
     )
 
     structure.dataset.current_structure = structure
@@ -2251,7 +2251,7 @@ def test_structure_export__comments(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description", metadata="datasets/gov/ivpk/adp"),
+        dataset=DatasetFactory(title="Title", description="Description", metadata=False),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -2294,7 +2294,7 @@ def test_structure_export__enums(app: DjangoTestApp, use_version):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description", metadata="datasets/gov/ivpk/adp"),
+        dataset=DatasetFactory(title="Title", description="Description", metadata=False),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -2350,7 +2350,7 @@ def test_structure_export__params(app: DjangoTestApp, use_version):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description", metadata="datasets/gov/ivpk/adp"),
+        dataset=DatasetFactory(title="Title", description="Description", metadata=False),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -2390,7 +2390,7 @@ def test_import_structure_with_wrong_datasets_name(app: DjangoTestApp):
         "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
         ",datasets/gov/ivpk/adp/ššš,,,,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp/ššš")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -2411,7 +2411,7 @@ def test_import_structure_with_errors_preserves_draft_metadata(app: DjangoTestAp
         "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
         ",datasets/gov/ivpk/adp/test,,,,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=valid_manifest)), dataset__metadata="datasets/gov/ivpk/adp/test")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=valid_manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     initial_version = create_structure_objects(structure)
@@ -2446,6 +2446,7 @@ def test_import_structure_with_errors_preserves_draft_metadata(app: DjangoTestAp
         object_id=broken_structure.pk,
     )
     assert comments.count() == 1
+    assert "kodiniame pavadinime gali būti naudojamos tik lotyniškos raidės." in comments[0].body
 
 
 @pytest.mark.django_db
@@ -2461,7 +2462,7 @@ def test_structure_resource__resource_title(app: DjangoTestApp):
         "5,,,,Country,,,,,,,,,,,,,,\n"
         "6,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -2483,7 +2484,7 @@ def test_structure_with_resource__dataset_title(app: DjangoTestApp):
         "5,,,,Country,,,,,,,,,,,,,,\n"
         "6,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -2505,7 +2506,7 @@ def test_structure_with_resource__no_title(app: DjangoTestApp):
         "5,,,,Country,,,,,,,,,,,,,,\n"
         "6,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -2527,7 +2528,7 @@ def test_structure_without_resource__dataset_title(app: DjangoTestApp):
         "4,,,,Country,,,,,,,,,,,,,,\n"
         "5,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -2562,7 +2563,7 @@ def test_structure_export_after_changing_model_name(app: DjangoTestApp):
         dataset=DatasetFactory(
             title="Title",
             description="Description",
-            metadata="dataset/org/test/test_dataset",
+            metadata=False,
             organization=OrganizationFactory(whitelisted_names=["dataset/org/test/"]),
         ),
     )
@@ -2619,16 +2620,13 @@ def test_structure_export_after_changing_dataset_title_and_description(app: Djan
         "id,dataset,resource,base,model,property,type,ref,source,prepare,prepare,level,status,visibility,access,uri,eli,title,description\n"
         "1,dataset/org/test/test_dataset,,,,,,,,,,,,,,,,Title,Description\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="dataset/org/test/test_dataset")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
 
     structure.dataset.current_structure = structure
     structure.dataset.organization = representative.content_object
     structure.dataset.save()
     WhitelistedCodeNameFactory(organization=representative.content_object, code_name="dataset/org/test/")
-    version = create_structure_objects(structure)
-    # Remove the factory-created metadata so the form updates
-    # the version-specific metadata created by the import.
-    structure.dataset.metadata.exclude(metadata_version=version).delete()
+    version = create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
 
     form = app.get(reverse("dataset-change", kwargs={"pk": structure.dataset.pk})).forms["dataset-form"]
     form["title"] = "Edited title"
@@ -2662,7 +2660,7 @@ def test_structure_export_after_changing_distribution_title_and_description(app:
         dataset=DatasetFactory(
             title="Dataset",
             description="Dataset description",
-            metadata="dataset/gov/test/test_dataset",
+            metadata=False,
             organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]),
         ),
     )
@@ -2712,7 +2710,7 @@ def test_structure_export_after_changing_distribution_level(app: DjangoTestApp):
         dataset=DatasetFactory(
             title="Dataset",
             description="Dataset description",
-            metadata="dataset/gov/test/test_dataset",
+            metadata=False,
             organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]),
         ),
     )
@@ -2766,13 +2764,12 @@ def test_structure_export__visibility_row(app: DjangoTestApp):
             title="Pavadinimas",
             description="Aprašymas",
             organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]),
-            metadata="dataset/gov/test/example",
         ),
     )
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure)
+    create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
 
     resp = app.get(reverse("dataset-structure-export-no-version", args=[structure.dataset.pk]))
     assert resp.text == (
@@ -2808,13 +2805,12 @@ def test_structure_export__eli_row(app: DjangoTestApp):
             title="Pavadinimas",
             description="Aprašymas",
             organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]),
-            metadata="dataset/gov/test/example",
         ),
     )
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure)
+    create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
 
     resp = app.get(reverse("dataset-structure-export-no-version", args=[structure.dataset.pk]))
     assert resp.text == (
@@ -2850,13 +2846,12 @@ def test_structure_export__status_row(app: DjangoTestApp, setup_default_status_d
             title="Pavadinimas",
             description="Aprašymas",
             organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]),
-            metadata="dataset/gov/test/example",
         ),
     )
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    create_structure_objects(structure)
+    create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
 
     resp = app.get(reverse("dataset-structure-export-no-version", args=[structure.dataset.pk]))
     assert resp.text == (
@@ -2885,7 +2880,7 @@ def test_structure_models_props_and_enums_with_visibility_status_eli(app: Django
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]), metadata="dataset/gov/test/example"),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"])),
     )
 
     structure.dataset.current_structure = structure
@@ -2942,7 +2937,7 @@ def test_structure_with_property_level_higher_then_model(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]), metadata="dataset/gov/test/example"),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"])),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -2966,7 +2961,7 @@ def test_structure_with_enum_level_higher_then_property(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]), metadata="dataset/gov/test/example"),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"])),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -2995,7 +2990,7 @@ def test_structure_with_enum_level_higher_then_model(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]), metadata="dataset/gov/test/example"),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"])),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -3015,7 +3010,7 @@ def test_structure_with_origin_source_type_headers(app: DjangoTestApp):
         "1,datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,,,\n"
         ",,,,City,,,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     metadata_version = create_structure_objects(structure)
@@ -3047,7 +3042,7 @@ class TestStructureBaseModels:
 
         structure = DatasetStructureFactory(
             file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]), metadata="dataset/gov/test/example"),
+            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"])),
         )
         structure.dataset.current_structure = structure
         structure.dataset.save()
@@ -3074,7 +3069,7 @@ class TestStructureBaseModels:
         )
         structure_model = DatasetStructureFactory(
             file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest_with_model_definition)),
-            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]), metadata="dataset/gov/test/example"),
+            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"])),
         )
         structure_model.dataset.current_structure = structure_model
         structure_model.dataset.save()
@@ -3092,7 +3087,7 @@ class TestStructureBaseModels:
         )
         structure_base = DatasetStructureFactory(
             file=FilerFileFactory(file=FileField(filename="file2.csv", data=manifest_with_base_reference)),
-            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/org/test/"]), metadata="dataset/org/test/example2"),
+            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/org/test/"])),
         )
         structure_base.dataset.current_structure = structure_base
         structure_base.dataset.save()
@@ -3120,7 +3115,7 @@ class TestStructureBaseModels:
         )
         structure_model = DatasetStructureFactory(
             file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest_with_model_definition)),
-            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]), metadata="dataset/gov/test/example"),
+            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"])),
         )
         structure_model.dataset.current_structure = structure_model
         structure_model.dataset.save()
@@ -3138,7 +3133,7 @@ class TestStructureBaseModels:
         )
         structure_base = DatasetStructureFactory(
             file=FilerFileFactory(file=FileField(filename="file2.csv", data=manifest_with_base_reference)),
-            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/org/test/"]), metadata="dataset/org/test/example2"),
+            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/org/test/"])),
         )
         structure_base.dataset.current_structure = structure_base
         structure_base.dataset.save()
@@ -3151,7 +3146,7 @@ class TestStructureBaseModels:
         error_comment = Comment.objects.get(content_type=ContentType.objects.get_for_model(Model))
         assert error_comment.type == Comment.STRUCTURE_ERROR
         assert error_comment.body == (
-            "Nepavyko susieti bazinio modelio „dataset/gov/test/example/Animal”. "
+            "Nepavyko susieti bazinio modelio „dataset/gov/test/example/Animal“. "
             "Įsitikinkite, kad jis egzistuoja ir turi patvirtintą (stabilią) versiją."
         )
 
@@ -3169,7 +3164,7 @@ class TestStructureBaseModels:
 
         structure = DatasetStructureFactory(
             file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]), metadata="dataset/gov/test/example"),
+            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"])),
         )
         structure.dataset.current_structure = structure
         structure.dataset.save()
@@ -3182,7 +3177,7 @@ class TestStructureBaseModels:
         error_comment = Comment.objects.get(content_type=ContentType.objects.get_for_model(Model))
         assert error_comment.type == Comment.STRUCTURE_ERROR
         assert error_comment.body == (
-            "Nepavyko susieti bazinio modelio „dataset/gov/test/example/Animal”. "
+            "Nepavyko susieti bazinio modelio „dataset/gov/test/example/Animal“. "
             "Įsitikinkite, kad jis egzistuoja ir turi patvirtintą (stabilią) versiją."
         )
 
@@ -3204,7 +3199,7 @@ class TestStructureComments:
 
         structure = DatasetStructureFactory(
             file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]), metadata="dataset/gov/test/dataset"),
+            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"])),
         )
         structure.dataset.current_structure = structure
         structure.dataset.save()
@@ -3232,7 +3227,7 @@ def test_structure_boolean_enums(app: DjangoTestApp):
         "5,,,,,,,,False,false,,,,,,,,,,,\n"
     )
 
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/dataset")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
 
@@ -3257,7 +3252,7 @@ def test_structure_boolean_enums_invalid_source(app: DjangoTestApp):
         "5,,,,,,,,False,False,,,,,,,,,,,\n"
     )
 
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/dataset")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
 
@@ -3282,7 +3277,7 @@ def test_structure_number_enums(app: DjangoTestApp):
         ",,,,,,,,1.3,1.4,,,,,,,,,,,\n"
     )
 
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/example")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
 
@@ -3304,7 +3299,7 @@ def test_unresolvable_ref_creates_structure_error_comment(app: DjangoTestApp):
         "1,,,,Country,,,,,,,,,,,,,,\n"
         ",,,,,continent,ref,nonexistent/Continent,,,5,,,open,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -3318,7 +3313,7 @@ def test_unresolvable_ref_creates_structure_error_comment(app: DjangoTestApp):
     )
     assert error_comments.count() == 1
     assert error_comments.first().body == (
-        "Nepavyko susieti savybės „continent” per nurodytą ryšį „datasets/gov/ivpk/adp/nonexistent/Continent”. "
+        "Nepavyko susieti savybės „continent“ per nurodytą ryšį „datasets/gov/ivpk/adp/nonexistent/Continent“. "
         "Įsitikinkite, kad nurodytas modelis egzistuoja."
     )
 
@@ -3333,7 +3328,7 @@ def test_resolvable_ref_does_not_create_structure_error_comment(app: DjangoTestA
         "2,,,,Continent,,,,,,,,,,,,,,\n"
         ",,,,,id,integer,,,,5,,,open,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     create_structure_objects(structure)
@@ -3356,16 +3351,29 @@ def test_generate_mermaid(app: DjangoTestApp):
 
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description", metadata="datasets/gov/ivpk/adp"),
+        dataset=DatasetFactory(title="Title", description="Description"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
     mermaid = generate_mermaid_diagram(structure.dataset, version)
-    assert "classDiagram" in mermaid
-    assert "class Licence" in mermaid
-    assert "class Catalog" in mermaid
-    assert 'Licence --> "[0..1]" Catalog : catalog' in mermaid
+    assert (
+        """
+classDiagram
+namespace `datasets/gov/ivpk/adp` {
+class `datasets/gov/ivpk/adp/Licence`["Licence"]:::Entity {
+«optional»
+id : integer [0..1]
+}
+class `datasets/gov/ivpk/adp/Catalog`["Catalog"]:::Entity {
+«optional»
+id : integer [0..1]
+}
+}
+`datasets/gov/ivpk/adp/Licence` --> "[0..1]" `datasets/gov/ivpk/adp/Catalog` : catalog<br/>«optional»
+"""
+        in mermaid
+    )
 
     base_url = f"{settings.META_SITE_PROTOCOL}://{settings.META_SITE_DOMAIN}"
     dataset_pk = structure.dataset.pk
@@ -3393,7 +3401,7 @@ def test_generate_mermaid_model_click_links(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(metadata="datasets/gov/ivpk/adp"),
+        dataset=DatasetFactory(),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -3426,7 +3434,6 @@ def test_generate_mermaid_with_base_chain_across_datasets(app: DjangoTestApp):
         file=FilerFileFactory(file=FileField(filename="file.csv", data=grandparent_manifest)),
         dataset=DatasetFactory(
             organization=OrganizationFactory(whitelisted_names=["datasets/gov/grand/"]),
-            metadata="datasets/gov/grand/dataset",
         ),
     )
     grandparent_structure.dataset.current_structure = grandparent_structure
@@ -3447,7 +3454,6 @@ def test_generate_mermaid_with_base_chain_across_datasets(app: DjangoTestApp):
         file=FilerFileFactory(file=FileField(filename="file.csv", data=parent_manifest)),
         dataset=DatasetFactory(
             organization=OrganizationFactory(whitelisted_names=["datasets/gov/parent/"]),
-            metadata="datasets/gov/parent/dataset",
         ),
     )
     parent_structure.dataset.current_structure = parent_structure
@@ -3470,7 +3476,6 @@ def test_generate_mermaid_with_base_chain_across_datasets(app: DjangoTestApp):
             title="Main",
             description="Root",
             organization=OrganizationFactory(whitelisted_names=["datasets/gov/main/"]),
-            metadata="datasets/gov/main/dataset",
         ),
     )
     main_structure.dataset.current_structure = main_structure
@@ -3479,12 +3484,32 @@ def test_generate_mermaid_with_base_chain_across_datasets(app: DjangoTestApp):
 
     mermaid = generate_mermaid_diagram(main_structure.dataset, main_version)
 
-    assert "classDiagram" in mermaid
-    assert "GrandparentModel" in mermaid
-    assert "ParentModel" in mermaid
-    assert "ChildModel" in mermaid
-    assert "ChildModel --|> ParentModel" in mermaid
-    assert "ParentModel --|> GrandparentModel" in mermaid
+    assert (
+        """
+classDiagram
+namespace `datasets/gov/grand/dataset` {
+class `datasets/gov/grand/dataset/GrandparentModel`["GrandparentModel"]:::Entity {
+«optional»
+id : integer [0..1]
+}
+}
+namespace `datasets/gov/parent/dataset` {
+class `datasets/gov/parent/dataset/ParentModel`["ParentModel"]:::Entity {
+«optional»
+id : integer [0..1]
+}
+}
+namespace `datasets/gov/main/dataset` {
+class `datasets/gov/main/dataset/ChildModel`["ChildModel"]:::Entity {
+«optional»
+id : integer [0..1]
+}
+}
+`datasets/gov/main/dataset/ChildModel` --|> `datasets/gov/parent/dataset/ParentModel`
+`datasets/gov/parent/dataset/ParentModel` --|> `datasets/gov/grand/dataset/GrandparentModel`
+"""
+        in mermaid
+    )
 
     base_url = f"{settings.META_SITE_PROTOCOL}://{settings.META_SITE_DOMAIN}"
     child_url = reverse(
@@ -3522,7 +3547,7 @@ def test_structure_export__scopes(app: DjangoTestApp, use_version):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description", metadata="datasets/gov/ivpk/adp"),
+        dataset=DatasetFactory(title="Title", description="Description", metadata=False),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()

--- a/tests/structure/test_services.py
+++ b/tests/structure/test_services.py
@@ -145,7 +145,8 @@ def test_structure_datasets(app: DjangoTestApp):
         ",datasets/gov/ivpk/adp2,,,,,,,,,,,,,,,,,\n"
         ",datasets/gov/ivpk/adp3,,,,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp3")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -294,7 +295,7 @@ def test_structure_with_base_model_two_manifests(app: DjangoTestApp):
 
     base_structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest_base)),
-        dataset=DatasetFactory(organization=organization),
+        dataset=DatasetFactory(organization=organization, metadata="datasets/gov/rc/ar/apskritis"),
     )
 
     manifest_with_base = (
@@ -311,7 +312,7 @@ def test_structure_with_base_model_two_manifests(app: DjangoTestApp):
 
     structure_with_base = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest_with_base)),
-        dataset=DatasetFactory(organization=organization),
+        dataset=DatasetFactory(organization=organization, metadata="datasets/gov/rc/ar/savivaldybe"),
     )
 
     base_structure.dataset.current_structure = base_structure
@@ -375,7 +376,7 @@ def test_structure_with_property_ref_two_manifests(app: DjangoTestApp):
 
     ref_object_structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=ref_manifest)),
-        dataset=DatasetFactory(organization=organization),
+        dataset=DatasetFactory(organization=organization, metadata="datasets/gov/rc/ar/apskritis"),
     )
 
     ref_object_structure.dataset.current_structure = ref_object_structure
@@ -396,7 +397,7 @@ def test_structure_with_property_ref_two_manifests(app: DjangoTestApp):
 
     structure_with_ref = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest_with_ref)),
-        dataset=DatasetFactory(organization=organization),
+        dataset=DatasetFactory(organization=organization, metadata="datasets/gov/rc/ar/savivaldybe")
     )
 
     structure_with_ref.dataset.current_structure = structure_with_ref
@@ -490,7 +491,8 @@ def test_structure_with_existing_structure(app: DjangoTestApp):
         "7,,,,City,,,,,,,,,,,,,,\n"
         "8,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp2")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
     structure.dataset.current_structure = structure
     structure.dataset.save()
     metadata_version = create_structure_objects(structure)
@@ -498,7 +500,7 @@ def test_structure_with_existing_structure(app: DjangoTestApp):
 
     new_manifest = (
         "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
-        "2,datasets/gov/ivpk/adp2/updated,,,,,,,,,,,,,,,,,\n"
+        "2,datasets/gov/ivpk/adp2,,,,,,,,,,,,,,,,,\n"
         ",,,,,,prefix,dct,,,,,,,http://www.purl.org/dc/terms/,,,,\n"
         ",,resource2,,,,,,,,,,,,,,,,\n"
         "3,,,,CountryUpdated,,,,,,,,,,,,,,\n"
@@ -511,8 +513,8 @@ def test_structure_with_existing_structure(app: DjangoTestApp):
     structure.dataset.save()
     metadata_version = create_structure_objects(structure, metadata_version)
     assert Metadata.objects.filter(dataset=structure.dataset, metadata_version=metadata_version).count() == 7
-    assert Metadata.objects.get(uuid="2").name == "datasets/gov/ivpk/adp2/updated"
-    assert Metadata.objects.get(uuid="3").name == "datasets/gov/ivpk/adp2/updated/CountryUpdated"
+    assert Metadata.objects.get(uuid="2").name == "datasets/gov/ivpk/adp2"
+    assert Metadata.objects.get(uuid="3").name == "datasets/gov/ivpk/adp2/CountryUpdated"
     assert Metadata.objects.get(uuid="4").type == "string"
     assert Metadata.objects.filter(uuid="1").count() == 0
     assert Metadata.objects.filter(uuid="6").count() == 0
@@ -1885,6 +1887,7 @@ def test_structure_export__multiple_versions(app: DjangoTestApp):
         title="Multi-Version Dataset",
         description="Dataset with multiple versions",
         organization=OrganizationFactory(whitelisted_names=["datasets/gov/test/"]),
+        metadata="datasets/gov/test/multi"
     )
 
     # Version 1: one model, one property, one prefix, one enum, and one param
@@ -2053,7 +2056,7 @@ def test_structure_export__models_and_props(app: DjangoTestApp, use_version):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description", metadata=False),
+        dataset=DatasetFactory(title="Title", description="Description"),
     )
 
     structure.dataset.current_structure = structure
@@ -2104,7 +2107,7 @@ def test_structure_export__base_model(app: DjangoTestApp, use_version):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description", metadata=False),
+        dataset=DatasetFactory(title="Title", description="Description"),
     )
 
     structure.dataset.current_structure = structure
@@ -2155,7 +2158,7 @@ def test_structure_export__property_ref(app: DjangoTestApp, use_version):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description", metadata=False),
+        dataset=DatasetFactory(title="Title", description="Description"),
     )
 
     structure.dataset.current_structure = structure
@@ -2205,7 +2208,7 @@ def test_structure_export__model_ref(app: DjangoTestApp, use_version):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description", metadata=False),
+        dataset=DatasetFactory(title="Title", description="Description"),
     )
 
     structure.dataset.current_structure = structure
@@ -2251,7 +2254,7 @@ def test_structure_export__comments(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description", metadata=False),
+        dataset=DatasetFactory(title="Title", description="Description"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -2294,7 +2297,7 @@ def test_structure_export__enums(app: DjangoTestApp, use_version):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description", metadata=False),
+        dataset=DatasetFactory(title="Title", description="Description"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -2350,7 +2353,7 @@ def test_structure_export__params(app: DjangoTestApp, use_version):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description", metadata=False),
+        dataset=DatasetFactory(title="Title", description="Description"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -2390,7 +2393,8 @@ def test_import_structure_with_wrong_datasets_name(app: DjangoTestApp):
         "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
         ",datasets/gov/ivpk/adp/ššš,,,,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp/ššš")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -2409,7 +2413,7 @@ def test_import_structure_with_wrong_datasets_name(app: DjangoTestApp):
 def test_import_structure_with_errors_preserves_draft_metadata(app: DjangoTestApp):
     valid_manifest = (
         "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
-        ",datasets/gov/ivpk/adp/test,,,,,,,,,,,,,,,,,\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
     )
     structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=valid_manifest)))
     structure.dataset.current_structure = structure
@@ -2425,7 +2429,8 @@ def test_import_structure_with_errors_preserves_draft_metadata(app: DjangoTestAp
 
     broken_manifest = (
         "id,dataset,resource,base,model,property,type,ref,source,prepare,level,status,visibility,access,uri,eli,title,description,count\n"
-        ",datasets/gov/ivpk/adp/ššš,,,,,,,,,,,,,,,,,\n"
+        ",datasets/gov/ivpk/adp,,,,,,,,,,,,,,,,,\n"
+        ",very,broken,manifest,broken,,,,,,,,,,,,,,\n"
     )
     broken_structure = DatasetStructureFactory(
         dataset=structure.dataset,
@@ -2446,7 +2451,7 @@ def test_import_structure_with_errors_preserves_draft_metadata(app: DjangoTestAp
         object_id=broken_structure.pk,
     )
     assert comments.count() == 1
-    assert "kodiniame pavadinime gali būti naudojamos tik lotyniškos raidės." in comments[0].body
+    assert "Pirmas modelio kodinio pavadinimo simbolis turi būti didžioji raidė" in comments[0].body
 
 
 @pytest.mark.django_db
@@ -2563,7 +2568,7 @@ def test_structure_export_after_changing_model_name(app: DjangoTestApp):
         dataset=DatasetFactory(
             title="Title",
             description="Description",
-            metadata=False,
+            metadata="dataset/org/test/test_dataset",
             organization=OrganizationFactory(whitelisted_names=["dataset/org/test/"]),
         ),
     )
@@ -2620,7 +2625,8 @@ def test_structure_export_after_changing_dataset_title_and_description(app: Djan
         "id,dataset,resource,base,model,property,type,ref,source,prepare,prepare,level,status,visibility,access,uri,eli,title,description\n"
         "1,dataset/org/test/test_dataset,,,,,,,,,,,,,,,,Title,Description\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    dataset = DatasetFactory(metadata="dataset/org/test/test_dataset")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
 
     structure.dataset.current_structure = structure
     structure.dataset.organization = representative.content_object
@@ -2660,7 +2666,7 @@ def test_structure_export_after_changing_distribution_title_and_description(app:
         dataset=DatasetFactory(
             title="Dataset",
             description="Dataset description",
-            metadata=False,
+            metadata="dataset/gov/test/test_dataset",
             organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]),
         ),
     )
@@ -2710,7 +2716,7 @@ def test_structure_export_after_changing_distribution_level(app: DjangoTestApp):
         dataset=DatasetFactory(
             title="Dataset",
             description="Dataset description",
-            metadata=False,
+            metadata="dataset/gov/test/test_dataset",
             organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]),
         ),
     )
@@ -2763,6 +2769,7 @@ def test_structure_export__visibility_row(app: DjangoTestApp):
         dataset=DatasetFactory(
             title="Pavadinimas",
             description="Aprašymas",
+            metadata="dataset/gov/test/example",
             organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]),
         ),
     )
@@ -2804,6 +2811,7 @@ def test_structure_export__eli_row(app: DjangoTestApp):
         dataset=DatasetFactory(
             title="Pavadinimas",
             description="Aprašymas",
+            metadata="dataset/gov/test/example",
             organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]),
         ),
     )
@@ -2845,6 +2853,7 @@ def test_structure_export__status_row(app: DjangoTestApp, setup_default_status_d
         dataset=DatasetFactory(
             title="Pavadinimas",
             description="Aprašymas",
+            metadata="dataset/gov/test/example",
             organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]),
         ),
     )
@@ -2880,7 +2889,7 @@ def test_structure_models_props_and_enums_with_visibility_status_eli(app: Django
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"])),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]), metadata="dataset/gov/test/example"),
     )
 
     structure.dataset.current_structure = structure
@@ -2937,7 +2946,7 @@ def test_structure_with_property_level_higher_then_model(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"])),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]), metadata="dataset/gov/test/example"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -2961,7 +2970,7 @@ def test_structure_with_enum_level_higher_then_property(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"])),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]), metadata="dataset/gov/test/example"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -2990,7 +2999,7 @@ def test_structure_with_enum_level_higher_then_model(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"])),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]), metadata="dataset/gov/test/example"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -3039,10 +3048,9 @@ class TestStructureBaseModels:
             ",,,,,action,string,,source_dog_action,,4,completed,package,protected,,,,\n"
             ",,,/,,,,,,,,,,,,,,\n"
         )
-
         structure = DatasetStructureFactory(
             file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"])),
+            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]), metadata="dataset/gov/test/example"),
         )
         structure.dataset.current_structure = structure
         structure.dataset.save()
@@ -3069,7 +3077,7 @@ class TestStructureBaseModels:
         )
         structure_model = DatasetStructureFactory(
             file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest_with_model_definition)),
-            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"])),
+            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]), metadata="dataset/gov/test/example"),
         )
         structure_model.dataset.current_structure = structure_model
         structure_model.dataset.save()
@@ -3087,7 +3095,7 @@ class TestStructureBaseModels:
         )
         structure_base = DatasetStructureFactory(
             file=FilerFileFactory(file=FileField(filename="file2.csv", data=manifest_with_base_reference)),
-            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/org/test/"])),
+            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/org/test/"]), metadata="dataset/org/test/example2"),
         )
         structure_base.dataset.current_structure = structure_base
         structure_base.dataset.save()
@@ -3115,7 +3123,7 @@ class TestStructureBaseModels:
         )
         structure_model = DatasetStructureFactory(
             file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest_with_model_definition)),
-            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"])),
+            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]), metadata="dataset/gov/test/example"),
         )
         structure_model.dataset.current_structure = structure_model
         structure_model.dataset.save()
@@ -3133,7 +3141,7 @@ class TestStructureBaseModels:
         )
         structure_base = DatasetStructureFactory(
             file=FilerFileFactory(file=FileField(filename="file2.csv", data=manifest_with_base_reference)),
-            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/org/test/"])),
+            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/org/test/"]), metadata="dataset/org/test/example2"),
         )
         structure_base.dataset.current_structure = structure_base
         structure_base.dataset.save()
@@ -3164,7 +3172,7 @@ class TestStructureBaseModels:
 
         structure = DatasetStructureFactory(
             file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"])),
+            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]), metadata="dataset/gov/test/example"),
         )
         structure.dataset.current_structure = structure
         structure.dataset.save()
@@ -3199,7 +3207,7 @@ class TestStructureComments:
 
         structure = DatasetStructureFactory(
             file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"])),
+            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]), metadata="dataset/gov/test/dataset"),
         )
         structure.dataset.current_structure = structure
         structure.dataset.save()
@@ -3226,8 +3234,8 @@ def test_structure_boolean_enums(app: DjangoTestApp):
         "4,,,,,,enum,,True,true,,,,,,,,,,,\n"
         "5,,,,,,,,False,false,,,,,,,,,,,\n"
     )
-
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    dataset = DatasetFactory(metadata="datasets/gov/ivpk/dataset")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
     structure.dataset.current_structure = structure
     structure.dataset.save()
 
@@ -3251,8 +3259,8 @@ def test_structure_boolean_enums_invalid_source(app: DjangoTestApp):
         "4,,,,,,enum,,True,True,,,,,,,,,,,\n"
         "5,,,,,,,,False,False,,,,,,,,,,,\n"
     )
-
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    dataset = DatasetFactory(metadata="datasets/gov/ivpk/dataset")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
     structure.dataset.current_structure = structure
     structure.dataset.save()
 
@@ -3276,8 +3284,8 @@ def test_structure_number_enums(app: DjangoTestApp):
         ",,,,,,enum,,1.1,1.2,,,,,,,,,,,\n"
         ",,,,,,,,1.3,1.4,,,,,,,,,,,\n"
     )
-
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    dataset = DatasetFactory(metadata="datasets/gov/ivpk/example")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
     structure.dataset.current_structure = structure
     structure.dataset.save()
 
@@ -3547,7 +3555,7 @@ def test_structure_export__scopes(app: DjangoTestApp, use_version):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description", metadata=False),
+        dataset=DatasetFactory(title="Title", description="Description"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()

--- a/tests/structure/test_services.py
+++ b/tests/structure/test_services.py
@@ -146,7 +146,9 @@ def test_structure_datasets(app: DjangoTestApp):
         ",datasets/gov/ivpk/adp3,,,,,,,,,,,,,,,,,\n"
     )
     dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp3")
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset
+    )
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -397,7 +399,7 @@ def test_structure_with_property_ref_two_manifests(app: DjangoTestApp):
 
     structure_with_ref = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest_with_ref)),
-        dataset=DatasetFactory(organization=organization, metadata="datasets/gov/rc/ar/savivaldybe")
+        dataset=DatasetFactory(organization=organization, metadata="datasets/gov/rc/ar/savivaldybe"),
     )
 
     structure_with_ref.dataset.current_structure = structure_with_ref
@@ -492,7 +494,9 @@ def test_structure_with_existing_structure(app: DjangoTestApp):
         "8,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,,\n"
     )
     dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp2")
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset
+    )
     structure.dataset.current_structure = structure
     structure.dataset.save()
     metadata_version = create_structure_objects(structure)
@@ -1887,7 +1891,7 @@ def test_structure_export__multiple_versions(app: DjangoTestApp):
         title="Multi-Version Dataset",
         description="Dataset with multiple versions",
         organization=OrganizationFactory(whitelisted_names=["datasets/gov/test/"]),
-        metadata="datasets/gov/test/multi"
+        metadata="datasets/gov/test/multi",
     )
 
     # Version 1: one model, one property, one prefix, one enum, and one param
@@ -2394,7 +2398,9 @@ def test_import_structure_with_wrong_datasets_name(app: DjangoTestApp):
         ",datasets/gov/ivpk/adp/ššš,,,,,,,,,,,,,,,,,\n"
     )
     dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp/ššš")
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset
+    )
 
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -2626,7 +2632,9 @@ def test_structure_export_after_changing_dataset_title_and_description(app: Djan
         "1,dataset/org/test/test_dataset,,,,,,,,,,,,,,,,Title,Description\n"
     )
     dataset = DatasetFactory(metadata="dataset/org/test/test_dataset")
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset
+    )
 
     structure.dataset.current_structure = structure
     structure.dataset.organization = representative.content_object
@@ -2889,7 +2897,10 @@ def test_structure_models_props_and_enums_with_visibility_status_eli(app: Django
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]), metadata="dataset/gov/test/example"),
+        dataset=DatasetFactory(
+            organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]),
+            metadata="dataset/gov/test/example",
+        ),
     )
 
     structure.dataset.current_structure = structure
@@ -2946,7 +2957,10 @@ def test_structure_with_property_level_higher_then_model(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]), metadata="dataset/gov/test/example"),
+        dataset=DatasetFactory(
+            organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]),
+            metadata="dataset/gov/test/example",
+        ),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -2970,7 +2984,10 @@ def test_structure_with_enum_level_higher_then_property(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]), metadata="dataset/gov/test/example"),
+        dataset=DatasetFactory(
+            organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]),
+            metadata="dataset/gov/test/example",
+        ),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -2999,7 +3016,10 @@ def test_structure_with_enum_level_higher_then_model(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]), metadata="dataset/gov/test/example"),
+        dataset=DatasetFactory(
+            organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]),
+            metadata="dataset/gov/test/example",
+        ),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -3050,7 +3070,10 @@ class TestStructureBaseModels:
         )
         structure = DatasetStructureFactory(
             file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]), metadata="dataset/gov/test/example"),
+            dataset=DatasetFactory(
+                organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]),
+                metadata="dataset/gov/test/example",
+            ),
         )
         structure.dataset.current_structure = structure
         structure.dataset.save()
@@ -3077,7 +3100,10 @@ class TestStructureBaseModels:
         )
         structure_model = DatasetStructureFactory(
             file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest_with_model_definition)),
-            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]), metadata="dataset/gov/test/example"),
+            dataset=DatasetFactory(
+                organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]),
+                metadata="dataset/gov/test/example",
+            ),
         )
         structure_model.dataset.current_structure = structure_model
         structure_model.dataset.save()
@@ -3095,7 +3121,10 @@ class TestStructureBaseModels:
         )
         structure_base = DatasetStructureFactory(
             file=FilerFileFactory(file=FileField(filename="file2.csv", data=manifest_with_base_reference)),
-            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/org/test/"]), metadata="dataset/org/test/example2"),
+            dataset=DatasetFactory(
+                organization=OrganizationFactory(whitelisted_names=["dataset/org/test/"]),
+                metadata="dataset/org/test/example2",
+            ),
         )
         structure_base.dataset.current_structure = structure_base
         structure_base.dataset.save()
@@ -3123,7 +3152,10 @@ class TestStructureBaseModels:
         )
         structure_model = DatasetStructureFactory(
             file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest_with_model_definition)),
-            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]), metadata="dataset/gov/test/example"),
+            dataset=DatasetFactory(
+                organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]),
+                metadata="dataset/gov/test/example",
+            ),
         )
         structure_model.dataset.current_structure = structure_model
         structure_model.dataset.save()
@@ -3141,7 +3173,10 @@ class TestStructureBaseModels:
         )
         structure_base = DatasetStructureFactory(
             file=FilerFileFactory(file=FileField(filename="file2.csv", data=manifest_with_base_reference)),
-            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/org/test/"]), metadata="dataset/org/test/example2"),
+            dataset=DatasetFactory(
+                organization=OrganizationFactory(whitelisted_names=["dataset/org/test/"]),
+                metadata="dataset/org/test/example2",
+            ),
         )
         structure_base.dataset.current_structure = structure_base
         structure_base.dataset.save()
@@ -3172,7 +3207,10 @@ class TestStructureBaseModels:
 
         structure = DatasetStructureFactory(
             file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]), metadata="dataset/gov/test/example"),
+            dataset=DatasetFactory(
+                organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]),
+                metadata="dataset/gov/test/example",
+            ),
         )
         structure.dataset.current_structure = structure
         structure.dataset.save()
@@ -3207,7 +3245,10 @@ class TestStructureComments:
 
         structure = DatasetStructureFactory(
             file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-            dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]), metadata="dataset/gov/test/dataset"),
+            dataset=DatasetFactory(
+                organization=OrganizationFactory(whitelisted_names=["dataset/gov/test/"]),
+                metadata="dataset/gov/test/dataset",
+            ),
         )
         structure.dataset.current_structure = structure
         structure.dataset.save()
@@ -3235,7 +3276,9 @@ def test_structure_boolean_enums(app: DjangoTestApp):
         "5,,,,,,,,False,false,,,,,,,,,,,\n"
     )
     dataset = DatasetFactory(metadata="datasets/gov/ivpk/dataset")
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset
+    )
     structure.dataset.current_structure = structure
     structure.dataset.save()
 
@@ -3260,7 +3303,9 @@ def test_structure_boolean_enums_invalid_source(app: DjangoTestApp):
         "5,,,,,,,,False,False,,,,,,,,,,,\n"
     )
     dataset = DatasetFactory(metadata="datasets/gov/ivpk/dataset")
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset
+    )
     structure.dataset.current_structure = structure
     structure.dataset.save()
 
@@ -3285,7 +3330,9 @@ def test_structure_number_enums(app: DjangoTestApp):
         ",,,,,,,,1.3,1.4,,,,,,,,,,,\n"
     )
     dataset = DatasetFactory(metadata="datasets/gov/ivpk/example")
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset
+    )
     structure.dataset.current_structure = structure
     structure.dataset.save()
 

--- a/tests/structure/test_services.py
+++ b/tests/structure/test_services.py
@@ -3415,7 +3415,6 @@ def test_generate_mermaid(app: DjangoTestApp):
     assert (
         """
 classDiagram
-namespace `datasets/gov/ivpk/adp` {
 class `datasets/gov/ivpk/adp/Licence`["Licence"]:::Entity {
 «optional»
 id : integer [0..1]
@@ -3424,7 +3423,7 @@ class `datasets/gov/ivpk/adp/Catalog`["Catalog"]:::Entity {
 «optional»
 id : integer [0..1]
 }
-}
+
 `datasets/gov/ivpk/adp/Licence` --> "[0..1]" `datasets/gov/ivpk/adp/Catalog` : catalog<br/>«optional»
 """
         in mermaid
@@ -3510,6 +3509,7 @@ def test_generate_mermaid_with_base_chain_across_datasets(app: DjangoTestApp):
         file=FilerFileFactory(file=FileField(filename="file.csv", data=parent_manifest)),
         dataset=DatasetFactory(
             organization=OrganizationFactory(whitelisted_names=["datasets/gov/parent/"]),
+            metadata="datasets/gov/parent/dataset",
         ),
     )
     parent_structure.dataset.current_structure = parent_structure
@@ -3532,6 +3532,7 @@ def test_generate_mermaid_with_base_chain_across_datasets(app: DjangoTestApp):
             title="Main",
             description="Root",
             organization=OrganizationFactory(whitelisted_names=["datasets/gov/main/"]),
+            metadata="datasets/gov/main/dataset",
         ),
     )
     main_structure.dataset.current_structure = main_structure
@@ -3555,12 +3556,11 @@ class `datasets/gov/parent/dataset/ParentModel`["ParentModel"]:::Entity {
 id : integer [0..1]
 }
 }
-namespace `datasets/gov/main/dataset` {
 class `datasets/gov/main/dataset/ChildModel`["ChildModel"]:::Entity {
 «optional»
 id : integer [0..1]
 }
-}
+
 `datasets/gov/main/dataset/ChildModel` --|> `datasets/gov/parent/dataset/ParentModel`
 `datasets/gov/parent/dataset/ParentModel` --|> `datasets/gov/grand/dataset/GrandparentModel`
 """

--- a/tests/structure/test_tasks.py
+++ b/tests/structure/test_tasks.py
@@ -23,7 +23,7 @@ def test_update_uml_diagram():
 
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description"),
+        dataset=DatasetFactory(title="Title", description="Description", metadata="datasets/gov/ivpk/adp"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -39,23 +39,10 @@ def test_update_uml_diagram():
     uml_diagram.refresh_from_db()
 
     assert uml_diagram.status == UMLDiagramStatus.UP_TO_DATE
-    assert (
-        """
-classDiagram
-namespace `datasets/gov/ivpk/adp` {
-class `datasets/gov/ivpk/adp/Licence`["Licence"]:::Entity {
-«optional»
-id : integer [0..1]
-}
-class `datasets/gov/ivpk/adp/Catalog`["Catalog"]:::Entity {
-«optional»
-id : integer [0..1]
-}
-}
-`datasets/gov/ivpk/adp/Licence` --> "[0..1]" `datasets/gov/ivpk/adp/Catalog` : catalog<br/>«optional»
-"""
-        in uml_diagram.mermaid
-    )
+    assert "classDiagram" in uml_diagram.mermaid
+    assert "class Licence" in uml_diagram.mermaid
+    assert "class Catalog" in uml_diagram.mermaid
+    assert 'Licence --> "[0..1]" Catalog : catalog' in uml_diagram.mermaid
 
     base_url = f"{settings.META_SITE_PROTOCOL}://{settings.META_SITE_DOMAIN}"
     dataset_pk = structure.dataset.pk

--- a/tests/structure/test_tasks.py
+++ b/tests/structure/test_tasks.py
@@ -23,7 +23,7 @@ def test_update_uml_diagram():
 
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description", metadata="datasets/gov/ivpk/adp"),
+        dataset=DatasetFactory(title="Title", description="Description"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -39,10 +39,23 @@ def test_update_uml_diagram():
     uml_diagram.refresh_from_db()
 
     assert uml_diagram.status == UMLDiagramStatus.UP_TO_DATE
-    assert "classDiagram" in uml_diagram.mermaid
-    assert "class Licence" in uml_diagram.mermaid
-    assert "class Catalog" in uml_diagram.mermaid
-    assert 'Licence --> "[0..1]" Catalog : catalog' in uml_diagram.mermaid
+    assert (
+        """
+classDiagram
+namespace `datasets/gov/ivpk/adp` {
+class `datasets/gov/ivpk/adp/Licence`["Licence"]:::Entity {
+«optional»
+id : integer [0..1]
+}
+class `datasets/gov/ivpk/adp/Catalog`["Catalog"]:::Entity {
+«optional»
+id : integer [0..1]
+}
+}
+`datasets/gov/ivpk/adp/Licence` --> "[0..1]" `datasets/gov/ivpk/adp/Catalog` : catalog<br/>«optional»
+"""
+        in uml_diagram.mermaid
+    )
 
     base_url = f"{settings.META_SITE_PROTOCOL}://{settings.META_SITE_DOMAIN}"
     dataset_pk = structure.dataset.pk

--- a/tests/structure/test_tasks.py
+++ b/tests/structure/test_tasks.py
@@ -42,7 +42,6 @@ def test_update_uml_diagram():
     assert (
         """
 classDiagram
-namespace `datasets/gov/ivpk/adp` {
 class `datasets/gov/ivpk/adp/Licence`["Licence"]:::Entity {
 «optional»
 id : integer [0..1]
@@ -51,7 +50,7 @@ class `datasets/gov/ivpk/adp/Catalog`["Catalog"]:::Entity {
 «optional»
 id : integer [0..1]
 }
-}
+
 `datasets/gov/ivpk/adp/Licence` --> "[0..1]" `datasets/gov/ivpk/adp/Catalog` : catalog<br/>«optional»
 """
         in uml_diagram.mermaid

--- a/tests/structure/test_tasks.py
+++ b/tests/structure/test_tasks.py
@@ -23,7 +23,7 @@ def test_update_uml_diagram():
 
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(title="Title", description="Description"),
+        dataset=DatasetFactory(title="Title", description="Description", metadata="datasets/gov/ivpk/adp"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -893,7 +893,9 @@ def test_private_model(app: DjangoTestApp):
     )
     dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
     dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset
+    )
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -919,7 +921,9 @@ def test_private_model_with_access(app: DjangoTestApp):
         ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
     )
     dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset
+    )
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -953,7 +957,9 @@ def test_private_property(app: DjangoTestApp):
         ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
     )
     dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset
+    )
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -978,7 +984,9 @@ def test_private_property_with_access(app: DjangoTestApp):
         ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
     )
     dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset
+    )
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -1013,7 +1021,9 @@ def test_private_comment(app: DjangoTestApp):
         ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
     dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset
+    )
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -1040,7 +1050,9 @@ def test_private_comment_with_access(app: DjangoTestApp):
         ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
     dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset
+    )
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -3958,7 +3970,9 @@ def test_visibility_without_access(app: DjangoTestApp):
         ",,,,,residence,string,,,,5,,public,open,dct:residence,,,,\n"
     )
     dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset
+    )
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -4076,9 +4090,10 @@ def test_model_visibility_with_manager_access(app: DjangoTestApp):
         ",,,,,residence,string,,,,5,,public,open,dct:residence,,,,\n"
     )
 
-
     dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset
+    )
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -4204,7 +4219,9 @@ def test_model_visibility_with_open_data_representative_access(app: DjangoTestAp
     )
     organization = OrganizationFactory(kind=Organization.GOV)
     dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset
+    )
     structure.dataset.organization = organization
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -4329,7 +4346,9 @@ def test_model_visibility_with_information_system_representative_access(app: Dja
     )
     organization = OrganizationFactory(kind=Organization.GOV)
     dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset
+    )
     structure.dataset.organization = organization
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -5374,7 +5393,9 @@ def test_changed_metadata_keeps_status_after_publishing(app: DjangoTestApp):
         ",,,,,,,,,,,,,,,,,,\n"
     )
     dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset
+    )
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -5460,7 +5481,9 @@ def test_draft_metadata_defaults_to_develop_after_hard_change(app: DjangoTestApp
         ",,,,,,,,,,,,,,,,,,\n"
     )
     dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset
+    )
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -5522,7 +5545,9 @@ def test_changing_multiple_fields_in_draft_structure_respects_status(app: Django
         ",,,,,,,,,,,,,,,,,,\n"
     )
     dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset
+    )
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -5588,7 +5613,9 @@ def test_draft_metadata_form_does_not_change_status_is_kept(app: DjangoTestApp):
         ",,,,,,,,,,,,,,,,,,\n"
     )
     dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset
+    )
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -6020,7 +6047,9 @@ def test_publish_form_shows_all_metadata_rows_params(app: DjangoTestApp):
         "9,,,,,type,string,,,,5,,,open,dct:type,,,,\n"
     )
     dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset
+    )
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -6046,7 +6075,9 @@ def test_publish_form_shows_all_metadata_rows_base(app: DjangoTestApp):
         ",,,,,title,string,,,,2,,,,,,,,,\n"
     )
     dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset
+    )
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -6073,7 +6104,9 @@ def test_publish_form_shows_all_metadata_rows_enum(app: DjangoTestApp):
         "11,,,,,,,,,'''MODIFIED''',,,,,,,,,\n"
     )
     dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset
+    )
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -8553,8 +8586,7 @@ class TestStructureUMLviews(BaseTestCreateManifest):
         app.set_user(user)
         dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
         structure = DatasetStructureFactory(
-            file=FilerFileFactory(file=FileField(filename="file.csv", data=self.MANIFEST)),
-            dataset=dataset
+            file=FilerFileFactory(file=FileField(filename="file.csv", data=self.MANIFEST)), dataset=dataset
         )
         structure.dataset.current_structure = structure
         structure.dataset.save()
@@ -8576,7 +8608,9 @@ class TestStructureUMLviews(BaseTestCreateManifest):
             "8,,,,,id,integer,,,,,,,,,,,,\n"
         )
         dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
-        structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
+        structure = DatasetStructureFactory(
+            file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset
+        )
         structure.dataset.current_structure = structure
         structure.dataset.save()
         version = create_structure_objects(structure)
@@ -8603,7 +8637,9 @@ class TestStructureUMLviews(BaseTestCreateManifest):
             "8,,,,,id,integer,,,,,,,,,,,,\n"
         )
         dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
-        structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
+        structure = DatasetStructureFactory(
+            file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset
+        )
         structure.dataset.current_structure = structure
         structure.dataset.save()
         version = create_structure_objects(structure)
@@ -8634,7 +8670,9 @@ class TestStructureUMLviews(BaseTestCreateManifest):
             "8,,,,,id,integer,,,,,,,,,,,,\n"
         )
         dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
-        structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
+        structure = DatasetStructureFactory(
+            file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset
+        )
         structure.dataset.current_structure = structure
         structure.dataset.save()
         version = create_structure_objects(structure)
@@ -8663,7 +8701,9 @@ class TestStructureUMLviews(BaseTestCreateManifest):
             "8,,,,,id,integer,,,,,,,,,,,,\n"
         )
         dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
-        structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
+        structure = DatasetStructureFactory(
+            file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset
+        )
         structure.dataset.current_structure = structure
         structure.dataset.save()
         version = create_structure_objects(structure)

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -892,7 +892,6 @@ def test_private_model(app: DjangoTestApp):
         ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
     )
     dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
-    dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset
     )

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -1,6 +1,4 @@
-import csv
 import datetime
-import io
 import json
 import uuid
 from http import HTTPStatus
@@ -66,18 +64,11 @@ class BaseTestCreateManifest:
     def _create_manifest(
         self, manifest: str, title: str = "", description: str = "", whitelisted_names: list[str] | None = None
     ) -> Dataset:
-        reader = csv.DictReader(io.StringIO(manifest))
-        dataset_code_name = next(
-            (row["dataset"] for row in reader if row.get("dataset")),
-            "datasets/gov/test/dataset",
-        )
-        org_prefix, _, code_name = dataset_code_name.rpartition("/")
         dataset = DatasetFactory(
-            title=code_name,
+            title=title,
             description=description,
-            organization=OrganizationFactory(
-                name=org_prefix, whitelisted_names=whitelisted_names if whitelisted_names else []
-            ),
+            metadata=False,
+            organization=OrganizationFactory(whitelisted_names=whitelisted_names if whitelisted_names else []),
         )
         structure = DatasetStructureFactory(
             file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset
@@ -368,8 +359,8 @@ def test_model_data_page_contains_correct_table_url(client):
     client.force_login(user)
 
     dataset = DatasetFactory(metadata="test/dataset")
-    version = VersionFactory(dataset=dataset)
-    dataset.metadata.update(metadata_version=version)
+    dataset_metadata = Metadata.objects.get(object_id=dataset.pk, dataset=dataset)
+    version = dataset_metadata.metadata_version
     model = ModelFactory(dataset=dataset, metadata_version=version)
 
     MetadataFactory(
@@ -895,7 +886,7 @@ def test_private_model(app: DjangoTestApp):
         ",,,,,id,integer,,,,5,,,private,dct:identifier,,Identifikatorius,,\n"
         ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -920,7 +911,7 @@ def test_private_model_with_access(app: DjangoTestApp):
         ",,,,,id,integer,,,,5,,,private,dct:identifier,,Identifikatorius,,\n"
         ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -953,7 +944,7 @@ def test_private_property(app: DjangoTestApp):
         ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
         ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -977,7 +968,7 @@ def test_private_property_with_access(app: DjangoTestApp):
         ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
         ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -1011,7 +1002,7 @@ def test_private_comment(app: DjangoTestApp):
         ",,,,,,comment,type,,,,,,private,,,,Private comment,\n"
         ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -1037,7 +1028,7 @@ def test_private_comment_with_access(app: DjangoTestApp):
         ",,,,,,comment,type,,,,private,,,,,,Private comment,\n"
         ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -2113,8 +2104,7 @@ def test_model_create(app: DjangoTestApp):
     app.set_user(user)
 
     dataset = DatasetFactory(metadata="test/dataset")
-    version = VersionFactory(dataset=dataset)
-    dataset.metadata.update(metadata_version=version)
+    version = dataset.metadata.first().metadata_version
     model = ModelFactory(dataset=dataset, metadata_version=version)
     PrefixFactory(name="dcat", metadata_version=version)
 
@@ -2191,8 +2181,7 @@ def test_model_update(app: DjangoTestApp):
     app.set_user(user)
 
     dataset = DatasetFactory(metadata="test/dataset")
-    version = VersionFactory(dataset=dataset)
-    dataset.metadata.update(metadata_version=version)
+    version = dataset.metadata.first().metadata_version
     model = ModelFactory(dataset=dataset, metadata_version=version)
     PrefixFactory(name="dcat", metadata_version=version)
 
@@ -3956,7 +3945,7 @@ def test_visibility_without_access(app: DjangoTestApp):
         ",,,,,number,string,,,,5,,package,open,dct:number,,,,\n"
         ",,,,,residence,string,,,,5,,public,open,dct:residence,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -4074,7 +4063,7 @@ def test_model_visibility_with_manager_access(app: DjangoTestApp):
         ",,,,,residence,string,,,,5,,public,open,dct:residence,,,,\n"
     )
 
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -4199,7 +4188,7 @@ def test_model_visibility_with_open_data_representative_access(app: DjangoTestAp
         ",,,,,residence,string,,,,5,,public,open,dct:residence,,,,\n"
     )
     organization = OrganizationFactory(kind=Organization.GOV)
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.organization = organization
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -4323,7 +4312,7 @@ def test_model_visibility_with_information_system_representative_access(app: Dja
         ",,,,,residence,string,,,,5,,public,open,dct:residence,,,,\n"
     )
     organization = OrganizationFactory(kind=Organization.GOV)
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.organization = organization
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -4991,7 +4980,7 @@ def test_manifest_export_openapi(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"]), metadata="datasets/gov/ivpk/adp"),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -5056,7 +5045,7 @@ def test_manifest_export_openapi_with_dependent_models(app: DjangoTestApp):
     )
     city_structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=city_manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/test/"]), metadata="datasets/gov/test/city"),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/test/"])),
     )
     city_structure.dataset.current_structure = city_structure
     city_structure.dataset.save()
@@ -5071,7 +5060,7 @@ def test_manifest_export_openapi_with_dependent_models(app: DjangoTestApp):
         ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
         ",,,,,city,ref,/datasets/gov/test/city/City,,,,5,,,private,dct:title,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=main_manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=main_manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
@@ -5110,7 +5099,7 @@ def test_manifest_export_openapi_soap_params(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"]), metadata="datasets/gov/ivpk/adp"),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -5145,7 +5134,7 @@ def test_manifest_export_openapi_with_scopes(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"]), metadata="datasets/gov/ivpk/adp"),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -5189,7 +5178,7 @@ def test_imported_metadata_gets_develop_status(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"]), metadata="datasets/gov/ivpk/adp"),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -5239,7 +5228,7 @@ def test_updating_metadata_in_not_draft_version_not_allowed(app: DjangoTestApp, 
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"]), metadata="datasets/gov/ivpk/adp"),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -5301,7 +5290,7 @@ def test_published_metadata_gets_completed_status(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"]), metadata="datasets/gov/ivpk/adp"),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -5367,7 +5356,7 @@ def test_changed_metadata_keeps_status_after_publishing(app: DjangoTestApp):
         ",,,,,,enum,,,'SMALL',,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -5452,7 +5441,7 @@ def test_draft_metadata_defaults_to_develop_after_hard_change(app: DjangoTestApp
         ",,,,,,,,,BIG,,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -5513,7 +5502,7 @@ def test_changing_multiple_fields_in_draft_structure_respects_status(app: Django
         ",,,,,,enum,,,'''SMALL''',,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -5578,7 +5567,7 @@ def test_draft_metadata_form_does_not_change_status_is_kept(app: DjangoTestApp):
         ",,,,,,,,,'''BIG''',,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -6009,7 +5998,7 @@ def test_publish_form_shows_all_metadata_rows_params(app: DjangoTestApp):
         "8,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
         "9,,,,,type,string,,,,5,,,open,dct:type,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -6034,7 +6023,7 @@ def test_publish_form_shows_all_metadata_rows_base(app: DjangoTestApp):
         ",,,,,id,integer,,,,3,,,,,,,,,\n"
         ",,,,,title,string,,,,2,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -6060,7 +6049,7 @@ def test_publish_form_shows_all_metadata_rows_enum(app: DjangoTestApp):
         "10,,,,,,enum,,,'''CREATED''',,,,,,,,,\n"
         "11,,,,,,,,,'''MODIFIED''',,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -6087,7 +6076,7 @@ def test_publish_form_shows_all_metadata_rows_single_defined_resource(app: Djang
 
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"]), metadata="datasets/gov/ivpk/adp"),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -6116,7 +6105,7 @@ def test_publish_form_shows_all_metadata_rows_multiple_resources(app: DjangoTest
 
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"]), metadata="datasets/gov/ivpk/adp"),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -6151,7 +6140,7 @@ def test_publish_form_shows_all_metadata_rows_denorm_props(app: DjangoTestApp):
 
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"]), metadata="datasets/gov/ivpk/adp"),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -6704,12 +6693,11 @@ def test_publishing_property_with_ref_to_another_model(app: DjangoTestApp):
 
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"]), metadata="datasets/gov/ivpk/adp"),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    init_version = structure.dataset.metadata.first().metadata_version
-    version = create_structure_objects(structure, init_version)
+    version = create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
 
     original_metadata_count = 4
     original_model_count = 2
@@ -6759,12 +6747,11 @@ def test_publishing_property_with_ref_to_another_property(app: DjangoTestApp):
 
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"]), metadata="datasets/gov/ivpk/adp"),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    init_version = structure.dataset.metadata.first().metadata_version
-    version = create_structure_objects(structure, init_version)
+    version = create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
 
     assert Metadata.objects.filter(dataset=structure.dataset).count() == 5
     assert Model.objects.filter(dataset=structure.dataset).count() == 2
@@ -6807,13 +6794,11 @@ def test_publishing_model_with_base_from_published_version_same_dataset(app: Dja
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"]), metadata="datasets/gov/ivpk/adp"),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    init_version = VersionFactory(dataset=structure.dataset)
-    structure.dataset.metadata.update(metadata_version=init_version)
-    version = create_structure_objects(structure, init_version)
+    version = create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
 
     assert Metadata.objects.filter(dataset=structure.dataset).count() == 3
     assert Model.objects.filter(dataset=structure.dataset).count() == 2
@@ -6944,6 +6929,7 @@ def test_publishing_model_with_base_from_draft_version_different_dataset(app: Dj
     app.set_user(user)
     first_dataset = DatasetFactory()
     first_version = first_dataset.metadata.first().metadata_version
+    first_dataset.metadata.first()
     first_model = ModelFactory(dataset=first_dataset, metadata_version=first_version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(first_model),
@@ -7215,6 +7201,7 @@ def test_publishing_property_with_draft_model_ref_different_dataset(app: DjangoT
     app.set_user(user)
     first_dataset = DatasetFactory()
     first_version = first_dataset.metadata.first().metadata_version
+    first_dataset.metadata.first()
     first_model = ModelFactory(dataset=first_dataset, metadata_version=first_version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(first_model),
@@ -7365,7 +7352,7 @@ class TestModelDelete:
         user = UserFactory(is_staff=True)
         app.set_user(user)
         dataset = DatasetFactory()
-        metadata_version = VersionFactory(dataset=dataset)
+        metadata_version = dataset.metadata.first().metadata_version
         model = ModelFactory(dataset=dataset, metadata_version=metadata_version)
         MetadataFactory(
             dataset=dataset,
@@ -7383,7 +7370,7 @@ class TestModelDelete:
         user = UserFactory(is_staff=False)
         app.set_user(user)
         dataset = DatasetFactory()
-        metadata_version = VersionFactory(dataset=dataset)
+        metadata_version = dataset.metadata.first().metadata_version
         model = ModelFactory(dataset=dataset, metadata_version=metadata_version)
         MetadataFactory(
             dataset=dataset,
@@ -7405,7 +7392,7 @@ class TestModelDelete:
         user = UserFactory(is_staff=False)
         app.set_user(user)
         dataset = DatasetFactory()
-        metadata_version = VersionFactory(dataset=dataset)
+        metadata_version = dataset.metadata.first().metadata_version
         metadata_version.status = status
         model = ModelFactory(dataset=dataset, metadata_version=metadata_version)
         MetadataFactory(
@@ -7427,7 +7414,7 @@ class TestModelDelete:
         user = UserFactory(is_staff=True)
         app.set_user(user)
         dataset = DatasetFactory()
-        metadata_version = VersionFactory(dataset=dataset)
+        metadata_version = dataset.metadata.first().metadata_version
         resp = app.post(
             reverse("model-delete", args=[dataset.pk, metadata_version.pk, "NonExistent"]), expect_errors=True
         )
@@ -7435,7 +7422,7 @@ class TestModelDelete:
 
     def test_requires_login(self, app: DjangoTestApp):
         dataset = DatasetFactory()
-        metadata_version = VersionFactory(dataset=dataset)
+        metadata_version = dataset.metadata.first().metadata_version
         model = ModelFactory(dataset=dataset, metadata_version=metadata_version)
         MetadataFactory(
             dataset=dataset,
@@ -7453,7 +7440,7 @@ class TestModelDelete:
         user = UserFactory(is_staff=True)
         app.set_user(user)
         dataset = DatasetFactory()
-        metadata_version = VersionFactory(dataset=dataset)
+        metadata_version = dataset.metadata.first().metadata_version
         model = ModelFactory(dataset=dataset, metadata_version=metadata_version)
         metadata = MetadataFactory(
             dataset=dataset,
@@ -7472,7 +7459,7 @@ class TestModelDelete:
         user = UserFactory(is_staff=True)
         app.set_user(user)
         dataset = DatasetFactory()
-        metadata_version = VersionFactory(dataset=dataset)
+        metadata_version = dataset.metadata.first().metadata_version
         model = ModelFactory(dataset=dataset, metadata_version=metadata_version)
         MetadataFactory(
             dataset=dataset,
@@ -7511,7 +7498,7 @@ class TestStructure(BaseTestCreateManifest):
         assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
-            "1,datasets/gov/ivpk/dataset,,,,,,,,,,,,,,,,,,dataset,Dataset with ref property",
+            "1,datasets/gov/ivpk/dataset,,,,,,,,,,,,,,,,,,Dataset,Dataset with ref property",
             "2,,dataset,,,,,,https://get.data.gov.lt/datasets/gov/main/dataset/:ns,,,,,,,,,,,dataset,",
             "3,,,,Country,,,id,,,,,,,develop,,,,,,",
             "4,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,",
@@ -7545,7 +7532,7 @@ class TestStructure(BaseTestCreateManifest):
         assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
-            "1,datasets/gov/ivpk/test,,,,,,,,,,,,,,,,,,test,Description",
+            "1,datasets/gov/ivpk/test,,,,,,,,,,,,,,,,,,Title,Description",
             "2,,resource_wsdl,,,,wsdl,,http://127.0.0.1:8001/api/v1/test/testing/?wsdl,,,,,,,,,,,resource_wsdl,",
             "3,,resource_soap,,,,soap,,TestTesting.TestPort.TestPort.test,,wsdl(rc_wsdl),,,,,,,,,resource_soap,",
             "4,,,,,,param,action_type,input/ActionType,,input(),,,,develop,,,,,,",
@@ -7592,7 +7579,7 @@ class TestStructure(BaseTestCreateManifest):
         assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
-            "1,datasets/gov/ivpk/test,,,,,,,,,,,,,,,,,,test,Description",
+            "1,datasets/gov/ivpk/test,,,,,,,,,,,,,,,,,,Title,Description",
             "2,,service,,,,dask/xml,,,,eval(param(nested_xml)),,,,,,,,,service,",
         ]
 
@@ -7623,7 +7610,7 @@ class TestStructure(BaseTestCreateManifest):
         assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
-            "1,datasets/gov/ivpk/test,,,,,,,,,,,,,,,,,,test,Dataset with ref property",
+            "1,datasets/gov/ivpk/test,,,,,,,,,,,,,,,,,,Dataset,Dataset with ref property",
             "2,,nested_read,,,,dask/xml,,,,eval(param(nested_xml)),,,,,,,,,nested_read,",
             "3,,,,,,param,nested_xml,GetData,,read().response_data,,,,develop,,,,,,",
             "4,,,,,,param,action_type,input/ActionType,,input(),,,,develop,,,,,,",
@@ -7660,7 +7647,7 @@ class TestStructure(BaseTestCreateManifest):
         assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
-            "1,datasets/gov/ivpk/example,,,,,,,,,,,,,,,,,,example,Dataset with ref property",
+            "1,datasets/gov/ivpk/example,,,,,,,,,,,,,,,,,,Dataset,Dataset with ref property",
             "2,,,,Animal,,,,,,,,,0,completed,public,,,,,",
             "3,,,,,id,string,,source_animal_id,,,,,4,completed,package,protected,,,,",
             ",,,,,,,,,,,,,,,,,,,,",
@@ -7705,9 +7692,9 @@ class TestStructure(BaseTestCreateManifest):
         assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
-            "1,datasets/gov/ivpk/example,,,,,,,,,,,,,,,,,,example,Dataset that defines base model.",
+            "1,datasets/gov/ivpk/example,,,,,,,,,,,,,,,,,,Model Dataset,Dataset that defines base model.",
             "2,,,,Animal,,,,,,,,,0,completed,public,,,,,",
-            "1,datasets/gov/test/example2,,,,,,,,,,,,,,,,,,example2,Dataset that references model with base",
+            "1,datasets/gov/test/example2,,,,,,,,,,,,,,,,,,Base Dataset,Dataset that references model with base",
             "2,,,datasets/gov/ivpk/example/Animal,,,,,,,,,,,,,,,,,",
             "3,,,,Dog,,,,,,,,,0,completed,public,,,,,",
             "4,,,,,action,string,,source_dog_action,,,,,4,completed,package,protected,,,,",
@@ -7746,7 +7733,7 @@ class TestStructure(BaseTestCreateManifest):
         assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
-            "1,datasets/gov/test/example2,,,,,,,,,,,,,,,,,,example2,Dataset that references model with base",
+            "1,datasets/gov/test/example2,,,,,,,,,,,,,,,,,,Base Dataset,Dataset that references model with base",
             "3,,,,Dog,,,,,,,,,0,completed,public,,,,,",
             "4,,,,,action,string,,source_dog_action,,,,,4,completed,package,protected,,,,",
             ",,,,,,,,,,,,,,,,,,,,",
@@ -7755,7 +7742,7 @@ class TestStructure(BaseTestCreateManifest):
         error_comment = Comment.objects.get(content_type=ContentType.objects.get_for_model(Model))
         assert error_comment.type == Comment.STRUCTURE_ERROR
         assert error_comment.body == (
-            "Nepavyko susieti bazinio modelio „datasets/gov/ivpk/example/Animal”. "
+            "Nepavyko susieti bazinio modelio „datasets/gov/ivpk/example/Animal“. "
             "Įsitikinkite, kad jis egzistuoja ir turi patvirtintą (stabilią) versiją."
         )
 
@@ -7779,7 +7766,7 @@ class TestStructure(BaseTestCreateManifest):
         assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [  # Base could not be linked, so it is missing.
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
-            "1,datasets/gov/ivpk/example,,,,,,,,,,,,,,,,,,example,Dataset with ref property",
+            "1,datasets/gov/ivpk/example,,,,,,,,,,,,,,,,,,Dataset,Dataset with ref property",
             "3,,,,Dog,,,,,,,,,0,completed,public,,,,,",
             "4,,,,,action,string,,source_dog_action,,,,,4,completed,package,protected,,,,",
             ",,,,,,,,,,,,,,,,,,,,",
@@ -7788,7 +7775,7 @@ class TestStructure(BaseTestCreateManifest):
         error_comment = Comment.objects.get(content_type=ContentType.objects.get_for_model(Model))
         assert error_comment.type == Comment.STRUCTURE_ERROR
         assert error_comment.body == (
-            "Nepavyko susieti bazinio modelio „datasets/gov/ivpk/example/Animal”. "
+            "Nepavyko susieti bazinio modelio „datasets/gov/ivpk/example/Animal“. "
             "Įsitikinkite, kad jis egzistuoja ir turi patvirtintą (stabilią) versiją."
         )
 
@@ -7813,7 +7800,7 @@ class TestStructure(BaseTestCreateManifest):
         assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
-            "1,datasets/gov/ivpk/test,,,,,,,,,,,,,,,,,,test,Dataset with ref property",
+            "1,datasets/gov/ivpk/test,,,,,,,,,,,,,,,,,,Dataset,Dataset with ref property",
             "2,,,,Animal,,,,source_animal_model,,,,,,develop,,,,,,",
             '3,,,,,,comment,model,,,"update(model: ""Animal/:part"")",,,2,develop,,open,https://github.com/example/issues/1,,,',
             "4,,,,,id,string,,source_animal_id,,,,,4,develop,,,,,,",
@@ -7844,7 +7831,7 @@ class TestStructure(BaseTestCreateManifest):
         assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
-            "1,datasets/gov/ivpk/dataset,,,,,,,,,,,,,,,,,,dataset,Dataset",
+            "1,datasets/gov/ivpk/dataset,,,,,,,,,,,,,,,,,,Dataset,Dataset",
             "2,,,,Approver,,,,,,,,,1,develop,,,,,,",
             "3,,,,,is_active,boolean,,IsActive/text(),,,,,,develop,,,,,,",
             "4,,,,,,enum,,True,,true,,,,develop,,,,,,",
@@ -7871,7 +7858,7 @@ class TestStructure(BaseTestCreateManifest):
         assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
-            "1,datasets/gov/ivpk/example,,,,,,,,,,,,,,,,,,example,Dataset",
+            "1,datasets/gov/ivpk/example,,,,,,,,,,,,,,,,,,Dataset,Dataset",
             "2,,,,Dataset,,,,,,,,,1,develop,,,,,,",
             "3,,,,,type,number required,,TypeID/text(),,,,,,develop,,,,,,",
             "4,,,,,,enum,,1.1,,1.2,,,,develop,,,,,,",
@@ -7901,7 +7888,7 @@ class TestStructure(BaseTestCreateManifest):
         assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
-            "1,datasets/gov/ivpk/dataset,,,,,,,,,,,,,,,,,,dataset,Dataset",
+            "1,datasets/gov/ivpk/dataset,,,,,,,,,,,,,,,,,,Dataset,Dataset",
             "2,,,,,,enum,DatasetEnum,,,1,,,,develop,,,,,,",
             "3,,,,,,,,,,2,,,,develop,,,,,,",
             ",,,,,,,,,,,,,,,,,,,,",
@@ -7932,7 +7919,7 @@ class TestStructure(BaseTestCreateManifest):
         assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
-            "1,datasets/gov/ivpk/dataset,,,,,,,,,,,,,,,,,,dataset,Dataset",
+            "1,datasets/gov/ivpk/dataset,,,,,,,,,,,,,,,,,,Dataset,Dataset",
             "2,,,,Dataset,,,,,,,,,1,develop,,,,,,",
             "3,,,,,code,integer,,,,,,,4,develop,,,,,,",
             "4,,,,,,enum,,,,10,,,,develop,,,,,,",
@@ -7989,10 +7976,10 @@ class TestStructureExportDependentModels(BaseTestCreateManifest):
         resp = app.get(reverse("dataset-structure-export", args=[main_dataset.pk, main_dataset.latest_version().pk]))
         assert resp.text == (
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
-            "7,datasets/gov/ref/dataset,,,,,,,,,,,,,,,,,,dataset,Dataset that will be referenced\r\n"
+            "7,datasets/gov/ref/dataset,,,,,,,,,,,,,,,,,,Referenced Dataset,Dataset that will be referenced\r\n"
             "8,,,,Continent,,,id,,,,,,,develop,,,,,,\r\n"
             "9,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
-            "1,datasets/gov/main/dataset,,,,,,,,,,,,,,,,,,dataset,Dataset with reference to other dataset\r\n"
+            "1,datasets/gov/main/dataset,,,,,,,,,,,,,,,,,,Main Dataset,Dataset with reference to other dataset\r\n"
             "2,,dataset,,,,,,https://get.data.gov.lt/datasets/gov/main/dataset/:ns,,,,,,,,,,,dataset,\r\n"
             '3,,,,Country,,,"id, title",,,,,,,develop,,,,,,\r\n'
             "4,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
@@ -8040,11 +8027,11 @@ class TestStructureExportDependentModels(BaseTestCreateManifest):
         resp = app.get(reverse("dataset-structure-export", args=[main_dataset.pk, main_dataset.latest_version().pk]))
         assert resp.text == (
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
-            "7,datasets/gov/ref/dataset,,,,,,,,,,,,,,,,,,dataset,Dataset that will be referenced\r\n"
+            "7,datasets/gov/ref/dataset,,,,,,,,,,,,,,,,,,Referenced Dataset,Dataset that will be referenced\r\n"
             '8,,,,Continent,,,"id, title",,,,,,,develop,,,,,,\r\n'
             "9,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
             "10,,,,,title,string,,,,,,,5,develop,,open,dct:title,,,\r\n"
-            "1,datasets/gov/main/dataset,,,,,,,,,,,,,,,,,,dataset,Dataset with reference to other dataset\r\n"
+            "1,datasets/gov/main/dataset,,,,,,,,,,,,,,,,,,Main Dataset,Dataset with reference to other dataset\r\n"
             "2,,dataset,,,,,,https://get.data.gov.lt/datasets/gov/main/dataset/:ns,,,,,,,,,,,dataset,\r\n"
             '3,,,,Country,,,"id, title",,,,,,,develop,,,,,,\r\n'
             "4,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
@@ -8096,14 +8083,14 @@ class TestStructureExportDependentModels(BaseTestCreateManifest):
         resp = app.get(reverse("dataset-structure-export", args=[main_dataset.pk, main_dataset.latest_version().pk]))
         assert resp.text == (
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
-            "12,datasets/gov/other/dataset,,,,,,,,,,,,,,,,,,dataset,Dependent dataset depth 2\r\n"
+            "12,datasets/gov/other/dataset,,,,,,,,,,,,,,,,,,Other Dataset,Dependent dataset depth 2\r\n"
             "13,,,,Other,,,title,,,,,,,develop,,,,,,\r\n"
             "14,,,,,title,string,,,,,,,5,develop,,open,dct:title,,,\r\n"
-            "7,datasets/gov/ref/dataset,,,,,,,,,,,,,,,,,,dataset,Dependent dataset depth 1\r\n"
+            "7,datasets/gov/ref/dataset,,,,,,,,,,,,,,,,,,Referenced Dataset,Dependent dataset depth 1\r\n"
             '8,,,,Continent,,,"id, title",,,,,,,develop,,,,,,\r\n'
             "9,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
             "10,,,,,title,ref,/datasets/gov/other/dataset/Other,,,,,,5,develop,,open,dct:title,,,\r\n"
-            "1,datasets/gov/main/dataset,,,,,,,,,,,,,,,,,,dataset,Root dataset\r\n"
+            "1,datasets/gov/main/dataset,,,,,,,,,,,,,,,,,,Main Dataset,Root dataset\r\n"
             "2,,dataset,,,,,,https://get.data.gov.lt/datasets/gov/main/dataset/:ns,,,,,,,,,,,dataset,\r\n"
             '3,,,,Country,,,"id, title",,,,,,,develop,,,,,,\r\n'
             "4,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
@@ -8136,7 +8123,7 @@ class TestStructureExportDependentModels(BaseTestCreateManifest):
         resp = app.get(reverse("dataset-structure-export", args=[main_dataset.pk, main_dataset.latest_version().pk]))
         assert resp.text == (
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
-            "1,datasets/gov/main/dataset,,,,,,,,,,,,,,,,,,dataset,Dataset with reference to other dataset\r\n"
+            "1,datasets/gov/main/dataset,,,,,,,,,,,,,,,,,,Main Dataset,Dataset with reference to other dataset\r\n"
             "2,,dataset,,,,,,https://get.data.gov.lt/datasets/gov/main/dataset/:ns,,,,,,,,,,,dataset,\r\n"
             '3,,,,Country,,,"id, title",,,,,,,develop,,,,,,\r\n'
             "4,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
@@ -8189,7 +8176,7 @@ class TestStructureExportDependentModels(BaseTestCreateManifest):
         resp = app.get(reverse("dataset-structure-export", args=[main_dataset.pk, main_dataset.latest_version().pk]))
         assert resp.text == (
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
-            "7,datasets/gov/ref/d1,,,,,,,,,,,,,,,,,,d1,Dataset with reference to other dataset\r\n"
+            "7,datasets/gov/ref/d1,,,,,,,,,,,,,,,,,,Referenced Dataset,Dataset with reference to other dataset\r\n"
             "8,,,,D1BaseModel,,,id,,,,,,,develop,,,,,,\r\n"
             "9,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
             "11,,,D1BaseModel,,,,,,,,,,,,,,,,,\r\n"
@@ -8198,7 +8185,7 @@ class TestStructureExportDependentModels(BaseTestCreateManifest):
             '15,,,,D1Model2,,,"id, prop2",,,,,,,develop,,,,,,\r\n'
             "16,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
             "17,,,,,prop2,string,,,,,,,5,develop,,open,dct:prop2,,,\r\n"
-            "1,datasets/gov/main/dataset,,,,,,,,,,,,,,,,,,dataset,Dataset with reference to other dataset\r\n"
+            "1,datasets/gov/main/dataset,,,,,,,,,,,,,,,,,,Main Dataset,Dataset with reference to other dataset\r\n"
             "2,,dataset,,,,,,https://get.data.gov.lt/datasets/gov/main/dataset/:ns,,,,,,,,,,,dataset,\r\n"
             '3,,,,MainModel,,,"id, prop1",,,,,,,develop,,,,,,\r\n'
             "4,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
@@ -8541,8 +8528,7 @@ class TestStructureUMLviews(BaseTestCreateManifest):
         user = UserFactory(is_staff=True)
         app.set_user(user)
         structure = DatasetStructureFactory(
-            file=FilerFileFactory(file=FileField(filename="file.csv", data=self.MANIFEST)),
-            dataset__metadata="datasets/gov/ivpk/adp",
+            file=FilerFileFactory(file=FileField(filename="file.csv", data=self.MANIFEST))
         )
         structure.dataset.current_structure = structure
         structure.dataset.save()
@@ -8563,7 +8549,7 @@ class TestStructureUMLviews(BaseTestCreateManifest):
             "7,,,,Catalog,,,,,,,,,,,,,,\n"
             "8,,,,,id,integer,,,,,,,,,,,,\n"
         )
-        structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+        structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
         structure.dataset.current_structure = structure
         structure.dataset.save()
         version = create_structure_objects(structure)
@@ -8589,7 +8575,7 @@ class TestStructureUMLviews(BaseTestCreateManifest):
             "7,,,,Catalog,,,,,,,,,,,,,,\n"
             "8,,,,,id,integer,,,,,,,,,,,,\n"
         )
-        structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+        structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
         structure.dataset.current_structure = structure
         structure.dataset.save()
         version = create_structure_objects(structure)
@@ -8619,7 +8605,7 @@ class TestStructureUMLviews(BaseTestCreateManifest):
             "7,,,,Catalog,,,,,,,,,,,,,,\n"
             "8,,,,,id,integer,,,,,,,,,,,,\n"
         )
-        structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+        structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
         structure.dataset.current_structure = structure
         structure.dataset.save()
         version = create_structure_objects(structure)
@@ -8647,7 +8633,7 @@ class TestStructureUMLviews(BaseTestCreateManifest):
             "7,,,,Catalog,,,,,,,,,,,,,,\n"
             "8,,,,,id,integer,,,,,,,,,,,,\n"
         )
-        structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
+        structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
         structure.dataset.current_structure = structure
         structure.dataset.save()
         version = create_structure_objects(structure)

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -1,4 +1,6 @@
+import csv
 import datetime
+import io
 import json
 import uuid
 from http import HTTPStatus
@@ -64,11 +66,18 @@ class BaseTestCreateManifest:
     def _create_manifest(
         self, manifest: str, title: str = "", description: str = "", whitelisted_names: list[str] | None = None
     ) -> Dataset:
+        reader = csv.DictReader(io.StringIO(manifest))
+        dataset_code_name = next(
+            (row["dataset"] for row in reader if row.get("dataset")),
+            "datasets/gov/test/dataset",
+        )
+        org_prefix, _, code_name = dataset_code_name.rpartition("/")
         dataset = DatasetFactory(
-            title=title,
+            title=code_name,
             description=description,
-            metadata=False,
-            organization=OrganizationFactory(whitelisted_names=whitelisted_names if whitelisted_names else []),
+            organization=OrganizationFactory(
+                name=org_prefix, whitelisted_names=whitelisted_names if whitelisted_names else []
+            ),
         )
         structure = DatasetStructureFactory(
             file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset
@@ -359,8 +368,8 @@ def test_model_data_page_contains_correct_table_url(client):
     client.force_login(user)
 
     dataset = DatasetFactory(metadata="test/dataset")
-    dataset_metadata = Metadata.objects.get(object_id=dataset.pk, dataset=dataset)
-    version = dataset_metadata.metadata_version
+    version = VersionFactory(dataset=dataset)
+    dataset.metadata.update(metadata_version=version)
     model = ModelFactory(dataset=dataset, metadata_version=version)
 
     MetadataFactory(
@@ -886,7 +895,7 @@ def test_private_model(app: DjangoTestApp):
         ",,,,,id,integer,,,,5,,,private,dct:identifier,,Identifikatorius,,\n"
         ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -911,7 +920,7 @@ def test_private_model_with_access(app: DjangoTestApp):
         ",,,,,id,integer,,,,5,,,private,dct:identifier,,Identifikatorius,,\n"
         ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -944,7 +953,7 @@ def test_private_property(app: DjangoTestApp):
         ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
         ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -968,7 +977,7 @@ def test_private_property_with_access(app: DjangoTestApp):
         ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
         ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -1002,7 +1011,7 @@ def test_private_comment(app: DjangoTestApp):
         ",,,,,,comment,type,,,,,,private,,,,Private comment,\n"
         ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -1028,7 +1037,7 @@ def test_private_comment_with_access(app: DjangoTestApp):
         ",,,,,,comment,type,,,,private,,,,,,Private comment,\n"
         ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -2104,7 +2113,8 @@ def test_model_create(app: DjangoTestApp):
     app.set_user(user)
 
     dataset = DatasetFactory(metadata="test/dataset")
-    version = dataset.metadata.first().metadata_version
+    version = VersionFactory(dataset=dataset)
+    dataset.metadata.update(metadata_version=version)
     model = ModelFactory(dataset=dataset, metadata_version=version)
     PrefixFactory(name="dcat", metadata_version=version)
 
@@ -2181,7 +2191,8 @@ def test_model_update(app: DjangoTestApp):
     app.set_user(user)
 
     dataset = DatasetFactory(metadata="test/dataset")
-    version = dataset.metadata.first().metadata_version
+    version = VersionFactory(dataset=dataset)
+    dataset.metadata.update(metadata_version=version)
     model = ModelFactory(dataset=dataset, metadata_version=version)
     PrefixFactory(name="dcat", metadata_version=version)
 
@@ -3945,7 +3956,7 @@ def test_visibility_without_access(app: DjangoTestApp):
         ",,,,,number,string,,,,5,,package,open,dct:number,,,,\n"
         ",,,,,residence,string,,,,5,,public,open,dct:residence,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -4063,7 +4074,7 @@ def test_model_visibility_with_manager_access(app: DjangoTestApp):
         ",,,,,residence,string,,,,5,,public,open,dct:residence,,,,\n"
     )
 
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -4188,7 +4199,7 @@ def test_model_visibility_with_open_data_representative_access(app: DjangoTestAp
         ",,,,,residence,string,,,,5,,public,open,dct:residence,,,,\n"
     )
     organization = OrganizationFactory(kind=Organization.GOV)
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.organization = organization
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -4312,7 +4323,7 @@ def test_model_visibility_with_information_system_representative_access(app: Dja
         ",,,,,residence,string,,,,5,,public,open,dct:residence,,,,\n"
     )
     organization = OrganizationFactory(kind=Organization.GOV)
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.organization = organization
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -4980,7 +4991,7 @@ def test_manifest_export_openapi(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"]), metadata="datasets/gov/ivpk/adp"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -5045,7 +5056,7 @@ def test_manifest_export_openapi_with_dependent_models(app: DjangoTestApp):
     )
     city_structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=city_manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/test/"])),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/test/"]), metadata="datasets/gov/test/city"),
     )
     city_structure.dataset.current_structure = city_structure
     city_structure.dataset.save()
@@ -5060,7 +5071,7 @@ def test_manifest_export_openapi_with_dependent_models(app: DjangoTestApp):
         ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
         ",,,,,city,ref,/datasets/gov/test/city/City,,,,5,,,private,dct:title,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=main_manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=main_manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
@@ -5099,7 +5110,7 @@ def test_manifest_export_openapi_soap_params(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"]), metadata="datasets/gov/ivpk/adp"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -5134,7 +5145,7 @@ def test_manifest_export_openapi_with_scopes(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"]), metadata="datasets/gov/ivpk/adp"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -5178,7 +5189,7 @@ def test_imported_metadata_gets_develop_status(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"]), metadata="datasets/gov/ivpk/adp"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -5228,7 +5239,7 @@ def test_updating_metadata_in_not_draft_version_not_allowed(app: DjangoTestApp, 
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"]), metadata="datasets/gov/ivpk/adp"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -5290,7 +5301,7 @@ def test_published_metadata_gets_completed_status(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"]), metadata="datasets/gov/ivpk/adp"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -5356,7 +5367,7 @@ def test_changed_metadata_keeps_status_after_publishing(app: DjangoTestApp):
         ",,,,,,enum,,,'SMALL',,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -5441,7 +5452,7 @@ def test_draft_metadata_defaults_to_develop_after_hard_change(app: DjangoTestApp
         ",,,,,,,,,BIG,,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -5502,7 +5513,7 @@ def test_changing_multiple_fields_in_draft_structure_respects_status(app: Django
         ",,,,,,enum,,,'''SMALL''',,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -5567,7 +5578,7 @@ def test_draft_metadata_form_does_not_change_status_is_kept(app: DjangoTestApp):
         ",,,,,,,,,'''BIG''',,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -5998,7 +6009,7 @@ def test_publish_form_shows_all_metadata_rows_params(app: DjangoTestApp):
         "8,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
         "9,,,,,type,string,,,,5,,,open,dct:type,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -6023,7 +6034,7 @@ def test_publish_form_shows_all_metadata_rows_base(app: DjangoTestApp):
         ",,,,,id,integer,,,,3,,,,,,,,,\n"
         ",,,,,title,string,,,,2,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -6049,7 +6060,7 @@ def test_publish_form_shows_all_metadata_rows_enum(app: DjangoTestApp):
         "10,,,,,,enum,,,'''CREATED''',,,,,,,,,\n"
         "11,,,,,,,,,'''MODIFIED''',,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -6076,7 +6087,7 @@ def test_publish_form_shows_all_metadata_rows_single_defined_resource(app: Djang
 
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"]), metadata="datasets/gov/ivpk/adp"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -6105,7 +6116,7 @@ def test_publish_form_shows_all_metadata_rows_multiple_resources(app: DjangoTest
 
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"]), metadata="datasets/gov/ivpk/adp"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -6140,7 +6151,7 @@ def test_publish_form_shows_all_metadata_rows_denorm_props(app: DjangoTestApp):
 
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"]), metadata="datasets/gov/ivpk/adp"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -6693,11 +6704,12 @@ def test_publishing_property_with_ref_to_another_model(app: DjangoTestApp):
 
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"]), metadata="datasets/gov/ivpk/adp"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    version = create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
+    init_version = structure.dataset.metadata.first().metadata_version
+    version = create_structure_objects(structure, init_version)
 
     original_metadata_count = 4
     original_model_count = 2
@@ -6747,11 +6759,12 @@ def test_publishing_property_with_ref_to_another_property(app: DjangoTestApp):
 
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"]), metadata="datasets/gov/ivpk/adp"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    version = create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
+    init_version = structure.dataset.metadata.first().metadata_version
+    version = create_structure_objects(structure, init_version)
 
     assert Metadata.objects.filter(dataset=structure.dataset).count() == 5
     assert Model.objects.filter(dataset=structure.dataset).count() == 2
@@ -6794,11 +6807,13 @@ def test_publishing_model_with_base_from_published_version_same_dataset(app: Dja
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
+        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"]), metadata="datasets/gov/ivpk/adp"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
-    version = create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)
+    init_version = VersionFactory(dataset=structure.dataset)
+    structure.dataset.metadata.update(metadata_version=init_version)
+    version = create_structure_objects(structure, init_version)
 
     assert Metadata.objects.filter(dataset=structure.dataset).count() == 3
     assert Model.objects.filter(dataset=structure.dataset).count() == 2
@@ -6929,7 +6944,6 @@ def test_publishing_model_with_base_from_draft_version_different_dataset(app: Dj
     app.set_user(user)
     first_dataset = DatasetFactory()
     first_version = first_dataset.metadata.first().metadata_version
-    first_dataset.metadata.first()
     first_model = ModelFactory(dataset=first_dataset, metadata_version=first_version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(first_model),
@@ -7201,7 +7215,6 @@ def test_publishing_property_with_draft_model_ref_different_dataset(app: DjangoT
     app.set_user(user)
     first_dataset = DatasetFactory()
     first_version = first_dataset.metadata.first().metadata_version
-    first_dataset.metadata.first()
     first_model = ModelFactory(dataset=first_dataset, metadata_version=first_version)
     MetadataFactory(
         content_type=ContentType.objects.get_for_model(first_model),
@@ -7352,7 +7365,7 @@ class TestModelDelete:
         user = UserFactory(is_staff=True)
         app.set_user(user)
         dataset = DatasetFactory()
-        metadata_version = dataset.metadata.first().metadata_version
+        metadata_version = VersionFactory(dataset=dataset)
         model = ModelFactory(dataset=dataset, metadata_version=metadata_version)
         MetadataFactory(
             dataset=dataset,
@@ -7370,7 +7383,7 @@ class TestModelDelete:
         user = UserFactory(is_staff=False)
         app.set_user(user)
         dataset = DatasetFactory()
-        metadata_version = dataset.metadata.first().metadata_version
+        metadata_version = VersionFactory(dataset=dataset)
         model = ModelFactory(dataset=dataset, metadata_version=metadata_version)
         MetadataFactory(
             dataset=dataset,
@@ -7392,7 +7405,7 @@ class TestModelDelete:
         user = UserFactory(is_staff=False)
         app.set_user(user)
         dataset = DatasetFactory()
-        metadata_version = dataset.metadata.first().metadata_version
+        metadata_version = VersionFactory(dataset=dataset)
         metadata_version.status = status
         model = ModelFactory(dataset=dataset, metadata_version=metadata_version)
         MetadataFactory(
@@ -7414,7 +7427,7 @@ class TestModelDelete:
         user = UserFactory(is_staff=True)
         app.set_user(user)
         dataset = DatasetFactory()
-        metadata_version = dataset.metadata.first().metadata_version
+        metadata_version = VersionFactory(dataset=dataset)
         resp = app.post(
             reverse("model-delete", args=[dataset.pk, metadata_version.pk, "NonExistent"]), expect_errors=True
         )
@@ -7422,7 +7435,7 @@ class TestModelDelete:
 
     def test_requires_login(self, app: DjangoTestApp):
         dataset = DatasetFactory()
-        metadata_version = dataset.metadata.first().metadata_version
+        metadata_version = VersionFactory(dataset=dataset)
         model = ModelFactory(dataset=dataset, metadata_version=metadata_version)
         MetadataFactory(
             dataset=dataset,
@@ -7440,7 +7453,7 @@ class TestModelDelete:
         user = UserFactory(is_staff=True)
         app.set_user(user)
         dataset = DatasetFactory()
-        metadata_version = dataset.metadata.first().metadata_version
+        metadata_version = VersionFactory(dataset=dataset)
         model = ModelFactory(dataset=dataset, metadata_version=metadata_version)
         metadata = MetadataFactory(
             dataset=dataset,
@@ -7459,7 +7472,7 @@ class TestModelDelete:
         user = UserFactory(is_staff=True)
         app.set_user(user)
         dataset = DatasetFactory()
-        metadata_version = dataset.metadata.first().metadata_version
+        metadata_version = VersionFactory(dataset=dataset)
         model = ModelFactory(dataset=dataset, metadata_version=metadata_version)
         MetadataFactory(
             dataset=dataset,
@@ -7498,7 +7511,7 @@ class TestStructure(BaseTestCreateManifest):
         assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
-            "1,datasets/gov/ivpk/dataset,,,,,,,,,,,,,,,,,,Dataset,Dataset with ref property",
+            "1,datasets/gov/ivpk/dataset,,,,,,,,,,,,,,,,,,dataset,Dataset with ref property",
             "2,,dataset,,,,,,https://get.data.gov.lt/datasets/gov/main/dataset/:ns,,,,,,,,,,,dataset,",
             "3,,,,Country,,,id,,,,,,,develop,,,,,,",
             "4,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,",
@@ -7532,7 +7545,7 @@ class TestStructure(BaseTestCreateManifest):
         assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
-            "1,datasets/gov/ivpk/test,,,,,,,,,,,,,,,,,,Title,Description",
+            "1,datasets/gov/ivpk/test,,,,,,,,,,,,,,,,,,test,Description",
             "2,,resource_wsdl,,,,wsdl,,http://127.0.0.1:8001/api/v1/test/testing/?wsdl,,,,,,,,,,,resource_wsdl,",
             "3,,resource_soap,,,,soap,,TestTesting.TestPort.TestPort.test,,wsdl(rc_wsdl),,,,,,,,,resource_soap,",
             "4,,,,,,param,action_type,input/ActionType,,input(),,,,develop,,,,,,",
@@ -7579,7 +7592,7 @@ class TestStructure(BaseTestCreateManifest):
         assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
-            "1,datasets/gov/ivpk/test,,,,,,,,,,,,,,,,,,Title,Description",
+            "1,datasets/gov/ivpk/test,,,,,,,,,,,,,,,,,,test,Description",
             "2,,service,,,,dask/xml,,,,eval(param(nested_xml)),,,,,,,,,service,",
         ]
 
@@ -7610,7 +7623,7 @@ class TestStructure(BaseTestCreateManifest):
         assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
-            "1,datasets/gov/ivpk/test,,,,,,,,,,,,,,,,,,Dataset,Dataset with ref property",
+            "1,datasets/gov/ivpk/test,,,,,,,,,,,,,,,,,,test,Dataset with ref property",
             "2,,nested_read,,,,dask/xml,,,,eval(param(nested_xml)),,,,,,,,,nested_read,",
             "3,,,,,,param,nested_xml,GetData,,read().response_data,,,,develop,,,,,,",
             "4,,,,,,param,action_type,input/ActionType,,input(),,,,develop,,,,,,",
@@ -7647,7 +7660,7 @@ class TestStructure(BaseTestCreateManifest):
         assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
-            "1,datasets/gov/ivpk/example,,,,,,,,,,,,,,,,,,Dataset,Dataset with ref property",
+            "1,datasets/gov/ivpk/example,,,,,,,,,,,,,,,,,,example,Dataset with ref property",
             "2,,,,Animal,,,,,,,,,0,completed,public,,,,,",
             "3,,,,,id,string,,source_animal_id,,,,,4,completed,package,protected,,,,",
             ",,,,,,,,,,,,,,,,,,,,",
@@ -7692,9 +7705,9 @@ class TestStructure(BaseTestCreateManifest):
         assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
-            "1,datasets/gov/ivpk/example,,,,,,,,,,,,,,,,,,Model Dataset,Dataset that defines base model.",
+            "1,datasets/gov/ivpk/example,,,,,,,,,,,,,,,,,,example,Dataset that defines base model.",
             "2,,,,Animal,,,,,,,,,0,completed,public,,,,,",
-            "1,datasets/gov/test/example2,,,,,,,,,,,,,,,,,,Base Dataset,Dataset that references model with base",
+            "1,datasets/gov/test/example2,,,,,,,,,,,,,,,,,,example2,Dataset that references model with base",
             "2,,,datasets/gov/ivpk/example/Animal,,,,,,,,,,,,,,,,,",
             "3,,,,Dog,,,,,,,,,0,completed,public,,,,,",
             "4,,,,,action,string,,source_dog_action,,,,,4,completed,package,protected,,,,",
@@ -7733,7 +7746,7 @@ class TestStructure(BaseTestCreateManifest):
         assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
-            "1,datasets/gov/test/example2,,,,,,,,,,,,,,,,,,Base Dataset,Dataset that references model with base",
+            "1,datasets/gov/test/example2,,,,,,,,,,,,,,,,,,example2,Dataset that references model with base",
             "3,,,,Dog,,,,,,,,,0,completed,public,,,,,",
             "4,,,,,action,string,,source_dog_action,,,,,4,completed,package,protected,,,,",
             ",,,,,,,,,,,,,,,,,,,,",
@@ -7742,7 +7755,7 @@ class TestStructure(BaseTestCreateManifest):
         error_comment = Comment.objects.get(content_type=ContentType.objects.get_for_model(Model))
         assert error_comment.type == Comment.STRUCTURE_ERROR
         assert error_comment.body == (
-            "Nepavyko susieti bazinio modelio „datasets/gov/ivpk/example/Animal“. "
+            "Nepavyko susieti bazinio modelio „datasets/gov/ivpk/example/Animal”. "
             "Įsitikinkite, kad jis egzistuoja ir turi patvirtintą (stabilią) versiją."
         )
 
@@ -7766,7 +7779,7 @@ class TestStructure(BaseTestCreateManifest):
         assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [  # Base could not be linked, so it is missing.
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
-            "1,datasets/gov/ivpk/example,,,,,,,,,,,,,,,,,,Dataset,Dataset with ref property",
+            "1,datasets/gov/ivpk/example,,,,,,,,,,,,,,,,,,example,Dataset with ref property",
             "3,,,,Dog,,,,,,,,,0,completed,public,,,,,",
             "4,,,,,action,string,,source_dog_action,,,,,4,completed,package,protected,,,,",
             ",,,,,,,,,,,,,,,,,,,,",
@@ -7775,7 +7788,7 @@ class TestStructure(BaseTestCreateManifest):
         error_comment = Comment.objects.get(content_type=ContentType.objects.get_for_model(Model))
         assert error_comment.type == Comment.STRUCTURE_ERROR
         assert error_comment.body == (
-            "Nepavyko susieti bazinio modelio „datasets/gov/ivpk/example/Animal“. "
+            "Nepavyko susieti bazinio modelio „datasets/gov/ivpk/example/Animal”. "
             "Įsitikinkite, kad jis egzistuoja ir turi patvirtintą (stabilią) versiją."
         )
 
@@ -7800,7 +7813,7 @@ class TestStructure(BaseTestCreateManifest):
         assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
-            "1,datasets/gov/ivpk/test,,,,,,,,,,,,,,,,,,Dataset,Dataset with ref property",
+            "1,datasets/gov/ivpk/test,,,,,,,,,,,,,,,,,,test,Dataset with ref property",
             "2,,,,Animal,,,,source_animal_model,,,,,,develop,,,,,,",
             '3,,,,,,comment,model,,,"update(model: ""Animal/:part"")",,,2,develop,,open,https://github.com/example/issues/1,,,',
             "4,,,,,id,string,,source_animal_id,,,,,4,develop,,,,,,",
@@ -7831,7 +7844,7 @@ class TestStructure(BaseTestCreateManifest):
         assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
-            "1,datasets/gov/ivpk/dataset,,,,,,,,,,,,,,,,,,Dataset,Dataset",
+            "1,datasets/gov/ivpk/dataset,,,,,,,,,,,,,,,,,,dataset,Dataset",
             "2,,,,Approver,,,,,,,,,1,develop,,,,,,",
             "3,,,,,is_active,boolean,,IsActive/text(),,,,,,develop,,,,,,",
             "4,,,,,,enum,,True,,true,,,,develop,,,,,,",
@@ -7858,7 +7871,7 @@ class TestStructure(BaseTestCreateManifest):
         assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
-            "1,datasets/gov/ivpk/example,,,,,,,,,,,,,,,,,,Dataset,Dataset",
+            "1,datasets/gov/ivpk/example,,,,,,,,,,,,,,,,,,example,Dataset",
             "2,,,,Dataset,,,,,,,,,1,develop,,,,,,",
             "3,,,,,type,number required,,TypeID/text(),,,,,,develop,,,,,,",
             "4,,,,,,enum,,1.1,,1.2,,,,develop,,,,,,",
@@ -7888,7 +7901,7 @@ class TestStructure(BaseTestCreateManifest):
         assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
-            "1,datasets/gov/ivpk/dataset,,,,,,,,,,,,,,,,,,Dataset,Dataset",
+            "1,datasets/gov/ivpk/dataset,,,,,,,,,,,,,,,,,,dataset,Dataset",
             "2,,,,,,enum,DatasetEnum,,,1,,,,develop,,,,,,",
             "3,,,,,,,,,,2,,,,develop,,,,,,",
             ",,,,,,,,,,,,,,,,,,,,",
@@ -7919,7 +7932,7 @@ class TestStructure(BaseTestCreateManifest):
         assert response.status_code == HTTPStatus.OK
         assert response.text.splitlines() == [
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description",
-            "1,datasets/gov/ivpk/dataset,,,,,,,,,,,,,,,,,,Dataset,Dataset",
+            "1,datasets/gov/ivpk/dataset,,,,,,,,,,,,,,,,,,dataset,Dataset",
             "2,,,,Dataset,,,,,,,,,1,develop,,,,,,",
             "3,,,,,code,integer,,,,,,,4,develop,,,,,,",
             "4,,,,,,enum,,,,10,,,,develop,,,,,,",
@@ -7976,10 +7989,10 @@ class TestStructureExportDependentModels(BaseTestCreateManifest):
         resp = app.get(reverse("dataset-structure-export", args=[main_dataset.pk, main_dataset.latest_version().pk]))
         assert resp.text == (
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
-            "7,datasets/gov/ref/dataset,,,,,,,,,,,,,,,,,,Referenced Dataset,Dataset that will be referenced\r\n"
+            "7,datasets/gov/ref/dataset,,,,,,,,,,,,,,,,,,dataset,Dataset that will be referenced\r\n"
             "8,,,,Continent,,,id,,,,,,,develop,,,,,,\r\n"
             "9,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
-            "1,datasets/gov/main/dataset,,,,,,,,,,,,,,,,,,Main Dataset,Dataset with reference to other dataset\r\n"
+            "1,datasets/gov/main/dataset,,,,,,,,,,,,,,,,,,dataset,Dataset with reference to other dataset\r\n"
             "2,,dataset,,,,,,https://get.data.gov.lt/datasets/gov/main/dataset/:ns,,,,,,,,,,,dataset,\r\n"
             '3,,,,Country,,,"id, title",,,,,,,develop,,,,,,\r\n'
             "4,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
@@ -8027,11 +8040,11 @@ class TestStructureExportDependentModels(BaseTestCreateManifest):
         resp = app.get(reverse("dataset-structure-export", args=[main_dataset.pk, main_dataset.latest_version().pk]))
         assert resp.text == (
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
-            "7,datasets/gov/ref/dataset,,,,,,,,,,,,,,,,,,Referenced Dataset,Dataset that will be referenced\r\n"
+            "7,datasets/gov/ref/dataset,,,,,,,,,,,,,,,,,,dataset,Dataset that will be referenced\r\n"
             '8,,,,Continent,,,"id, title",,,,,,,develop,,,,,,\r\n'
             "9,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
             "10,,,,,title,string,,,,,,,5,develop,,open,dct:title,,,\r\n"
-            "1,datasets/gov/main/dataset,,,,,,,,,,,,,,,,,,Main Dataset,Dataset with reference to other dataset\r\n"
+            "1,datasets/gov/main/dataset,,,,,,,,,,,,,,,,,,dataset,Dataset with reference to other dataset\r\n"
             "2,,dataset,,,,,,https://get.data.gov.lt/datasets/gov/main/dataset/:ns,,,,,,,,,,,dataset,\r\n"
             '3,,,,Country,,,"id, title",,,,,,,develop,,,,,,\r\n'
             "4,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
@@ -8083,14 +8096,14 @@ class TestStructureExportDependentModels(BaseTestCreateManifest):
         resp = app.get(reverse("dataset-structure-export", args=[main_dataset.pk, main_dataset.latest_version().pk]))
         assert resp.text == (
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
-            "12,datasets/gov/other/dataset,,,,,,,,,,,,,,,,,,Other Dataset,Dependent dataset depth 2\r\n"
+            "12,datasets/gov/other/dataset,,,,,,,,,,,,,,,,,,dataset,Dependent dataset depth 2\r\n"
             "13,,,,Other,,,title,,,,,,,develop,,,,,,\r\n"
             "14,,,,,title,string,,,,,,,5,develop,,open,dct:title,,,\r\n"
-            "7,datasets/gov/ref/dataset,,,,,,,,,,,,,,,,,,Referenced Dataset,Dependent dataset depth 1\r\n"
+            "7,datasets/gov/ref/dataset,,,,,,,,,,,,,,,,,,dataset,Dependent dataset depth 1\r\n"
             '8,,,,Continent,,,"id, title",,,,,,,develop,,,,,,\r\n'
             "9,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
             "10,,,,,title,ref,/datasets/gov/other/dataset/Other,,,,,,5,develop,,open,dct:title,,,\r\n"
-            "1,datasets/gov/main/dataset,,,,,,,,,,,,,,,,,,Main Dataset,Root dataset\r\n"
+            "1,datasets/gov/main/dataset,,,,,,,,,,,,,,,,,,dataset,Root dataset\r\n"
             "2,,dataset,,,,,,https://get.data.gov.lt/datasets/gov/main/dataset/:ns,,,,,,,,,,,dataset,\r\n"
             '3,,,,Country,,,"id, title",,,,,,,develop,,,,,,\r\n'
             "4,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
@@ -8123,7 +8136,7 @@ class TestStructureExportDependentModels(BaseTestCreateManifest):
         resp = app.get(reverse("dataset-structure-export", args=[main_dataset.pk, main_dataset.latest_version().pk]))
         assert resp.text == (
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
-            "1,datasets/gov/main/dataset,,,,,,,,,,,,,,,,,,Main Dataset,Dataset with reference to other dataset\r\n"
+            "1,datasets/gov/main/dataset,,,,,,,,,,,,,,,,,,dataset,Dataset with reference to other dataset\r\n"
             "2,,dataset,,,,,,https://get.data.gov.lt/datasets/gov/main/dataset/:ns,,,,,,,,,,,dataset,\r\n"
             '3,,,,Country,,,"id, title",,,,,,,develop,,,,,,\r\n'
             "4,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
@@ -8176,7 +8189,7 @@ class TestStructureExportDependentModels(BaseTestCreateManifest):
         resp = app.get(reverse("dataset-structure-export", args=[main_dataset.pk, main_dataset.latest_version().pk]))
         assert resp.text == (
             "id,dataset,resource,base,model,property,type,ref,source,source.type,prepare,origin,count,level,status,visibility,access,uri,eli,title,description\r\n"
-            "7,datasets/gov/ref/d1,,,,,,,,,,,,,,,,,,Referenced Dataset,Dataset with reference to other dataset\r\n"
+            "7,datasets/gov/ref/d1,,,,,,,,,,,,,,,,,,d1,Dataset with reference to other dataset\r\n"
             "8,,,,D1BaseModel,,,id,,,,,,,develop,,,,,,\r\n"
             "9,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
             "11,,,D1BaseModel,,,,,,,,,,,,,,,,,\r\n"
@@ -8185,7 +8198,7 @@ class TestStructureExportDependentModels(BaseTestCreateManifest):
             '15,,,,D1Model2,,,"id, prop2",,,,,,,develop,,,,,,\r\n'
             "16,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
             "17,,,,,prop2,string,,,,,,,5,develop,,open,dct:prop2,,,\r\n"
-            "1,datasets/gov/main/dataset,,,,,,,,,,,,,,,,,,Main Dataset,Dataset with reference to other dataset\r\n"
+            "1,datasets/gov/main/dataset,,,,,,,,,,,,,,,,,,dataset,Dataset with reference to other dataset\r\n"
             "2,,dataset,,,,,,https://get.data.gov.lt/datasets/gov/main/dataset/:ns,,,,,,,,,,,dataset,\r\n"
             '3,,,,MainModel,,,"id, prop1",,,,,,,develop,,,,,,\r\n'
             "4,,,,,id,integer,,,,,,,5,develop,,open,dct:identifier,,Identifikatorius,\r\n"
@@ -8528,7 +8541,8 @@ class TestStructureUMLviews(BaseTestCreateManifest):
         user = UserFactory(is_staff=True)
         app.set_user(user)
         structure = DatasetStructureFactory(
-            file=FilerFileFactory(file=FileField(filename="file.csv", data=self.MANIFEST))
+            file=FilerFileFactory(file=FileField(filename="file.csv", data=self.MANIFEST)),
+            dataset__metadata="datasets/gov/ivpk/adp",
         )
         structure.dataset.current_structure = structure
         structure.dataset.save()
@@ -8549,7 +8563,7 @@ class TestStructureUMLviews(BaseTestCreateManifest):
             "7,,,,Catalog,,,,,,,,,,,,,,\n"
             "8,,,,,id,integer,,,,,,,,,,,,\n"
         )
-        structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+        structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
         structure.dataset.current_structure = structure
         structure.dataset.save()
         version = create_structure_objects(structure)
@@ -8575,7 +8589,7 @@ class TestStructureUMLviews(BaseTestCreateManifest):
             "7,,,,Catalog,,,,,,,,,,,,,,\n"
             "8,,,,,id,integer,,,,,,,,,,,,\n"
         )
-        structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+        structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
         structure.dataset.current_structure = structure
         structure.dataset.save()
         version = create_structure_objects(structure)
@@ -8605,7 +8619,7 @@ class TestStructureUMLviews(BaseTestCreateManifest):
             "7,,,,Catalog,,,,,,,,,,,,,,\n"
             "8,,,,,id,integer,,,,,,,,,,,,\n"
         )
-        structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+        structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
         structure.dataset.current_structure = structure
         structure.dataset.save()
         version = create_structure_objects(structure)
@@ -8633,7 +8647,7 @@ class TestStructureUMLviews(BaseTestCreateManifest):
             "7,,,,Catalog,,,,,,,,,,,,,,\n"
             "8,,,,,id,integer,,,,,,,,,,,,\n"
         )
-        structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+        structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset__metadata="datasets/gov/ivpk/adp")
         structure.dataset.current_structure = structure
         structure.dataset.save()
         version = create_structure_objects(structure)

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -1,4 +1,6 @@
+import csv
 import datetime
+import io
 import json
 import uuid
 from http import HTTPStatus
@@ -54,6 +56,7 @@ from vitrina.structure.models import (
     PropertyList,
     UMLDiagram,
 )
+from vitrina.datasets.structure import read
 from vitrina.structure.services import create_structure_objects, generate_mermaid_diagram
 from vitrina.users.factories import UserFactory
 from vitrina.structure.models import Version as _Version
@@ -64,10 +67,12 @@ class BaseTestCreateManifest:
     def _create_manifest(
         self, manifest: str, title: str = "", description: str = "", whitelisted_names: list[str] | None = None
     ) -> Dataset:
+        state = read(csv.DictReader(io.StringIO(manifest)))
+        dataset_name = next(iter(state.manifest.datasets), "datasets/gov/ivpk/dataset")
         dataset = DatasetFactory(
             title=title,
             description=description,
-            metadata=False,
+            metadata=dataset_name,
             organization=OrganizationFactory(whitelisted_names=whitelisted_names if whitelisted_names else []),
         )
         structure = DatasetStructureFactory(
@@ -886,7 +891,9 @@ def test_private_model(app: DjangoTestApp):
         ",,,,,id,integer,,,,5,,,private,dct:identifier,,Identifikatorius,,\n"
         ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
+    dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -911,7 +918,8 @@ def test_private_model_with_access(app: DjangoTestApp):
         ",,,,,id,integer,,,,5,,,private,dct:identifier,,Identifikatorius,,\n"
         ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -944,7 +952,8 @@ def test_private_property(app: DjangoTestApp):
         ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
         ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -968,7 +977,8 @@ def test_private_property_with_access(app: DjangoTestApp):
         ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
         ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -1002,7 +1012,8 @@ def test_private_comment(app: DjangoTestApp):
         ",,,,,,comment,type,,,,,,private,,,,Private comment,\n"
         ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -1028,7 +1039,8 @@ def test_private_comment_with_access(app: DjangoTestApp):
         ",,,,,,comment,type,,,,private,,,,,,Private comment,\n"
         ",,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -3945,7 +3957,8 @@ def test_visibility_without_access(app: DjangoTestApp):
         ",,,,,number,string,,,,5,,package,open,dct:number,,,,\n"
         ",,,,,residence,string,,,,5,,public,open,dct:residence,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -4063,7 +4076,9 @@ def test_model_visibility_with_manager_access(app: DjangoTestApp):
         ",,,,,residence,string,,,,5,,public,open,dct:residence,,,,\n"
     )
 
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+
+    dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -4188,7 +4203,8 @@ def test_model_visibility_with_open_data_representative_access(app: DjangoTestAp
         ",,,,,residence,string,,,,5,,public,open,dct:residence,,,,\n"
     )
     organization = OrganizationFactory(kind=Organization.GOV)
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
     structure.dataset.organization = organization
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -4312,7 +4328,8 @@ def test_model_visibility_with_information_system_representative_access(app: Dja
         ",,,,,residence,string,,,,5,,public,open,dct:residence,,,,\n"
     )
     organization = OrganizationFactory(kind=Organization.GOV)
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
     structure.dataset.organization = organization
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -4980,7 +4997,7 @@ def test_manifest_export_openapi(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
+        dataset=DatasetFactory(metadata="datasets/gov/ivpk/adp"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -5099,7 +5116,7 @@ def test_manifest_export_openapi_soap_params(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
+        dataset=DatasetFactory(metadata="datasets/gov/ivpk/adp"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -5134,7 +5151,7 @@ def test_manifest_export_openapi_with_scopes(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
+        dataset=DatasetFactory(metadata="datasets/gov/ivpk/adp"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -5178,7 +5195,7 @@ def test_imported_metadata_gets_develop_status(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
+        dataset=DatasetFactory(metadata="datasets/gov/ivpk/adp"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -5228,7 +5245,7 @@ def test_updating_metadata_in_not_draft_version_not_allowed(app: DjangoTestApp, 
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
+        dataset=DatasetFactory(metadata="datasets/gov/ivpk/adp"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -5290,7 +5307,7 @@ def test_published_metadata_gets_completed_status(app: DjangoTestApp):
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
+        dataset=DatasetFactory(metadata="datasets/gov/ivpk/adp"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -5356,7 +5373,8 @@ def test_changed_metadata_keeps_status_after_publishing(app: DjangoTestApp):
         ",,,,,,enum,,,'SMALL',,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -5441,7 +5459,8 @@ def test_draft_metadata_defaults_to_develop_after_hard_change(app: DjangoTestApp
         ",,,,,,,,,BIG,,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -5502,7 +5521,8 @@ def test_changing_multiple_fields_in_draft_structure_respects_status(app: Django
         ",,,,,,enum,,,'''SMALL''',,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -5567,7 +5587,8 @@ def test_draft_metadata_form_does_not_change_status_is_kept(app: DjangoTestApp):
         ",,,,,,,,,'''BIG''',,,,,,,,,\n"
         ",,,,,,,,,,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -5998,7 +6019,8 @@ def test_publish_form_shows_all_metadata_rows_params(app: DjangoTestApp):
         "8,,,,,id,integer,,,,5,,,open,dct:identifier,,Identifikatorius,,\n"
         "9,,,,,type,string,,,,5,,,open,dct:type,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -6023,7 +6045,8 @@ def test_publish_form_shows_all_metadata_rows_base(app: DjangoTestApp):
         ",,,,,id,integer,,,,3,,,,,,,,,\n"
         ",,,,,title,string,,,,2,,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -6049,7 +6072,8 @@ def test_publish_form_shows_all_metadata_rows_enum(app: DjangoTestApp):
         "10,,,,,,enum,,,'''CREATED''',,,,,,,,,\n"
         "11,,,,,,,,,'''MODIFIED''',,,,,,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+    dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure)
@@ -6076,7 +6100,7 @@ def test_publish_form_shows_all_metadata_rows_single_defined_resource(app: Djang
 
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
+        dataset=DatasetFactory(metadata="datasets/gov/ivpk/adp"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -6105,7 +6129,7 @@ def test_publish_form_shows_all_metadata_rows_multiple_resources(app: DjangoTest
 
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
+        dataset=DatasetFactory(metadata="datasets/gov/ivpk/adp"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -6140,7 +6164,7 @@ def test_publish_form_shows_all_metadata_rows_denorm_props(app: DjangoTestApp):
 
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
+        dataset=DatasetFactory(metadata="datasets/gov/ivpk/adp"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -6693,7 +6717,7 @@ def test_publishing_property_with_ref_to_another_model(app: DjangoTestApp):
 
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
+        dataset=DatasetFactory(metadata="datasets/gov/ivpk/adp"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -6747,7 +6771,7 @@ def test_publishing_property_with_ref_to_another_property(app: DjangoTestApp):
 
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
+        dataset=DatasetFactory(metadata="datasets/gov/ivpk/adp"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -6794,7 +6818,7 @@ def test_publishing_model_with_base_from_published_version_same_dataset(app: Dja
     )
     structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/ivpk/"])),
+        dataset=DatasetFactory(metadata="datasets/gov/ivpk/adp"),
     )
     structure.dataset.current_structure = structure
     structure.dataset.save()
@@ -8527,8 +8551,10 @@ class TestStructureUMLviews(BaseTestCreateManifest):
     def _setup_uml(self, app: DjangoTestApp, **uml_kwargs):
         user = UserFactory(is_staff=True)
         app.set_user(user)
+        dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
         structure = DatasetStructureFactory(
-            file=FilerFileFactory(file=FileField(filename="file.csv", data=self.MANIFEST))
+            file=FilerFileFactory(file=FileField(filename="file.csv", data=self.MANIFEST)),
+            dataset=dataset
         )
         structure.dataset.current_structure = structure
         structure.dataset.save()
@@ -8549,7 +8575,8 @@ class TestStructureUMLviews(BaseTestCreateManifest):
             "7,,,,Catalog,,,,,,,,,,,,,,\n"
             "8,,,,,id,integer,,,,,,,,,,,,\n"
         )
-        structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+        dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
+        structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
         structure.dataset.current_structure = structure
         structure.dataset.save()
         version = create_structure_objects(structure)
@@ -8575,7 +8602,8 @@ class TestStructureUMLviews(BaseTestCreateManifest):
             "7,,,,Catalog,,,,,,,,,,,,,,\n"
             "8,,,,,id,integer,,,,,,,,,,,,\n"
         )
-        structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+        dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
+        structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
         structure.dataset.current_structure = structure
         structure.dataset.save()
         version = create_structure_objects(structure)
@@ -8605,7 +8633,8 @@ class TestStructureUMLviews(BaseTestCreateManifest):
             "7,,,,Catalog,,,,,,,,,,,,,,\n"
             "8,,,,,id,integer,,,,,,,,,,,,\n"
         )
-        structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+        dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
+        structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
         structure.dataset.current_structure = structure
         structure.dataset.save()
         version = create_structure_objects(structure)
@@ -8633,7 +8662,8 @@ class TestStructureUMLviews(BaseTestCreateManifest):
             "7,,,,Catalog,,,,,,,,,,,,,,\n"
             "8,,,,,id,integer,,,,,,,,,,,,\n"
         )
-        structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)))
+        dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
+        structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=manifest)), dataset=dataset)
         structure.dataset.current_structure = structure
         structure.dataset.save()
         version = create_structure_objects(structure)

--- a/tests/structure/test_views.py
+++ b/tests/structure/test_views.py
@@ -5080,7 +5080,10 @@ def test_manifest_export_openapi_with_dependent_models(app: DjangoTestApp):
     )
     city_structure = DatasetStructureFactory(
         file=FilerFileFactory(file=FileField(filename="file.csv", data=city_manifest)),
-        dataset=DatasetFactory(organization=OrganizationFactory(whitelisted_names=["datasets/gov/test/"])),
+        dataset=DatasetFactory(
+            organization=OrganizationFactory(whitelisted_names=["datasets/gov/test/"]),
+            metadata="datasets/gov/test/city",
+        ),
     )
     city_structure.dataset.current_structure = city_structure
     city_structure.dataset.save()
@@ -5095,7 +5098,10 @@ def test_manifest_export_openapi_with_dependent_models(app: DjangoTestApp):
         ",,,,,title,string,,,,5,,,private,dct:title,,,,\n"
         ",,,,,city,ref,/datasets/gov/test/city/City,,,,5,,,private,dct:title,,,,\n"
     )
-    structure = DatasetStructureFactory(file=FilerFileFactory(file=FileField(filename="file.csv", data=main_manifest)))
+    dataset = DatasetFactory(metadata="datasets/gov/ivpk/adp")
+    structure = DatasetStructureFactory(
+        file=FilerFileFactory(file=FileField(filename="file.csv", data=main_manifest)), dataset=dataset
+    )
     structure.dataset.current_structure = structure
     structure.dataset.save()
     version = create_structure_objects(structure, structure.dataset.metadata.first().metadata_version)

--- a/vitrina/datasets/factories.py
+++ b/vitrina/datasets/factories.py
@@ -130,10 +130,7 @@ class DatasetFactory(DjangoModelFactory):
     def metadata(self, create: bool, extracted: str, **kwargs) -> None:
         if not create:
             return
-        if extracted is False:
-            return
-        name = extracted if extracted is not None else ((self.organization.name or "datasets/gov/test/") + "abcd")
-
+        name = extracted if extracted is not None else ((self.organization.name or "datasets/gov/ivpk/") + "adp")
         MetadataFactory.create(
             dataset=self, content_type=ContentType.objects.get_for_model(self), object_id=self.pk, name=name
         )

--- a/vitrina/datasets/factories.py
+++ b/vitrina/datasets/factories.py
@@ -1,3 +1,4 @@
+import re
 from typing import Union
 
 import factory
@@ -130,12 +131,11 @@ class DatasetFactory(DjangoModelFactory):
     def metadata(self, create: bool, extracted: str, **kwargs) -> None:
         if not create:
             return
-        if extracted is False:
-            return
-        name = extracted if extracted is not None else ((self.organization.name or "datasets/gov/test/") + "abcd")
-
+        name = extracted if extracted is not None else (
+            self.organization.name.rstrip("/") + "/" + re.sub(r"[^a-z0-9\-]", "-", self.en_title().lower()).strip("-")
+        )
         MetadataFactory.create(
-            dataset=self, content_type=ContentType.objects.get_for_model(self), object_id=self.pk, name=name
+            dataset=self, content_type=ContentType.objects.get_for_model(self), object_id=self.pk, name=name,
         )
 
 

--- a/vitrina/datasets/factories.py
+++ b/vitrina/datasets/factories.py
@@ -130,7 +130,7 @@ class DatasetFactory(DjangoModelFactory):
     def metadata(self, create: bool, extracted: str, **kwargs) -> None:
         if not create:
             return
-        name = extracted if extracted is not None else ((self.organization.name or "datasets/gov/ivpk/") + "adp")
+        name = extracted if extracted is not None else "datasets/gov/ivpk/adp"
         MetadataFactory.create(
             dataset=self, content_type=ContentType.objects.get_for_model(self), object_id=self.pk, name=name
         )

--- a/vitrina/datasets/factories.py
+++ b/vitrina/datasets/factories.py
@@ -1,4 +1,3 @@
-import re
 from typing import Union
 
 import factory
@@ -131,11 +130,12 @@ class DatasetFactory(DjangoModelFactory):
     def metadata(self, create: bool, extracted: str, **kwargs) -> None:
         if not create:
             return
-        name = extracted if extracted is not None else (
-            self.organization.name.rstrip("/") + "/" + re.sub(r"[^a-z0-9\-]", "-", self.en_title().lower()).strip("-")
-        )
+        if extracted is False:
+            return
+        name = extracted if extracted is not None else ((self.organization.name or "datasets/gov/test/") + "abcd")
+
         MetadataFactory.create(
-            dataset=self, content_type=ContentType.objects.get_for_model(self), object_id=self.pk, name=name,
+            dataset=self, content_type=ContentType.objects.get_for_model(self), object_id=self.pk, name=name
         )
 
 

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-27 12:56+0300\n"
+"POT-Creation-Date: 2026-06-03 10:19+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4894,6 +4894,17 @@ msgstr "UML diagrams"
 
 msgid "UML diagrama mermaid sintaksės formatu."
 msgstr "UML diagram in mermaid syntax format."
+
+#, python-format
+msgid ""
+"Kodinis pavadinimas (%(manifest_names)s) nesutampa su rinkinio kodiniu "
+"pavadinimu %(dataset_name)s."
+msgstr ""
+"Code name (%(manifest_names)s) does not match with the dataset code name "
+"%(dataset_name)s."
+
+msgid "Manifeste nenurodytas duomenų rinkinio kodinis pavadinimas."
+msgstr "Dataset code name not defined in the manifest"
 
 #, python-brace-format
 msgid ""

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -4903,7 +4903,7 @@ msgstr ""
 "Code name (%(manifest_names)s) does not match with the dataset code name "
 "%(dataset_name)s."
 
-msgid "Manifeste nenurodytas duomenų rinkinio kodinis pavadinimas."
+msgid "Duomenų struktūros apraše nenurodytas duomenų rinkinio kodinis pavadinimas."
 msgstr "Dataset code name not defined in the manifest"
 
 #, python-brace-format

--- a/vitrina/structure/services.py
+++ b/vitrina/structure/services.py
@@ -22,7 +22,6 @@ from django.utils.translation import gettext, gettext_lazy as _, get_language
 from vitrina import settings
 from vitrina.classifiers.models import Status
 from vitrina.comments.models import Comment
-from vitrina.datasets.helpers import get_name_prefixes
 from vitrina.datasets.models import DatasetStructure, Dataset
 from vitrina.datasets.structure import detect_read_errors, read
 from vitrina.helpers import none_to_string, get_encoding
@@ -221,14 +220,15 @@ def _load_datasets(state: struct.State, dataset: Dataset, metadata_version: Vers
             type=Comment.STRUCTURE,
         ).only("pk", "object_id")
     )
-    to_process, main_prefix, whitelisted = _get_manifest_datasets_to_import(state, dataset)
+    to_process, all_manifest_names = _get_manifest_datasets_to_import(state, dataset)
     if not to_process:
-        if whitelisted:
+        if all_manifest_names:
+            names_str = ", ".join(all_manifest_names)
             message = _(
-                "Kodinis pavadinimas turi prasidėti nuo „%(expected)s“ arba vieno iš leidžiamų kodinio pavadinimo pradžių: „%(whitelisted)s“."
-            ) % {"expected": main_prefix, "whitelisted": ", ".join(whitelisted)}
+                "Kodinis pavadinimas (%(manifest_names)s) nesutampa su rinkinio kodiniu pavadinimu %(dataset_name)s."
+            ) % {"manifest_names": names_str, "dataset_name": dataset.name}
         else:
-            message = _("Kodinis pavadinimas turi prasidėti nuo „%(expected)s“.") % {"expected": main_prefix}
+            message = _("Manifeste nenurodytas duomenų rinkinio kodinis pavadinimas.")
         _create_errors([message], dataset.current_structure)
         return
 
@@ -243,14 +243,13 @@ def _load_datasets(state: struct.State, dataset: Dataset, metadata_version: Vers
         ).only("uuid", "name"):
             dataset_meta_uuid_by_name.setdefault(metadata.name, metadata.uuid)
 
-    # One query: names already claimed by another dataset for this version (replaces N loop queries).
+    # One query: names already claimed by another dataset (globally, not version-scoped).
     conflict_by_name: dict[str, Metadata] = {}
     if manifest_names:
         for metadata in (
             Metadata.objects.filter(
                 content_type=ct,
                 name__in=manifest_names,
-                metadata_version=metadata_version,
             )
             .exclude(dataset=dataset)
             .order_by("pk")
@@ -269,7 +268,6 @@ def _load_datasets(state: struct.State, dataset: Dataset, metadata_version: Vers
                 Metadata.objects.filter(
                     content_type=ct,
                     name=meta.name,
-                    metadata_version=metadata_version,
                 )
                 .exclude(dataset=dataset)
                 .first()
@@ -345,24 +343,20 @@ def _get_manifest_datasets_to_process(state: struct.State, dataset: Dataset) -> 
 
 def _get_manifest_datasets_to_import(
     state: struct.State, dataset: Dataset
-) -> tuple[list[tuple[int, struct.Dataset]], str, list[str]]:
+) -> tuple[list[tuple[int, struct.Dataset]], list[str]]:
     """
     Get manifest datasets to import.
 
-    - Re-import: matches by dataset.name.
-    - First import: falls back to last dataset with a matching organization prefix.
-
-    Also returns main_prefix and whitelisted for error reporting.
+    Requires an exact name match with dataset.name.
+    Also returns all manifest dataset names for error reporting.
     """
     datasets = list(state.manifest.datasets.values())
     result: list[tuple[int, struct.Dataset]] = []
-    main_prefix, whitelisted = "", []
+    all_manifest_names: list[str] = [meta.name for meta in datasets if meta.name]
     for order, meta in enumerate(datasets, 1):
-        is_last = order == len(datasets)
-        matched_prefix, main_prefix, whitelisted = get_name_prefixes(meta.name, dataset.organization, dataset)
-        if meta.name == dataset.name or (matched_prefix and is_last):
+        if meta.name == dataset.name:
             result.append((order, meta))
-    return result, main_prefix, whitelisted
+    return result, all_manifest_names
 
 
 def _load_prefixes(

--- a/vitrina/structure/services.py
+++ b/vitrina/structure/services.py
@@ -1,7 +1,6 @@
 import csv
 import json
 import logging
-import tempfile
 import uuid
 from io import StringIO
 from json import JSONDecodeError
@@ -348,34 +347,15 @@ def _get_manifest_datasets_to_import(
     """
     Get manifest datasets to import.
 
-    Prefers exact name match with dataset.name.
-    Falls back to UUID match (for re-imports where the dataset name changed).
+    Requires an exact name match with dataset.name.
     Also returns all manifest dataset names for error reporting.
     """
     datasets = list(state.manifest.datasets.values())
     result: list[tuple[int, struct.Dataset]] = []
     all_manifest_names: list[str] = [meta.name for meta in datasets if meta.name]
-
-    # First pass: exact name match.
     for order, meta in enumerate(datasets, 1):
         if meta.name == dataset.name:
             result.append((order, meta))
-
-    if result:
-        return result, all_manifest_names
-
-    # Second pass: UUID match (handles re-imports where the dataset name changed).
-    ct = ContentType.objects.get_for_model(Dataset)
-    existing_uuids: set[str] = set(
-        Metadata.objects.filter(content_type=ct, object_id=dataset.pk)
-        .exclude(uuid="")
-        .values_list("uuid", flat=True)
-        .distinct()
-    )
-    for order, meta in enumerate(datasets, 1):
-        if meta.id and str(meta.id) in existing_uuids:
-            result.append((order, meta))
-
     return result, all_manifest_names
 
 
@@ -1469,7 +1449,7 @@ def _link_base(
             else:
                 meta.errors.append(
                     _(
-                        f"Nepavyko susieti bazinio modelio „{meta.name}”. "
+                        f"Nepavyko susieti bazinio modelio „{meta.name}“. "
                         f"Įsitikinkite, kad jis egzistuoja ir turi patvirtintą (stabilią) versiją."
                     )
                 )
@@ -1570,7 +1550,7 @@ def _link_properties(
                         ).delete()
                 else:
                     message = _(
-                        "Nepavyko susieti savybės „%(name)s” per nurodytą ryšį „%(ref)s”. "
+                        "Nepavyko susieti savybės „%(name)s“ per nurodytą ryšį „%(ref)s“. "
                         "Įsitikinkite, kad nurodytas modelis egzistuoja."
                     ) % {"name": prop_meta.name, "ref": prop_meta.ref}
                     _create_errors([message], model)
@@ -2510,7 +2490,7 @@ def _to_relative_model_name(name: str, dataset: Dataset) -> str:
             return name
         prefix = dataset.name + "/"
         if name.startswith(prefix):
-            return name[len(prefix):]
+            return name[len(prefix) :]
     return name
 
 
@@ -2607,11 +2587,7 @@ def generate_mermaid_diagram(dataset: Dataset, version: Version) -> str:
         verbose=False,
         check_config=False,
     )
-    with tempfile.NamedTemporaryFile(mode="r", suffix=".mmd", delete=False) as tmp:
-        tmp_path = tmp.name
-    write_mermaid_manifest(context, tmp_path, manifest)
-    with open(tmp_path) as f:
-        mermaid = f.read()
+    mermaid = write_mermaid_manifest(context, manifest, dataset.name)
     mermaid_click_links = _generate_mermaid_model_click_links(dataset, version)
     return mermaid + "\n" + mermaid_click_links
 

--- a/vitrina/structure/services.py
+++ b/vitrina/structure/services.py
@@ -228,7 +228,7 @@ def _load_datasets(state: struct.State, dataset: Dataset, metadata_version: Vers
                 "Kodinis pavadinimas (%(manifest_names)s) nesutampa su rinkinio kodiniu pavadinimu %(dataset_name)s."
             ) % {"manifest_names": names_str, "dataset_name": dataset.name}
         else:
-            message = _("Manifeste nenurodytas duomenų rinkinio kodinis pavadinimas.")
+            message = _("Duomenų struktūros apraše nenurodytas duomenų rinkinio kodinis pavadinimas.")
         _create_errors([message], dataset.current_structure)
         return
 

--- a/vitrina/structure/services.py
+++ b/vitrina/structure/services.py
@@ -1,6 +1,7 @@
 import csv
 import json
 import logging
+import tempfile
 import uuid
 from io import StringIO
 from json import JSONDecodeError
@@ -347,15 +348,34 @@ def _get_manifest_datasets_to_import(
     """
     Get manifest datasets to import.
 
-    Requires an exact name match with dataset.name.
+    Prefers exact name match with dataset.name.
+    Falls back to UUID match (for re-imports where the dataset name changed).
     Also returns all manifest dataset names for error reporting.
     """
     datasets = list(state.manifest.datasets.values())
     result: list[tuple[int, struct.Dataset]] = []
     all_manifest_names: list[str] = [meta.name for meta in datasets if meta.name]
+
+    # First pass: exact name match.
     for order, meta in enumerate(datasets, 1):
         if meta.name == dataset.name:
             result.append((order, meta))
+
+    if result:
+        return result, all_manifest_names
+
+    # Second pass: UUID match (handles re-imports where the dataset name changed).
+    ct = ContentType.objects.get_for_model(Dataset)
+    existing_uuids: set[str] = set(
+        Metadata.objects.filter(content_type=ct, object_id=dataset.pk)
+        .exclude(uuid="")
+        .values_list("uuid", flat=True)
+        .distinct()
+    )
+    for order, meta in enumerate(datasets, 1):
+        if meta.id and str(meta.id) in existing_uuids:
+            result.append((order, meta))
+
     return result, all_manifest_names
 
 
@@ -1449,7 +1469,7 @@ def _link_base(
             else:
                 meta.errors.append(
                     _(
-                        f"Nepavyko susieti bazinio modelio „{meta.name}“. "
+                        f"Nepavyko susieti bazinio modelio „{meta.name}”. "
                         f"Įsitikinkite, kad jis egzistuoja ir turi patvirtintą (stabilią) versiją."
                     )
                 )
@@ -1550,7 +1570,7 @@ def _link_properties(
                         ).delete()
                 else:
                     message = _(
-                        "Nepavyko susieti savybės „%(name)s“ per nurodytą ryšį „%(ref)s“. "
+                        "Nepavyko susieti savybės „%(name)s” per nurodytą ryšį „%(ref)s”. "
                         "Įsitikinkite, kad nurodytas modelis egzistuoja."
                     ) % {"name": prop_meta.name, "ref": prop_meta.ref}
                     _create_errors([message], model)
@@ -2490,7 +2510,7 @@ def _to_relative_model_name(name: str, dataset: Dataset) -> str:
             return name
         prefix = dataset.name + "/"
         if name.startswith(prefix):
-            return name[len(prefix) :]
+            return name[len(prefix):]
     return name
 
 
@@ -2587,7 +2607,11 @@ def generate_mermaid_diagram(dataset: Dataset, version: Version) -> str:
         verbose=False,
         check_config=False,
     )
-    mermaid = write_mermaid_manifest(context, manifest, dataset.name)
+    with tempfile.NamedTemporaryFile(mode="r", suffix=".mmd", delete=False) as tmp:
+        tmp_path = tmp.name
+    write_mermaid_manifest(context, tmp_path, manifest)
+    with open(tmp_path) as f:
+        mermaid = f.read()
     mermaid_click_links = _generate_mermaid_model_click_links(dataset, version)
     return mermaid + "\n" + mermaid_click_links
 


### PR DESCRIPTION
Renamed branch from bg/dataset_name

A bug, which allows importing the same DSA on different datasets from the same organization.

The mistake happens, because dataset code name can be changed by the uploaded manifest, which only has to have the organization prefix. The changes make it so the code names have to match 1:1, not only the prefix

