### PR TITLE
2716 data last updated

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,11 @@ v 1.23.0 (current)
 - Clean up README.rst
 - Fix webpack bundle output path to ``vitrina/static`` (was writing to an unserved root ``static/``).
 
+
+https://github.com/atviriduomenys/katalogas/issues/2716
+
+- Separate data freshness from metadata freshness for dataset distributions.
+
 https://github.com/atviriduomenys/katalogas/issues/2719
 
 - Fix data download in the structure "Duomenys" view producing a broken Spinta request. RQL query

--- a/tests/api/test_views.py
+++ b/tests/api/test_views.py
@@ -1344,8 +1344,9 @@ def test_create_dataset_distribution_with_overwrite(app: DjangoTestApp):
         "url": f"http://{domain}{distribution.dataset.get_absolute_url()}",
         "version": distribution.distribution_version,
         "upload_to_storage": distribution.upload_to_storage,
-        "data_last_updated": None,
+        "data_last_updated": res.json["data_last_updated"],
     }
+    assert res.json["data_last_updated"] is not None
 
 
 @pytest.mark.parametrize("access_rights", [Dataset.NON_PUBLIC, Dataset.CONFIDENTIAL])
@@ -2028,8 +2029,9 @@ def test_update_dataset_distribution_with_file(app: DjangoTestApp):
         "url": f"http://{domain}{distribution.dataset.get_absolute_url()}",
         "version": distribution.distribution_version,
         "upload_to_storage": distribution.upload_to_storage,
-        "data_last_updated": None,
+        "data_last_updated": res.json["data_last_updated"],
     }
+    assert res.json["data_last_updated"] is not None
 
 
 @pytest.mark.django_db
@@ -2073,8 +2075,9 @@ def test_update_dataset_distribution_with_url(app: DjangoTestApp):
         "url": "http://example.com/",
         "version": distribution.distribution_version,
         "upload_to_storage": distribution.upload_to_storage,
-        "data_last_updated": None,
+        "data_last_updated": res.json["data_last_updated"],
     }
+    assert res.json["data_last_updated"] is not None
 
 
 @pytest.mark.django_db
@@ -2120,8 +2123,9 @@ def test_update_dataset_distribution_with_internal_id(app: DjangoTestApp):
         "url": f"http://{domain}{dataset.get_absolute_url()}",
         "version": distribution.distribution_version,
         "upload_to_storage": distribution.upload_to_storage,
-        "data_last_updated": None,
+        "data_last_updated": res.json["data_last_updated"],
     }
+    assert res.json["data_last_updated"] is not None
 
 
 @pytest.mark.django_db

--- a/tests/datasets/test_views.py
+++ b/tests/datasets/test_views.py
@@ -4202,7 +4202,7 @@ def test_dataset_rdf_download__dataset_with_landing_page(app: DjangoTestApp):
                 <dct:title xml:lang="lt">Failas 1</dct:title>
                 <dct:description xml:lang="lt">Failas su prieigos nuoroda</dct:description>
                 <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">{dist1.created.strftime("%Y-%m-%d")}</dct:issued>
-                    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">{dist1.modified.strftime("%Y-%m-%d")}</dct:modified>
+                    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">{dist1.created.strftime("%Y-%m-%d")}</dct:modified>
                 <dcat:accessURL rdf:resource="{dist1.access_url}"/>
                 <dcat:downloadURL rdf:resource="http://localhost{dist1.file.url}"/>
                 <dct:rights>
@@ -4227,7 +4227,7 @@ def test_dataset_rdf_download__dataset_with_landing_page(app: DjangoTestApp):
                 <dct:title xml:lang="lt">Failas 2</dct:title>
                 <dct:description xml:lang="lt">Failas be prieigos nuorodos</dct:description>
                 <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">{dist2.created.strftime("%Y-%m-%d")}</dct:issued>
-                    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">{dist2.modified.strftime("%Y-%m-%d")}</dct:modified>
+                    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">{dist2.created.strftime("%Y-%m-%d")}</dct:modified>
                 <dcat:accessURL rdf:resource="{dataset.landing_page}"/>
                 <dcat:downloadURL rdf:resource="http://localhost{dist2.file.url}"/>
                 <dct:rights>
