### PR TITLE
[No ticket] Implement custom regex validation

### DIFF
--- a/tests/datasets/test_views.py
+++ b/tests/datasets/test_views.py
@@ -1330,7 +1330,7 @@ class TestDatasetUpdateView:
         form["identifier"] = "not-valid-identifier"
         form.submit()
         response = form.submit(expect_errors=True)
-        assert "Žymėjimas turi atitikti šabloną" in response.text
+        assert "Žymėjimas turi būti sudarytas iš keturių skaitmenų." in response.text
 
     def test_dataset_update_non_existing_identifier(self, app: DjangoTestApp):
         subclass = DCATResourceSubclassFactory(name="information_system")
@@ -2047,7 +2047,7 @@ class TestDatasetCreateView:
         form["identifier"] = "not-valid-identifier"
         form.submit()
         response = form.submit(expect_errors=True)
-        assert "Žymėjimas turi atitikti šabloną" in response.text
+        assert "Žymėjimas turi būti sudarytas iš keturių skaitmenų." in response.text
 
     def test_dataset_create_with_applicable_legislation(self, app: DjangoTestApp):
         FrequencyFactory(is_default=True)

--- a/tests/dcat/forms/test_dataset_forms.py
+++ b/tests/dcat/forms/test_dataset_forms.py
@@ -287,7 +287,7 @@ class TestInformationSystemResourceForm:
 
         assert not form.is_valid()
         assert "identifier" in form.errors
-        assert "Žymėjimas turi atitikti šabloną: ^\\d{4}$" in form.errors["identifier"]
+        assert "Žymėjimas turi būti sudarytas iš keturių skaitmenų." in form.errors["identifier"]
 
     def test_valid_identifier_passes(self):
         organization = OrganizationFactory()
@@ -602,6 +602,7 @@ class TestInformationSystemUpdateForm:
                 "uri": "http://registrai.lt",
                 "identifier_validation_type": "REGEXP",
                 "identifier_validation_options": r"^\d{4}$",
