### PR TITLE
Add CSP nonces to inline scripts and styles

### DIFF
--- a/vitrina/cms/templates/vitrina/cms/learning_material_detail.html
+++ b/vitrina/cms/templates/vitrina/cms/learning_material_detail.html
@@ -4,7 +4,7 @@
 {% block current_title %}{{ object.topic }}{% endblock %}
 
 {% block head %}
-<style>
+<style nonce="{{ request.csp_nonce }}">
 .file-download-section {
     background-color: #f8f9fa;
     border: 1px solid #e9ecef;

--- a/vitrina/datasets/templates/vitrina/datasets/admin/dataset_report_change_list.html
+++ b/vitrina/datasets/templates/vitrina/datasets/admin/dataset_report_change_list.html
@@ -13,7 +13,7 @@
         {% translate "Eksportuoti" %}
     </button>
 </form>
-<style>
+<style nonce="{{ request.csp_nonce }}">
      #changelist-form .results {
     transform: rotateX(180deg);
     overflow-x: auto;

--- a/vitrina/datasets/templates/vitrina/datasets/categories.html
+++ b/vitrina/datasets/templates/vitrina/datasets/categories.html
@@ -50,7 +50,7 @@
 {% endblock %}
 
 {% block scripts %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ request.csp_nonce }}">
         $(function () {
             let ctx = document.getElementById("chart").getContext("2d");
             const data = {{data|safe}};

--- a/vitrina/datasets/templates/vitrina/datasets/dataset_categories.html
+++ b/vitrina/datasets/templates/vitrina/datasets/dataset_categories.html
@@ -21,7 +21,7 @@
 {% endblock %}
 
 {% block scripts %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ request.csp_nonce }}">
         $(document).ready(function () {
             let search = $('input#id_search');
             let showSelected = $('input#show_selected_id');

--- a/vitrina/datasets/templates/vitrina/datasets/detail.html
+++ b/vitrina/datasets/templates/vitrina/datasets/detail.html
@@ -19,7 +19,7 @@
     {% include "component/page_title.html" %}
 {% endblock %}
 {% block head %}
-    <style>
+    <style nonce="{{ request.csp_nonce }}">
         .max-128x128 {
 		  	max-width: 128px;
 		  	max-height: 128px;
@@ -310,7 +310,7 @@
 {% block scripts %}
     {% load static %}
     {% get_hit_count_js_variables for dataset as hitcount %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ request.csp_nonce }}">
         $(document).ready(function () {
             $.postCSRF("{{ hitcount.ajax_url }}", { hitcountPK : "{{ hitcount.pk }}" });
 
@@ -401,6 +401,6 @@
         });
     </script>
     {% if public_status %}
-        <script type="application/ld+json" async>{{ json_ld|safe }}</script>
+        <script type="application/ld+json" async nonce="{{ request.csp_nonce }}">{{ json_ld|safe }}</script>
     {% endif %}
 {% endblock %}

--- a/vitrina/datasets/templates/vitrina/datasets/filters.html
+++ b/vitrina/datasets/templates/vitrina/datasets/filters.html
@@ -137,7 +137,7 @@
 </nav>
 {% endfor %}
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{ request.csp_nonce }}">
     $(function () {
         $('.filters-more').click(function () {
             let targetClass = 'filter-hidden-' + $(this).attr('id').split('-').pop();

--- a/vitrina/datasets/templates/vitrina/datasets/jurisdictions.html
+++ b/vitrina/datasets/templates/vitrina/datasets/jurisdictions.html
@@ -69,7 +69,7 @@
 
 
 {% block scripts %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ request.csp_nonce }}">
         $(function () {
             let ctx = document.getElementById("chart").getContext("2d");
             const data = {{data|safe}};

--- a/vitrina/datasets/templates/vitrina/datasets/list.html
+++ b/vitrina/datasets/templates/vitrina/datasets/list.html
@@ -11,7 +11,7 @@
     | {% translate "Duomenų ištekliai" %}
 {% endblock %}
 {% block head %}
-    <style>
+    <style nonce="{{ request.csp_nonce }}">
         .autocomplete {
             /*the container must be positioned relative:*/
             position: relative;
@@ -303,7 +303,7 @@
     {% include '../component/requestBlock.twig' %}
 {% endblock %}
 {% block scripts %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ request.csp_nonce }}">
         $(function () {
 
             var query = $('#search-q-val').val();

--- a/vitrina/datasets/templates/vitrina/datasets/organizations.html
+++ b/vitrina/datasets/templates/vitrina/datasets/organizations.html
@@ -43,7 +43,7 @@
 {% endblock %}
 
 {% block scripts %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ request.csp_nonce }}">
         $(function () {
             let ctx = document.getElementById("chart").getContext("2d");
             const data = {{data|safe}};

--- a/vitrina/datasets/templates/vitrina/datasets/plans.html
+++ b/vitrina/datasets/templates/vitrina/datasets/plans.html
@@ -16,7 +16,7 @@
 {% endblock %}
 
 {% block head %}
-    <style>
+    <style nonce="{{ request.csp_nonce }}">
         .list_item {
 		  	list-style-type: disc;
 		  	margin-left: 1em;

--- a/vitrina/datasets/templates/vitrina/datasets/published_dates.html
+++ b/vitrina/datasets/templates/vitrina/datasets/published_dates.html
@@ -194,7 +194,7 @@
 {% endblock %}
 
 {% block scripts %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ request.csp_nonce }}">
         $(function () {
             selectTab();
             let ctx = document.getElementById("chart").getContext("2d");

--- a/vitrina/datasets/templates/vitrina/datasets/statistics_graph.html
+++ b/vitrina/datasets/templates/vitrina/datasets/statistics_graph.html
@@ -42,7 +42,7 @@
 {% endblock %}
 
 {% block scripts %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ request.csp_nonce }}">
         $(function () {
             let ctx = document.getElementById("chart").getContext("2d");
             const data = {{data|safe}};

--- a/vitrina/dcat/templates/vitrina/dcat/_wizard_codename_preview_script.html
+++ b/vitrina/dcat/templates/vitrina/dcat/_wizard_codename_preview_script.html
@@ -1,4 +1,4 @@
-<script>
+<script nonce="{{ request.csp_nonce }}">
     (function() {
         var prefix = "{{ form.codename_prefix|escapejs }}";
         $("#id_name").on("input", function() {

--- a/vitrina/messages/templates/vitrina/messages/form.html
+++ b/vitrina/messages/templates/vitrina/messages/form.html
@@ -2,7 +2,7 @@
 {% load i18n parler_tags %}
 
 {% block scripts %}
-<script>
+<script nonce="{{ request.csp_nonce }}">
         $(document).ready(function() {
             function updateFieldState(updateField, commentsField, fieldDiv) {
                 if (updateField.is(':checked')) {

--- a/vitrina/orgs/templates/vitrina/orgs/admin/organization_publisher_change_form.html
+++ b/vitrina/orgs/templates/vitrina/orgs/admin/organization_publisher_change_form.html
@@ -5,7 +5,7 @@
 {% block extrahead %}
 {{ block.super }}
 
-<style>
+<style nonce="{{ request.csp_nonce }}">
     @media (prefers-color-scheme: dark) {
         .select2-selection--single {
             background-color: #2a2c2e;
@@ -108,7 +108,7 @@
     }
 </style>
 
-<script>
+<script nonce="{{ request.csp_nonce }}">
 document.addEventListener('DOMContentLoaded', function() {
     setTimeout(function() {
         const availableTitleDataset = document.querySelector('.field-datasets .selector-available h2');

--- a/vitrina/orgs/templates/vitrina/orgs/apikeys.html
+++ b/vitrina/orgs/templates/vitrina/orgs/apikeys.html
@@ -5,7 +5,7 @@
 {% block current_title %}{% translate "Raktai" %}{% endblock%}
 
 {% block head %}
-    <style>
+    <style nonce="{{ request.csp_nonce }}">
         .list_item {
 		  	list-style-type: disc;
 		  	margin-left: 1em;

--- a/vitrina/orgs/templates/vitrina/orgs/apikeys_detail.html
+++ b/vitrina/orgs/templates/vitrina/orgs/apikeys_detail.html
@@ -5,7 +5,7 @@
 {% block current_title %}{% translate "Raktai" %}{% endblock%}
 
 {% block head %}
-    <style>
+    <style nonce="{{ request.csp_nonce }}">
         .list_item {
 		  	list-style-type: disc;
 		  	margin-left: 1em;

--- a/vitrina/orgs/templates/vitrina/orgs/detail.html
+++ b/vitrina/orgs/templates/vitrina/orgs/detail.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block head %}
-    <style>
+    <style nonce="{{ request.csp_nonce }}">
         .max-128x128 {
 		  	max-width: 128px;
 		  	max-height: 128px;

--- a/vitrina/orgs/templates/vitrina/orgs/jurisdictions.html
+++ b/vitrina/orgs/templates/vitrina/orgs/jurisdictions.html
@@ -133,7 +133,7 @@
     <br/>
 {% endblock %}
 {% block scripts %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ request.csp_nonce }}">
         $(function () {
             selectTab();
             let ctx = document.getElementById("chart").getContext("2d");

--- a/vitrina/orgs/templates/vitrina/orgs/list.html
+++ b/vitrina/orgs/templates/vitrina/orgs/list.html
@@ -154,7 +154,7 @@
     <br/>
 {% endblock %}
 {% block scripts %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ request.csp_nonce }}">
         $(function () {
             $('.facets-more').click(function () {
                 $('.' + this.id).toggleClass('is-hidden');

--- a/vitrina/orgs/templates/vitrina/orgs/organization_create_search.html
+++ b/vitrina/orgs/templates/vitrina/orgs/organization_create_search.html
@@ -17,7 +17,7 @@
 {% endblock %}
 
 {% block scripts %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ request.csp_nonce }}">
         $(function () {
             let orgSearchInput = $('#company_name_input');
             orgSearchInput.on('input', function(){

--- a/vitrina/orgs/templates/vitrina/orgs/partners/register_form.html
+++ b/vitrina/orgs/templates/vitrina/orgs/partners/register_form.html
@@ -12,7 +12,7 @@
 
 {% block head %}
     {{ block.super }}
-    <style>
+    <style nonce="{{ request.csp_nonce }}">
         #div_id_request_form label span.asterisk {
             display: none;
         }

--- a/vitrina/orgs/templates/vitrina/orgs/plans.html
+++ b/vitrina/orgs/templates/vitrina/orgs/plans.html
@@ -5,7 +5,7 @@
 {% block current_title %}{% translate "Planas" %}{% endblock%}
 
 {% block head %}
-    <style>
+    <style nonce="{{ request.csp_nonce }}">
         .list_item {
 		  	list-style-type: disc;
 		  	margin-left: 1em;

--- a/vitrina/orgs/templates/vitrina/orgs/wizard.html
+++ b/vitrina/orgs/templates/vitrina/orgs/wizard.html
@@ -293,7 +293,7 @@
         </div>
     </div>
 
-    <script>
+    <script nonce="{{ request.csp_nonce }}">
         // Offset overlay below any fixed CMS toolbar (absent in production, so top stays 0).
         // Uses window.load so Django CMS has fully initialised and applied its body margin-top.
         function applyToolbarOffset() {

--- a/vitrina/plans/templates/vitrina/plans/form.html
+++ b/vitrina/plans/templates/vitrina/plans/form.html
@@ -11,7 +11,7 @@
 
 {% block head %}
     {{ block.super }}
-    <style>
+    <style nonce="{{ request.csp_nonce }}">
         #div_id_organizations {
             display: none;
         }

--- a/vitrina/plans/templates/vitrina/plans/plan_form.html
+++ b/vitrina/plans/templates/vitrina/plans/plan_form.html
@@ -12,7 +12,7 @@
 
 {% block head %}
     {{ block.super }}
-    <style>
+    <style nonce="{{ request.csp_nonce }}">
         #div_id_organizations {
             display: none;
         }

--- a/vitrina/projects/templates/vitrina/projects/apikeys_detail.html
+++ b/vitrina/projects/templates/vitrina/projects/apikeys_detail.html
@@ -5,7 +5,7 @@
 {% block current_title %}{% translate "Raktai" %}{% endblock%}
 
 {% block head %}
-    <style>
+    <style nonce="{{ request.csp_nonce }}">
         .list_item {
 		  	list-style-type: disc;
 		  	margin-left: 1em;

--- a/vitrina/projects/templates/vitrina/projects/client_detail.html
+++ b/vitrina/projects/templates/vitrina/projects/client_detail.html
@@ -5,7 +5,7 @@
 {% block current_title %}{% translate "Klientai" %}{% endblock%}
 
 {% block head %}
-    <style>
+    <style nonce="{{ request.csp_nonce }}">
         .list_item {
 		  	list-style-type: disc;
 		  	margin-left: 1em;

--- a/vitrina/projects/templates/vitrina/projects/detail.html
+++ b/vitrina/projects/templates/vitrina/projects/detail.html
@@ -90,7 +90,7 @@
 {% endblock %}
 {% block scripts %}
     {% get_hit_count_js_variables for project as hitcount %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ request.csp_nonce }}">
         $(function () {
             $.postCSRF("{{ hitcount.ajax_url }}", {hitcountPK: "{{ hitcount.pk }}"});
         });

--- a/vitrina/requests/templates/vitrina/requests/detail.html
+++ b/vitrina/requests/templates/vitrina/requests/detail.html
@@ -340,7 +340,7 @@
 {% endblock %}
 {% block scripts %}
     {% get_hit_count_js_variables for request_object as hitcount %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ request.csp_nonce }}">
         $(function () {
             $.postCSRF("{{ hitcount.ajax_url }}", { hitcountPK : "{{ hitcount.pk }}" });
 

--- a/vitrina/requests/templates/vitrina/requests/filters.html
+++ b/vitrina/requests/templates/vitrina/requests/filters.html
@@ -112,7 +112,7 @@
 
 {% endfor %}
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{ request.csp_nonce }}">
     $(function () {
         $('.filters-more').click(function () {
             let targetClass = 'filter-hidden-' + $(this).attr('id').split('-').pop();

--- a/vitrina/requests/templates/vitrina/requests/list.html
+++ b/vitrina/requests/templates/vitrina/requests/list.html
@@ -7,7 +7,7 @@
 {% block current_title %}{% translate "Gauti poreikiai duomenų rinkiniams" %}{% endblock %}
 
 {% block head %}
-    <style>
+    <style nonce="{{ request.csp_nonce }}">
         .dataset-list-description {
             word-break: break-word;
         }
@@ -209,7 +209,7 @@
     </div>
 {% endblock %}
 {% block scripts %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ request.csp_nonce }}">
         $(function () {
 
             var query = $('#search-q-val').val();

--- a/vitrina/requests/templates/vitrina/requests/plans.html
+++ b/vitrina/requests/templates/vitrina/requests/plans.html
@@ -16,7 +16,7 @@
 {% endblock %}
 
 {% block head %}
-    <style>
+    <style nonce="{{ request.csp_nonce }}">
         .list_item {
 		  	list-style-type: disc;
 		  	margin-left: 1em;

--- a/vitrina/requests/templates/vitrina/requests/request_dataset_add.html
+++ b/vitrina/requests/templates/vitrina/requests/request_dataset_add.html
@@ -18,7 +18,7 @@
 {% endblock %}
 
 {% block scripts %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ request.csp_nonce }}">
         let manFilter = $('#request-dataset-input');
         manFilter.on('input', function(){
             $('#dataset-list').html('').load(

--- a/vitrina/resources/templates/vitrina/resources/form.html
+++ b/vitrina/resources/templates/vitrina/resources/form.html
@@ -2,7 +2,7 @@
 {% load i18n parler_tags %}
 
 {% block scripts %}
-    <script>
+    <script nonce="{{ request.csp_nonce }}">
         document.getElementById('id_download_url').addEventListener('input', function() {
             var uploadField = document.getElementById('id_upload_to_storage');
             if (this.value.includes('get.data.gov.lt')) {

--- a/vitrina/statistics/templates/vitrina/statistics/stats.html
+++ b/vitrina/statistics/templates/vitrina/statistics/stats.html
@@ -68,7 +68,7 @@
 
 
 {% block scripts %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ request.csp_nonce }}">
         $(function () {
             selectTab();
             let ctx = document.getElementById("chart").getContext("2d");

--- a/vitrina/structure/templates/vitrina/structure/api.html
+++ b/vitrina/structure/templates/vitrina/structure/api.html
@@ -53,7 +53,7 @@
 {% endblock %}
 
 {% block scripts %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ request.csp_nonce }}">
         $(function () {
            selectTab();
         });

--- a/vitrina/structure/templates/vitrina/structure/dataset_structure.html
+++ b/vitrina/structure/templates/vitrina/structure/dataset_structure.html
@@ -300,7 +300,7 @@
         {% comments obj=structure user=request.user is_structure=True %}
     </div>
     {% endif %}
-<script>
+<script nonce="{{ request.csp_nonce }}">
     document.querySelectorAll('.show-model-delete-form').forEach(button => {
         button.addEventListener('click', (e) => {
             e.preventDefault();

--- a/vitrina/structure/templates/vitrina/structure/model_data.html
+++ b/vitrina/structure/templates/vitrina/structure/model_data.html
@@ -34,7 +34,7 @@
 {% endblock %}
 
 {% block scripts %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ request.csp_nonce }}">
         const MODEL_DATA_TABLE_URL = "{% url 'model-data-table' pk=dataset.pk version_id=version_id model=model.name %}";
         $(function () {
             let datasetId = {{ dataset.pk }};

--- a/vitrina/structure/templates/vitrina/structure/object_data.html
+++ b/vitrina/structure/templates/vitrina/structure/object_data.html
@@ -53,7 +53,7 @@
 
 
 {% block scripts %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ request.csp_nonce }}">
         $(function () {
             let datasetId = {{ dataset.pk }};
             let model = "{{model.name}}";

--- a/vitrina/structure/templates/vitrina/structure/property_form.html
+++ b/vitrina/structure/templates/vitrina/structure/property_form.html
@@ -1,7 +1,7 @@
 {% extends "base_form.html" %}
 
 {% block scripts %}
-    <script>
+    <script nonce="{{ request.csp_nonce }}">
         $(document).ready(function() {
             function toggleRefFields() {
                 let type = $('select#id_type').val();

--- a/vitrina/structure/templates/vitrina/structure/property_structure.html
+++ b/vitrina/structure/templates/vitrina/structure/property_structure.html
@@ -16,7 +16,7 @@
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.1/dist/leaflet.css" integrity="sha512-Rksm5RenBEKSKFjgI3a41vrjkw4EVPlJ3+OiI65vTjIdo9brlAacEuKOiQ5OFh7cOI1bkDwLqdLw3Zg0cRJAAQ==" crossorigin="" />
     <script src="https://unpkg.com/leaflet@1.3.1/dist/leaflet.js" integrity="sha512-/Nsx9X4HebavoBvEBuyp3I7od5tA0UzAxs+j83KgC8PU0kgB4XiK4Lfe4y4cgBtaRJQEIFCW+oC506aPT2L1zw==" crossorigin=""></script>
 
-    <style>
+    <style nonce="{{ request.csp_nonce }}">
       .leaflet-tooltip-pane .text {
           color: white;
           font-weight: bold;
@@ -372,7 +372,7 @@
 
 
 {% block scripts %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ request.csp_nonce }}">
         $(function () {
             let datasetId = {{ dataset.pk }};
             let model = "{{model.name}}";

--- a/vitrina/structure/templates/vitrina/structure/publish_form.html
+++ b/vitrina/structure/templates/vitrina/structure/publish_form.html
@@ -19,7 +19,7 @@
 {% endblock %}
 
 {% block head %}
-    <style>
+    <style nonce="{{ request.csp_nonce }}">
         #div_id_metadata div.control {
           margin-bottom: 0.5rem;
        }
@@ -36,7 +36,7 @@
 {% endblock %}
 
 {% block scripts %}
-    <script>
+    <script nonce="{{ request.csp_nonce }}">
         $(document).ready(function() {
             const $related_version = $('#id_related_version').closest('.field, .form-group, .control');
             const $related_version_label = $('label[for="id_related_version"]');

--- a/vitrina/structure/templates/vitrina/structure/side_menu.html
+++ b/vitrina/structure/templates/vitrina/structure/side_menu.html
@@ -69,7 +69,7 @@
     {% endfor %}
 </nav>
 
-<script>
+<script nonce="{{ request.csp_nonce }}">
      $(document).ready(function() {
         $('span#side_menu_elem').each(function() {
             let width = this.offsetWidth;

--- a/vitrina/structure/templates/vitrina/structure/uml_canvas.html
+++ b/vitrina/structure/templates/vitrina/structure/uml_canvas.html
@@ -11,7 +11,7 @@
 
 {% else %}
 
-<style>
+<style nonce="{{ request.csp_nonce }}">
     #viewport {
         position: relative;
         width: 100%;
@@ -109,8 +109,8 @@
 </div>
 
 {% if uml_diagram.status == "UP_TO_DATE" %}
-<script type="text/mermaid" id="mermaid-source">{{ uml_diagram.mermaid|safe }}</script>
-<script type="module">
+<script type="text/mermaid" id="mermaid-source" nonce="{{ request.csp_nonce }}">{{ uml_diagram.mermaid|safe }}</script>
+<script type="module" nonce="{{ request.csp_nonce }}">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11.14.0/dist/mermaid.esm.min.mjs';
     import Panzoom from 'https://cdn.jsdelivr.net/npm/@panzoom/panzoom@4.6.0/+esm';
 
@@ -188,7 +188,7 @@
     });
 </script>
 {% else %}
-<script>setTimeout(() => location.reload(), 5000);</script>
+<script nonce="{{ request.csp_nonce }}">setTimeout(() => location.reload(), 5000);</script>
 {% endif %}
 
 {% endif %}

--- a/vitrina/structure/templates/vitrina/structure/uml_diagram.html
+++ b/vitrina/structure/templates/vitrina/structure/uml_diagram.html
@@ -52,7 +52,7 @@
     </div>
 </div>
 
-<script>
+<script nonce="{{ request.csp_nonce }}">
     document.querySelectorAll('.show-model-delete-form').forEach(button => {
         button.addEventListener('click', (e) => {
             e.preventDefault();

--- a/vitrina/structure/templates/vitrina/structure/uml_diagram_expanded.html
+++ b/vitrina/structure/templates/vitrina/structure/uml_diagram_expanded.html
@@ -6,7 +6,7 @@
         <meta charset="UTF-8" />
         <title>{{ current_title }}</title>
         <link type="text/css" href="{% static 'css/bundle.css' %}" rel="stylesheet" media="screen">
-        <style>
+        <style nonce="{{ request.csp_nonce }}">
             html, body {
                 margin: 0;
                 height: 100%;

--- a/vitrina/structure/templates/vitrina/structure/version_detail.html
+++ b/vitrina/structure/templates/vitrina/structure/version_detail.html
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block head %}
-    <style>
+    <style nonce="{{ request.csp_nonce }}">
         .model_metadata {
             padding-left: 1.5em;
         }

--- a/vitrina/templates/base.html
+++ b/vitrina/templates/base.html
@@ -32,7 +32,7 @@
     <link href="{% static 'fontawesomefree/css/all.min.css' %}" rel="stylesheet" type="text/css">
     <script defer src="{% static 'js/bundle.js' %}"></script>
     <script src="{% static 'js/jquery.js' %}"></script>
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ request.csp_nonce }}">
         $ = window.jquery.$;
         jQuery = window.jquery.$;
     </script>
@@ -43,7 +43,7 @@
     {% if GOOGLE_ANALYTICS_ID != None %}
         <script async
                 src="https://www.googletagmanager.com/gtag/js?id={% get_setting 'GOOGLE_ANALYTICS_ID' default='' %}"></script>
-        <script>
+        <script nonce="{{ request.csp_nonce }}">
             window.dataLayer = window.dataLayer || [];
 
             function gtag() {
@@ -60,7 +60,7 @@
     {% include "component/favicon.html" %}
     {% block head %}{% endblock %}
     {% if cssOverride %}
-        <style>
+        <style nonce="{{ request.csp_nonce }}">
             {{ cssOverride }}
         </style>
     {% endif %}
@@ -134,7 +134,7 @@
 {% block before_render_js %}{% endblock %}
 {% render_block "js" %}
 {% block after_render_js %}{% endblock %}
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{ request.csp_nonce }}">
     function openMenu() {
         var burger = document.querySelector('.burger');
         var nav = document.querySelector('#navbarBasic');

--- a/vitrina/templates/base_form.html
+++ b/vitrina/templates/base_form.html
@@ -36,7 +36,7 @@
 {% endblock %}
 
 {% block head %}
-    <style>
+    <style nonce="{{ request.csp_nonce }}">
         {# Match select width #}
         div.select, div.select select, .select2.select2-container {
             width: 100% !important;
@@ -90,7 +90,7 @@
 {% endblock %}
 
 {% block scripts %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ request.csp_nonce }}">
         $(document).on('select2:clear select2:unselect', 'select.select2-hidden-accessible', function () {
             var $el = $(this);
             $el.one('select2:open', function () {

--- a/vitrina/templates/component/breadcrumbs.html
+++ b/vitrina/templates/component/breadcrumbs.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<style>
+<style nonce="{{ request.csp_nonce }}">
     ul.p-t-sm li {
         flex-basis: auto;
         min-width: 0;

--- a/vitrina/templates/component/clearable_file_input.html
+++ b/vitrina/templates/component/clearable_file_input.html
@@ -13,7 +13,7 @@
 <input type="file" name="{{ widget.name }}" onchange="onFileSelected(this, '{{widget.name}}')" style="display: none;" {% include "django/forms/widgets/attrs.html" %}>
 
 {% block form_scripts %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ request.csp_nonce }}">
         if (django != undefined && django.jQuery != undefined) {
             var $ = django.jQuery;
         }

--- a/vitrina/templates/component/comments.html
+++ b/vitrina/templates/component/comments.html
@@ -48,7 +48,7 @@
 {% endif %}
 
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{ request.csp_nonce }}">
     $(document).ready(function () {
         $('.media-content').submit(function () {
             $(this).find(":submit").attr('disabled', 'disabled');

--- a/vitrina/templates/component/form.html
+++ b/vitrina/templates/component/form.html
@@ -24,7 +24,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.61.0/mode/yaml/yaml.min.js" integrity="sha384-LekyoEGHzBMGUx26EEtC5G6HD6iyIr0msuy3LP3F8V98vVS5ZoNfIyiirXsoqAt/" crossorigin="anonymous"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.61.0/theme/eclipse.min.css" integrity="sha384-dq10nYMe5EzlTlySS4PL3lt13I+hSWRGzpsgTbwcrbXrI3hXw2NpiZIi4vAnxjI3" crossorigin="anonymous">
 
-    <script>
+    <script nonce="{{ request.csp_nonce }}">
         document.addEventListener("DOMContentLoaded", function() {
             var editor = CodeMirror.fromTextArea(document.querySelector('.codemirror'), {
                 lineNumbers: true,

--- a/vitrina/templates/component/multi_input.html
+++ b/vitrina/templates/component/multi_input.html
@@ -34,7 +34,7 @@
   </div>
 </div>
 
-<script>
+<script nonce="{{ request.csp_nonce }}">
 (function(){
   if (window.__stringListBound) return;
   window.__stringListBound = true;

--- a/vitrina/templates/component/page_title.html
+++ b/vitrina/templates/component/page_title.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<style>
+<style nonce="{{ request.csp_nonce }}">
     .page-header {
         width: 100%;
         height: auto;

--- a/vitrina/templates/component/stats_parameter_select.html
+++ b/vitrina/templates/component/stats_parameter_select.html
@@ -50,7 +50,7 @@
     </div>
 </div>
 
-<script>
+<script nonce="{{ request.csp_nonce }}">
     function updateURL(param, value, label) {
         var url = new URL(window.location.href);
         url.searchParams.set(param, value);

--- a/vitrina/templates/landing.html
+++ b/vitrina/templates/landing.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load i18n %}
 {% block head %}
-    <style>
+    <style nonce="{{ request.csp_nonce }}">
         .autocomplete {
             /*the container must be positioned relative:*/
             position: relative;
@@ -82,7 +82,7 @@
     {% include "landing/stats.html" %}
 {% endblock %}
 {% block scripts %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ request.csp_nonce }}">
         function HideMessage(){
           var notificationBar = document.getElementById('top-bar');
           notificationBar.classList.add('is-hidden');

--- a/vitrina/templatetags/comment_tags.py
+++ b/vitrina/templatetags/comment_tags.py
@@ -59,7 +59,7 @@ def comments(context, obj: "Model", user: SimpleLazyObject, is_structure: bool =
         "object": obj,
         "comment_form": comment_form_class(obj, is_opened=is_opened),
         "submit_button_id": "id_submit_button_request" if isinstance(obj, Request) else "id_submit_button",
-        "request": context.get("request"),
+        "request": context["request"],
     }
 
 

--- a/vitrina/templatetags/comment_tags.py
+++ b/vitrina/templatetags/comment_tags.py
@@ -90,7 +90,7 @@ def external_comments(context, content_type, object_id, user, dataset):
         "external": True,
         "dataset": dataset,
         "object": dataset,
-        "request": context.get("request"),
+        "request": context["request"],
     }
 
 

--- a/vitrina/templatetags/comment_tags.py
+++ b/vitrina/templatetags/comment_tags.py
@@ -22,8 +22,8 @@ register = template.Library()
 assignment_tag = getattr(register, "assignment_tag", register.simple_tag)
 
 
-@register.inclusion_tag("component/comments.html")
-def comments(obj: "Model", user: SimpleLazyObject, is_structure: bool = False) -> dict[str, Any]:
+@register.inclusion_tag("component/comments.html", takes_context=True)
+def comments(context, obj: "Model", user: SimpleLazyObject, is_structure: bool = False) -> dict[str, Any]:
     object_content_type = ContentType.objects.get_for_model(obj)
 
     query_filters = Q(content_type=object_content_type, object_id=obj.pk)
@@ -59,11 +59,12 @@ def comments(obj: "Model", user: SimpleLazyObject, is_structure: bool = False) -
         "object": obj,
         "comment_form": comment_form_class(obj, is_opened=is_opened),
         "submit_button_id": "id_submit_button_request" if isinstance(obj, Request) else "id_submit_button",
+        "request": context.get("request"),
     }
 
 
-@register.inclusion_tag("component/comments.html")
-def external_comments(content_type, object_id, user, dataset):
+@register.inclusion_tag("component/comments.html", takes_context=True)
+def external_comments(context, content_type, object_id, user, dataset):
     obj_comments = Comment.objects.filter(
         external_content_type=content_type,
         external_object_id=object_id,
@@ -89,6 +90,7 @@ def external_comments(content_type, object_id, user, dataset):
         "external": True,
         "dataset": dataset,
         "object": dataset,
+        "request": context.get("request"),
     }
 
 

--- a/vitrina/uapi/templates/agents/agent_env_detail.html
+++ b/vitrina/uapi/templates/agents/agent_env_detail.html
@@ -317,7 +317,7 @@ backends:
 </p>
 
 
-<script>
+<script nonce="{{ request.csp_nonce }}">
         function copyToClipboard(id) {
             const el = document.getElementById(id);
             const text = el.innerText || el.textContent;

--- a/vitrina/users/templates/users_count_stats_chart.html
+++ b/vitrina/users/templates/users_count_stats_chart.html
@@ -21,7 +21,7 @@
         integrity="sha384-YAshAm4KKjf8V01c4sdNbPYiwU0D0Q82fjMHhKw8VvP0ecY4fxXsZAHxC4r4Ei+T"
         crossorigin="anonymous"></script>
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{ request.csp_nonce }}">
     $(function () {
             let ctx = document.getElementById("chart").getContext("2d");
             const data = {{data|safe}};

--- a/vitrina/users/templates/vitrina/users/admin/change_form.html
+++ b/vitrina/users/templates/vitrina/users/admin/change_form.html
@@ -3,7 +3,7 @@
 
 {% block extrastyle %}
     {{ block.super }}
-    <style>
+    <style nonce="{{ request.csp_nonce }}">
         .fieldBox.field-created_date {
             margin-right: 20px !important;
         }

--- a/vitrina/users/templates/vitrina/users/admin/login.html
+++ b/vitrina/users/templates/vitrina/users/admin/login.html
@@ -4,7 +4,7 @@
 
 {% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/login.css" %}">
 {{ form.media }}
-    <style>
+    <style nonce="{{ request.csp_nonce }}">
         .hidden-fields {
             display: none;
         }

--- a/vitrina/users/templates/vitrina/users/login.html
+++ b/vitrina/users/templates/vitrina/users/login.html
@@ -6,7 +6,7 @@
 {% block current_title %}{% translate "Prisijungimas" %}{% endblock %}
 
 {% block head %}
-    <style>
+    <style nonce="{{ request.csp_nonce }}">
         .hidden-fields {
             display: none;
         }

--- a/vitrina/users/templates/vitrina/users/profile.html
+++ b/vitrina/users/templates/vitrina/users/profile.html
@@ -194,7 +194,7 @@
 {% endblock %}
 
 {% block scripts %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ request.csp_nonce }}">
         function HideMessage() {
             var notificationBar = document.getElementById('top-bar');
             notificationBar.classList.add('is-hidden');

--- a/vitrina/users/templates/vitrina/users/register.html
+++ b/vitrina/users/templates/vitrina/users/register.html
@@ -22,7 +22,7 @@
 
 {% block scripts %}
     {% translate "naudojimo sąlygomis" as terms_of_use %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ request.csp_nonce }}">
         $(function () {
             let termsOfUse = '{{ terms_of_use }}';
             let agree_to_terms_label =  $('#div_id_agree_to_terms').find('label');


### PR DESCRIPTION
Add nonce="{{ request.csp_nonce }}" to every inline <script> and <style> block in our templates. While script-src/style-src still allow 'unsafe-inline' these nonces are inert (browsers honour unsafe-inline), so behaviour is unchanged. This prepares the templates so a follow-up PR can drop 'unsafe-inline' from script-src/style-src.
