### PR TITLE
[No ticket] Change number input to text input in DCAT forms

### DIFF
--- a/vitrina/dcat/forms/distribution_forms.py
+++ b/vitrina/dcat/forms/distribution_forms.py
@@ -73,6 +73,9 @@ class DatasetDistributionForm(TranslatableModelForm):
             "packaging_format": Select2Widget,
             "checksum_algorithm": Select2Widget,
             "download_url": URLInput,
+            # Change input type to text because browsers silently clear unparseable <input type="number">
+            # values to "" before submit, so IntegerField's server-side validation never sees the bad input.
+            "size": forms.TextInput,
             "status": Select2Widget,
             "issued": forms.TextInput(attrs={"type": "date"}),
             "date_modified": forms.TextInput(attrs={"type": "date"}),


### PR DESCRIPTION
**Summary:**
Changes `<input type="number">` to `<input type="text">` for `IntegerField`s in DCAT forms. This fixes two issues with number input fields:
- Removes increase/decrease arrows.
- Forces browser to not drop field value if it has invalid symbols (for example, letters). This way back-end validation can run
  - Locally, Mac with Firefox allows entering non-number characters, but submitting form clears it because it has invalid symbols, so empty string is submitted instead. Result is that original value is lost and empty value is saved without user knowing.

There is only one `IntegerField` in DCAT forms - "Dydis baitais" in distribution form.