+                "identifier_validation_error_message": "Žymėjimas turi būti sudarytas iš keturių skaitmenų.",
             },
         )
         Identifier.objects.create(

--- a/vitrina/datasets/form_helpers.py
+++ b/vitrina/datasets/form_helpers.py
@@ -96,11 +96,7 @@ def validate_identifier(identifier: str | None) -> None:
     is_regexp = agency.identifier_validation_type == Agency.IdentifierValidationType.REGEXP
 
     if is_regexp and (pattern := agency.identifier_validation_options) and not re.fullmatch(pattern, identifier):
-        raise ValidationError(
-            _("Žymėjimas turi atitikti šabloną: %(pattern)s"),
-            params={"pattern": pattern},
-            code="invalid_format",
-        )
+        raise ValidationError(agency.identifier_validation_error_message, code="invalid_format")
 
 
 def set_default_agent_endpoint_fields(cleaned_data: dict[str, Any]) -> dict[str, Any]:

--- a/vitrina/identifiers/admin.py
+++ b/vitrina/identifiers/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from parler.admin import TranslatableAdmin
 
 from .models import Identifier, Agency
 from vitrina.admin import RevisionCommentVersionAdmin
@@ -50,7 +51,7 @@ class IdentifierAdmin(RevisionCommentVersionAdmin):
 
 
 @admin.register(Agency)
-class AgencyAdmin(RevisionCommentVersionAdmin):
+class AgencyAdmin(TranslatableAdmin, RevisionCommentVersionAdmin):
     list_display = ("name", "uri")
     search_fields = ("name", "uri")
     inlines = [IdentifierInline]

--- a/vitrina/identifiers/factories.py
+++ b/vitrina/identifiers/factories.py
@@ -11,6 +11,7 @@ class AgencyFactory(DjangoModelFactory):
     uri = "http://registrai.lt"
     identifier_validation_type = "REGEXP"
     identifier_validation_options = r"^\d{4}$"
+    identifier_validation_error_message = "Žymėjimas turi būti sudarytas iš keturių skaitmenų."
 
     class Meta:
         model = Agency

--- a/vitrina/identifiers/migrations/0006_agency_identifier_validation_error_message.py
+++ b/vitrina/identifiers/migrations/0006_agency_identifier_validation_error_message.py
@@ -1,0 +1,127 @@
+from django.conf import settings
+from django.db import migrations, models
+
+import parler.fields
+import parler.models
+
+
+FOUR_DIGIT_PATTERN = r"^\d{4}$"
+FOUR_DIGIT_MESSAGE = "Žymėjimas turi būti sudarytas iš keturių skaitmenų."
+DEFAULT_REGEXP_MESSAGE_TEMPLATE = (
+    "Žymėjimas neatitinka reikalaujamo šablono „{pattern}“. "
+    "Šablono formatą galima patikrinti naudojant įrankį: https://regex101.com/"
+)
+
+
+class MakeAgencyTranslatableInState(migrations.operations.base.Operation):
+    """Add parler's TranslatableModelMixin to Agency's bases in migration state.
+
+    Needed so that the AgencyTranslation FK can attach to Agency during migration
+    state processing (parler asserts the master inherits from TranslatableModel).
+    Purely a state-level change — no DB effect.
+    """
+
+    reduces_to_sql = False
+    reversible = True
+
+    def state_forwards(self, app_label, state):
+        model_state = state.models[app_label, "agency"]
+        model_state.bases = (parler.models.TranslatableModelMixin, models.Model)
+        state.reload_model(app_label, "agency")
+
+    def state_backwards(self, app_label, state):
+        model_state = state.models[app_label, "agency"]
+        model_state.bases = (models.Model,)
+        state.reload_model(app_label, "agency")
+
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        pass
+
+    def database_backwards(self, app_label, schema_editor, from_state, to_state):
+        pass
+
+    def describe(self):
+        return "Mark Agency as translatable in migration state"
+
+
+def _configured_language_codes():
+    parler_languages = getattr(settings, "PARLER_LANGUAGES", {}) or {}
+    codes = []
+    for key, value in parler_languages.items():
+        if key == "default":
+            continue
+        for entry in value:
+            code = entry.get("code")
+            if code and code not in codes:
+                codes.append(code)
+    return codes or ["lt"]
+
+
+def prefill_error_messages(apps, schema_editor):
+    Agency = apps.get_model("vitrina_identifiers", "Agency")
+    AgencyTranslation = apps.get_model("vitrina_identifiers", "AgencyTranslation")
+
+    language_codes = _configured_language_codes()
+
+    for agency in Agency.objects.filter(identifier_validation_type="REGEXP"):
+        if agency.identifier_validation_options == FOUR_DIGIT_PATTERN:
+            message = FOUR_DIGIT_MESSAGE
+        else:
+            message = DEFAULT_REGEXP_MESSAGE_TEMPLATE.format(pattern=agency.identifier_validation_options)
+
+        for language_code in language_codes:
+            AgencyTranslation.objects.update_or_create(
+                master=agency,
+                language_code=language_code,
+                defaults={"identifier_validation_error_message": message},
+            )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("vitrina_identifiers", "0005_add_pasis_agency"),
+    ]
+
+    operations = [
+        MakeAgencyTranslatableInState(),
+        migrations.CreateModel(
+            name="AgencyTranslation",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("language_code", models.CharField(db_index=True, max_length=15, verbose_name="Language")),
+                (
+                    "identifier_validation_error_message",
+                    models.TextField(
+                        blank=True,
+                        help_text=(
+                            "Pranešimas, rodomas naudotojui, kai identifikatorius neatitinka nustatyto šablono. "
+                            "Privalomas, kai pasirinkta reguliarioji išraiška."
+                        ),
+                        null=True,
+                        verbose_name="Identifikatoriaus tikrinimo klaidos pranešimas",
+                    ),
+                ),
+                (
+                    "master",
+                    parler.fields.TranslationsForeignKey(
+                        editable=False,
+                        null=True,
+                        on_delete=models.CASCADE,
+                        related_name="translations",
+                        to="vitrina_identifiers.agency",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Atstovybė Translation",
+                "db_table": "vitrina_identifiers_agency_translation",
+                "db_tablespace": "",
+                "managed": True,
+                "default_permissions": (),
+                "unique_together": {("language_code", "master")},
+            },
+            bases=(parler.models.TranslatedFieldsModelMixin, models.Model),
+        ),
+        migrations.RunPython(prefill_error_messages, reverse_code=migrations.RunPython.noop),
+    ]

--- a/vitrina/identifiers/models.py
+++ b/vitrina/identifiers/models.py
@@ -3,11 +3,13 @@ from django.db import models
 from django.utils.translation import gettext_lazy as _
 from django.core.exceptions import ValidationError
 
+from parler.models import TranslatableModel, TranslatedFields
+
 from vitrina.datasets.models import Dataset
 from vitrina.models import UUIDBaseModel
 
 
-class Agency(UUIDBaseModel):
+class Agency(TranslatableModel, UUIDBaseModel):
     RISR_CODE = "risr"
     PASIS_CODE = "pasis"
 
@@ -38,6 +40,17 @@ class Agency(UUIDBaseModel):
         blank=True,
         help_text=_("Tikrinimo parametrai pagal pasirinktą tipą. Reguliariajai išraiškai - įveskite regex šabloną "),
     )
