### PR TITLE
[DCAT-47] Make `availability` a non-required field

### DIFF
--- a/tests/dcat/forms/test_distribution_forms.py
+++ b/tests/dcat/forms/test_distribution_forms.py
@@ -15,21 +15,16 @@ pytestmark = pytest.mark.django_db
 
 
 class TestDatasetDistributionForm:
-    def test_access_url_availability_title_description_are_required(self):
+    def test_required_and_optional_fields(self):
         dataset = DatasetFactory()
 
         form = DatasetDistributionForm(dataset)
 
-        assert form.fields["access_url"].required is True
-        assert form.fields["availability"].required is True
-        assert form.fields["title"].required is True
-        assert form.fields["description"].required is True
+        assert form.fields["access_url"].required
+        assert form.fields["title"].required
+        assert form.fields["description"].required
 
-    def test_data_service_and_format_not_required(self):
-        dataset = DatasetFactory()
-
-        form = DatasetDistributionForm(dataset)
-
+        assert not form.fields["availability"].required
         assert not form.fields["data_service"].required
         assert not form.fields["format"].required
 

--- a/vitrina/dcat/forms/distribution_forms.py
+++ b/vitrina/dcat/forms/distribution_forms.py
@@ -92,7 +92,6 @@ class DatasetDistributionForm(TranslatableModelForm):
 
         self.fields["access_url"].required = True
         self.fields["access_url"].label = _("Prieigos URL")
-        self.fields["availability"].required = True
         self.fields["availability"].queryset = Concept.ordered_by_label_objects.filter(
             concept_schemas__uri=DISTRIBUTION_AVAILABILITY_SCHEMA_URI
         ).prefetch_related("translations")


### PR DESCRIPTION
`availability` is only required when given (meaning optional);

According to the document:
<img width="1569" height="126" alt="image" src="https://github.com/user-attachments/assets/36faecaa-b548-417d-977a-c73dbb535724" />