@@ -4357,7 +4357,7 @@ def test_dataset_rdf_download__dataset_without_landing_page(app: DjangoTestApp):
                 <dct:title xml:lang="lt">Failas 1</dct:title>
                 <dct:description xml:lang="lt">Failas su prieigos nuoroda</dct:description>
                 <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">{dist1.created.strftime("%Y-%m-%d")}</dct:issued>
-                    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">{dist1.modified.strftime("%Y-%m-%d")}</dct:modified>
+                    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">{dist1.created.strftime("%Y-%m-%d")}</dct:modified>
                 <dcat:accessURL rdf:resource="{dist1.access_url}"/>
                 <dcat:downloadURL rdf:resource="http://localhost{dist1.file.url}"/>
                 <dct:rights>
@@ -4382,7 +4382,7 @@ def test_dataset_rdf_download__dataset_without_landing_page(app: DjangoTestApp):
                 <dct:title xml:lang="lt">Failas 2</dct:title>
                 <dct:description xml:lang="lt">Failas be prieigos nuorodos</dct:description>
                 <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">{dist2.created.strftime("%Y-%m-%d")}</dct:issued>
-                    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">{dist2.modified.strftime("%Y-%m-%d")}</dct:modified>
+                    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">{dist2.created.strftime("%Y-%m-%d")}</dct:modified>
                 <dcat:accessURL rdf:resource="http://localhost{dist2.file.url}"/>
                 <dcat:downloadURL rdf:resource="http://localhost{dist2.file.url}"/>
                 <dct:rights>