+    translations = TranslatedFields(
+        identifier_validation_error_message=models.TextField(
+            _("Identifikatoriaus tikrinimo klaidos pranešimas"),
+            null=True,
+            blank=True,
+            help_text=_(
+                "Pranešimas, rodomas naudotojui, kai identifikatorius neatitinka nustatyto šablono. "
+                "Privalomas, kai pasirinkta reguliarioji išraiška."
+            ),
+        ),
+    )
 
     class Meta:
         verbose_name = _("Atstovybė")
@@ -53,6 +66,18 @@ class Agency(UUIDBaseModel):
                     "Jei nustatytas vienas laukų „Identifikatoriaus tikrinimo tipas“ arba „parinktys“, "
                     "abu turi būti užpildyti."
                 )
+            )
+
+        if self.identifier_validation_type == self.IdentifierValidationType.REGEXP and not self.safe_translation_getter(
+            "identifier_validation_error_message", any_language=True
+        ):
+            raise ValidationError(
+                {
+                    "identifier_validation_error_message": _(
+                        "Identifikatoriaus tikrinimo klaidos pranešimas privalomas, "
+                        "kai pasirinkta reguliarioji išraiška."
+                    )
+                }
             )
 
 
@@ -102,9 +127,8 @@ class Identifier(UUIDBaseModel):
             return
         is_regexp = agency.identifier_validation_type == Agency.IdentifierValidationType.REGEXP
         if is_regexp and (pattern := agency.identifier_validation_options) and not re.fullmatch(pattern, self.notation):
-            raise ValidationError(
-                {"notation": _("Žymėjimas turi atitikti šabloną: %(pattern)s") % {"pattern": pattern}}
-            )
+            message = agency.safe_translation_getter("identifier_validation_error_message", any_language=True)
+            raise ValidationError({"notation": message})
 
     def save(self, *args, **kwargs):
         self.full_clean()  # ensures clean() is called

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-22 15:45+0300\n"
+"POT-Creation-Date: 2026-07-21 12:37+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,12 +17,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-
-msgid "Organizacija"
-msgstr "Organization"
-
-msgid "Duomenų skelbėjas"
-msgstr "Data publisher"
 
 msgid "Versijos duomenys"
 msgstr "Version data"
@@ -58,6 +52,9 @@ msgstr "API key"
 
 msgid "Taikymo sritis"
 msgstr "Application area"
+
+msgid "Organizacija"
+msgstr "Organization"
 
 msgid "Duomenų išteklius"
 msgstr "Resource"
@@ -114,9 +111,11 @@ msgstr "Categories"
 msgid "Atnaujinti pasirinktų sąvokų schemų sąvokas"
 msgstr "Update selected concept scheme concepts"
 
+#, python-brace-format
 msgid "Sėkmingai atnaujintos {} sąvokų schemų sąvokos. Pilnas sąrašas: <br>{}"
 msgstr "Successfully updated {} concept scheme concepts. Full list: <br>{}"
 
+#, python-brace-format
 msgid "Nepavyko atsisiųsti dalies sąvokų. Pilnas sąrašas: <br>{}"
 msgstr "Failed to download some concepts. Full list: <br>{}"
 
