### PR TITLE
DCAT - Design fixes and improvements

### DIFF
--- a/vitrina/dcat/form_helpers.py
+++ b/vitrina/dcat/form_helpers.py
@@ -1,4 +1,6 @@
 from django import forms
+from django.utils.html import conditional_escape, escape
+from django.utils.safestring import mark_safe
 
 from vitrina.classifiers.models import FormFieldHelpText
 from vitrina.datasets.helpers import get_name_prefixes
@@ -8,8 +10,25 @@ from vitrina.orgs.models import Organization
 
 def apply_dynamic_help_texts(form: forms.BaseForm, form_name: str) -> None:
     for entry in FormFieldHelpText.objects.filter(form_name=form_name).prefetch_related("translations"):
-        if entry.field_name in form.fields and (help_text := entry.safe_translation_getter("help_text")):
-            form.fields[entry.field_name].help_text = help_text
+        if entry.field_name not in form.fields:
+            continue
+
+        field = form.fields[entry.field_name]
+        help_text = entry.safe_translation_getter("help_text") or ""
+        extended = entry.safe_translation_getter("extended_help_text") or ""
+
+        if help_text:
+            field.help_text = help_text
+
+        if extended and field.help_text:
+            popup_html = (
+                f' <span class="wizard-help-popup" x-data="{{open:false}}" @click.outside="open=false">'
+                f'<button type="button" class="wizard-help-popup-btn" @click.stop="open=!open">'
+                f'<i class="fas fa-question-circle"></i></button>'
+                f'<span class="wizard-help-popup-content" x-show="open" x-cloak>'
+                f'{escape(extended)}</span></span>'
+            )
+            field.help_text = mark_safe(f"{conditional_escape(field.help_text)}{popup_html}")
 
 
 def get_available_dcat_name_prefixes(parent_dataset: Dataset | None, organization: Organization) -> list[str]:

--- a/vitrina/dcat/form_helpers.py
+++ b/vitrina/dcat/form_helpers.py
@@ -27,7 +27,7 @@ def apply_dynamic_help_texts(form: forms.BaseForm, form_name: str) -> None:
                 f'<button type="button" class="wizard-help-popup-btn" aria-label="Daugiau informacijos" @click.stop="open=!open">'
                 f'<i class="fas fa-question-circle"></i></button>'
                 f'<span class="wizard-help-popup-content" x-show="open" x-cloak>'
-                f'{escape(extended)}</span></span>'
+                f"{escape(extended)}</span></span>"
             )
             field.help_text = mark_safe(f"{conditional_escape(field.help_text)}{popup_html}")
 

--- a/vitrina/dcat/form_helpers.py
+++ b/vitrina/dcat/form_helpers.py
@@ -9,6 +9,7 @@ from vitrina.orgs.models import Organization
 
 
 def apply_dynamic_help_texts(form: forms.BaseForm, form_name: str) -> None:
+    # Extended help text popup uses Alpine.js — this function is only called from wizard views.
     for entry in FormFieldHelpText.objects.filter(form_name=form_name).prefetch_related("translations"):
         if entry.field_name not in form.fields:
             continue
