### PR TITLE
Ft/dcat dataset delete

### DIFF
--- a/tests/dcat/test_view_helpers.py
+++ b/tests/dcat/test_view_helpers.py
@@ -12,12 +12,14 @@ from vitrina.datasets.factories import (
 )
 from vitrina.datasets.models import Attribution, DatasetAttribution, DatasetQualifiedRelation, DatasetRelation, Relation
 from vitrina.dcat.view_helpers import (
+    can_delete_distribution_in_wizard,
     save_dataset_attribution,
     save_dataset_qualified_relations,
     save_dataset_relations,
     save_produces_relations,
 )
 from vitrina.orgs.factories import OrganizationFactory
+from vitrina.resources.factories import DatasetDistributionFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -376,3 +378,13 @@ class TestSaveDatasetQualifiedRelations:
         save_dataset_qualified_relations(dataset, form)
 
         assert DatasetQualifiedRelation.objects.filter(dataset=dataset).count() == 0
+
+
+class TestCanDeleteDistributionInWizard:
+    def test_returns_true_when_dataset_is_not_public(self):
+        distribution = DatasetDistributionFactory(dataset=DatasetFactory(is_public=False))
+        assert can_delete_distribution_in_wizard(distribution) is True
+
+    def test_returns_false_when_dataset_is_public(self):
+        distribution = DatasetDistributionFactory(dataset=DatasetFactory(is_public=True))
+        assert can_delete_distribution_in_wizard(distribution) is False

--- a/tests/dcat/views/test_dataset_views.py
+++ b/tests/dcat/views/test_dataset_views.py
@@ -1,5 +1,9 @@
+import json
 import uuid
 from unittest.mock import patch
+
+from vitrina.dcat.view_helpers import can_delete_dataset_in_wizard
+from vitrina.resources.factories import DatasetDistributionFactory
 
 import pytest
 from django.conf import settings
@@ -24,9 +28,12 @@ from vitrina.datasets.factories import (
     ContactFactory,
     DatasetAttributionFactory,
     DatasetFactory,
+    DatasetQualifiedRelationFactory,
+    DatasetRelationFactory,
     DCATResourceSubclassFactory,
     RelationFactory,
 )
+from vitrina.structure.factories import MetadataFactory
 from vitrina.datasets.models import (
     Attribution,
     DatasetAttribution,
@@ -1336,3 +1343,227 @@ class TestDcatDatasetUpdateView:
         assert DatasetRelation.objects.filter(
             relation=produces_relation, dataset=dataset, part_of=produced_dataset
         ).exists()
+
+
+class TestDcatDatasetDeleteView:
+    def test_unauthenticated_redirects_to_login(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.DATASET)
+        dataset = DatasetFactory(organization=org, subclass=subclass, is_public=False)
+
+        url = reverse("dcat-dataset-delete", kwargs={"organization_id": org.pk, "dataset_id": dataset.pk})
+        response = app.get(url)
+
+        assert response.status_code == 302
+        assert settings.LOGIN_URL in response.location
+        assert Dataset.objects.filter(pk=dataset.pk).exists()
+
+    def test_no_permission_returns_403(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.DATASET)
+        dataset = DatasetFactory(organization=org, subclass=subclass, is_public=False)
+        user = UserFactory()
+        app.set_user(user)
+
+        url = reverse("dcat-dataset-delete", kwargs={"organization_id": org.pk, "dataset_id": dataset.pk})
+        response = app.get(url, expect_errors=True)
+
+        assert response.status_code == 403
+        assert Dataset.objects.filter(pk=dataset.pk).exists()
+
+    def test_public_dataset_shows_notice(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.DATASET)
+        dataset = DatasetFactory(organization=org, subclass=subclass, is_public=True)
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        url = reverse("dcat-dataset-delete", kwargs={"organization_id": org.pk, "dataset_id": dataset.pk})
+        response = app.get(url)
+
+        assert response.status_code == 200
+        assert Dataset.objects.filter(pk=dataset.pk).exists()
+
+    def test_dataset_with_children_shows_notice(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        is_subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
+        dataset_subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.DATASET)
+        parent = DatasetFactory(organization=org, subclass=is_subclass, is_public=False)
+        child = Dataset(
+            organization=org,
+            subclass=dataset_subclass,
+            is_public=False,
+            uuid=str(uuid.uuid4()),
+            version=1,
+            will_be_financed=False,
+            status=Dataset.HAS_DATA,
+            access_rights=Dataset.PUBLIC,
+        )
+        parent.add_child(instance=child)
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        url = reverse("dcat-dataset-delete", kwargs={"organization_id": org.pk, "dataset_id": parent.pk})
+        response = app.get(url)
+
+        assert response.status_code == 200
+        assert Dataset.objects.filter(pk=parent.pk).exists()
+
+    def test_dataset_with_distributions_shows_notice(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.DATASET)
+        dataset = DatasetFactory(organization=org, subclass=subclass, is_public=False)
+        DatasetDistributionFactory(dataset=dataset)
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        url = reverse("dcat-dataset-delete", kwargs={"organization_id": org.pk, "dataset_id": dataset.pk})
+        response = app.get(url)
+
+        assert response.status_code == 200
+        assert Dataset.objects.filter(pk=dataset.pk).exists()
+
+    def test_get_shows_confirmation_page(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.DATASET)
+        dataset = DatasetFactory(organization=org, subclass=subclass, is_public=False)
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        url = reverse("dcat-dataset-delete", kwargs={"organization_id": org.pk, "dataset_id": dataset.pk})
+        response = app.get(url)
+
+        assert response.status_code == 200
+        assert Dataset.objects.filter(pk=dataset.pk).exists()
+
+    def test_post_deletes_dataset(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        is_subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
+        dataset_subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.DATASET)
+        parent = DatasetFactory(organization=org, subclass=is_subclass, is_public=False)
+        child = Dataset(
+            organization=org,
+            subclass=dataset_subclass,
+            is_public=False,
+            uuid=str(uuid.uuid4()),
+            version=1,
+            will_be_financed=False,
+            status=Dataset.HAS_DATA,
+            access_rights=Dataset.PUBLIC,
+        )
+        parent.add_child(instance=child)
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        url = reverse("dcat-dataset-delete", kwargs={"organization_id": org.pk, "dataset_id": child.pk})
+        app.get(url).forms["delete-form"].submit()
+
+        assert not Dataset.objects.filter(pk=child.pk).exists()
+
+    def test_post_redirects_to_parent_after_delete(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        is_subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
+        dataset_subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.DATASET)
+        parent = DatasetFactory(organization=org, subclass=is_subclass, is_public=False)
+        child = Dataset(
+            organization=org,
+            subclass=dataset_subclass,
+            is_public=False,
+            uuid=str(uuid.uuid4()),
+            version=1,
+            will_be_financed=False,
+            status=Dataset.HAS_DATA,
+            access_rights=Dataset.PUBLIC,
+        )
+        parent.add_child(instance=child)
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        url = reverse("dcat-dataset-delete", kwargs={"organization_id": org.pk, "dataset_id": child.pk})
+        response = app.get(url).forms["delete-form"].submit()
+
+        assert response.status_code == 200
+        assert not Dataset.objects.filter(pk=child.pk).exists()
+        hx_trigger = json.loads(response.headers["HX-Trigger"])
+        assert "treeRefresh" in hx_trigger
+        assert hx_trigger["wizardnodecreated"]["nodeKey"] == f"is:{parent.pk}"
+
+    def test_post_redirects_to_org_when_no_parent(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.DATASET)
+        dataset = DatasetFactory(organization=org, subclass=subclass, is_public=False)
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        url = reverse("dcat-dataset-delete", kwargs={"organization_id": org.pk, "dataset_id": dataset.pk})
+        response = app.get(url).forms["delete-form"].submit()
+
+        assert not Dataset.objects.filter(pk=dataset.pk).exists()
+        assert response.status_code == 200
+        assert reverse("organization-detail", kwargs={"pk": org.pk}) in response.headers["HX-Redirect"]
+
+    def test_post_deletes_related_objects(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.DATASET)
+        dataset = DatasetFactory(organization=org, subclass=subclass, is_public=False)
+        attribution = DatasetAttributionFactory(dataset=dataset)
+        metadata = MetadataFactory(
+            dataset=dataset,
+            content_type=ContentType.objects.get_for_model(dataset),
+            object_id=dataset.pk,
+        )
+        dataset_relation = DatasetRelationFactory(dataset=dataset)
+        qualified_relation = DatasetQualifiedRelationFactory(dataset=dataset)
+        user = UserFactory(is_staff=True)
+        app.set_user(user)
+
+        url = reverse("dcat-dataset-delete", kwargs={"organization_id": org.pk, "dataset_id": dataset.pk})
+        app.get(url).forms["delete-form"].submit()
+
+        assert not DatasetAttribution.objects.filter(pk=attribution.pk).exists()
+        assert not Metadata.objects.filter(pk=metadata.pk).exists()
+        assert not DatasetRelation.objects.filter(pk=dataset_relation.pk).exists()
+        assert not DatasetQualifiedRelation.objects.filter(pk=qualified_relation.pk).exists()
+
+
+class TestCanDeleteDatasetInWizard:
+    def test_returns_true_when_not_public_no_children_no_distributions(self):
+        org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.DATASET)
+        dataset = DatasetFactory(organization=org, subclass=subclass, is_public=False)
+
+        assert can_delete_dataset_in_wizard(dataset) is True
+
+    def test_returns_false_when_dataset_is_public(self):
+        org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.DATASET)
+        dataset = DatasetFactory(organization=org, subclass=subclass, is_public=True)
+
+        assert can_delete_dataset_in_wizard(dataset) is False
+
+    def test_returns_false_when_dataset_has_children(self):
+        org = OrganizationFactory()
+        is_subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.INFORMATION_SYSTEM)
+        dataset_subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.DATASET)
+        parent = DatasetFactory(organization=org, subclass=is_subclass, is_public=False)
+        child = Dataset(
+            organization=org,
+            subclass=dataset_subclass,
+            is_public=False,
+            uuid=str(uuid.uuid4()),
+            version=1,
+            will_be_financed=False,
+            status=Dataset.HAS_DATA,
+            access_rights=Dataset.PUBLIC,
+        )
+        parent.add_child(instance=child)
+
+        assert can_delete_dataset_in_wizard(parent) is False
+
+    def test_returns_false_when_dataset_has_distributions(self):
+        org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.DATASET)
+        dataset = DatasetFactory(organization=org, subclass=subclass, is_public=False)
+        DatasetDistributionFactory(dataset=dataset)
+
+        assert can_delete_dataset_in_wizard(dataset) is False

