### PR TITLE
Make DCAT Distribution title not required

### DIFF
--- a/tests/dcat/forms/test_distribution_forms.py
+++ b/tests/dcat/forms/test_distribution_forms.py
@@ -21,7 +21,6 @@ class TestDatasetDistributionForm:
         form = DatasetDistributionForm(dataset)
 
         assert form.fields["access_url"].required
-        assert form.fields["title"].required
         assert form.fields["description"].required
 
         assert not form.fields["availability"].required

--- a/tests/resources/test_models.py
+++ b/tests/resources/test_models.py
@@ -4,6 +4,8 @@ from django.utils import timezone
 from vitrina.resources.factories import DatasetDistributionFactory
 from vitrina.resources.models import DatasetDistribution
 
+EMPTY_TITLE = {"en": "", "lt": ""}
+
 
 @pytest.mark.django_db
 def test_data_last_updated_field_is_nullable():
@@ -12,6 +14,25 @@ def test_data_last_updated_field_is_nullable():
     distribution.save(update_fields=["data_last_updated"])
     distribution.refresh_from_db()
     assert distribution.data_last_updated is None
+
+
+@pytest.mark.django_db
+def test_display_title_returns_title_when_set():
+    distribution = DatasetDistributionFactory(title={"en": "My distribution", "lt": "Mano pateiktis"})
+    distribution.set_current_language("lt")
+    assert distribution.display_title == "Mano pateiktis"
+
+
+@pytest.mark.django_db
+def test_display_title_falls_back_to_access_url():
+    distribution = DatasetDistributionFactory(title=EMPTY_TITLE, access_url="https://example.com/data")
+    assert distribution.display_title == "https://example.com/data"
+
+
+@pytest.mark.django_db
+def test_display_title_falls_back_to_id():
+    distribution = DatasetDistributionFactory(title=EMPTY_TITLE)
+    assert distribution.display_title == f"#{distribution.pk}"
 
 
 @pytest.mark.django_db

--- a/vitrina/dcat/forms/distribution_forms.py
+++ b/vitrina/dcat/forms/distribution_forms.py
@@ -129,7 +129,6 @@ class DatasetDistributionForm(TranslatableModelForm):
             "label", any_language=True
         )
 
-        self.fields["title"].required = True
         self.fields["description"].label = _("Aprašas")
         self.fields["description"].required = True
 

--- a/vitrina/dcat/templates/vitrina/dcat/_wizard_distribution_fragment.html
+++ b/vitrina/dcat/templates/vitrina/dcat/_wizard_distribution_fragment.html
@@ -21,12 +21,12 @@
         {% endfor %}
         <div class="wizard-crumb is-current">
             <span class="wizard-crumb-label">{% translate "Pateiktis" %}</span>
-            <span class="wizard-crumb-title">{{ object.title }}</span>
+            <span class="wizard-crumb-title">{{ object.display_title }}</span>
         </div>
     </nav>
 
     <div class="wizard-form-section-header">
-        <p class="wizard-form-section-title">{{ object.title }}</p>
+        <p class="wizard-form-section-title">{{ object.display_title }}</p>
         <p class="wizard-form-section-sub">{% translate "Redaguokite pateiktį" %}</p>
     </div>
 

--- a/vitrina/dcat/wizard.py
+++ b/vitrina/dcat/wizard.py
@@ -276,7 +276,7 @@ def _build_wizard_tree(organization: Organization) -> tuple[list[dict], dict[str
                 children.append(child_node)
 
         for dist in dataset.datasetdistribution_set.all():
-            dist_title = dist.safe_translation_getter("title", any_language=True) or f"#{dist.pk}"
+            dist_title = dist.display_title
             dist_key = f"{WIZARD_NODE_DISTRIBUTION}:{dist.pk}"
             dist_fragment_url = reverse(
                 "dcat-distribution-update",

--- a/vitrina/resources/models.py
+++ b/vitrina/resources/models.py
@@ -462,6 +462,14 @@ class DatasetDistribution(TranslatableModel):
     def __str__(self):
         return self.safe_translation_getter("title", language_code=self.get_current_language()) or ""
 
+    @property
+    def display_title(self) -> str:
+        return (
+            self.safe_translation_getter("title", language_code=self.get_current_language())
+            or self.access_url
+            or f"#{self.pk}"
+        )
+
     def extension(self) -> str:
         if self.file and self.file.file:
             return get_file_extension(self.file.file.name).upper()


### PR DESCRIPTION
**Summary:**
Makes `title` field not required in DCAT Distribution form