@@ -345,21 +344,27 @@ msgstr "Spatial coverage"
 msgid "Teritorinės aprėptys"
 msgstr "Spatial coverages"
 
+#, python-brace-format
 msgid "Nepavyko gauti uri: {}. Klaida: {}."
 msgstr "Failed to get uri: {}. Error: {}."
 
+#, python-brace-format
 msgid "{} nėra validus URI."
 msgstr "{} is not valid URI."
 
+#, python-brace-format
 msgid "Nepavyko gauti uri: {}. Uri atsakymas tuščias."
 msgstr "Failed to get uri: {}. Uri response is empty."
 
+#, python-brace-format
 msgid "Nepavyko gauti uri: {}. Gautas rezultatas nėra RDF formato."
 msgstr "Failed to get uri: {}. Response is not in RDF format."
 
+#, python-brace-format
 msgid "Sąvokų schemoje {} nerasta jokių \"{}\" elementų."
 msgstr "Concept scheme {} does not have any \"{}\" elements."
 
+#, python-brace-format
 msgid "Sąvokoje {} nerastas \"{}\" elementas."
 msgstr "Concept {} does not have \"{}\" element."
 
@@ -429,11 +434,26 @@ msgstr "Publication date"
 msgid "Mokymosi medžiaga"
 msgstr "Learning material"
 
+msgid "Informacinis"
+msgstr "Informative"
+
+msgid "Įspėjamasis"
+msgstr "Indicating"
+
+msgid "Kritinis"
+msgstr "Critical"
+
 msgid "Diegimo darbų pradžia"
 msgstr "Deployment start"
 
 msgid "Diegimo darbų pabaiga"
 msgstr "Deployment end"
+
+msgid "Pranešimo tipas"
+msgstr "Message type"
+
+msgid "Publikuoti"
+msgstr "Publish"
 
 msgid "Diegimo pranešimas"
 msgstr "Deployment message"
@@ -816,10 +836,6 @@ msgid ""
 "Kodinis pavadinimas yra privalomas, jei duomenų rinkinys jau turi kodinį "
 "pavadinimą."
 msgstr "A codename is required if the dataset already has a codename."
-
-#, python-format
-msgid "Žymėjimas turi atitikti šabloną: %(pattern)s"
-msgstr "The notation must match the pattern: %(pattern)s"
 
 #, python-brace-format
 msgid "Nepavyko rasti `{0}` pasirinkimų sąraše. Susisiekite su administracija."
@@ -1759,15 +1775,6 @@ msgstr "Go back to resources"
 msgid "Duomenų išteklių kategorijos"
 msgstr "Resource categories"
 
-msgid "Teminiai duomenų ištekliai"
-msgstr "Thematic data resources"
-
-msgid "Sveikatos duomenys"
-msgstr "Health data"
-
-msgid "Atsidaro naujame lange"
-msgstr "Opens in a new window"
-
 msgid "Patinka"
 msgstr "Like"
 
@@ -1979,6 +1986,12 @@ msgstr "Are you sure you want to delete this distribution?"
 msgid "Ištrinti"
 msgstr "Delete"
 
+msgid "Visas ekranas"
+msgstr "Full screen"
+
+msgid "Sumažinti"
+msgstr "Minimize"
+
 msgid "Duomenų ištekliaus peržiūros"
 msgstr "Resource views"
 
@@ -1990,6 +2003,9 @@ msgstr "Delete"
 
 msgid "Atsisiuntimo formatas"
 msgstr "Download format"
+
+msgid "Duomenų skelbėjas"
+msgstr "Data publisher"
 
 msgid "Kontaktinė informacija"
 msgstr "Contact information"
@@ -2065,6 +2081,9 @@ msgstr "Add a child resource"
 
 msgid "Rasta duomenų išteklių"
 msgstr "Found resources"
+
+msgid "Atsisiuntimų skaičius"
+msgstr "Number of downloads"
 
 msgid "Narių sąrašas"
 msgstr "Members"
@@ -2868,6 +2887,18 @@ msgstr "Select a file"
 msgid "Reikšmės privalo būti unikalios."
 msgstr "Values must be unique."
 
