### PR TITLE
[DCAT-62] Extend phone validator to organization form

### DIFF
--- a/tests/orgs/test_forms.py
+++ b/tests/orgs/test_forms.py
@@ -45,6 +45,22 @@ class TestOrganizationCreateForm:
         generated_name = form.cleaned_data["name"]
         assert generated_name == "datasets/gov/test-org/"
 
+    def test_phone_invalid_fails_validation(self, app: DjangoTestApp):
+        user = UserFactory()
+
+        form = OrganizationCreateForm(user=user, data={"phone": "invalid-phone"})
+
+        form.is_valid()
+        assert "phone" in form.errors
+
+    def test_phone_valid_passes_validation(self, app: DjangoTestApp):
+        user = UserFactory()
+
+        form = OrganizationCreateForm(user=user, data={"phone": "+37061234567"})
+
+        form.is_valid()
+        assert "phone" not in form.errors
+
 
 class TestRepresentativeCreateForm:
     def test_can_make_agreements_field_create_null_defaults_to_default_value(self, app: DjangoTestApp):

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -777,9 +777,6 @@ msgstr "Select either a dataset, or a distribution - not both."
 msgid "Būtina pasirinkti arba duomenų rinkinį, arba pateiktį."
 msgstr "At least one of dataset, or distribution must be selected."
 
-msgid "Būtina pridėti bent vieną pavadinimą."
-msgstr "At least one title must be selected"
-
 msgid "Turi būti nurodytas bent vienas matavimo rodiklis."
 msgstr "At least one measurement must be selected."
 

--- a/vitrina/locale/lt/LC_MESSAGES/django.po
+++ b/vitrina/locale/lt/LC_MESSAGES/django.po
@@ -728,9 +728,6 @@ msgstr ""
 msgid "Būtina pasirinkti arba duomenų rinkinį, arba pateiktį."
 msgstr ""
 
-msgid "Būtina pridėti bent vieną pavadinimą."
-msgstr ""
-
 msgid "Turi būti nurodytas bent vienas matavimo rodiklis."
 msgstr ""
 

--- a/vitrina/locale/lt/LC_MESSAGES/django.po
+++ b/vitrina/locale/lt/LC_MESSAGES/django.po
@@ -746,6 +746,24 @@ msgstr ""
 msgid "Būtina pasirinkti arba duomenų rinkinį, arba pateiktį."
 msgstr ""
 
+msgid "Būtina pridėti bent vieną pavadinimą."
+msgstr ""
+
+msgid "Turi būti nurodytas bent vienas matavimo rodiklis."
+msgstr ""
+
+msgid "Turi būti nurodytas bent vienas duomenų rinkinys."
+msgstr ""
+
+msgid "Turi būti nurodyta bent viena pateiktis."
+msgstr ""
+
+msgid "Pasirinkite arba duomenų rinkinį, arba pateiktį — ne abu."
+msgstr ""
+
+msgid "Būtina pasirinkti arba duomenų rinkinį, arba pateiktį."
+msgstr ""
+
 msgid "Turi būti nurodytas bent vienas matavimo rodiklis."
 msgstr ""
 
@@ -2289,6 +2307,14 @@ msgstr ""
 msgid ""
 "Nurodo, kiek nuoseklus yra duomenų rinkinys visoje sistemoje. Atitinka "
 "dqv:hasQualityAnnotation."
+msgstr ""
+
+msgid "Turi kokybės matavimą"
+msgstr ""
+
+msgid ""
+"Nurodo, kaip patikimas yra pateiktas duomenų rinkinys. Atitinka "
+"dqv:hasQualityMeasurement."
 msgstr ""
 
 msgid "Turi kokybės matavimą"

--- a/vitrina/orgs/factories.py
+++ b/vitrina/orgs/factories.py
@@ -28,7 +28,7 @@ class OrganizationFactory(DjangoModelFactory):
     name = factory.Sequence(lambda n: f"datasets/gov/test/{n:04d}/")
     company_code = factory.Faker("bothify", text="?????????", letters="ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
     email = factory.Faker("email")
-    phone = Faker().phone_number()
+    phone = factory.Sequence(lambda n: "+3706%07d" % n)
     address = Faker().address()
     is_public = True
     version = 1

--- a/vitrina/orgs/forms.py
+++ b/vitrina/orgs/forms.py
@@ -179,7 +179,7 @@ class OrganizationBaseForm(ModelForm):
     )
     image = FilerImageField(label=_("Paveiksliukas"), upload_to=Organization.UPLOAD_TO, required=False)
     email = CharField(label=_("Elektroninis paštas"), required=True)
-    phone = CharField(label=_("Telefono numeris"), required=True)
+    phone = CharField(label=_("Telefono numeris"), required=True, validators=[phone_validator])
     address = CharField(label=_("Adresas"), required=True)
     description = CharField(label=_("Aprašymas"), widget=Textarea(), required=False)
 


### PR DESCRIPTION
Extend the phone validator to organization forms:

<img width="799" height="226" alt="image" src="https://github.com/user-attachments/assets/32b93723-0651-496c-b07b-82ce562871bc" />
