### PR TITLE
DCAT wizard: Improve intuitiveness of the wizard navigation

### DIFF
--- a/vitrina/dcat/forms/distribution_forms.py
+++ b/vitrina/dcat/forms/distribution_forms.py
@@ -1,5 +1,4 @@
 from crispy_forms.helper import FormHelper
-from crispy_forms.layout import Submit
 from django import forms
 from django.core.exceptions import ValidationError
 from django.db.models import QuerySet, Q
@@ -85,11 +84,9 @@ class DatasetDistributionForm(TranslatableModelForm):
         super().__init__(*args, **kwargs)
         self.resource = self.instance if self.instance and self.instance.pk else None
 
-        button = _("Redaguoti") if self.resource else _("Sukurti")
         self.helper = FormHelper()
         self.helper.attrs["novalidate"] = ""
         self.helper.form_id = "resource-form"
-        self.helper.add_input(Submit("submit", button, css_class="button is-primary"))
 
         self.fields["access_url"].required = True
         self.fields["access_url"].label = _("Prieigos URL")

--- a/vitrina/dcat/views/wizard_views.py
+++ b/vitrina/dcat/views/wizard_views.py
@@ -13,8 +13,11 @@ from vitrina.dcat.wizard import (
     WIZARD_NODE_LABELS,
     WIZARD_NODE_ORGANIZATION,
     WIZARD_NODE_DISTRIBUTION,
+    WIZARD_TYPE_ORDER,
     WIZARD_TYPE_TO_SUBCLASS_NAME,
     _build_wizard_tree,
+    build_wizard_schema_matrix,
+    wizard_allowed_parents,
 )
 from vitrina.orgs.models import Organization
 from vitrina.orgs.services import Action, has_perm