+#, python-brace-format
+msgid ""
+"Failas „{file_name}“: XML su stilių aprašu (xml-stylesheet) uždraustas "
+"svetainės saugumo politikos"
+msgstr ""
+"File \"{file_name}\": XML with a stylesheet declaration (xml-stylesheet) is "
+"forbidden by the site's security policy"
+
+#, python-brace-format
+msgid "Failas „{file_name}“: nepavyko saugiai patikrinti XML pradžios."
+msgstr "File \"{file_name}\": could not securely verify the XML declaration."
+
 msgid "I ketvirtis"
 msgstr "I quarter"
 
@@ -2928,6 +2959,16 @@ msgstr "Coordinator count"
 msgid "Tvarkytojų skaičius"
 msgstr "Manager count"
 
+msgid "Nepavyko perskaityti įkelto failo turinio."
+msgstr "Failed to read the contents of the uploaded file"
+
+msgid ""
+"Nepavyko patikrinti failo turinio tipo. Kreipkitės į sistemos "
+"administratorių."
+msgstr ""
+"Could not verify the file's content type. Please contact your system "
+"administrator."
+
 msgid "Modelio laukas"
 msgstr "Model field."
 
@@ -2969,6 +3010,16 @@ msgstr ""
 "Validation parameters according to the selected type. For regular expression "
 "- enter regex pattern"
 
+msgid "Identifikatoriaus tikrinimo klaidos pranešimas"
+msgstr "Identifier validation error message"
+
+msgid ""
+"Pranešimas, rodomas naudotojui, kai identifikatorius neatitinka nustatyto "
+"šablono. Privalomas, kai pasirinkta reguliarioji išraiška."
+msgstr ""
+"The message displayed to the user when the identifier does not match the "
+"configured pattern. Required when a regular expression is selected."
+
 msgid "Atstovybė"
 msgstr "Agency"
 
@@ -2981,6 +3032,13 @@ msgid ""
 msgstr ""
 "If one of the fields “Identifier validation type” or “options” is set, both "
 "must be filled."
+
+msgid ""
+"Identifikatoriaus tikrinimo klaidos pranešimas privalomas, kai pasirinkta "
+"reguliarioji išraiška."
+msgstr ""
+"The identifier validation error message is required when a regular "
+"expression is selected."
 
 msgid "Nuoroda (URI)"
 msgstr "URI"
@@ -5784,9 +5842,6 @@ msgstr ""
 msgid "Priklauso versijai"
 msgstr "Depends on version"
 
-msgid "Publikuoti"
-msgstr "Publish"
-
 msgid "Tėvinė versija turi būti pasirinkta"
 msgstr "The parent version must be selected"
 
@@ -5977,7 +6032,8 @@ msgstr ""
 "Code name (%(manifest_names)s) does not match with the dataset code name "
 "%(dataset_name)s."
 
-msgid "Duomenų struktūros apraše nenurodytas duomenų rinkinio kodinis pavadinimas."
+msgid ""
+"Duomenų struktūros apraše nenurodytas duomenų rinkinio kodinis pavadinimas."
 msgstr "Dataset code name not defined in the manifest"
 
 #, python-brace-format
@@ -6506,6 +6562,15 @@ msgstr "Look for data..."
 
 msgid "Prenumeruoja:"
 msgstr "Subscribers"
+
+msgid "Teminiai duomenų ištekliai"
+msgstr "Thematic data resources"
+
+msgid "Atsidaro naujame lange"
+msgstr "Opens in a new window"
+
+msgid "Sveikatos duomenys"
+msgstr "Health data"
 
 msgid "Ar tikrai norite patvirtinti"
 msgstr "Are you sure you want ro confirm"
@@ -7430,9 +7495,6 @@ msgstr "Password reset"
 
 msgid "Naudotojo profilis"
 msgstr "User profile"
-
-msgid "Pranešimo tipas"
-msgstr "Message type"
 
 msgid "Prenumeratos"
 msgstr "Subscriptions"