@@ -4404,6 +4404,40 @@ def test_dataset_rdf_download__dataset_without_landing_page(app: DjangoTestApp):
     </dcat:Dataset>
 </rdf:RDF>'''
     )
+
+
+def test_dataset_rdf_distribution_modified_uses_created_not_metadata_modified(app: DjangoTestApp):
+    from django.utils.timezone import make_aware
+
+    from vitrina.resources.models import DatasetDistribution
+
+    po = "http://publications.europa.eu/resource/authority"
+    dataset = DatasetFactory(
+        published=datetime(2016, 8, 1),
+        frequency=FrequencyFactory(uri=f"{po}/frequency/IRREG"),
+        organization=OrganizationFactory(title="Data Enterprise", email="data@example.com"),
+    )
+    dist = DatasetDistributionFactory(
+        dataset=dataset,
+        title="Failas 1",
+        description="Failas su prieigos nuoroda",
+        format=FileFormat(uri=f"{po}/file-type/CSV"),
+        access_url="https://access-url.com",
+    )
+    ModelFactory(dataset=dataset, distribution=dist, metadata_version=dataset.metadata.first().metadata_version)
+
+    # created = real publication date (old); modified = later metadata churn; no storage date.
+    DatasetDistribution.objects.filter(pk=dist.pk).update(
+        created=make_aware(datetime(2019, 3, 3)),
+        modified=make_aware(datetime(2024, 9, 9)),
+        data_last_updated=None,
+    )
+
+    res = app.get(reverse("dataset-rdf-download", args=[dataset.pk]))
+
+    assert res.status_code == 200
+    assert '<dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-03-03</dct:modified>' in res.text
+    assert "2024-09-09" not in res.text
 
 
 def test_dataset_rdf_download__dataset_with_spinta_data(app: DjangoTestApp):
@@ -4538,7 +4572,7 @@ def test_dataset_rdf_download__dataset_with_spinta_data(app: DjangoTestApp):
                 <dct:title xml:lang="lt">Duomenys</dct:title>
                 <dct:description xml:lang="lt">Duomenys iš spintos</dct:description>
                 <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">{dist.created.strftime("%Y-%m-%d")}</dct:issued>
-                    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">{dist.modified.strftime("%Y-%m-%d")}</dct:modified>
+                    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">{dist.created.strftime("%Y-%m-%d")}</dct:modified>
                 <dcat:accessURL rdf:resource="{SPINTA_SERVER_URL}/test/dataset"/>
                 <dcat:downloadURL rdf:resource="{SPINTA_SERVER_URL}/test/dataset/:all/:format/json"/>
                 <dcat:accessService rdf:resource="http://localhost/datasets/{data_service.pk}/"/>
@@ -4564,7 +4598,7 @@ def test_dataset_rdf_download__dataset_with_spinta_data(app: DjangoTestApp):
                 <dct:title xml:lang="lt">Duomenys</dct:title>
                 <dct:description xml:lang="lt">Duomenys iš spintos</dct:description>
                 <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">{dist.created.strftime("%Y-%m-%d")}</dct:issued>
-                    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">{dist.modified.strftime("%Y-%m-%d")}</dct:modified>
+                    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">{dist.created.strftime("%Y-%m-%d")}</dct:modified>
                 <dcat:accessURL rdf:resource="{SPINTA_SERVER_URL}/test/dataset"/>
                 <dcat:downloadURL rdf:resource="{SPINTA_SERVER_URL}/test/dataset/:all/:format/jsonl"/>
                 <dcat:accessService rdf:resource="http://localhost/datasets/{data_service.pk}/"/>
@@ -4584,7 +4618,7 @@ def test_dataset_rdf_download__dataset_with_spinta_data(app: DjangoTestApp):
                 <dct:title xml:lang="lt">Duomenys</dct:title>
                 <dct:description xml:lang="lt">Duomenys iš spintos</dct:description>
                 <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">{dist.created.strftime("%Y-%m-%d")}</dct:issued>
-                    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">{dist.modified.strftime("%Y-%m-%d")}</dct:modified>
+                    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">{dist.created.strftime("%Y-%m-%d")}</dct:modified>
                 <dcat:accessURL rdf:resource="{SPINTA_SERVER_URL}/test/dataset"/>
                 <dcat:downloadURL rdf:resource="{SPINTA_SERVER_URL}/test/dataset/:all/:format/rdf"/>
                 <dcat:accessService rdf:resource="http://localhost/datasets/{data_service.pk}/"/>
@@ -4610,7 +4644,7 @@ def test_dataset_rdf_download__dataset_with_spinta_data(app: DjangoTestApp):
                 <dct:title xml:lang="lt">Duomenys</dct:title>
                 <dct:description xml:lang="lt">Duomenys iš spintos</dct:description>
                 <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">{dist.created.strftime("%Y-%m-%d")}</dct:issued>
-                    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">{dist.modified.strftime("%Y-%m-%d")}</dct:modified>
+                    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">{dist.created.strftime("%Y-%m-%d")}</dct:modified>
                 <dcat:accessURL rdf:resource="{SPINTA_SERVER_URL}/test/dataset"/>
                 <dcat:downloadURL rdf:resource="{SPINTA_SERVER_URL}/test/dataset/TestModel/:format/csv"/>
                 <dcat:accessService rdf:resource="http://localhost/datasets/{data_service.pk}/"/>

--- a/tests/resources/test_models.py
+++ b/tests/resources/test_models.py
@@ -1,6 +1,7 @@
 import pytest
 from django.utils import timezone
 
+from vitrina.cms.factories import FilerFileFactory
 from vitrina.resources.factories import DatasetDistributionFactory
 from vitrina.resources.models import DatasetDistribution
 
@@ -45,3 +46,61 @@ def test_data_last_updated_save_does_not_trigger_auto_now_on_modified():
 
     distribution.refresh_from_db()
     assert distribution.modified == original_modified
+
+
+@pytest.mark.django_db
+def test_data_last_updated_not_stamped_on_create():
+    distribution = DatasetDistributionFactory(file=None, download_url="http://example.com/new", type="URL")
+    assert distribution.data_last_updated is None
+
+
+@pytest.mark.django_db
+def test_data_last_updated_stamped_when_file_changes():
+    distribution = DatasetDistributionFactory()
+    DatasetDistribution.objects.filter(pk=distribution.pk).update(data_last_updated=None)
+    instance = DatasetDistribution.objects.get(pk=distribution.pk)
+
+    instance.file = FilerFileFactory()
+    instance.save()
+
+    instance.refresh_from_db()
+    assert instance.data_last_updated is not None
+
+
+@pytest.mark.django_db
+def test_data_last_updated_stamped_when_download_url_changes():
+    distribution = DatasetDistributionFactory(file=None, download_url="http://example.com/old", type="URL")
+    DatasetDistribution.objects.filter(pk=distribution.pk).update(data_last_updated=None)
+    instance = DatasetDistribution.objects.get(pk=distribution.pk)
+
+    instance.download_url = "http://example.com/new"
+    instance.save()
+
+    instance.refresh_from_db()
+    assert instance.data_last_updated is not None
+
+
+@pytest.mark.django_db
+def test_data_last_updated_not_stamped_on_metadata_only_change():
+    distribution = DatasetDistributionFactory(file=None, download_url="http://example.com/keep", type="URL")
+    DatasetDistribution.objects.filter(pk=distribution.pk).update(data_last_updated=None)
+    instance = DatasetDistribution.objects.get(pk=distribution.pk)
+
+    instance.name = "changed-name"
+    instance.save()
+
+    instance.refresh_from_db()
+    assert instance.data_last_updated is None
+
+
+@pytest.mark.django_db
+def test_data_last_updated_not_stamped_for_uapi_distribution():
+    distribution = DatasetDistributionFactory(uapi_format=True, file=None, download_url="http://example.com/old")
+    DatasetDistribution.objects.filter(pk=distribution.pk).update(data_last_updated=None)
+    instance = DatasetDistribution.objects.get(pk=distribution.pk)
+
+    instance.download_url = "http://example.com/new"
+    instance.save()
+
+    instance.refresh_from_db()
+    assert instance.data_last_updated is None

--- a/tests/resources/test_views.py
+++ b/tests/resources/test_views.py
@@ -12,6 +12,7 @@ from vitrina.orgs.models import Representative
 from vitrina.resources.factories import (
     DatasetDistributionFactory,
     FileFormat,
+    UapiFormat,
     CompressionFormatFactory,
     PackagingFormatFactory,
 )
@@ -904,8 +905,6 @@ def test_distribution_form_status_options(app: DjangoTestApp):
 
 @pytest.mark.django_db
 def test_data_last_updated_not_set_on_create(app: DjangoTestApp):
-    from vitrina.users.factories import UserFactory
-
     dataset = DatasetFactory()
     file_format = FileFormat(extension="URL")
     user = UserFactory(is_staff=True, organization=dataset.organization)
@@ -917,6 +916,89 @@ def test_data_last_updated_not_set_on_create(app: DjangoTestApp):
     resp = form.submit()
     assert resp.status_code == 302
     distribution = DatasetDistribution.objects.first()
+    assert distribution.data_last_updated is None
+
+
+@pytest.mark.django_db
+def test_data_last_updated_not_set_on_create_for_uapi(app: DjangoTestApp):
+    dataset = DatasetFactory()
+    uapi_format = UapiFormat()
+    user = UserFactory(is_staff=True, organization=dataset.organization)
+    app.set_user(user)
+    form = app.get(reverse("resource-add", kwargs={"pk": dataset.pk})).forms["resource-form"]
+    form["title"] = "Test resource"
+    form["format"] = uapi_format.id
+    form["download_url"] = "http://www.example.com"
+    resp = form.submit()
+    assert resp.status_code == 302
+    distribution = DatasetDistribution.objects.first()
+    assert distribution.data_last_updated is None
+
+
+@pytest.mark.django_db
+def test_data_last_updated_set_on_update_when_link_changes(app: DjangoTestApp):
+    dataset = DatasetFactory()
+    distribution = DatasetDistributionFactory(
+        dataset=dataset,
+        format=FileFormat(extension="URL"),
+        file=None,
+        download_url="http://www.example.com/old",
+        type="URL",
+    )
+    distribution.data_last_updated = None
+    distribution.save(update_fields=["data_last_updated"])
+    user = UserFactory(is_staff=True, organization=dataset.organization)
+    app.set_user(user)
+    form = app.get(reverse("resource-change-no-version", kwargs={"pk": distribution.pk})).forms["resource-form"]
+    form["download_url"] = "http://www.example.com/new"
+    resp = form.submit()
+    assert resp.status_code == 302
+    distribution.refresh_from_db()
+    assert distribution.data_last_updated is not None
+
+
+@pytest.mark.django_db
+def test_data_last_updated_not_set_on_metadata_only_update(app: DjangoTestApp):
+    dataset = DatasetFactory()
+    distribution = DatasetDistributionFactory(
+        dataset=dataset,
+        format=FileFormat(extension="URL"),
+        file=None,
+        download_url="http://www.example.com/keep",
+        type="URL",
+    )
+    distribution.data_last_updated = None
+    distribution.save(update_fields=["data_last_updated"])
+    user = UserFactory(is_staff=True, organization=dataset.organization)
+    app.set_user(user)
+    form = app.get(reverse("resource-change-no-version", kwargs={"pk": distribution.pk})).forms["resource-form"]
+    form["title"] = "Changed title only"
+    resp = form.submit()
+    assert resp.status_code == 302
+    distribution.refresh_from_db()
+    assert distribution.data_last_updated is None
+
+
+@pytest.mark.django_db
+def test_data_last_updated_not_set_on_metadata_only_update_when_download_url_null(app: DjangoTestApp):
+    dataset = DatasetFactory()
+    distribution = DatasetDistributionFactory(
+        dataset=dataset,
+        format=FileFormat(extension="URL"),
+        file=None,
+        download_url=None,
+        access_url="http://www.example.com/access",
+        type="URL",
+    )
+    distribution.data_last_updated = None
+    distribution.save(update_fields=["data_last_updated"])
+    user = UserFactory(is_staff=True, organization=dataset.organization)
+    app.set_user(user)
+    form = app.get(reverse("resource-change-no-version", kwargs={"pk": distribution.pk})).forms["resource-form"]
+    form["title"] = "Changed title only"
+    resp = form.submit()
+    assert resp.status_code == 302
+    distribution.refresh_from_db()
     assert distribution.data_last_updated is None
 
 

--- a/vitrina/api/templates/vitrina/api/edp/dcat_ap_rdf.html
+++ b/vitrina/api/templates/vitrina/api/edp/dcat_ap_rdf.html
@@ -211,8 +211,8 @@
                 {% endif %}
                 {% if dist.data_last_updated %}
                     <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">{{ dist.data_last_updated|date:"SHORT_DATE_FORMAT" }}</dct:modified>
-                {% elif dist.modified %}
-                    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">{{ dist.modified|date:"SHORT_DATE_FORMAT" }}</dct:modified>
+                {% elif dist.created %}
+                    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">{{ dist.created|date:"SHORT_DATE_FORMAT" }}</dct:modified>
                 {% endif %}
                 {% if dist.access_url|first in '/' %}
                 <dcat:accessURL rdf:resource="{{ current_domain_full }}{{ dist.access_url|encode_uri }}"/>

--- a/vitrina/datasets/admin.py
+++ b/vitrina/datasets/admin.py
@@ -116,7 +116,7 @@ class DatasetLateFilter(admin.SimpleListFilter):
         not_late_ids = []
         for obj in queryset:
             distribution = (
-                obj.datasetdistribution_set.annotate(effective_updated=Coalesce("data_last_updated", "modified"))
+                obj.datasetdistribution_set.annotate(effective_updated=Coalesce("data_last_updated", "created"))
                 .filter(effective_updated__isnull=False)
                 .order_by("-effective_updated")
                 .first()
@@ -338,7 +338,7 @@ class DatasetReportAdmin(RevisionCommentVersionAdmin):
 
     def distribution_modified_display(self, obj):
         distribution = (
-            obj.datasetdistribution_set.annotate(effective_updated=Coalesce("data_last_updated", "modified"))
+            obj.datasetdistribution_set.annotate(effective_updated=Coalesce("data_last_updated", "created"))
             .filter(effective_updated__isnull=False)
             .order_by("-effective_updated")
             .first()
@@ -353,7 +353,7 @@ class DatasetReportAdmin(RevisionCommentVersionAdmin):
     def _is_late_for(self, obj):
         text = ""
         distribution = (
-            obj.datasetdistribution_set.annotate(effective_updated=Coalesce("data_last_updated", "modified"))
+            obj.datasetdistribution_set.annotate(effective_updated=Coalesce("data_last_updated", "created"))
             .filter(effective_updated__isnull=False)
             .order_by("-effective_updated")
             .first()
@@ -379,7 +379,7 @@ class DatasetReportAdmin(RevisionCommentVersionAdmin):
 
     def _is_late_for_days(self, obj):
         distribution = (
-            obj.datasetdistribution_set.annotate(effective_updated=Coalesce("data_last_updated", "modified"))
+            obj.datasetdistribution_set.annotate(effective_updated=Coalesce("data_last_updated", "created"))
             .filter(effective_updated__isnull=False)
             .order_by("-effective_updated")
             .first()

--- a/vitrina/datasets/templates/vitrina/datasets/datatable.html
+++ b/vitrina/datasets/templates/vitrina/datasets/datatable.html
@@ -55,7 +55,7 @@
                     <td>{{dataset.frequency.title}}</td>
                 {% endif %}
             {% else %}
-                <td>{{ r.data_last_updated|default:r.modified|default:"-"|date:"SHORT_DATE_FORMAT" }}</td>
+                <td>{{ r.data_last_updated|default:r.created|default:"-"|date:"SHORT_DATE_FORMAT" }}</td>
             {% endif %}
 
             {% if r.file %}
@@ -157,7 +157,7 @@
                 {{ r.format|default:"-" }}
             </td>
             <td>{{  r.created|default:"-"|date:"SHORT_DATE_FORMAT" }}</td>
-            <td>{{ r.data_last_updated|default:r.modified|default:"-"|date:"SHORT_DATE_FORMAT" }}</td>
+            <td>{{ r.data_last_updated|default:r.created|default:"-"|date:"SHORT_DATE_FORMAT" }}</td>
 
             {% if can_add_resource %}
             <td>

--- a/vitrina/resources/models.py
+++ b/vitrina/resources/models.py
@@ -6,6 +6,7 @@ from django.contrib.contenttypes.fields import GenericRelation
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.urls import reverse
+from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from filer.fields.file import FilerFileField
 from parler.managers import TranslatableManager
@@ -461,6 +462,29 @@ class DatasetDistribution(TranslatableModel):
 
     def __str__(self):
         return self.safe_translation_getter("title", language_code=self.get_current_language()) or ""
+
+    def _data_source(self):
+        return (self.file_id, self.download_url or None, self.access_url or None)
+
+    @classmethod
+    def from_db(cls, db, field_names, values):
+        instance = super().from_db(db, field_names, values)
+        instance._loaded_data_source = instance._data_source()
+        return instance
+
+    def save(self, *args, **kwargs):
+        loaded_data_source = getattr(self, "_loaded_data_source", None)
+        if (
+            loaded_data_source is not None
+            and self._data_source() != loaded_data_source
+            and not (self.format and self.format.extension == FormatName.UAPI)
+        ):
+            self.data_last_updated = timezone.now()
+            if (update_fields := kwargs.get("update_fields")) is not None:
+                kwargs["update_fields"] = {*update_fields, "data_last_updated"}
+        super().save(*args, **kwargs)
+        if getattr(self, "_loaded_data_source", None) is not None:
+            self._loaded_data_source = self._data_source()
 
     @property
     def display_title(self) -> str:


### PR DESCRIPTION
A distribution's date now changes only when the actual data changes (file or link), not when metadata is edited or the edit form is re-saved with no change. So stale data no longer looks freshly updated.
