### PR TITLE
Build webpack css before collectstatic

### DIFF
--- a/auto-entrypoint.sh
+++ b/auto-entrypoint.sh
@@ -2,16 +2,16 @@
 echo "DJANGO_SETTINGS_MODULE=$DJANGO_SETTINGS_MODULE"
 echo "RUN_MODE=$RUN_MODE"
 
+cd webpack
+npm run build || echo "⚠️ Webpack build (partially) failed, continuing..."
+cd ..
+
 python3 manage.py collectstatic --noinput
 # --skip-checks bypasses the URL system check that queries the Site table before migrations run,
 # which causes Site.DoesNotExist on a fresh database (django-cms bootstrapping issue).
 python3 manage.py migrate --skip-checks -v 2 || exit 1
 python3 manage.py rebuild_index --noinput --using default
 export DJANGO_SUPERUSER_EMAIL=test@test.com; export DJANGO_SUPERUSER_USERNAME=test@test.com; export DJANGO_SUPERUSER_PASSWORD=test; python manage.py createsuperuser --noinput || True
-
-cd webpack
-npm run build || echo "⚠️ Webpack build (partially) failed, continuing..."
-cd ..
 
 if [[ $RUN_MODE == "DEVELOPMENT" ]]; then
   python3 manage.py runserver 0.0.0.0:8000

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,15 +2,15 @@
 echo "DJANGO_SETTINGS_MODULE=$DJANGO_SETTINGS_MODULE"
 echo "RUN_MODE=$RUN_MODE"
 
+cd webpack
+npm run build || echo "⚠️ Webpack build (partially) failed, continuing..."
+cd ..
+
 python3 manage.py collectstatic --noinput
 # --skip-checks bypasses the URL system check that queries the Site table before migrations run,
 # which causes Site.DoesNotExist on a fresh database (django-cms bootstrapping issue).
 python3 manage.py migrate --skip-checks -v 2 || exit 1
 python3 manage.py rebuild_index --noinput --using default
-
-cd webpack
-npm run build || echo "⚠️ Webpack build (partially) failed, continuing..."
-cd ..
 
 if [[ $RUN_MODE == "DEVELOPMENT" ]]; then
   python3 manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
**Summary:**
When redeploying app, old webpack static files are picked up by collectstatic because new webpack css files are built after collectstatic runs