### PR TITLE
[DCAT-87] UX/UI adjustments

### DIFF
--- a/vitrina/orgs/templates/vitrina/orgs/wizard.html
+++ b/vitrina/orgs/templates/vitrina/orgs/wizard.html
@@ -343,6 +343,14 @@
             _setDirty();
         });
 
+        // Prevent dropdown from auto-opening after clear/unselect
+        $(document).on('select2:clear select2:unselect', '#wizard-main-pane .django-select2', function () {
+            var $el = $(this);
+            $el.one('select2:open', function () {
+                $el.select2('close');
+            });
+        });
+
         // Prevent Enter in single-line inputs from submitting the wizard form
         // prematurely (which otherwise saves, re-renders the pane and scrolls to
         // the top). Delegated off document so it survives HTMX pane swaps.

--- a/vitrina/templates/base_form.html
+++ b/vitrina/templates/base_form.html
@@ -56,14 +56,18 @@
         .select2.select2-container .select2-selection--multiple {
             min-height: 2.5rem;
             border-color: #767676;
+            position: relative;
         }
-        {# Vertically center the clear (x) button within the field #}
-        .select2.select2-container .select2-selection--single .select2-selection__clear {
+        {# Clear (x) button: right side, with gap from the dropdown trigger area #}
+        .select2.select2-container .select2-selection--single .select2-selection__clear,
+        .select2.select2-container .select2-selection--multiple .select2-selection__clear {
             position: absolute;
-            right: 32px;
+            right: 52px;
+            left: auto;
             top: 50%;
             transform: translateY(-50%);
             margin: 0;
+            float: none;
         }
         {# Match select border color on hover #}
         .select2.select2-container:hover .select2-selection--single:hover,
@@ -87,6 +91,13 @@
 
 {% block scripts %}
     <script type="text/javascript">
+        $(document).on('select2:clear select2:unselect', '.django-select2', function () {
+            var $el = $(this);
+            $el.one('select2:open', function () {
+                $el.select2('close');
+            });
+        });
+
         $(document).ready(function () {
             $('select').on('select2:open', function (e) {
                 setTimeout(function() {

--- a/webpack/src/css/wizard.scss
+++ b/webpack/src/css/wizard.scss
@@ -818,10 +818,6 @@
 
 [x-cloak] { display: none !important; }
 
-/* Select2 dropdowns must float above the fixed wizard overlay (z-index 9999) */
-.select2-container--open .select2-dropdown {
-    z-index: 10000 !important;
-}
 div.select, div.select select, .select2.select2-container {
     width: 100% !important;
 }
@@ -838,23 +834,33 @@ div.select, div.select select, .select2.select2-container {
 .select2.select2-container .select2-selection--multiple {
     min-height: 2.5rem;
     border-color: #ccdae4;
+    position: relative;
 }
-.select2.select2-container .select2-selection--single .select2-selection__clear {
+.select2.select2-container .select2-selection--single .select2-selection__clear,
+.select2.select2-container .select2-selection--multiple .select2-selection__clear {
     position: absolute;
-    right: 32px;
+    right: 52px;
+    left: auto;
     top: 50%;
     transform: translateY(-50%);
     margin: 0;
+    float: none;
 }
 .select2.select2-container:hover .select2-selection--single:hover,
 .select2.select2-container:hover .select2-selection--multiple:hover {
     border-color: #375677;
 }
-/* Select2 calculates dropdown top via JS (getBoundingClientRect), but our field card
-   padding/border shifts the visual position. This offset compensates for that gap. */
-.select2-container .select2-dropdown {
+/* Dropdown is appended to <body> via dropdownParent:$('body'), so selectors must not
+   require a .select2-container ancestor. */
+.select2-dropdown {
     border-color: #ccdae4;
-    margin-top: 35px;
+    z-index: 10000 !important;
+}
+.select2-dropdown--below {
+    margin-top: 14px;
+}
+.select2-dropdown--above {
+    margin-bottom: 14px;
 }
 .select2-selection__arrow { display: none; }
 .select2.select2-container--default .select2-selection--single .select2-selection__placeholder {


### PR DESCRIPTION
Adjustments to user experience and user interface:

<img width="1134" height="146" alt="image" src="https://github.com/user-attachments/assets/a60823df-5f3c-4e52-9e0b-4109f849b030" />


- Moved the `X` button more to the left (so it wouldn't go on top of the dropdown menu)
<img width="762" height="88" alt="image" src="https://github.com/user-attachments/assets/2cdf8eae-f5cc-4da4-a617-f26a2347e915" />

- Clearing the fields with selections does not instantly pop-out the dropdown menu - user has to click again to access it manually. Based on the requirement:

> Tinka sis pasiulymas: Galima gal butu pabandyt kazkaip padesignint, kad neissoktu tas langas kai x paspaudziamas.

https://github.com/user-attachments/assets/0ed9460b-c8bf-4dae-8fd4-3fa8eb7eb758

*FYI:* We can revert the css changes if they seem to drastic;