--- a/vitrina/locale/lt/LC_MESSAGES/django.po
+++ b/vitrina/locale/lt/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-22 15:45+0300\n"
+"POT-Creation-Date: 2026-07-21 12:37+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,12 +19,6 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n % 10 == 1 && (n % 100 > 19 || n % 100 < "
 "11) ? 0 : (n % 10 >= 2 && n % 10 <=9) && (n % 100 > 19 || n % 100 < 11) ? "
 "1 : n % 1 != 0 ? 2: 3);\n"
-
-msgid "Organizacija"
-msgstr ""
-
-msgid "Duomenų skelbėjas"
-msgstr ""
 
 msgid "Versijos duomenys"
 msgstr ""
@@ -57,6 +51,9 @@ msgid "API raktas"
 msgstr ""
 
 msgid "Taikymo sritis"
+msgstr ""
+
+msgid "Organizacija"
 msgstr ""
 
 msgid "Duomenų išteklius"
@@ -113,9 +110,11 @@ msgstr ""
 msgid "Atnaujinti pasirinktų sąvokų schemų sąvokas"
 msgstr ""
 
+#, python-brace-format
 msgid "Sėkmingai atnaujintos {} sąvokų schemų sąvokos. Pilnas sąrašas: <br>{}"
 msgstr ""
 
+#, python-brace-format
 msgid "Nepavyko atsisiųsti dalies sąvokų. Pilnas sąrašas: <br>{}"
 msgstr ""
 
@@ -331,21 +330,27 @@ msgstr ""
 msgid "Teritorinės aprėptys"
 msgstr ""
 
+#, python-brace-format
 msgid "Nepavyko gauti uri: {}. Klaida: {}."
 msgstr ""
 
+#, python-brace-format
 msgid "{} nėra validus URI."
 msgstr ""
 
+#, python-brace-format
 msgid "Nepavyko gauti uri: {}. Uri atsakymas tuščias."
 msgstr ""
 
+#, python-brace-format
 msgid "Nepavyko gauti uri: {}. Gautas rezultatas nėra RDF formato."
 msgstr ""
 
+#, python-brace-format
 msgid "Sąvokų schemoje {} nerasta jokių \"{}\" elementų."
 msgstr ""
 
+#, python-brace-format
 msgid "Sąvokoje {} nerastas \"{}\" elementas."
 msgstr ""
 
@@ -415,10 +420,25 @@ msgstr ""
 msgid "Mokymosi medžiaga"
 msgstr ""
 
+msgid "Informacinis"
+msgstr ""
+
+msgid "Įspėjamasis"
+msgstr ""
+
+msgid "Kritinis"
+msgstr ""
+
 msgid "Diegimo darbų pradžia"
 msgstr ""
 
 msgid "Diegimo darbų pabaiga"
+msgstr ""
+
+msgid "Pranešimo tipas"
+msgstr ""
+
+msgid "Publikuoti"
 msgstr ""
 
 msgid "Diegimo pranešimas"
@@ -764,10 +784,6 @@ msgstr ""
 msgid ""
 "Kodinis pavadinimas yra privalomas, jei duomenų rinkinys jau turi kodinį "
 "pavadinimą."
-msgstr ""
-
-#, python-format
-msgid "Žymėjimas turi atitikti šabloną: %(pattern)s"
 msgstr ""
 
 #, python-brace-format
@@ -1606,15 +1622,6 @@ msgstr ""
 msgid "Duomenų išteklių kategorijos"
 msgstr ""
 
-msgid "Teminiai duomenų ištekliai"
-msgstr ""
-
-msgid "Sveikatos duomenys"
-msgstr ""
-
-msgid "Atsidaro naujame lange"
-msgstr ""
-
 msgid "Patinka"
 msgstr ""
 
@@ -1802,6 +1809,12 @@ msgstr ""
 msgid "Ištrinti"
 msgstr ""
 
+msgid "Visas ekranas"
+msgstr ""
+
+msgid "Sumažinti"
+msgstr ""
+
 msgid "Duomenų ištekliaus peržiūros"
 msgstr ""
 
@@ -1812,6 +1825,9 @@ msgid "Pašalinti"
 msgstr ""
 
 msgid "Atsisiuntimo formatas"
+msgstr ""
+
+msgid "Duomenų skelbėjas"
 msgstr ""
 
 msgid "Kontaktinė informacija"
