### PR TITLE
Do not show form save buttons in DCAT wizard new DCAT element selecti…

### DIFF
--- a/vitrina/orgs/templates/vitrina/orgs/wizard.html
+++ b/vitrina/orgs/templates/vitrina/orgs/wizard.html
@@ -261,7 +261,7 @@
                    onclick="event.preventDefault(); wizardNavigateTo(this.href);">
                     {% translate "Uždaryti" %}
                 </a>
-                <div class="buttons">
+                <div class="buttons" x-show="mode !== 'create'">
                     <div id="wizard-footer-extra"></div>
                     <button type="button" class="button is-light"
                             id="wizard-cancel-btn"


### PR DESCRIPTION
**Summary:**
Buttons "Ištrinti", "Atšaukti pakeitimus" and "Išsaugoti" were showed even when selecting what new element to add:
<img width="822" height="472" alt="image" src="https://github.com/user-attachments/assets/ffd97c73-4f12-4d37-a4b4-236752576018" />

After the fix, buttons are no longer showed in this page:
<img width="1209" height="742" alt="Screenshot 2026-07-21 at 16 10 15" src="https://github.com/user-attachments/assets/42c2bc28-04fb-41e8-81f7-dc67151dbc6b" />