@@ -43,14 +46,22 @@ class OrganizationWizardView(
         context["wizard_tree"] = tree
         context["wizard_node_labels"] = WIZARD_NODE_LABELS
         context["wizard_nodes_json"] = nodes_by_key
+        allowed_parents = wizard_allowed_parents()
         context["wizard_node_meta_json"] = {
             node_type: {
                 "type_label": str(WIZARD_NODE_LABELS[node_type]),
                 "icon": WIZARD_NODE_ICONS[node_type],
                 "helper": str(WIZARD_NODE_HELPERS.get(node_type, "")),
+                "parents_label": ", ".join(
+                    str(WIZARD_NODE_LABELS[parent_type]) for parent_type in allowed_parents.get(node_type, [])
+                ),
             }
             for node_type in WIZARD_NODE_HELPERS
         }
+        context["wizard_creatable_types_json"] = sorted(
+            WIZARD_NODE_HELPERS, key=lambda node_type: WIZARD_TYPE_ORDER.get(node_type, 99)
+        )
+        context["wizard_schema_matrix"] = build_wizard_schema_matrix()
         context["parent_links"].update({None: _("IS metaduomenys")})
         return context
 

--- a/vitrina/dcat/views/wizard_views.py
+++ b/vitrina/dcat/views/wizard_views.py
@@ -8,16 +8,16 @@ from django.views.generic import TemplateView, View
 
 from vitrina.datasets.models import DCATResourceSubclass
 from vitrina.dcat.wizard import (
+    WIZARD_ALLOWED_PARENTS,
+    WIZARD_CREATABLE_TYPES,
     WIZARD_NODE_HELPERS,
     WIZARD_NODE_ICONS,
     WIZARD_NODE_LABELS,
     WIZARD_NODE_ORGANIZATION,
     WIZARD_NODE_DISTRIBUTION,
-    WIZARD_TYPE_ORDER,
+    WIZARD_SCHEMA_MATRIX,
     WIZARD_TYPE_TO_SUBCLASS_NAME,
     _build_wizard_tree,
-    build_wizard_schema_matrix,
-    wizard_allowed_parents,
 )
 from vitrina.orgs.models import Organization
 from vitrina.orgs.services import Action, has_perm
@@ -46,22 +46,19 @@ class OrganizationWizardView(
         context["wizard_tree"] = tree
         context["wizard_node_labels"] = WIZARD_NODE_LABELS
         context["wizard_nodes_json"] = nodes_by_key
-        allowed_parents = wizard_allowed_parents()
         context["wizard_node_meta_json"] = {
             node_type: {
                 "type_label": str(WIZARD_NODE_LABELS[node_type]),
                 "icon": WIZARD_NODE_ICONS[node_type],
                 "helper": str(WIZARD_NODE_HELPERS.get(node_type, "")),
                 "parents_label": ", ".join(
-                    str(WIZARD_NODE_LABELS[parent_type]) for parent_type in allowed_parents.get(node_type, [])
+                    str(WIZARD_NODE_LABELS[parent_type]) for parent_type in WIZARD_ALLOWED_PARENTS.get(node_type, [])
                 ),
             }
-            for node_type in WIZARD_NODE_HELPERS
+            for node_type in WIZARD_CREATABLE_TYPES
         }
-        context["wizard_creatable_types_json"] = sorted(
-            WIZARD_NODE_HELPERS, key=lambda node_type: WIZARD_TYPE_ORDER.get(node_type, 99)
-        )
-        context["wizard_schema_matrix"] = build_wizard_schema_matrix()
+        context["wizard_creatable_types_json"] = WIZARD_CREATABLE_TYPES
+        context["wizard_schema_matrix"] = WIZARD_SCHEMA_MATRIX
         context["parent_links"].update({None: _("IS metaduomenys")})
         return context
 

--- a/vitrina/dcat/wizard.py
+++ b/vitrina/dcat/wizard.py
@@ -79,36 +79,38 @@ WIZARD_SUBCLASS_TO_NODE_TYPE: dict[str, str] = {
     DCATResourceSubclass.DATASET: WIZARD_NODE_DATASET,
 }
 
-_WIZARD_TREE_MAX_DEPTH = 8
+WIZARD_CREATABLE_TYPES: list[str] = sorted(
+    {child_type for child_types in WIZARD_ALLOWED_CHILDREN.values() for child_type in child_types},
+    key=lambda node_type: WIZARD_TYPE_ORDER.get(node_type, 99),
+)
 
 
-def wizard_allowed_parents() -> dict[str, list[str]]:
+def _build_allowed_parents() -> dict[str, list[str]]:
     """Invert WIZARD_ALLOWED_CHILDREN: child type → parent types that allow it."""
     allowed_parents: dict[str, list[str]] = {node_type: [] for node_type in WIZARD_ALLOWED_CHILDREN}
     for parent_type, child_types in WIZARD_ALLOWED_CHILDREN.items():
         for child_type in child_types:
-            allowed_parents[child_type].append(parent_type)
+            allowed_parents.setdefault(child_type, []).append(parent_type)
     return allowed_parents
 
 
-def build_wizard_schema_matrix() -> dict:
-    """"Kūrimo tvarka" legend matrix derived from WIZARD_ALLOWED_CHILDREN.
+WIZARD_ALLOWED_PARENTS: dict[str, list[str]] = _build_allowed_parents()
+
+
+def _build_schema_matrix() -> dict:
+    """„Kūrimo tvarka“ legend matrix derived from WIZARD_ALLOWED_CHILDREN.
 
     Columns are all creatable child types; rows are parent types that can have
     children. Each cell marks whether the column type can be created under the
     row type.
     """
-    child_types = sorted(
-        {child_type for child_types in WIZARD_ALLOWED_CHILDREN.values() for child_type in child_types},
-        key=lambda node_type: WIZARD_TYPE_ORDER.get(node_type, 99),
-    )
     columns = [
         {
             "type": child_type,
             "label": WIZARD_NODE_LABELS[child_type],
             "icon": WIZARD_NODE_ICONS[child_type],
         }
-        for child_type in child_types
+        for child_type in WIZARD_CREATABLE_TYPES
     ]
     rows = [
         {
@@ -117,11 +119,10 @@ def build_wizard_schema_matrix() -> dict:
             "icon": WIZARD_NODE_ICONS[parent_type],
             "cells": [
                 {
-                    "type": child_type,
                     "label": WIZARD_NODE_LABELS[child_type],
                     "allowed": child_type in allowed_children,
                 }
-                for child_type in child_types
+                for child_type in WIZARD_CREATABLE_TYPES
             ],
         }
         for parent_type, allowed_children in sorted(
@@ -130,6 +131,11 @@ def build_wizard_schema_matrix() -> dict:
         if allowed_children
     ]
     return {"columns": columns, "rows": rows}
+
+
+WIZARD_SCHEMA_MATRIX: dict = _build_schema_matrix()
+
+_WIZARD_TREE_MAX_DEPTH = 8
 
 
 def _wizard_node_type(dataset: Dataset) -> str:

--- a/vitrina/dcat/wizard.py
+++ b/vitrina/dcat/wizard.py
@@ -58,10 +58,10 @@ WIZARD_TYPE_ORDER: dict[str, int] = {
 }
 
 WIZARD_NODE_HELPERS: dict[str, str] = {
-    WIZARD_NODE_IS: _("Sukurti naują informacinę sistemą po šiuo mazgu."),
-    WIZARD_NODE_IS_PUBLIC_SERVICE: _("Sukurti naują e. paslaugą po šiuo mazgu."),
-    WIZARD_NODE_SERVICE: _("Sukurti naują duomenų paslaugą po šiuo mazgu."),
-    WIZARD_NODE_DATASET: _("Sukurti naują duomenų rinkinį po šiuo mazgu."),
+    WIZARD_NODE_IS: _("Sukurti naują informacinę sistemą po šiuo elementu."),
+    WIZARD_NODE_IS_PUBLIC_SERVICE: _("Sukurti naują e. paslaugą po šiuo elementu."),
+    WIZARD_NODE_SERVICE: _("Sukurti naują duomenų paslaugą po šiuo elementu."),
+    WIZARD_NODE_DATASET: _("Sukurti naują duomenų rinkinį po šiuo elementu."),
     WIZARD_NODE_DISTRIBUTION: _("Pridėti naują duomenų rinkinio pateiktį."),
 }
 

--- a/vitrina/dcat/wizard.py
+++ b/vitrina/dcat/wizard.py
@@ -26,7 +26,7 @@ WIZARD_NODE_ICONS: dict[str, str] = {
     WIZARD_NODE_IS: "fa-server",
     WIZARD_NODE_SERVICE: "fa-cogs",
     WIZARD_NODE_DATASET: "fa-database",
-    WIZARD_NODE_DISTRIBUTION: "fa-file-lines",
+    WIZARD_NODE_DISTRIBUTION: "fa-file-alt",
     WIZARD_NODE_IS_PUBLIC_SERVICE: "fa-globe",
 }
 
@@ -80,6 +80,56 @@ WIZARD_SUBCLASS_TO_NODE_TYPE: dict[str, str] = {
 }
 
 _WIZARD_TREE_MAX_DEPTH = 8
+
+
+def wizard_allowed_parents() -> dict[str, list[str]]:
+    """Invert WIZARD_ALLOWED_CHILDREN: child type → parent types that allow it."""
+    allowed_parents: dict[str, list[str]] = {node_type: [] for node_type in WIZARD_ALLOWED_CHILDREN}
+    for parent_type, child_types in WIZARD_ALLOWED_CHILDREN.items():
+        for child_type in child_types:
+            allowed_parents[child_type].append(parent_type)
+    return allowed_parents
+
+
+def build_wizard_schema_matrix() -> dict:
+    """"Kūrimo tvarka" legend matrix derived from WIZARD_ALLOWED_CHILDREN.
+
+    Columns are all creatable child types; rows are parent types that can have
+    children. Each cell marks whether the column type can be created under the
+    row type.
+    """
+    child_types = sorted(
+        {child_type for child_types in WIZARD_ALLOWED_CHILDREN.values() for child_type in child_types},
+        key=lambda node_type: WIZARD_TYPE_ORDER.get(node_type, 99),
+    )
+    columns = [
+        {
+            "type": child_type,
+            "label": WIZARD_NODE_LABELS[child_type],
+            "icon": WIZARD_NODE_ICONS[child_type],
+        }
+        for child_type in child_types
+    ]
+    rows = [
+        {
+            "type": parent_type,
+            "label": WIZARD_NODE_LABELS[parent_type],
+            "icon": WIZARD_NODE_ICONS[parent_type],
+            "cells": [
+                {
+                    "type": child_type,
+                    "label": WIZARD_NODE_LABELS[child_type],
+                    "allowed": child_type in allowed_children,
+                }
+                for child_type in child_types
+            ],
+        }
+        for parent_type, allowed_children in sorted(
+            WIZARD_ALLOWED_CHILDREN.items(), key=lambda item: WIZARD_TYPE_ORDER.get(item[0], 99)
+        )
+        if allowed_children
+    ]
+    return {"columns": columns, "rows": rows}
 
 
 def _wizard_node_type(dataset: Dataset) -> str:

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -2781,17 +2781,17 @@ msgstr "Distributions"
 msgid "E. paslaugos"
 msgstr "E-services"
 
-msgid "Sukurti naują informacinę sistemą po šiuo mazgu."
-msgstr "Create new information system under this node."
+msgid "Sukurti naują informacinę sistemą po šiuo elementu."
+msgstr "Create a new information system under this element."
 
-msgid "Sukurti naują e. paslaugą po šiuo mazgu."
-msgstr "Create a new e-service under this node."
+msgid "Sukurti naują e. paslaugą po šiuo elementu."
+msgstr "Create a new e-service under this element."
 
-msgid "Sukurti naują duomenų paslaugą po šiuo mazgu."
-msgstr "Create a new service under this node."
+msgid "Sukurti naują duomenų paslaugą po šiuo elementu."
+msgstr "Create a new data service under this element."
 
-msgid "Sukurti naują duomenų rinkinį po šiuo mazgu."
-msgstr "Create new dataset under this node."
+msgid "Sukurti naują duomenų rinkinį po šiuo elementu."
+msgstr "Create a new dataset under this element."
 
 msgid "Pridėti naują duomenų rinkinio pateiktį."
 msgstr "Add new dataset distribution."
@@ -3490,6 +3490,9 @@ msgstr "The unique codename, which can be used while creating data resources."
 msgid "Redaguokite organizacijos informaciją"
 msgstr "Edit organization information"
 
+msgid "Gali turėti"
+msgstr "Can contain"
+
 msgid "Šioje organizacijoje dar nėra turinio."
 msgstr "This organisation has no content yet."
 
@@ -3796,6 +3799,9 @@ msgstr ""
 "Entry of the organization's information system metadata according to DCAT-AP-"
 "LT"
 
+msgid "Kūrimo tvarka"
+msgstr "Creation order"
+
 msgid "Suskleisti viską"
 msgstr "Collapse all"
 
@@ -3808,17 +3814,20 @@ msgstr "Loading form..."
 msgid "Pasirinkite formą"
 msgstr "Select a form"
 
-msgid "Pasirinkite objektą"
-msgstr "Select an object"
+msgid "Pasirinkite elementą"
+msgstr "Select an element"
 
 msgid "Pasirinkite ką norite sukurti"
 msgstr "Select what to create"
 
-msgid "Žemiau rodomi objektų tipai, kuriuos galima sukurti po šiuo mazgu."
-msgstr "The object types that can be created under this node are shown below."
+msgid "Žemiau rodomi elementai, kuriuos galima sukurti po"
+msgstr "Below are the elements that can be created under"
 
-msgid "Šiam mazgui nėra leidžiamų vaikinių elementų."
-msgstr "This node has no allowed child types."
+msgid "Galima sukurti tik po šiais elementais:"
+msgstr "Can only be created under these elements:"
+
+msgid "Naują elementą galima sukurti tik turint aukštesnio lygio elementą."
+msgstr "A new element can only be created under an existing higher-level element."
 
 msgid "Atšaukti pakeitimus"
 msgstr "Cancel changes"
@@ -7528,3 +7537,9 @@ msgid ""
 "Prisijunkite su šiuo elektroniniu paštu ir bandykite viisp autentifikaciją "
 "iš naujo"
 msgstr "Log in with this e-mail address and try viisp authentication again"
+
+#~ msgid "Pasirinkite objektą"
+#~ msgstr "Select an object"
+
+#~ msgid "Šiam mazgui nėra leidžiamų vaikinių elementų."
+#~ msgstr "This node has no allowed child types."

--- a/vitrina/locale/lt/LC_MESSAGES/django.po
+++ b/vitrina/locale/lt/LC_MESSAGES/django.po
@@ -2552,16 +2552,16 @@ msgstr ""
 msgid "E. paslaugos"
 msgstr ""
 
-msgid "Sukurti naują informacinę sistemą po šiuo mazgu."
+msgid "Sukurti naują informacinę sistemą po šiuo elementu."
 msgstr ""
 
-msgid "Sukurti naują e. paslaugą po šiuo mazgu."
+msgid "Sukurti naują e. paslaugą po šiuo elementu."
 msgstr ""
 
-msgid "Sukurti naują duomenų paslaugą po šiuo mazgu."
+msgid "Sukurti naują duomenų paslaugą po šiuo elementu."
 msgstr ""
 
-msgid "Sukurti naują duomenų rinkinį po šiuo mazgu."
+msgid "Sukurti naują duomenų rinkinį po šiuo elementu."
 msgstr ""
 
 msgid "Pridėti naują duomenų rinkinio pateiktį."
@@ -3215,6 +3215,9 @@ msgstr ""
 msgid "Redaguokite organizacijos informaciją"
 msgstr ""
 
+msgid "Gali turėti"
+msgstr ""
+
 msgid "Šioje organizacijoje dar nėra turinio."
 msgstr ""
 
@@ -3503,6 +3506,9 @@ msgid ""
 "Organizacijos informacinių sistemų metaduomenų pildymas pagal DCAT-AP-LT"
 msgstr ""
 
+msgid "Kūrimo tvarka"
+msgstr ""
+
 msgid "Suskleisti viską"
 msgstr ""
 
@@ -3515,16 +3521,19 @@ msgstr ""
 msgid "Pasirinkite formą"
 msgstr ""
 
-msgid "Pasirinkite objektą"
+msgid "Pasirinkite elementą"
 msgstr ""
 
 msgid "Pasirinkite ką norite sukurti"
 msgstr ""
 
-msgid "Žemiau rodomi objektų tipai, kuriuos galima sukurti po šiuo mazgu."
+msgid "Žemiau rodomi elementai, kuriuos galima sukurti po"
 msgstr ""
 
-msgid "Šiam mazgui nėra leidžiamų vaikinių elementų."
+msgid "Galima sukurti tik po šiais elementais:"
+msgstr ""
+
+msgid "Naują elementą galima sukurti tik turint aukštesnio lygio elementą."
 msgstr ""
 
 msgid "Atšaukti pakeitimus"

--- a/vitrina/orgs/templates/vitrina/orgs/_wizard_schema_matrix.html
+++ b/vitrina/orgs/templates/vitrina/orgs/_wizard_schema_matrix.html
@@ -1,0 +1,46 @@
+{% load i18n %}
+{# "Kūrimo tvarka" legend matrix. Expects `wizard_schema_matrix` from build_wizard_schema_matrix. #}
+<table class="wizard-schema-table">
+    <thead>
+        <tr>
+            <th class="wizard-schema-corner">
+                {% translate "Gali turėti" %}
+                <i class="fas fa-arrow-right fa-xs"></i>
+            </th>
+            {% for column in wizard_schema_matrix.columns %}
+                <th>
+                    <span class="wizard-schema-tile"
+                          :class="selected && selected.type === '{{ column.type }}' ? 'is-filled' : ''"
+                          title="{{ column.label }}">
+                        <i class="fas {{ column.icon }} fa-xs"></i>
+                    </span>
+                </th>
+            {% endfor %}
+        </tr>
+    </thead>
+    <tbody>
+        {% for row in wizard_schema_matrix.rows %}
+            <tr :class="selected && selected.type === '{{ row.type }}' ? 'is-current' : ''">
+                <th>
+                    <span class="wizard-schema-row-head">
+                        <span class="wizard-schema-tile"
+                              :class="selected && selected.type === '{{ row.type }}' ? 'is-filled' : ''">
+                            <i class="fas {{ row.icon }} fa-xs"></i>
+                        </span>
+                        <span class="wizard-schema-row-label">{{ row.label }}</span>
+                    </span>
+                </th>
+                {% for cell in row.cells %}
+                    <td>
+                        {% if cell.allowed %}
+                            <i class="fas fa-check fa-sm wizard-schema-check"
+                               title="{{ row.label }} → {{ cell.label }}"></i>
+                        {% else %}
+                            <span class="wizard-schema-dot" aria-hidden="true"></span>
+                        {% endif %}
+                    </td>
+                {% endfor %}
+            </tr>
+        {% endfor %}
+    </tbody>
+</table>

--- a/vitrina/orgs/templates/vitrina/orgs/wizard.html
+++ b/vitrina/orgs/templates/vitrina/orgs/wizard.html
@@ -70,7 +70,7 @@
                  treeExpanded: false,
                  schemaOpen: true,
                  canCreate(type) {
-                     return !!(this.selected && this.selected.allowed_children && this.selected.allowed_children.includes(type));
+                     return !!(this.selected && this.selected.create_urls && this.selected.create_urls[type]);
                  },
                  select(key, nextMode) {
                      this.selected = this.nodes[key] || { key: key };

--- a/vitrina/orgs/templates/vitrina/orgs/wizard.html
+++ b/vitrina/orgs/templates/vitrina/orgs/wizard.html
@@ -17,6 +17,7 @@
 {% block root %}
     {{ wizard_nodes_json|json_script:"wizard-nodes" }}
     {{ wizard_node_meta_json|json_script:"wizard-node-meta" }}
+    {{ wizard_creatable_types_json|json_script:"wizard-creatable-types" }}
 
     <div class="wizard-overlay">
         <div class="wizard-overlay-inner">
@@ -62,10 +63,15 @@
              x-data="{
                  nodes: JSON.parse(document.getElementById('wizard-nodes').textContent),
                  meta: JSON.parse(document.getElementById('wizard-node-meta').textContent),
+                 creatable: JSON.parse(document.getElementById('wizard-creatable-types').textContent),
                  selected: null,
                  mode: 'detail',
                  createAttempt: null,
                  treeExpanded: false,
+                 schemaOpen: true,
+                 canCreate(type) {
+                     return !!(this.selected && this.selected.allowed_children && this.selected.allowed_children.includes(type));
+                 },
                  select(key, nextMode) {
                      this.selected = this.nodes[key] || { key: key };
                      this.mode = nextMode || 'detail';
@@ -91,6 +97,19 @@
 
                 {# Left sidebar — tree navigation #}
                 <aside class="column is-one-quarter wizard-sidebar p-4">
+                    <section class="wizard-schema-block">
+                        <button type="button" class="wizard-schema-header"
+                                :aria-expanded="schemaOpen ? 'true' : 'false'"
+                                @click="schemaOpen = !schemaOpen">
+                            <span>{% translate "Kūrimo tvarka" %}</span>
+                            <span class="wizard-tree-expand-icon" :class="schemaOpen ? 'is-open' : ''">
+                                <i class="fas fa-chevron-down fa-xs"></i>
+                            </span>
+                        </button>
+                        <div class="wizard-schema-body" x-show="schemaOpen" x-cloak>
+                            {% include "vitrina/orgs/_wizard_schema_matrix.html" %}
+                        </div>
+                    </section>
                     <ul class="wizard-tree">
                         <li class="wizard-tree-group wizard-tree-group-root">
                             <span aria-hidden="true">{% translate "Organizacija" %}</span>
@@ -206,26 +225,35 @@
                         </nav>
 
                         <h2 class="wizard-picker-title">{% translate "Pasirinkite ką norite sukurti" %}</h2>
-                        <p class="wizard-picker-sub">{% translate "Žemiau rodomi objektų tipai, kuriuos galima sukurti po šiuo mazgu." %}</p>
+                        <p class="wizard-picker-sub">
+                            {% translate "Žemiau rodomi objektų tipai, kuriuos galima sukurti po" %}
+                            „<span x-text="selected && selected.title"></span>“.
+                        </p>
 
-                        <template x-for="type in (selected ? selected.allowed_children : [])" :key="type">
-                            <div class="wizard-picker-card" @click="attemptCreate(type)">
+                        <template x-for="type in creatable" :key="type">
+                            <div class="wizard-picker-card"
+                                 :class="canCreate(type) ? '' : 'is-disabled'"
+                                 :aria-disabled="canCreate(type) ? 'false' : 'true'"
+                                 @click="canCreate(type) && attemptCreate(type)">
                                 <span class="wizard-picker-card-icon">
                                     <i class="fas" :class="meta[type] && meta[type].icon"></i>
                                 </span>
                                 <div class="wizard-picker-card-body">
                                     <div class="wizard-picker-card-title" x-text="meta[type] && meta[type].type_label"></div>
-                                    <div class="wizard-picker-card-helper" x-text="meta[type] && meta[type].helper"></div>
+                                    <div class="wizard-picker-card-helper" x-show="canCreate(type)"
+                                         x-text="meta[type] && meta[type].helper"></div>
+                                    <div class="wizard-picker-card-helper" x-show="!canCreate(type)">
+                                        {% translate "Galima sukurti tik po šiais elementais:" %}
+                                        <strong x-text="meta[type] && meta[type].parents_label"></strong>
+                                    </div>
                                 </div>
-                                <span class="wizard-picker-card-chevron">
+                                <span class="wizard-picker-card-chevron" x-show="canCreate(type)">
                                     <i class="fas fa-chevron-right"></i>
                                 </span>
-                            </div>
-                        </template>
-
-                        <template x-if="selected && selected.allowed_children.length === 0">
-                            <div class="notification is-info is-light">
-                                {% translate "Šiam mazgui nėra leidžiamų vaikinių elementų." %}
+                                <span class="wizard-picker-card-locks" x-show="!canCreate(type)"
+                                      title="{% translate 'Naują įrašą galima sukurti tik turint aukštesnio lygio įrašą.' %}">
+                                    <i class="fas fa-lock"></i>
+                                </span>
                             </div>
                         </template>
 

--- a/vitrina/orgs/templates/vitrina/orgs/wizard.html
+++ b/vitrina/orgs/templates/vitrina/orgs/wizard.html
@@ -220,13 +220,13 @@
                             </div>
                             <div class="wizard-crumb is-current">
                                 <span class="wizard-crumb-label">{% translate "Pasirinkite formą" %}</span>
-                                <span class="wizard-crumb-title">{% translate "Pasirinkite objektą" %}</span>
+                                <span class="wizard-crumb-title">{% translate "Pasirinkite elementą" %}</span>
                             </div>
                         </nav>
 
                         <h2 class="wizard-picker-title">{% translate "Pasirinkite ką norite sukurti" %}</h2>
                         <p class="wizard-picker-sub">
-                            {% translate "Žemiau rodomi objektų tipai, kuriuos galima sukurti po" %}
+                            {% translate "Žemiau rodomi elementai, kuriuos galima sukurti po" %}
                             „<span x-text="selected && selected.title"></span>“.
                         </p>
 
@@ -251,7 +251,7 @@
                                     <i class="fas fa-chevron-right"></i>
                                 </span>
                                 <span class="wizard-picker-card-locks" x-show="!canCreate(type)"
-                                      title="{% translate 'Naują įrašą galima sukurti tik turint aukštesnio lygio įrašą.' %}">
+                                      title="{% translate 'Naują elementą galima sukurti tik turint aukštesnio lygio elementą.' %}">
                                     <i class="fas fa-lock"></i>
                                 </span>
                             </div>

--- a/webpack/src/css/wizard.scss
+++ b/webpack/src/css/wizard.scss
@@ -646,6 +646,106 @@
 }
 .wizard-tree-add:hover { background-color: #d6e5f4 !important; }
 
+/* ── "Kūrimo tvarka" legend matrix ── */
+.wizard-schema-block {
+    margin-bottom: 0.85rem;
+    background: #fff;
+    overflow: hidden;
+}
+.wizard-schema-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    padding: 0.6rem 0.85rem;
+    border: none;
+    background: none;
+    cursor: pointer;
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: #0f181f;
+}
+.wizard-schema-header:hover { background: #f9fafb; }
+.wizard-schema-body {
+    padding: 0 0.5rem 0.5rem;
+}
+.wizard-schema-table {
+    width: 100%;
+    border-collapse: collapse;
+    background: transparent;
+}
+.wizard-schema-table th,
+.wizard-schema-table td {
+    padding: 0.4rem 0.15rem;
+    text-align: center;
+    vertical-align: middle;
+    border: none;
+    font-weight: 400;
+}
+.wizard-schema-table tbody tr {
+    border-top: 1px solid #eef1f4;
+}
+.wizard-schema-corner {
+    text-align: right !important;
+    padding-right: 0.5rem !important;
+    font-size: 0.625rem;
+    font-weight: 600 !important;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: #8a949b;
+    white-space: nowrap;
+}
+.wizard-schema-table tbody th {
+    text-align: left;
+}
+.wizard-schema-row-head {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    min-width: 0;
+}
+.wizard-schema-row-label {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: #1c1c1c;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.wizard-schema-tile {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.6rem;
+    height: 1.6rem;
+    border-radius: 7px;
+    border: 1px solid rgba(55, 86, 119, 0.45);
+    background: rgba(55, 86, 119, 0.06);
+    color: #375677;
+}
+.wizard-schema-tile.is-filled {
+    color: #fff;
+    border-color: #375677;
+    background: #375677;
+}
+.wizard-schema-check { color: #375677; }
+.wizard-schema-dot {
+    display: inline-block;
+    width: 3px;
+    height: 3px;
+    border-radius: 50%;
+    background: #ccd4da;
+    vertical-align: middle;
+}
+.wizard-schema-table tbody tr.is-current {
+    background: #ebf1f9;
+}
+.wizard-schema-table tbody tr.is-current .wizard-schema-row-label {
+    color: #375677;
+}
+
 /* ── Type picker ── */
 .wizard-picker-title { font-size: 1.35rem; font-weight: 600; color: #0f181f; margin-bottom: 0.25rem; }
 .wizard-picker-sub { color: #59656e; margin-bottom: 1.25rem; }
@@ -677,6 +777,30 @@
 .wizard-picker-card-title { font-weight: 600; color: #0f181f; }
 .wizard-picker-card-helper { font-size: 0.8rem; color: #59656e; }
 .wizard-picker-card-chevron { color: #59656e; flex: 0 0 auto; }
+.wizard-picker-card.is-disabled {
+    cursor: not-allowed;
+    background: #f9fafb;
+    border-color: #e3e9ed;
+}
+.wizard-picker-card.is-disabled:hover {
+    border-color: #e3e9ed;
+    box-shadow: none;
+}
+.wizard-picker-card.is-disabled .wizard-picker-card-title { color: #8a949b; }
+.wizard-picker-card.is-disabled .wizard-picker-card-helper { color: #8a949b; }
+.wizard-picker-card.is-disabled .wizard-picker-card-helper strong { color: #59656e; }
+.wizard-picker-card.is-disabled .wizard-picker-card-icon {
+    background: #eef1f3;
+    color: #8a949b;
+}
+.wizard-picker-card-locks {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    color: #8a949b;
+    flex: 0 0 auto;
+    cursor: help;
+}
 
 /* ── Fragment area ── */
 #wizard-main-pane { min-height: 0; }


### PR DESCRIPTION
Improve organisation wizard intuitiveness — make it clear which element types can be created at which hierarchy level.

### Changes:

  - **"Kūrimo tvarka" legend** — added a collapsible matrix table at the top of the wizard sidebar showing which child types each parent type can have;
  - **Stable type picker** — the create screen now always lists all five element types in a fixed order, but only allowed elements are selectable;
  - **Consistent terminology** — unified "mazgas" / "objektas" / "įrašas" wording to "elementas" across wizard helpers, breadcrumbs and tooltips;
  - **Single source of truth for type config**;
  - **Pateiktis form cleanup** — removed the leftover inline "Redaguoti"/"Sukurti" button;

Example:
<img width="2051" height="1153" alt="image" src="https://github.com/user-attachments/assets/96cc6f38-5bff-4ea6-9cbb-1ca06598bdd5" />