@@ -23,7 +24,7 @@ def apply_dynamic_help_texts(form: forms.BaseForm, form_name: str) -> None:
         if extended and field.help_text:
             popup_html = (
                 f' <span class="wizard-help-popup" x-data="{{open:false}}" @click.outside="open=false">'
-                f'<button type="button" class="wizard-help-popup-btn" @click.stop="open=!open">'
+                f'<button type="button" class="wizard-help-popup-btn" aria-label="Daugiau informacijos" @click.stop="open=!open">'
                 f'<i class="fas fa-question-circle"></i></button>'
                 f'<span class="wizard-help-popup-content" x-show="open" x-cloak>'
                 f'{escape(extended)}</span></span>'

--- a/vitrina/dcat/view_helpers.py
+++ b/vitrina/dcat/view_helpers.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 from django.contrib import messages
 from django.core.handlers.wsgi import WSGIRequest
 from django.db import transaction
+from django.db.models import Q, QuerySet
 from django.utils.translation import gettext_lazy as _
 
 from vitrina.datasets.models import (
@@ -11,11 +12,33 @@ from vitrina.datasets.models import (
     DatasetAttribution,
     DatasetQualifiedRelation,
     DatasetRelation,
+    DCATResourceSubclass,
     Relation,
 )
 
 if TYPE_CHECKING:
+    from vitrina.orgs.models import Organization
     from vitrina.dcat.forms.dataset_forms import BaseResourceForm
+
+
+def datasets_in_org_scope(organization: "Organization") -> QuerySet:
+    """Return a Dataset queryset scoped to the wizard organization.
+
+    Includes datasets directly owned by the org AND datasets that are
+    descendants of IS nodes owned by the org (which may have a different
+    organization FK set as their data provider).
+    """
+    is_paths = list(
+        Dataset.objects.filter(
+            organization=organization,
+            is_public=False,
+            subclass__name=DCATResourceSubclass.INFORMATION_SYSTEM,
+        ).values_list("path", flat=True)
+    )
+    conditions = Q(organization=organization)
+    for path in is_paths:
+        conditions |= Q(path__startswith=path)
+    return Dataset.objects.filter(conditions)
 
 
 def wizard_breadcrumb_ancestors(dataset: "Dataset | None", organization, include_self: bool = False) -> list[dict]:

--- a/vitrina/dcat/views/dataset_views.py
+++ b/vitrina/dcat/views/dataset_views.py
@@ -27,6 +27,7 @@ from vitrina.datasets.view_helpers import (
     save_dataset_creator,
 )
 from vitrina.dcat.view_helpers import (
+    datasets_in_org_scope,
     save_dataset_relations,
     save_dataset_attribution,
     save_dataset_qualified_relations,
@@ -403,7 +404,10 @@ class DcatDatasetUpdateView(
         return context
 
     def get_queryset(self) -> QuerySet[Dataset]:
-        return super().get_queryset().filter(organization=self.organization).select_related("organization", "subclass")
+        return (
+            datasets_in_org_scope(self.organization)
+            .select_related("organization", "subclass")
+        )
 
     def get_object(self, queryset: QuerySet[Dataset] | None = None) -> Dataset:
         obj = super().get_object(queryset)

--- a/vitrina/dcat/views/dataset_views.py
+++ b/vitrina/dcat/views/dataset_views.py
@@ -404,10 +404,7 @@ class DcatDatasetUpdateView(
         return context
 
     def get_queryset(self) -> QuerySet[Dataset]:
-        return (
-            datasets_in_org_scope(self.organization)
-            .select_related("organization", "subclass")
-        )
+        return datasets_in_org_scope(self.organization).select_related("organization", "subclass")
 
     def get_object(self, queryset: QuerySet[Dataset] | None = None) -> Dataset:
         obj = super().get_object(queryset)

--- a/vitrina/dcat/views/distribution_views.py
+++ b/vitrina/dcat/views/distribution_views.py
@@ -11,13 +11,14 @@ from django.utils.functional import cached_property
 from parler.views import TranslatableCreateView, TranslatableUpdateView
 
 from vitrina.datasets.models import Dataset
+from vitrina.orgs.models import Organization
 from vitrina.dcat.forms.distribution_forms import DatasetDistributionForm
 from vitrina.orgs.services import has_perm, Action
 from vitrina.resources.models import DatasetDistribution
 
 from django.utils.translation import gettext_lazy as _, get_language
 
-from vitrina.dcat.view_helpers import wizard_breadcrumb_ancestors
+from vitrina.dcat.view_helpers import datasets_in_org_scope, wizard_breadcrumb_ancestors
 from vitrina.resources.view_helpers import get_default_distribution_name
 from vitrina.structure.models import Version
 
@@ -29,9 +30,9 @@ class DcatDistributionCreateView(LoginRequiredMixin, PermissionRequiredMixin, Tr
 
     @cached_property
     def dataset(self) -> Dataset:
+        organization = get_object_or_404(Organization, pk=self.kwargs.get("organization_id"))
         return get_object_or_404(
-            Dataset.objects.select_related("organization", "subclass"),
-            organization_id=self.kwargs.get("organization_id"),
+            datasets_in_org_scope(organization).select_related("organization", "subclass"),
             pk=self.kwargs.get("dataset_id"),
         )
 
@@ -136,11 +137,13 @@ class DcatDistributionUpdateView(LoginRequiredMixin, PermissionRequiredMixin, Tr
         return super().dispatch(request, *args, **kwargs)
 
     def get_queryset(self) -> QuerySet:
+        organization = get_object_or_404(Organization, pk=self.kwargs.get("organization_id"))
+        scoped_dataset_ids = datasets_in_org_scope(organization).values_list("pk", flat=True)
         return (
             super()
             .get_queryset()
             .filter(
-                dataset__organization_id=self.kwargs.get("organization_id"),
+                dataset_id__in=scoped_dataset_ids,
                 dataset_id=self.kwargs.get("dataset_id"),
             )
             .select_related("dataset__organization", "dataset__subclass")

--- a/vitrina/orgs/templates/vitrina/orgs/wizard.html
+++ b/vitrina/orgs/templates/vitrina/orgs/wizard.html
@@ -22,28 +22,32 @@
         <div class="wizard-overlay-inner">
     <div class="wizard-card card">
         <header class="card-header wizard-card-header">
-            {# Left — org identity #}
+            {# Left — wizard title #}
             <div class="wizard-header-org">
-                <div class="wizard-org-avatar">
-                    {% if organization.image %}
-                        <img src="{{ organization.image.url }}"
-                             alt="{{ organization.title }}"
-                             onerror="this.style.display='none';this.nextElementSibling.style.display='flex';">
-                        <span class="wizard-org-avatar-letter" style="display:none;">{{ organization.title|first|upper }}</span>
-                    {% else %}
-                        <span class="wizard-org-avatar-letter">{{ organization.title|first|upper }}</span>
-                    {% endif %}
-                </div>
                 <div class="wizard-org-info">
-                    <p class="wizard-org-name" title="{{ organization.title }}">{{ organization.title }}</p>
-                    <p class="wizard-org-type">{% translate "Organizacija" %}</p>
+                    <p class="wizard-card-title">{% translate "Duomenų pildymo aplinka" %}</p>
+                    <p class="wizard-card-subtitle-label">{% translate "Supildykite duomenų rinkinius" %}</p>
                 </div>
             </div>
 
-            {# Right — wizard title #}
+            {# Right — org identity #}
             <div class="wizard-header-title">
-                <p class="wizard-card-title">{% translate "Duomenų pildymo aplinka" %}</p>
-                <p class="wizard-card-subtitle-label">{% translate "Supildykite duomenų rinkinius" %}</p>
+                <div class="is-flex is-align-items-center" style="gap:1rem; min-width:0;">
+                    <div class="wizard-org-avatar" style="flex-shrink:0;">
+                        {% if organization.image %}
+                            <img src="{{ organization.image.url }}"
+                                 alt="{{ organization.title }}"
+                                 onerror="this.style.display='none';this.nextElementSibling.style.display='flex';">
+                            <span class="wizard-org-avatar-letter" style="display:none;">{{ organization.title|first|upper }}</span>
+                        {% else %}
+                            <span class="wizard-org-avatar-letter">{{ organization.title|first|upper }}</span>
+                        {% endif %}
+                    </div>
+                    <div class="wizard-org-info" style="min-width:0;">
+                        <p class="wizard-org-name" title="{{ organization.title }}">{{ organization.title }}</p>
+                        <p class="wizard-org-type">{% translate "Organizacija" %}</p>
+                    </div>
+                </div>
             </div>
 
             {# Close button #}

--- a/vitrina/orgs/templates/vitrina/orgs/wizard.html
+++ b/vitrina/orgs/templates/vitrina/orgs/wizard.html
@@ -23,7 +23,7 @@
     <div class="wizard-card card">
         <header class="card-header wizard-card-header">
             {# Left — wizard title #}
-            <div class="wizard-header-org">
+            <div class="wizard-header-left">
                 <div class="wizard-org-info">
                     <p class="wizard-card-title">{% translate "Duomenų pildymo aplinka" %}</p>
                     <p class="wizard-card-subtitle-label">{% translate "Supildykite duomenų rinkinius" %}</p>
@@ -31,9 +31,9 @@
             </div>
 
             {# Right — org identity #}
-            <div class="wizard-header-title">
-                <div class="is-flex is-align-items-center" style="gap:1rem; min-width:0;">
-                    <div class="wizard-org-avatar" style="flex-shrink:0;">
+            <div class="wizard-header-right">
+                <div class="wizard-header-identity">
+                    <div class="wizard-org-avatar">
                         {% if organization.image %}
                             <img src="{{ organization.image.url }}"
                                  alt="{{ organization.title }}"
@@ -43,7 +43,7 @@
                             <span class="wizard-org-avatar-letter">{{ organization.title|first|upper }}</span>
                         {% endif %}
                     </div>
-                    <div class="wizard-org-info" style="min-width:0;">
+                    <div class="wizard-org-info">
                         <p class="wizard-org-name" title="{{ organization.title }}">{{ organization.title }}</p>
                         <p class="wizard-org-type">{% translate "Organizacija" %}</p>
                     </div>

--- a/webpack/src/css/wizard.scss
+++ b/webpack/src/css/wizard.scss
@@ -285,8 +285,8 @@
 
 /* Label — small caption at top of each field card */
 .wizard-form-body .label {
-    font-size: 0.75rem;
-    font-weight: 400;
+    font-size: 0.875rem;
+    font-weight: 600;
     color: #375677;
     margin-bottom: 0.1rem;
     letter-spacing: 0.6px;
@@ -335,7 +335,7 @@
 }
 .wizard-form-body .help {
     font-size: 0.75rem;
-    color: #59656e;
+    color: #9aabb4;
     margin-top: 0.25rem;
     line-height: 1.4;
 }
@@ -387,13 +387,13 @@
 }
 #wizard-relationship-panel .label {
     font-size: 1rem;
-    font-weight: 400;
+    font-weight: 600;
     color: #0f181f;
     margin-bottom: 0.25rem;
 }
 #wizard-relationship-panel .help {
     font-size: 0.875rem;
-    color: #59656e;
+    color: #9aabb4;
     margin-bottom: 0.5rem;
     line-height: 1.4;
 }
@@ -635,9 +635,11 @@ div.select, div.select select, .select2.select2-container {
 .select2.select2-container:hover .select2-selection--multiple:hover {
     border-color: #375677;
 }
+/* Select2 calculates dropdown top via JS (getBoundingClientRect), but our field card
+   padding/border shifts the visual position. This offset compensates for that gap. */
 .select2-container .select2-dropdown {
     border-color: #ccdae4;
-    margin-top: 46px;
+    margin-top: 35px;
 }
 .select2-selection__arrow { display: none; }
 .select2.select2-container--default .select2-selection--single .select2-selection__placeholder {

--- a/webpack/src/css/wizard.scss
+++ b/webpack/src/css/wizard.scss
@@ -63,10 +63,10 @@
     border-bottom: 1px solid #ccdae4;
     flex: 0 0 auto;
 }
-.wizard-header-org {
+.wizard-header-left {
     display: flex;
     align-items: center;
-    gap: 1rem;
+    align-self: stretch;
     padding: 1rem 1.5rem;
     border-right: 1px solid #ccdae4;
     min-width: 0;
@@ -115,13 +115,18 @@
     text-transform: none;
     letter-spacing: 0;
 }
-.wizard-header-title {
+.wizard-header-right {
     flex: 1 1 auto;
     min-width: 0;
     padding: 1rem 2rem;
     display: flex;
-    flex-direction: column;
-    gap: 4px;
+    align-items: center;
+}
+.wizard-header-identity {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    min-width: 0;
 }
 .wizard-card-title {
     font-size: 1.375rem;
@@ -172,7 +177,7 @@
    This rule adds .wizard-main for 0-3-0 specificity, winning at equal !important. */
 .columns.is-gapless > .column.wizard-main,
 .wizard-main {
-    padding: 2rem 2.5rem !important;
+    padding: 1.5rem 2.5rem 2rem !important;
 }
 
 /* ── Footer ── */
@@ -370,7 +375,8 @@
     font-size: 0.75rem;
     color: #59656e;
     line-height: 1.5;
-    width: 280px;
+    width: max-content;
+    max-width: 280px;
     box-shadow: 0 4px 12px rgba(55,86,119,0.12);
     z-index: 100;
     white-space: normal;
@@ -540,7 +546,7 @@
     padding: 0.5rem 0.4rem 0.2rem;
     user-select: none;
 }
-.wizard-tree-group-root { padding-top: 0; }
+.wizard-tree-group-root { padding-top: 1rem; }
 .wizard-tree-row {
     padding: 0.25rem 0.4rem;
     border-radius: 6px;

--- a/webpack/src/css/wizard.scss
+++ b/webpack/src/css/wizard.scss
@@ -235,7 +235,7 @@
 
 /* ── Field-card: each form field gets its own rounded bordered box ── */
 .wizard-form-body .field {
-    border: 1px solid #ebf1f9;
+    border: 1px solid #ccdae4;
     border-radius: 16px;
     padding: 0.5rem 0.9375rem;
     background: #fff;

--- a/webpack/src/css/wizard.scss
+++ b/webpack/src/css/wizard.scss
@@ -1,7 +1,9 @@
 /* ── Design tokens ──
    brand:        #375677  (primary dark navy-blue)
-   brand-light:  #ebf1f9  (light blue background / field borders)
+   brand-light:  #ebf1f9  (light blue background / relationship panel)
    border:       #ccdae4  (structural borders)
+   surface:      #f9fafb  (neutral page/pane background)
+   sidebar:      #f5f5f4  (sidebar background)
    text-heading: #0f181f
    text-primary: #375677
    text-muted:   #59656e
@@ -68,8 +70,9 @@
     padding: 1rem 1.5rem;
     border-right: 1px solid #ccdae4;
     min-width: 0;
-    flex: 0 0 auto;
-    max-width: 320px;
+    flex: 0 0 25%;
+    max-width: 25%;
+    background: #f5f5f4;
 }
 .wizard-org-avatar {
     width: 3.5rem;
@@ -154,6 +157,7 @@
     border-right: 1px solid #ccdae4;
     overflow-y: auto;
     flex: 0 0 auto;
+    background: #f5f5f4;
 }
 
 /* ── Main pane ── */
@@ -161,7 +165,7 @@
     overflow-y: auto;
     flex: 1 1 auto;
     min-width: 0;
-    background: #fff;
+    background: #f9fafb;
 }
 /* Bulma .is-gapless uses !important on column padding (specificity 0-2-0).
    This rule adds .wizard-main for 0-3-0 specificity, winning at equal !important. */

--- a/webpack/src/css/wizard.scss
+++ b/webpack/src/css/wizard.scss
@@ -73,6 +73,7 @@
     flex: 0 0 25%;
     max-width: 25%;
     background: #f5f5f4;
+    overflow: hidden;
 }
 .wizard-org-avatar {
     width: 3.5rem;

--- a/webpack/src/css/wizard.scss
+++ b/webpack/src/css/wizard.scss
@@ -340,6 +340,41 @@
     margin-top: 0.25rem;
     line-height: 1.4;
 }
+.wizard-help-popup {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    vertical-align: middle;
+}
+.wizard-help-popup-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: #9aabb4;
+    padding: 0 0 0 0.25rem;
+    font-size: 0.8125rem;
+    line-height: 1;
+    display: inline-flex;
+    align-items: center;
+}
+.wizard-help-popup-btn:hover { color: #375677; }
+.wizard-help-popup-content {
+    position: absolute;
+    bottom: calc(100% + 0.5rem);
+    left: 50%;
+    transform: translateX(-50%);
+    background: #fff;
+    border: 1px solid #ccdae4;
+    border-radius: 8px;
+    padding: 0.75rem 1rem;
+    font-size: 0.75rem;
+    color: #59656e;
+    line-height: 1.5;
+    width: 280px;
+    box-shadow: 0 4px 12px rgba(55,86,119,0.12);
+    z-index: 100;
+    white-space: normal;
+}
 .wizard-form-body .field:has(input[type=file]) {
     border: none;
     padding: 0;


### PR DESCRIPTION
  **Bug fixes:**
  - datasets_in_org_scope() helper in view_helpers.py — fixes 404s when accessing datasets/distributions
  that are children of IS nodes. Already created fix had to be applied in more places.

  **Feature:**
  - apply_dynamic_help_texts() extended to render an Alpine.js popup for extended_help_text — opens on `?`
  button click, closes on outside click but stays open for in-box text selection/copy, has aria-label,
  uses max-width: 280px not fixed width.

  **Design:**
  - Header swap: wizard title on left, org identity on right — long org names no longer overflow
  - Backgrounds adjusted for: Sidebar, main pane, and relationship panel
  - Field borders stronger, labels bold + slightly larger, help text muted
  - Select2 dropdown offset fixed so there's no gap
  - Sidebar tree top padding aligned with breadcrumbs
  - CSS class names renamed to position-based — no inline styles
  
  Before:
  
<img width="2056" height="1125" alt="image" src="https://github.com/user-attachments/assets/eedd1ee1-e489-436f-8a9f-84db59b5cf62" />

After:
<img width="2054" height="1120" alt="image" src="https://github.com/user-attachments/assets/9d0dabb6-47e7-4b09-9b06-66cdfb7c549b" />