@@ -1887,6 +1903,9 @@ msgid "Pridėti vaikinį duomenų išteklių"
 msgstr ""
 
 msgid "Rasta duomenų išteklių"
+msgstr ""
+
+msgid "Atsisiuntimų skaičius"
 msgstr ""
 
 msgid "Narių sąrašas"
@@ -2630,6 +2649,16 @@ msgstr ""
 msgid "Reikšmės privalo būti unikalios."
 msgstr ""
 
+#, python-brace-format
+msgid ""
+"Failas „{file_name}“: XML su stilių aprašu (xml-stylesheet) uždraustas "
+"svetainės saugumo politikos"
+msgstr ""
+
+#, python-brace-format
+msgid "Failas „{file_name}“: nepavyko saugiai patikrinti XML pradžios."
+msgstr ""
+
 msgid "I ketvirtis"
 msgstr ""
 
@@ -2690,6 +2719,14 @@ msgstr ""
 msgid "Tvarkytojų skaičius"
 msgstr ""
 
+msgid "Nepavyko perskaityti įkelto failo turinio."
+msgstr ""
+
+msgid ""
+"Nepavyko patikrinti failo turinio tipo. Kreipkitės į sistemos "
+"administratorių."
+msgstr ""
+
 msgid "Modelio laukas"
 msgstr ""
 
@@ -2727,6 +2764,14 @@ msgid ""
 "įveskite regex šabloną "
 msgstr ""
 
+msgid "Identifikatoriaus tikrinimo klaidos pranešimas"
+msgstr ""
+
+msgid ""
+"Pranešimas, rodomas naudotojui, kai identifikatorius neatitinka nustatyto "
+"šablono. Privalomas, kai pasirinkta reguliarioji išraiška."
+msgstr ""
+
 msgid "Atstovybė"
 msgstr ""
 
@@ -2736,6 +2781,11 @@ msgstr ""
 msgid ""
 "Jei nustatytas vienas laukų „Identifikatoriaus tikrinimo tipas“ arba "
 "„parinktys“, abu turi būti užpildyti."
+msgstr ""
+
+msgid ""
+"Identifikatoriaus tikrinimo klaidos pranešimas privalomas, kai pasirinkta "
+"reguliarioji išraiška."
 msgstr ""
 
 msgid "Nuoroda (URI)"
@@ -5310,9 +5360,6 @@ msgstr ""
 msgid "Priklauso versijai"
 msgstr ""
 
-msgid "Publikuoti"
-msgstr ""
-
 msgid "Tėvinė versija turi būti pasirinkta"
 msgstr ""
 
@@ -5483,6 +5530,16 @@ msgid "UML diagramos"
 msgstr ""
 
 msgid "UML diagrama mermaid sintaksės formatu."
+msgstr ""
+
+#, python-format
+msgid ""
+"Kodinis pavadinimas (%(manifest_names)s) nesutampa su rinkinio kodiniu "
+"pavadinimu %(dataset_name)s."
+msgstr ""
+
+msgid ""
+"Duomenų struktūros apraše nenurodytas duomenų rinkinio kodinis pavadinimas."
 msgstr ""
 
 #, python-brace-format
@@ -5997,6 +6054,15 @@ msgid "Ieškoti duomenų..."
 msgstr ""
 
 msgid "Prenumeruoja:"
+msgstr ""
+
+msgid "Teminiai duomenų ištekliai"
+msgstr ""
+
+msgid "Atsidaro naujame lange"
+msgstr ""
+
+msgid "Sveikatos duomenys"
 msgstr ""
 
 msgid "Ar tikrai norite patvirtinti"
@@ -6842,9 +6908,6 @@ msgid "Slaptažodžio atstatymas"
 msgstr ""
 
 msgid "Naudotojo profilis"
-msgstr ""
-
-msgid "Pranešimo tipas"
 msgstr ""
 
 msgid "Prenumeratos"


### PR DESCRIPTION
Implement translations for custom regex field validation;

The current approach is not enough - it only shows that there is a problem with an entered value and the regex; We need a custom field that helps the administrator give the user information on what is expected in the field (sort of an explanation for the regex itself);