--- a/tests/dcat/views/test_distribution_views.py
+++ b/tests/dcat/views/test_distribution_views.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 from django.conf import settings
 
@@ -25,6 +27,7 @@ from vitrina.resources.models import (
     DISTRIBUTION_STANDARD_URI,
 )
 from vitrina.structure.factories import MetadataFactory, VersionFactory
+from vitrina.structure.models import Metadata
 from vitrina.users.factories import UserFactory
 
 pytestmark = pytest.mark.django_db
@@ -628,3 +631,87 @@ class TestDcatDistributionUpdateView:
         assert language in distribution.languages.all()
         assert conforms_to_concept in distribution.conforms_to.all()
         assert distribution.documentation.filter(documentation_link="https://example.com/updated-doc").exists()
+
+
+class TestDcatDistributionDeleteView:
+    def _url(self, org, dataset, distribution):
+        return reverse(
+            "dcat-distribution-delete",
+            kwargs={
+                "organization_id": org.pk,
+                "dataset_id": dataset.pk,
+                "distribution_id": distribution.pk,
+            },
+        )
+
+    def test_unauthenticated_redirects_to_login(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        dataset = DatasetFactory(organization=org, is_public=False)
+        distribution = DatasetDistributionFactory(dataset=dataset)
+
+        response = app.get(self._url(org, dataset, distribution))
+
+        assert response.status_code == 302
+        assert settings.LOGIN_URL in response.location
+        assert DatasetDistribution.objects.filter(pk=distribution.pk).exists()
+
+    def test_no_permission_returns_403(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        dataset = DatasetFactory(organization=org, is_public=False)
+        distribution = DatasetDistributionFactory(dataset=dataset)
+        app.set_user(UserFactory())
+
+        response = app.get(self._url(org, dataset, distribution), expect_errors=True)
+
+        assert response.status_code == 403
+        assert DatasetDistribution.objects.filter(pk=distribution.pk).exists()
+
+    def test_public_dataset_shows_notice(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        dataset = DatasetFactory(organization=org, is_public=True)
+        distribution = DatasetDistributionFactory(dataset=dataset)
+        app.set_user(UserFactory(is_staff=True))
+
+        response = app.get(self._url(org, dataset, distribution))
+
+        assert response.status_code == 200
+        assert DatasetDistribution.objects.filter(pk=distribution.pk).exists()
+
+    def test_post_deletes_distribution(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        dataset = DatasetFactory(organization=org, is_public=False)
+        distribution = DatasetDistributionFactory(dataset=dataset)
+        app.set_user(UserFactory(is_staff=True))
+
+        app.get(self._url(org, dataset, distribution)).forms["delete-form"].submit()
+
+        assert not DatasetDistribution.objects.filter(pk=distribution.pk).exists()
+
+    def test_post_deletes_metadata(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        dataset = DatasetFactory(organization=org, is_public=False)
+        distribution = DatasetDistributionFactory(dataset=dataset)
+        metadata = MetadataFactory(
+            content_type=ContentType.objects.get_for_model(distribution),
+            object_id=distribution.pk,
+        )
+        app.set_user(UserFactory(is_staff=True))
+
+        app.get(self._url(org, dataset, distribution)).forms["delete-form"].submit()
+
+        assert not Metadata.objects.filter(pk=metadata.pk).exists()
+
+    def test_post_renders_dataset_fragment(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        subclass = DCATResourceSubclassFactory(name=DCATResourceSubclass.DATASET)
+        dataset = DatasetFactory(organization=org, subclass=subclass, is_public=False)
+        distribution = DatasetDistributionFactory(dataset=dataset)
+        app.set_user(UserFactory(is_staff=True))
+
+        response = app.get(self._url(org, dataset, distribution)).forms["delete-form"].submit()
+
+        assert response.status_code == 200
+        assert not DatasetDistribution.objects.filter(pk=distribution.pk).exists()
+        hx_trigger = json.loads(response.headers["HX-Trigger"])
+        assert "treeRefresh" in hx_trigger
+        assert hx_trigger["wizardnodecreated"]["nodeKey"] == f"dataset:{dataset.pk}"

--- a/tests/orgs/test_services.py
+++ b/tests/orgs/test_services.py
@@ -2229,6 +2229,58 @@ def test_dataset_delete_wizard_not_allowed_for_public_dataset(role: str):
     assert res is False
 
 
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "access_rights,role,expected",
+    [
+        (Dataset.PUBLIC, Representative.RESOURCE_COORDINATOR, True),
+        (Dataset.RESTRICTED, Representative.RESOURCE_COORDINATOR, True),
+        (Dataset.NON_PUBLIC, Representative.RESOURCE_COORDINATOR, True),
+        (Dataset.CONFIDENTIAL, Representative.RESOURCE_COORDINATOR, True),
+        (Dataset.PUBLIC, Representative.RESOURCE_MANAGER, True),
+        (Dataset.RESTRICTED, Representative.RESOURCE_MANAGER, True),
+        (Dataset.NON_PUBLIC, Representative.RESOURCE_MANAGER, True),
+        (Dataset.CONFIDENTIAL, Representative.RESOURCE_MANAGER, True),
+        (Dataset.PUBLIC, Representative.OPEN_DATA_COORDINATOR, False),
+        (Dataset.PUBLIC, Representative.OPEN_DATA_MANAGER, False),
+    ],
+)
+def test_dataset_distribution_delete_wizard_permission_non_public_dataset(
+    access_rights: str, role: str, expected: bool
+):
+    distribution = DatasetDistributionFactory(dataset=DatasetFactory(is_public=False, access_rights=access_rights))
+    ct = ContentType.objects.get_for_model(distribution.dataset)
+    rep = RepresentativeFactory(content_type=ct, object_id=distribution.dataset.pk, role=role)
+    res = has_perm(rep.user, Action.DELETE_WIZARD, distribution)
+    assert res is expected
+
+
+@pytest.mark.django_db
+def test_dataset_distribution_delete_wizard_permission_global_manager():
+    distribution = DatasetDistributionFactory(dataset=DatasetFactory(is_public=False))
+    user = UserFactory(is_staff=True)
+    res = has_perm(user, Action.DELETE_WIZARD, distribution)
+    assert res is True
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "role",
+    [
+        Representative.RESOURCE_COORDINATOR,
+        Representative.RESOURCE_MANAGER,
+        Representative.OPEN_DATA_COORDINATOR,
+        Representative.OPEN_DATA_MANAGER,
+    ],
+)
+def test_dataset_distribution_delete_wizard_not_allowed_for_public_dataset(role: str):
+    distribution = DatasetDistributionFactory(dataset=DatasetFactory(is_public=True, access_rights=Dataset.PUBLIC))
+    ct = ContentType.objects.get_for_model(distribution.dataset)
+    rep = RepresentativeFactory(content_type=ct, object_id=distribution.dataset.pk, role=role)
+    res = has_perm(rep.user, Action.DELETE_WIZARD, distribution)
+    assert res is False
+
+
 class TestHasDatasetPerm:
     @pytest.mark.parametrize("access_rights", [Dataset.PUBLIC, Dataset.RESTRICTED])
     def test_permissions_with_dataset_open_data_representative(self, access_rights: str):

--- a/tests/orgs/test_services.py
+++ b/tests/orgs/test_services.py
@@ -2179,6 +2179,56 @@ def test_dataset_update_wizard_not_allowed_for_public_is(role: str):
     assert res is False
 
 
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "access_rights,role,expected",
+    [
+        (Dataset.PUBLIC, Representative.RESOURCE_COORDINATOR, True),
+        (Dataset.RESTRICTED, Representative.RESOURCE_COORDINATOR, True),
+        (Dataset.NON_PUBLIC, Representative.RESOURCE_COORDINATOR, True),
+        (Dataset.CONFIDENTIAL, Representative.RESOURCE_COORDINATOR, True),
+        (Dataset.PUBLIC, Representative.RESOURCE_MANAGER, True),
+        (Dataset.RESTRICTED, Representative.RESOURCE_MANAGER, True),
+        (Dataset.NON_PUBLIC, Representative.RESOURCE_MANAGER, True),
+        (Dataset.CONFIDENTIAL, Representative.RESOURCE_MANAGER, True),
+        (Dataset.PUBLIC, Representative.OPEN_DATA_COORDINATOR, False),
+        (Dataset.PUBLIC, Representative.OPEN_DATA_MANAGER, False),
+    ],
+)
+def test_dataset_delete_wizard_permission_non_public_dataset(access_rights: str, role: str, expected: bool):
+    dataset = DatasetFactory(is_public=False, access_rights=access_rights)
+    ct = ContentType.objects.get_for_model(dataset)
+    rep = RepresentativeFactory(content_type=ct, object_id=dataset.pk, role=role)
+    res = has_perm(rep.user, Action.DELETE_WIZARD, dataset)
+    assert res is expected
+
+
+@pytest.mark.django_db
+def test_dataset_delete_wizard_permission_global_manager():
+    dataset = DatasetFactory(is_public=False)
+    user = UserFactory(is_staff=True)
+    res = has_perm(user, Action.DELETE_WIZARD, dataset)
+    assert res is True
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "role",
+    [
+        Representative.RESOURCE_COORDINATOR,
+        Representative.RESOURCE_MANAGER,
+        Representative.OPEN_DATA_COORDINATOR,
+        Representative.OPEN_DATA_MANAGER,
+    ],
+)
+def test_dataset_delete_wizard_not_allowed_for_public_dataset(role: str):
+    dataset = DatasetFactory(is_public=True, access_rights=Dataset.PUBLIC)
+    ct = ContentType.objects.get_for_model(dataset)
+    rep = RepresentativeFactory(content_type=ct, object_id=dataset.pk, role=role)
+    res = has_perm(rep.user, Action.DELETE_WIZARD, dataset)
+    assert res is False
+
+
 class TestHasDatasetPerm:
     @pytest.mark.parametrize("access_rights", [Dataset.PUBLIC, Dataset.RESTRICTED])
     def test_permissions_with_dataset_open_data_representative(self, access_rights: str):

--- a/vitrina/dcat/templates/vitrina/dcat/_wizard_dataset_create_fragment.html
+++ b/vitrina/dcat/templates/vitrina/dcat/_wizard_dataset_create_fragment.html
@@ -38,3 +38,4 @@
     </div>
 </form>
 {% include "vitrina/dcat/_wizard_codename_preview_script.html" %}
+<div id="wizard-footer-extra" hx-swap-oob="innerHTML"></div>

--- a/vitrina/dcat/templates/vitrina/dcat/_wizard_dataset_delete_fragment.html
+++ b/vitrina/dcat/templates/vitrina/dcat/_wizard_dataset_delete_fragment.html
@@ -1,0 +1,52 @@
+{% load i18n %}
+<nav class="wizard-crumbs">
+    {% for crumb in breadcrumb_ancestors %}
+    <div class="is-flex is-align-items-flex-end">
+        <div class="wizard-crumb">
+            <span class="wizard-crumb-label">{{ crumb.type_label }}</span>
+            <span class="wizard-crumb-title">{{ crumb.title }}</span>
+        </div>
+        <span class="wizard-crumb-sep">&rsaquo;</span>
+    </div>
+    {% endfor %}
+    <div class="wizard-crumb is-current">
+        <span class="wizard-crumb-label">{{ form_title }}</span>
+        <span class="wizard-crumb-title">{{ object.title }}</span>
+    </div>
+</nav>
+
+<div class="wizard-form-section-header">
+    <p class="wizard-form-section-title">{{ object.title }}</p>
+    <p class="wizard-form-section-sub">{% translate "Ištrinti" %} {{ form_title|lower }}</p>
+</div>
+
+{% include "vitrina/_wizard_messages.html" %}
+
+<div class="wizard-form-body">
+    <p class="mb-4">
+        {% blocktranslate with title=object.title %}
+            Ar tikrai norite ištrinti „{{ title }}"? Šio veiksmo atšaukti negalima.
+        {% endblocktranslate %}
+    </p>
+
+    <div class="buttons">
+        <a href="{% url 'dcat-dataset-update' organization_id=organization.pk dataset_id=object.pk %}"
+           hx-get="{% url 'dcat-dataset-update' organization_id=organization.pk dataset_id=object.pk %}"
+           hx-target="#wizard-main-pane"
+           hx-swap="innerHTML"
+           class="button is-light">
+            {% translate "Atšaukti" %}
+        </a>
+
+        <form id="delete-form"
+              method="post"
+              hx-post="{% url 'dcat-dataset-delete' organization_id=organization.pk dataset_id=object.pk %}"
+              hx-target="#wizard-main-pane"
+              hx-swap="innerHTML"
+              style="display: inline-block;">
+            {% csrf_token %}
+            <button type="submit" class="button is-danger">{% translate "Ištrinti" %}</button>
+        </form>
+    </div>
+</div>
+<div id="wizard-footer-extra" hx-swap-oob="innerHTML"></div>

--- a/vitrina/dcat/templates/vitrina/dcat/_wizard_dataset_delete_fragment.html
+++ b/vitrina/dcat/templates/vitrina/dcat/_wizard_dataset_delete_fragment.html
@@ -24,14 +24,12 @@
 
 <div class="wizard-form-body">
     <p class="mb-4">
-        {% blocktranslate with title=object.title %}
-            Ar tikrai norite ištrinti „{{ title }}"? Šio veiksmo atšaukti negalima.
-        {% endblocktranslate %}
+        {% blocktranslate with title=object.title %}Ar tikrai norite ištrinti „{{ title }}"? Šio veiksmo atšaukti negalima.{% endblocktranslate %}
     </p>
 
     <div class="buttons">
-        <a href="{% url 'dcat-dataset-update' organization_id=organization.pk dataset_id=object.pk %}"
-           hx-get="{% url 'dcat-dataset-update' organization_id=organization.pk dataset_id=object.pk %}"
+        <a href="{{ cancel_url }}"
+           hx-get="{{ cancel_url }}"
            hx-target="#wizard-main-pane"
            hx-swap="innerHTML"
            class="button is-light">
@@ -40,7 +38,7 @@
 
         <form id="delete-form"
               method="post"
-              hx-post="{% url 'dcat-dataset-delete' organization_id=organization.pk dataset_id=object.pk %}"
+              hx-post="{{ delete_url }}"
               hx-target="#wizard-main-pane"
               hx-swap="innerHTML"
               style="display: inline-block;">

--- a/vitrina/dcat/templates/vitrina/dcat/_wizard_dataset_fragment.html
+++ b/vitrina/dcat/templates/vitrina/dcat/_wizard_dataset_fragment.html
@@ -57,5 +57,17 @@
             <div class="column is-two-fifths" id="wizard-relationship-panel"></div>
         {% endif %}
     </div>
+
 </form>
 {% include "vitrina/dcat/_wizard_codename_preview_script.html" %}
+<div id="wizard-footer-extra" hx-swap-oob="innerHTML">
+    {% if can_delete %}
+        <a href="{% url 'dcat-dataset-delete' organization_id=organization.pk dataset_id=dataset.pk %}"
+           hx-get="{% url 'dcat-dataset-delete' organization_id=organization.pk dataset_id=dataset.pk %}"
+           hx-target="#wizard-main-pane"
+           hx-swap="innerHTML"
+           class="button is-danger is-light">
+            {% translate "Ištrinti" %}
+        </a>
+    {% endif %}
+</div>

--- a/vitrina/dcat/templates/vitrina/dcat/_wizard_distribution_create_fragment.html
+++ b/vitrina/dcat/templates/vitrina/dcat/_wizard_distribution_create_fragment.html
@@ -37,3 +37,4 @@
         {% crispy form %}
     </div>
 </form>
+<div id="wizard-footer-extra" hx-swap-oob="innerHTML"></div>

--- a/vitrina/dcat/templates/vitrina/dcat/_wizard_distribution_fragment.html
+++ b/vitrina/dcat/templates/vitrina/dcat/_wizard_distribution_fragment.html
@@ -36,5 +36,15 @@
     <div class="wizard-form-body">
         {% crispy form %}
     </div>
+
 </form>
-<div id="wizard-footer-extra" hx-swap-oob="innerHTML"></div>
+<div id="wizard-footer-extra" hx-swap-oob="innerHTML">
+    {% if can_delete %}
+        <a hx-get="{% url 'dcat-distribution-delete' organization_id=object.dataset.organization.pk dataset_id=object.dataset.pk distribution_id=object.pk %}"
+           hx-target="#wizard-main-pane"
+           hx-swap="innerHTML"
+           class="button is-danger is-light">
+            {% translate "Ištrinti" %}
+        </a>
+    {% endif %}
+</div>

--- a/vitrina/dcat/templates/vitrina/dcat/_wizard_distribution_fragment.html
+++ b/vitrina/dcat/templates/vitrina/dcat/_wizard_distribution_fragment.html
@@ -37,3 +37,4 @@
         {% crispy form %}
     </div>
 </form>
+<div id="wizard-footer-extra" hx-swap-oob="innerHTML"></div>

--- a/vitrina/dcat/urls.py
+++ b/vitrina/dcat/urls.py
@@ -7,7 +7,11 @@ from vitrina.dcat.views.dataset_views import (
     DcatDatasetRelationshipUpdateView,
     DcatDatasetDeleteView,
 )
-from vitrina.dcat.views.distribution_views import DcatDistributionCreateView, DcatDistributionUpdateView
+from vitrina.dcat.views.distribution_views import (
+    DcatDistributionCreateView,
+    DcatDistributionDeleteView,
+    DcatDistributionUpdateView,
+)
 
 urlpatterns = [
     path(
@@ -54,6 +58,11 @@ urlpatterns = [
         "organization/<int:organization_id>/dcat/dataset/<int:dataset_id>/distribution/<int:distribution_id>/update/",
         DcatDistributionUpdateView.as_view(),
         name="dcat-distribution-update",
+    ),
+    path(
+        "organization/<int:organization_id>/dcat/dataset/<int:dataset_id>/distribution/<int:distribution_id>/delete/",
+        DcatDistributionDeleteView.as_view(),
+        name="dcat-distribution-delete",
     ),
     path(
         "organization/<int:organization_id>/dcat/dataset/<int:dataset_id>/distribution/<int:distribution_id>/update/version/<int:version_id>/",

--- a/vitrina/dcat/urls.py
+++ b/vitrina/dcat/urls.py
@@ -5,6 +5,7 @@ from vitrina.dcat.views.dataset_views import (
     DcatDatasetCreateView,
     DcatDatasetUpdateView,
     DcatDatasetRelationshipUpdateView,
+    DcatDatasetDeleteView,
 )
 from vitrina.dcat.views.distribution_views import DcatDistributionCreateView, DcatDistributionUpdateView
 
@@ -38,6 +39,11 @@ urlpatterns = [
         "organization/<int:organization_id>/dcat/dataset/<int:dataset_id>/relationships/update/",
         DcatDatasetRelationshipUpdateView.as_view(),
         name="dcat-dataset-relationships-update",
+    ),
+    path(
+        "organization/<int:organization_id>/dcat/dataset/<int:dataset_id>/delete/",
+        DcatDatasetDeleteView.as_view(),
+        name="dcat-dataset-delete",
     ),
     path(
         "organization/<int:organization_id>/dcat/dataset/<int:dataset_id>/distribution/",

--- a/vitrina/dcat/view_helpers.py
+++ b/vitrina/dcat/view_helpers.py
@@ -184,3 +184,7 @@ def can_delete_dataset_in_wizard(dataset: Dataset) -> bool:
     return (
         not dataset.is_public and not dataset.get_children().exists() and not dataset.datasetdistribution_set.exists()
     )
+
+
+def can_delete_distribution_in_wizard(distribution) -> bool:
+    return not distribution.dataset.is_public

--- a/vitrina/dcat/view_helpers.py
+++ b/vitrina/dcat/view_helpers.py
@@ -178,3 +178,9 @@ def save_dataset_qualified_relations(dataset: Dataset, form: "BaseResourceForm")
     for url in form.cleaned_data["qualified_relation"]:
         DatasetQualifiedRelation.objects.get_or_create(dataset=dataset, url=url)
     dataset.save()
+
+
+def can_delete_dataset_in_wizard(dataset: Dataset) -> bool:
+    return (
+        not dataset.is_public and not dataset.get_children().exists() and not dataset.datasetdistribution_set.exists()
+    )

--- a/vitrina/dcat/views/dataset_views.py
+++ b/vitrina/dcat/views/dataset_views.py
@@ -8,9 +8,10 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.handlers.wsgi import WSGIRequest
 from django.db.models import QuerySet
 from django.db import transaction
-from django.http import HttpResponseRedirect, HttpResponseBase
+from django.http import HttpResponse, HttpResponseRedirect, HttpResponseBase
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
+from django.views.generic import DeleteView
 from django.utils.functional import cached_property
 from django.utils.translation import get_language
 from django.views import View
@@ -27,6 +28,7 @@ from vitrina.datasets.view_helpers import (
     save_dataset_creator,
 )
 from vitrina.dcat.view_helpers import (
+    can_delete_dataset_in_wizard,
     datasets_in_org_scope,
     save_dataset_relations,
     save_dataset_attribution,
@@ -34,7 +36,7 @@ from vitrina.dcat.view_helpers import (
     save_produces_relations,
     wizard_breadcrumb_ancestors,
 )
-from vitrina.dcat.wizard import WIZARD_SUBCLASS_TO_NODE_TYPE
+from vitrina.dcat.wizard import WIZARD_SUBCLASS_TO_NODE_TYPE, _wizard_node_type
 from vitrina.dcat.forms.dataset_forms import (
     InformationSystemResourceForm,
     BaseResourceForm,
@@ -100,6 +102,38 @@ DCAT_SUBCLASS_UPDATE_SUCCESS_MAP = {
     DCATResourceSubclass.DATASET: _("Duomenų rinkinys atnaujintas sėkmingai! Kodinis pavadinimas: {0}"),
     DCATResourceSubclass.IS_PUBLIC_SERVICE: _("E. paslauga atnaujinta sėkmingai!"),
 }
+
+DCAT_SUBCLASS_DELETE_SUCCESS_MAP = {
+    DCATResourceSubclass.INFORMATION_SYSTEM: _("Informacinė sistema ištrinta sėkmingai!"),
+    DCATResourceSubclass.SERVICE: _("Duomenų paslauga ištrinta sėkmingai!"),
+    DCATResourceSubclass.DATASET: _("Duomenų rinkinys ištrintas sėkmingai!"),
+    DCATResourceSubclass.IS_PUBLIC_SERVICE: _("E. paslauga ištrinta sėkmingai!"),
+}
+
+
+def _render_dataset_fragment(
+    request: WSGIRequest,
+    dataset: Dataset,
+    organization: Organization,
+    relationship_form: BaseResourceForm | None = None,
+) -> HttpResponse:
+    dataset.set_current_language(get_language())
+    subclass_name = dataset.subclass.name
+    form = DCAT_SUBCLASS_UPDATE_FORM_MAP[subclass_name](organization, None, instance=dataset)
+    form.helper.form_tag = False
+    if relationship_form is None:
+        rel_form_class = DCAT_SUBCLASS_RELATIONSHIP_FORM_MAP.get(subclass_name)
+        relationship_form = rel_form_class(dataset) if rel_form_class else None
+    context = {
+        "form": form,
+        "relationship_form": relationship_form,
+        "dataset": dataset,
+        "organization": organization,
+        "form_title": dataset.subclass.translated_title,
+        "breadcrumb_ancestors": wizard_breadcrumb_ancestors(dataset, organization, include_self=False),
+        "can_delete": can_delete_dataset_in_wizard(dataset),
+    }
+    return render(request, "vitrina/dcat/_wizard_dataset_fragment.html", context)
 
 
 class DcatDatasetCreateView(
@@ -315,21 +349,8 @@ class DcatDatasetCreateView(
 
         messages.success(self.request, DCAT_SUBCLASS_CREATE_SUCCESS_MAP.get(self.subclass.name).format(dataset_name))
 
-        self.object.set_current_language(get_language())
         self.object.refresh_from_db(fields=["path", "depth"])
-        update_form = DCAT_SUBCLASS_UPDATE_FORM_MAP[self.subclass.name](self.organization, None, instance=self.object)
-        update_form.helper.form_tag = False
-        rel_form_class = DCAT_SUBCLASS_RELATIONSHIP_FORM_MAP.get(self.subclass.name)
-        context = {
-            "form": update_form,
-            "relationship_form": rel_form_class(self.object) if rel_form_class else None,
-            "dataset": self.object,
-            "organization": self.organization,
-            "form_title": self.subclass.translated_title,
-            "information_title": self.subclass.translated_title,
-            "breadcrumb_ancestors": wizard_breadcrumb_ancestors(self.object, self.organization, include_self=False),
-        }
-        response = render(self.request, "vitrina/dcat/_wizard_dataset_fragment.html", context)
+        response = _render_dataset_fragment(self.request, self.object, self.organization)
         node_prefix = WIZARD_SUBCLASS_TO_NODE_TYPE.get(self.subclass.name, "dataset")
         response["HX-Trigger"] = json.dumps(
             {
@@ -369,8 +390,6 @@ class DcatDatasetUpdateView(
         return has_perm(self.request.user, Action.UPDATE_WIZARD, self.get_object())
 
     def _wizard_notice(self, message: str) -> HttpResponseBase:
-        from django.http import HttpResponse
-
         return HttpResponse(f'<div class="notification is-warning is-light">{message}</div>')
 
     def dispatch(self, request: WSGIRequest, *args, **kwargs) -> HttpResponseBase:
@@ -412,6 +431,7 @@ class DcatDatasetUpdateView(
         context["breadcrumb_ancestors"] = wizard_breadcrumb_ancestors(
             self.object, self.organization, include_self=False
         )
+        context["can_delete"] = can_delete_dataset_in_wizard(self.object)
         return context
 
     def get_queryset(self) -> QuerySet[Dataset]:
@@ -556,13 +576,7 @@ class DcatDatasetUpdateView(
 
         messages.success(self.request, DCAT_SUBCLASS_UPDATE_SUCCESS_MAP.get(self.subclass.name).format(dataset_name))
 
-        self.object.set_current_language(get_language())
-        fresh_form = DCAT_SUBCLASS_UPDATE_FORM_MAP[self.subclass.name](self.organization, None, instance=self.object)
-        response = render(
-            self.request,
-            "vitrina/dcat/_wizard_dataset_fragment.html",
-            self.get_context_data(form=fresh_form),
-        )
+        response = _render_dataset_fragment(self.request, self.object, self.organization)
         response["HX-Trigger"] = "treeRefresh"
         return response
 
@@ -598,23 +612,68 @@ class DcatDatasetRelationshipUpdateView(LoginRequiredMixin, PermissionRequiredMi
         return self._render_fragment(relationship_form=relationship_form)
 
     def _render_fragment(self, relationship_form=None) -> HttpResponseBase:
-        main_form_class = DCAT_SUBCLASS_UPDATE_FORM_MAP.get(self.dataset.subclass.name)
-        main_form = main_form_class(self.organization, None, instance=self.dataset) if main_form_class else None
-        if main_form and hasattr(main_form, "helper"):
-            main_form.helper.form_tag = False
-
-        if relationship_form is None:
-            form_class = DCAT_SUBCLASS_RELATIONSHIP_FORM_MAP.get(self.dataset.subclass.name)
-            relationship_form = form_class(self.dataset) if form_class else None
-
-        context = {
-            "form": main_form,
-            "relationship_form": relationship_form,
-            "dataset": self.dataset,
-            "organization": self.organization,
-            "form_title": self.dataset.subclass.translated_title,
-            "information_title": self.dataset.subclass.translated_title,
-        }
-        response = render(self.request, "vitrina/dcat/_wizard_dataset_fragment.html", context)
+        response = _render_dataset_fragment(self.request, self.dataset, self.organization, relationship_form)
         response["HX-Trigger"] = "treeRefresh"
+        return response
+
+
+class DcatDatasetDeleteView(LoginRequiredMixin, PermissionRequiredMixin, DeleteView):
+    model = Dataset
+    pk_url_kwarg = "dataset_id"
+    template_name = "vitrina/dcat/_wizard_dataset_delete_fragment.html"
+
+    @cached_property
+    def organization(self) -> Organization:
+        return get_object_or_404(Organization, pk=self.kwargs["organization_id"])
+
+    def has_permission(self) -> bool:
+        return has_perm(self.request.user, Action.DELETE_WIZARD, self.get_object())
+
+    def _wizard_notice(self, message: str) -> HttpResponseBase:
+        messages.warning(self.request, message)
+        return _render_dataset_fragment(self.request, self.get_object(), self.organization)
+
+    def dispatch(self, request: WSGIRequest, *args, **kwargs) -> HttpResponseBase:
+        obj = self.get_object()
+        if not can_delete_dataset_in_wizard(obj):
+            return self._wizard_notice(str(_("Šio duomenų ištekliaus ištrinti negalima.")))
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_queryset(self) -> QuerySet[Dataset]:
+        return datasets_in_org_scope(self.organization).select_related("organization", "subclass")
+
+    def get_context_data(self, **kwargs) -> dict:
+        context = super().get_context_data(**kwargs)
+        context.update(
+            {
+                "organization": self.organization,
+                "form_title": self.object.subclass.translated_title,
+                "breadcrumb_ancestors": wizard_breadcrumb_ancestors(self.object, self.organization, include_self=False),
+            }
+        )
+        return context
+
+    def form_valid(self, form) -> HttpResponseBase:
+        parent = self.object.get_parent()
+        subclass_name = self.object.subclass.name
+        self.object.metadata.all().delete()
+        self.object.datasetattribution_set.all().delete()
+        self.object.dataset_relations.all().delete()
+        self.object.qualified_relations.all().delete()
+        self.object.delete()
+        messages.success(self.request, DCAT_SUBCLASS_DELETE_SUCCESS_MAP[subclass_name])
+
+        if parent:
+            response = _render_dataset_fragment(self.request, parent, self.organization)
+            parent_node_key = f"{_wizard_node_type(parent)}:{parent.pk}"
+            response["HX-Trigger"] = json.dumps(
+                {
+                    "treeRefresh": None,
+                    "wizardnodecreated": {"nodeKey": parent_node_key},
+                }
+            )
+            return response
+
+        response = HttpResponse()
+        response["HX-Redirect"] = reverse("organization-wizard", kwargs={"pk": self.organization.pk})
         return response

--- a/vitrina/dcat/views/dataset_views.py
+++ b/vitrina/dcat/views/dataset_views.py
@@ -649,6 +649,14 @@ class DcatDatasetDeleteView(LoginRequiredMixin, PermissionRequiredMixin, DeleteV
                 "organization": self.organization,
                 "form_title": self.object.subclass.translated_title,
                 "breadcrumb_ancestors": wizard_breadcrumb_ancestors(self.object, self.organization, include_self=False),
+                "cancel_url": reverse(
+                    "dcat-dataset-update",
+                    kwargs={"organization_id": self.organization.pk, "dataset_id": self.object.pk},
+                ),
+                "delete_url": reverse(
+                    "dcat-dataset-delete",
+                    kwargs={"organization_id": self.organization.pk, "dataset_id": self.object.pk},
+                ),
             }
         )
         return context

--- a/vitrina/dcat/views/distribution_views.py
+++ b/vitrina/dcat/views/distribution_views.py
@@ -8,6 +8,7 @@ from django.http import HttpResponseBase, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils.functional import cached_property
+from django.views.generic import DeleteView
 from parler.views import TranslatableCreateView, TranslatableUpdateView
 
 from vitrina.datasets.models import Dataset
@@ -18,7 +19,12 @@ from vitrina.resources.models import DatasetDistribution
 
 from django.utils.translation import gettext_lazy as _, get_language
 
-from vitrina.dcat.view_helpers import datasets_in_org_scope, wizard_breadcrumb_ancestors
+from vitrina.dcat.view_helpers import (
+    can_delete_distribution_in_wizard,
+    datasets_in_org_scope,
+    wizard_breadcrumb_ancestors,
+)
+from vitrina.dcat.views.dataset_views import _render_dataset_fragment
 from vitrina.resources.view_helpers import get_default_distribution_name
 from vitrina.structure.models import Version
 
@@ -165,6 +171,7 @@ class DcatDistributionUpdateView(LoginRequiredMixin, PermissionRequiredMixin, Tr
         context["breadcrumb_ancestors"] = wizard_breadcrumb_ancestors(
             distribution.dataset, distribution.dataset.organization, include_self=True
         )
+        context["can_delete"] = can_delete_distribution_in_wizard(distribution)
         return context
 
     def form_valid(self, form: DatasetDistributionForm) -> HttpResponseBase:
@@ -198,4 +205,89 @@ class DcatDistributionUpdateView(LoginRequiredMixin, PermissionRequiredMixin, Tr
             self.get_context_data(form=fresh_form),
         )
         response["HX-Trigger"] = "treeRefresh"
+        return response
+
+
+class DcatDistributionDeleteView(LoginRequiredMixin, PermissionRequiredMixin, DeleteView):
+    model = DatasetDistribution
+    pk_url_kwarg = "distribution_id"
+    template_name = "vitrina/dcat/_wizard_dataset_delete_fragment.html"
+
+    @cached_property
+    def organization(self) -> Organization:
+        return get_object_or_404(Organization, pk=self.kwargs["organization_id"])
+
+    def has_permission(self) -> bool:
+        return has_perm(self.request.user, Action.DELETE_WIZARD, self.get_object())
+
+    def _wizard_notice(self, message: str) -> HttpResponseBase:
+        distribution = self.get_object()
+        distribution.set_current_language(get_language())
+        messages.warning(self.request, message)
+        form = DatasetDistributionForm(instance=distribution, dataset=distribution.dataset)
+        form.helper.form_tag = False
+        context = {
+            "object": distribution,
+            "form": form,
+            "breadcrumb_ancestors": wizard_breadcrumb_ancestors(
+                distribution.dataset, self.organization, include_self=True
+            ),
+            "can_delete": False,
+        }
+        return render(self.request, "vitrina/dcat/_wizard_distribution_fragment.html", context)
+
+    def dispatch(self, request: WSGIRequest, *args, **kwargs) -> HttpResponseBase:
+        obj = self.get_object()
+        if not can_delete_distribution_in_wizard(obj):
+            return self._wizard_notice(str(_("Šios pateikties ištrinti negalima.")))
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_queryset(self) -> QuerySet:
+        scoped_dataset_ids = datasets_in_org_scope(self.organization).values_list("pk", flat=True)
+        return (
+            super()
+            .get_queryset()
+            .filter(dataset_id__in=scoped_dataset_ids, dataset_id=self.kwargs.get("dataset_id"))
+            .select_related("dataset__organization", "dataset__subclass")
+        )
+
+    def get_context_data(self, **kwargs) -> dict:
+        context = super().get_context_data(**kwargs)
+        context["organization"] = self.organization
+        context["breadcrumb_ancestors"] = wizard_breadcrumb_ancestors(
+            self.object.dataset, self.organization, include_self=True
+        )
+        context["form_title"] = _("Pateiktis")
+        context["cancel_url"] = reverse(
+            "dcat-distribution-update",
+            kwargs={
+                "organization_id": self.organization.pk,
+                "dataset_id": self.object.dataset_id,
+                "distribution_id": self.object.pk,
+            },
+        )
+        context["delete_url"] = reverse(
+            "dcat-distribution-delete",
+            kwargs={
+                "organization_id": self.organization.pk,
+                "dataset_id": self.object.dataset_id,
+                "distribution_id": self.object.pk,
+            },
+        )
+        return context
+
+    def form_valid(self, form) -> HttpResponseBase:
+        dataset = self.object.dataset
+        self.object.metadata.all().delete()
+        self.object.delete()
+        messages.success(self.request, _("Pateiktis ištrinta sėkmingai!"))
+
+        response = _render_dataset_fragment(self.request, dataset, self.organization)
+        dataset_node_key = f"dataset:{dataset.pk}"
+        response["HX-Trigger"] = json.dumps(
+            {
+                "treeRefresh": None,
+                "wizardnodecreated": {"nodeKey": dataset_node_key},
+            }
+        )
         return response

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-09 13:33+0300\n"
+"POT-Creation-Date: 2026-06-09 15:57+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,6 +17,12 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "Organizacija"
+msgstr "Organization"
+
+msgid "Duomenų skelbėjas"
+msgstr "Data publisher"
 
 msgid "Versijos duomenys"
 msgstr "Version data"
@@ -52,9 +58,6 @@ msgstr "API key"
 
 msgid "Taikymo sritis"
 msgstr "Application area"
-
-msgid "Organizacija"
-msgstr "Organization"
 
 msgid "Duomenų išteklius"
 msgstr "Resource"
@@ -111,11 +114,9 @@ msgstr "Categories"
 msgid "Atnaujinti pasirinktų sąvokų schemų sąvokas"
 msgstr "Update selected concept scheme concepts"
 
-#, python-brace-format
 msgid "Sėkmingai atnaujintos {} sąvokų schemų sąvokos. Pilnas sąrašas: <br>{}"
 msgstr "Successfully updated {} concept scheme concepts. Full list: <br>{}"
 
-#, python-brace-format
 msgid "Nepavyko atsisiųsti dalies sąvokų. Pilnas sąrašas: <br>{}"
 msgstr "Failed to download some concepts. Full list: <br>{}"
 
@@ -344,27 +345,21 @@ msgstr "Spacial coverage"
 msgid "Teritorinės aprėptys"
 msgstr "Spacial coverages"
 
-#, python-brace-format
 msgid "Nepavyko gauti uri: {}. Klaida: {}."
 msgstr "Failed to get uri: {}. Error: {}."
 
-#, python-brace-format
 msgid "{} nėra validus URI."
 msgstr "{} is not valid URI."
 
-#, python-brace-format
 msgid "Nepavyko gauti uri: {}. Uri atsakymas tuščias."
 msgstr "Failed to get uri: {}. Uri response is empty."
 
-#, python-brace-format
 msgid "Nepavyko gauti uri: {}. Gautas rezultatas nėra RDF formato."
 msgstr "Failed to get uri: {}. Response is not in RDF format."
 
-#, python-brace-format
 msgid "Sąvokų schemoje {} nerasta jokių \"{}\" elementų."
 msgstr "Concept scheme {} does not have any \"{}\" elements."
 
-#, python-brace-format
 msgid "Sąvokoje {} nerastas \"{}\" elementas."
 msgstr "Concept {} does not have \"{}\" element."
 
@@ -1983,9 +1978,6 @@ msgstr "Delete"
 msgid "Atsisiuntimo formatas"
 msgstr "Download format"
 
-msgid "Duomenų skelbėjas"
-msgstr "Data publisher"
-
 msgid "Kontaktinė informacija"
 msgstr "Contact information"
 
@@ -2649,6 +2641,10 @@ msgstr "Distribution with this download link already exists."
 msgid "Kontrolinės sumos reikšmei gali būti naudojamos tik mažosios raidės."
 msgstr "Checksum value can only include lowercase letters."
 
+#, python-format
+msgid "Ar tikrai norite ištrinti „%(title)s\"? Šio veiksmo atšaukti negalima."
+msgstr "Are you sure you want to delete \"%(title)s\"? This action cannot be undone."
+
 msgid "Redaguokite"
 msgstr "Edit"
 
@@ -2735,6 +2731,18 @@ msgstr "Dataset updated successfully! Codename: {0}"
 msgid "E. paslauga atnaujinta sėkmingai!"
 msgstr "E-service updated successfully!"
 
+msgid "Informacinė sistema ištrinta sėkmingai!"
+msgstr "Information system deleted successfully!"
+
+msgid "Duomenų paslauga ištrinta sėkmingai!"
+msgstr "Service deleted successfully!"
+
+msgid "Duomenų rinkinys ištrintas sėkmingai!"
+msgstr "Dataset deleted successfully!"
+
+msgid "E. paslauga ištrinta sėkmingai!"
+msgstr "E-service deleted successfully!"
+
 msgid "Vedlio negalima naudoti su šiuo duomenų ištekliaus poklasiu"
 msgstr "Form creation tool cannot be used for this resource subclass"
 
@@ -2749,6 +2757,9 @@ msgstr "Form creation tool cannot be used for this resource subclass."
 
 msgid "Ryšiai atnaujinti sėkmingai"
 msgstr "Relations updated successfully"
+
+msgid "Šio duomenų ištekliaus ištrinti negalima."
+msgstr "Cannot delete this resource."
 
 msgid "Vedlio negalima naudoti su atvirais duomenų ištekliais"
 msgstr "Form creation tool cannot be used with open data resources"
@@ -2767,6 +2778,12 @@ msgstr "Dataset distribution edit"
 
 msgid "Pateiktis atnaujinta sėkmingai!"
 msgstr "Distribution updated successfully!"
+
+msgid "Šios pateikties ištrinti negalima."
+msgstr "Cannot delete this distribution."
+
+msgid "Pateiktis ištrinta sėkmingai!"
+msgstr "Distribution deleted successfully!"
 
 msgid "IS metaduomenys"
 msgstr "IS metadata"

--- a/vitrina/locale/lt/LC_MESSAGES/django.po
+++ b/vitrina/locale/lt/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-09 13:33+0300\n"
+"POT-Creation-Date: 2026-06-09 15:57+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,6 +19,12 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n % 10 == 1 && (n % 100 > 19 || n % 100 < "
 "11) ? 0 : (n % 10 >= 2 && n % 10 <=9) && (n % 100 > 19 || n % 100 < 11) ? "
 "1 : n % 1 != 0 ? 2: 3);\n"
+
+msgid "Organizacija"
+msgstr ""
+
+msgid "Duomenų skelbėjas"
+msgstr ""
 
 msgid "Versijos duomenys"
 msgstr ""
@@ -51,9 +57,6 @@ msgid "API raktas"
 msgstr ""
 
 msgid "Taikymo sritis"
-msgstr ""
-
-msgid "Organizacija"
 msgstr ""
 
 msgid "Duomenų išteklius"
@@ -110,11 +113,9 @@ msgstr ""
 msgid "Atnaujinti pasirinktų sąvokų schemų sąvokas"
 msgstr ""
 
-#, python-brace-format
 msgid "Sėkmingai atnaujintos {} sąvokų schemų sąvokos. Pilnas sąrašas: <br>{}"
 msgstr ""
 
-#, python-brace-format
 msgid "Nepavyko atsisiųsti dalies sąvokų. Pilnas sąrašas: <br>{}"
 msgstr ""
 
@@ -330,27 +331,21 @@ msgstr ""
 msgid "Teritorinės aprėptys"
 msgstr ""
 
-#, python-brace-format
 msgid "Nepavyko gauti uri: {}. Klaida: {}."
 msgstr ""
 
-#, python-brace-format
 msgid "{} nėra validus URI."
 msgstr ""
 
-#, python-brace-format
 msgid "Nepavyko gauti uri: {}. Uri atsakymas tuščias."
 msgstr ""
 
-#, python-brace-format
 msgid "Nepavyko gauti uri: {}. Gautas rezultatas nėra RDF formato."
 msgstr ""
 
-#, python-brace-format
 msgid "Sąvokų schemoje {} nerasta jokių \"{}\" elementų."
 msgstr ""
 
-#, python-brace-format
 msgid "Sąvokoje {} nerastas \"{}\" elementas."
 msgstr ""
 
@@ -1808,9 +1803,6 @@ msgstr ""
 msgid "Atsisiuntimo formatas"
 msgstr ""
 
-msgid "Duomenų skelbėjas"
-msgstr ""
-
 msgid "Kontaktinė informacija"
 msgstr ""
 
@@ -2424,6 +2416,10 @@ msgstr ""
 msgid "Kontrolinės sumos reikšmei gali būti naudojamos tik mažosios raidės."
 msgstr ""
 
+#, python-format
+msgid "Ar tikrai norite ištrinti „%(title)s\"? Šio veiksmo atšaukti negalima."
+msgstr ""
+
 msgid "Redaguokite"
 msgstr ""
 
@@ -2506,6 +2502,18 @@ msgstr ""
 msgid "E. paslauga atnaujinta sėkmingai!"
 msgstr ""
 
+msgid "Informacinė sistema ištrinta sėkmingai!"
+msgstr ""
+
+msgid "Duomenų paslauga ištrinta sėkmingai!"
+msgstr ""
+
+msgid "Duomenų rinkinys ištrintas sėkmingai!"
+msgstr ""
+
+msgid "E. paslauga ištrinta sėkmingai!"
+msgstr ""
+
 msgid "Vedlio negalima naudoti su šiuo duomenų ištekliaus poklasiu"
 msgstr ""
 
@@ -2519,6 +2527,9 @@ msgid "Vedlio negalima naudoti su šiuo duomenų ištekliaus poklasiu."
 msgstr ""
 
 msgid "Ryšiai atnaujinti sėkmingai"
+msgstr ""
+
+msgid "Šio duomenų ištekliaus ištrinti negalima."
 msgstr ""
 
 msgid "Vedlio negalima naudoti su atvirais duomenų ištekliais"
@@ -2537,6 +2548,12 @@ msgid "Duomenų rinkinio pateikties redagavimas"
 msgstr ""
 
 msgid "Pateiktis atnaujinta sėkmingai!"
+msgstr ""
+
+msgid "Šios pateikties ištrinti negalima."
+msgstr ""
+
+msgid "Pateiktis ištrinta sėkmingai!"
 msgstr ""
 
 msgid "IS metaduomenys"

--- a/vitrina/orgs/services.py
+++ b/vitrina/orgs/services.py
@@ -48,6 +48,7 @@ class Action(Enum):
     ASSIGN = "assign"
     CREATE_WIZARD = "create_wizard"
     UPDATE_WIZARD = "update_wizard"
+    DELETE_WIZARD = "delete_wizard"
 
 
 class Role(Enum):
@@ -200,6 +201,28 @@ _dataset_update_acl: ACL = inherit_acl(_dataset_base_update_acl) | {
         Role.GLOBAL_MANAGER,
     },
     (Dataset, not DATASET_IS_PUBLIC, Dataset.CONFIDENTIAL, Action.UPDATE_WIZARD): {
+        Role.RESOURCE_COORDINATOR,
+        Role.RESOURCE_MANAGER,
+        Role.GLOBAL_MANAGER,
+    },
+}
+_dataset_delete_wizard_acl: ACL = {
+    (Dataset, not DATASET_IS_PUBLIC, Dataset.PUBLIC, Action.DELETE_WIZARD): {
+        Role.RESOURCE_COORDINATOR,
+        Role.RESOURCE_MANAGER,
+        Role.GLOBAL_MANAGER,
+    },
+    (Dataset, not DATASET_IS_PUBLIC, Dataset.RESTRICTED, Action.DELETE_WIZARD): {
+        Role.RESOURCE_COORDINATOR,
+        Role.RESOURCE_MANAGER,
+        Role.GLOBAL_MANAGER,
+    },
+    (Dataset, not DATASET_IS_PUBLIC, Dataset.NON_PUBLIC, Action.DELETE_WIZARD): {
+        Role.RESOURCE_COORDINATOR,
+        Role.RESOURCE_MANAGER,
+        Role.GLOBAL_MANAGER,
+    },
+    (Dataset, not DATASET_IS_PUBLIC, Dataset.CONFIDENTIAL, Action.DELETE_WIZARD): {
         Role.RESOURCE_COORDINATOR,
         Role.RESOURCE_MANAGER,
         Role.GLOBAL_MANAGER,
@@ -369,6 +392,7 @@ acl: ACL = (
     | _dataset_create_acl
     | _information_system_update_acl
     | _dataset_update_acl
+    | _dataset_delete_wizard_acl
     | _dataset_comment_acl
     | _dataset_delete_acl
     | _dataset_history_view_acl

--- a/vitrina/orgs/services.py
+++ b/vitrina/orgs/services.py
@@ -289,6 +289,9 @@ _dataset_structure_acl: ACL = inherit_acl(_dataset_update_acl, new_action=Action
 _dataset_distribution_create_acl: ACL = inherit_acl(_dataset_create_acl, new_model_class=DatasetDistribution)
 _dataset_distribution_update_acl: ACL = inherit_acl(_dataset_update_acl, new_model_class=DatasetDistribution)
 _dataset_distribution_delete_acl: ACL = inherit_acl(_dataset_delete_acl, new_model_class=DatasetDistribution)
+_dataset_distribution_delete_wizard_acl: ACL = inherit_acl(
+    _dataset_delete_wizard_acl, new_model_class=DatasetDistribution
+)
 
 _dataset_attribution_create_acl: ACL = inherit_acl(_dataset_create_acl, new_model_class=DatasetAttribution)
 _dataset_attribution_update_acl: ACL = inherit_acl(_dataset_update_acl, new_model_class=DatasetAttribution)
@@ -399,6 +402,7 @@ acl: ACL = (
     | _dataset_distribution_create_acl
     | _dataset_distribution_update_acl
     | _dataset_distribution_delete_acl
+    | _dataset_distribution_delete_wizard_acl
     | _dataset_attribution_create_acl
     | _dataset_attribution_update_acl
     | _dataset_attribution_delete_acl

--- a/vitrina/orgs/templates/vitrina/orgs/_wizard_org_fragment.html
+++ b/vitrina/orgs/templates/vitrina/orgs/_wizard_org_fragment.html
@@ -21,3 +21,4 @@
         {% crispy form %}
     </div>
 </form>
+<div id="wizard-footer-extra" hx-swap-oob="innerHTML"></div>

--- a/vitrina/orgs/templates/vitrina/orgs/wizard.html
+++ b/vitrina/orgs/templates/vitrina/orgs/wizard.html
@@ -276,6 +276,7 @@
                     {% translate "Uždaryti" %}
                 </a>
                 <div class="buttons">
+                    <div id="wizard-footer-extra"></div>
                     <button type="button" class="button is-light"
                             id="wizard-cancel-btn"
                             @click="window.wizardFormDirty = false; document.querySelector('.wizard-tree-row.is-active')?.click()">

--- a/webpack/src/css/wizard.scss
+++ b/webpack/src/css/wizard.scss
@@ -219,6 +219,17 @@
 .wizard-footer .button.is-dark:hover {
     background: #2d4761 !important;
 }
+#wizard-footer-extra:not(:empty) {
+    margin-right: 0.5rem;
+}
+.wizard-footer .button.is-danger {
+    border-color: #ff3860 !important;
+    color: #ff3860 !important;
+    background: transparent !important;
+}
+.wizard-footer .button.is-danger:hover {
+    background: #fff0f3 !important;
+}
 
 /* ── Form body container — transparent, no outer card ── */
 .wizard-form-body {


### PR DESCRIPTION
**Summary:**
- Adds delete for datasets and distributions. Can only delete objects if it has no related child objects.
- Delete button is added at the bottom row

<img width="1643" height="927" alt="Screenshot 2026-06-09 at 16 04 15" src="https://github.com/user-attachments/assets/36eae032-805a-4611-9d4d-7ae61d873388" />
