### PR TITLE
Move inline style="" attributes to CSS utility classes (CSP)

### DIFF
--- a/tests/security/test_security_headers.py
+++ b/tests/security/test_security_headers.py
@@ -159,3 +159,79 @@ class TestContentSecurityPolicy:
             "https://www.gstatic.com",
         }
         assert expected_embed_origins <= parsed_origins
+
+
+class TestStrictCspReportOnly:
+    """Strict, nonce-based policy shipped as Content-Security-Policy-Report-Only (WEB-5).
+
+    It runs alongside the still-permissive enforced policy so violations can be collected in a
+    real environment before switching to enforcement.
+    """
+
+    def test_report_only_policy_defined(self):
+        assert "DIRECTIVES" in settings.CONTENT_SECURITY_POLICY_REPORT_ONLY
+
+    def test_enforced_policy_stays_permissive_while_reporting(self):
+        """Nothing may actually be blocked while the strict policy is only being reported."""
+        enforced = settings.CONTENT_SECURITY_POLICY["DIRECTIVES"]
+        assert "'unsafe-inline'" in enforced["script-src"]
+        assert "'unsafe-inline'" in enforced["style-src"]
+
+    def test_report_only_uses_nonce_and_drops_unsafe_inline(self):
+        from csp.constants import NONCE
+
+        strict = settings.CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]
+        assert NONCE in strict["script-src"]
+        assert NONCE in strict["style-src"]
+        assert "'unsafe-inline'" not in strict["script-src"]
+        assert "'unsafe-inline'" not in strict["style-src"]
+
+    def test_report_only_keeps_unsafe_eval_for_alpine(self):
+        """Alpine.js (webpack/src/wizard.js) evaluates its directives with new Function()."""
+        strict = settings.CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]
+        assert "'unsafe-eval'" in strict["script-src"]
+
+    def test_report_only_preserves_locked_down_directives(self):
+        strict = settings.CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]
+        assert strict["object-src"] == ["'none'"]
+        assert strict["frame-ancestors"] == ["'self'"]
+
+
+class TestCspScopeMiddleware:
+    """CSPScopeMiddleware relaxes CSP to the permissive policy for admin / CMS surfaces (WEB-5)."""
+
+    def test_middleware_enabled_right_after_csp_middleware(self):
+        mw = settings.MIDDLEWARE
+        assert "vitrina.middleware.CSPScopeMiddleware" in mw
+        assert mw.index("vitrina.middleware.CSPScopeMiddleware") == mw.index("csp.middleware.CSPMiddleware") + 1
+
+    @staticmethod
+    def _report_only_script_src(path):
+        """Drive the CSP + scope middleware pair for ``path`` and return its report-only script-src."""
+        from django.test import RequestFactory
+        from django.http import HttpResponse
+        from csp.middleware import CSPMiddleware
+        from vitrina.middleware import CSPScopeMiddleware
+
+        def view(request):
+            str(request.csp_nonce)  # emulate a template rendering {{ request.csp_nonce }}
+            return HttpResponse("ok")
+
+        # CSPMiddleware is the outer wrapper (listed first); CSPScopeMiddleware the inner one.
+        stack = CSPMiddleware(get_response=CSPScopeMiddleware(get_response=view))
+        response = stack(RequestFactory().get(path))
+        header = response.headers.get("Content-Security-Policy-Report-Only", "")
+        return next(p.strip() for p in header.split(";") if p.strip().startswith("script-src"))
+
+    def test_public_page_reports_strict_nonce_policy(self):
+        script_src = self._report_only_script_src("/")
+        assert "'nonce-" in script_src
+        assert "'unsafe-inline'" not in script_src
+
+    def test_admin_page_relaxed_to_permissive(self):
+        script_src = self._report_only_script_src("/admin/")
+        assert "'unsafe-inline'" in script_src
+
+    def test_coordinator_admin_relaxed_to_permissive(self):
+        script_src = self._report_only_script_src("/coordinator-admin/foo/")
+        assert "'unsafe-inline'" in script_src

--- a/tests/security/test_security_headers.py
+++ b/tests/security/test_security_headers.py
@@ -235,3 +235,30 @@ class TestCspScopeMiddleware:
     def test_coordinator_admin_relaxed_to_permissive(self):
         script_src = self._report_only_script_src("/coordinator-admin/foo/")
         assert "'unsafe-inline'" in script_src
+
+
+class TestCspReportEndpoint:
+    """Endpoint that collects browser violation reports while the strict policy is report-only."""
+
+    def test_report_uri_is_configured(self):
+        directives = settings.CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]
+        assert directives["report-uri"] == ["/csp-report/"]
+
+    @staticmethod
+    def _post(body):
+        from django.test import RequestFactory
+        from vitrina.views import csp_report_view
+
+        request = RequestFactory().post("/csp-report/", data=body, content_type="application/csp-report")
+        return csp_report_view(request)
+
+    def test_accepts_a_violation_report(self):
+        body = (
+            '{"csp-report": {"effective-directive": "script-src", "blocked-uri": "inline",'
+            ' "document-uri": "https://example.lt/page/"}}'
+        )
+        assert self._post(body).status_code == 204
+
+    def test_ignores_a_malformed_body(self):
+        """A public endpoint must never raise on junk input."""
+        assert self._post(b"not json").status_code == 204

--- a/vitrina/cms/templates/pages/other.html
+++ b/vitrina/cms/templates/pages/other.html
@@ -1,12 +1,12 @@
 <h2>{{ title }}</h2>
 {% if items|length > 0 %}
-    <div style="padding-bottom: 30px">
+    <div class="u-pb-30">
         {% for site in items %}
             <div class="row">
                 <div class="cell">
                     {% if site.image %}
                     <a href="{{ site.url }}" target="_blank">
-                        <img style="max-height: 96px;" src="{{ site.image.url }}" alt="{{ site.title }}">
+                        <img class="u-maxh-96" src="{{ site.image.url }}" alt="{{ site.title }}">
                     </a>
                     {% endif %}
                 </div>

--- a/vitrina/cms/templates/vitrina/cms/learning_material_detail.html
+++ b/vitrina/cms/templates/vitrina/cms/learning_material_detail.html
@@ -143,7 +143,7 @@
                     {% endif %}
                     {% if object.video_url %}
                         <figure class="mt-4">
-                            <iframe class="has-ratio u-uml-canvas" src="https://www.youtube.com/embed/{{ object.video_url }}">
+                            <iframe class="has-ratio u-w-800-h-640" src="https://www.youtube.com/embed/{{ object.video_url }}">
                             </iframe>
                         </figure>
                     {% endif %}

--- a/vitrina/cms/templates/vitrina/cms/learning_material_detail.html
+++ b/vitrina/cms/templates/vitrina/cms/learning_material_detail.html
@@ -97,19 +97,19 @@
                                     <div class="file-info">
                                         <span class="file-icon">
                                             {% if file.file.name|slice:"-4:" == ".pdf" %}
-                                                <i class="fas fa-file-pdf" style="color: #dc3545;"></i>
+                                                <i class="fas fa-file-pdf u-color-dc3545"></i>
                                             {% elif file.file.name|slice:"-4:" == ".doc" or file.file.name|slice:"-5:" == ".docx" %}
-                                                <i class="fas fa-file-word" style="color: #007bff;"></i>
+                                                <i class="fas fa-file-word u-color-007bff"></i>
                                             {% elif file.file.name|slice:"-4:" == ".xls" or file.file.name|slice:"-5:" == ".xlsx" %}
-                                                <i class="fas fa-file-excel" style="color: #28a745;"></i>
+                                                <i class="fas fa-file-excel u-color-28a745"></i>
                                             {% elif file.file.name|slice:"-4:" == ".ppt" or file.file.name|slice:"-5:" == ".pptx" %}
-                                                <i class="fas fa-file-powerpoint" style="color: #fd7e14;"></i>
+                                                <i class="fas fa-file-powerpoint u-color-fd7e14"></i>
                                             {% elif file.file.name|slice:"-4:" == ".zip" or file.file.name|slice:"-4:" == ".rar" %}
-                                                <i class="fas fa-file-archive" style="color: #6f42c1;"></i>
+                                                <i class="fas fa-file-archive u-color-6f42c1"></i>
                                             {% elif file.file.name|slice:"-4:" == ".jpg" or file.file.name|slice:"-4:" == ".png" or file.file.name|slice:"-4:" == ".gif" %}
-                                                <i class="fas fa-file-image" style="color: #20c997;"></i>
+                                                <i class="fas fa-file-image u-color-20c997"></i>
                                             {% else %}
-                                                <i class="fas fa-file" style="color: #6c757d;"></i>
+                                                <i class="fas fa-file u-color-6c757d"></i>
                                             {% endif %}
                                         </span>
                                         <div class="file-details">
@@ -143,7 +143,7 @@
                     {% endif %}
                     {% if object.video_url %}
                         <figure class="mt-4">
-                            <iframe class="has-ratio" style="width:800px;height:640px" src="https://www.youtube.com/embed/{{ object.video_url }}">
+                            <iframe class="has-ratio u-uml-canvas" src="https://www.youtube.com/embed/{{ object.video_url }}">
                             </iframe>
                         </figure>
                     {% endif %}

--- a/vitrina/cms/templates/vitrina/cms/sparql.html
+++ b/vitrina/cms/templates/vitrina/cms/sparql.html
@@ -28,7 +28,7 @@
     <form class="control" action="#" method="post">
         <div class="field control is-expanded">
                 <label for="textarea_query_box" class="has-text-weight-bold">{% translate "SPARQL paieškos laukas" %}</label>
-                <textarea style="font-family: monospace;" class="textarea is-info is-fullwidth" name="query"
+                <textarea class="textarea is-info is-fullwidth u-monospace" name="query"
                           rows="10" id="textarea_query_box">{% if query %}{{ query }}{% else %}{{ 'PREFIX dcat: <http://www.w3.org/ns/dcat#>\nPREFIX dc: <http://purl.org/dc/terms/>\nPREFIX foaf: <http://xmlns.com/foaf/0.1/>\nPREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\nPREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n\nSELECT ?key ?value\nWHERE {?subject ?key ?value}\nLIMIT 100' }}{% endif %}</textarea>
         </div>
         {% if error %}

--- a/vitrina/datasets/templates/vitrina/datasets/add_resource.html
+++ b/vitrina/datasets/templates/vitrina/datasets/add_resource.html
@@ -6,7 +6,6 @@
         {% endif %}
         class="button is-primary is-normal is-size-6-mobile is-flex{% if selected_version.external_version %} is-disabled{% endif %}"
         {% if selected_version.external_version %}
-            style="pointer-events: none; opacity: 0.5;"
             aria-disabled="true"
         {% endif %}
         id="add_resource"

--- a/vitrina/datasets/templates/vitrina/datasets/categories.html
+++ b/vitrina/datasets/templates/vitrina/datasets/categories.html
@@ -33,7 +33,7 @@
                             href="/datasets/stats/category/{{ cat.filter_value }}?{{ request.GET.urlencode }}"
                         {% endif %}
                         id="{{ area.filter_value }}_id">
-                        <strong style="color: black;">{{ cat.display_value }}</strong>
+                        <strong class="u-color-black">{{ cat.display_value }}</strong>
                     </a>
                     <div class="stays-right">
                         <a href="/datasets/{{ cat.url }}">

--- a/vitrina/datasets/templates/vitrina/datasets/datatable.html
+++ b/vitrina/datasets/templates/vitrina/datasets/datatable.html
@@ -60,7 +60,7 @@
 
             {% if r.file %}
                 <td>
-                    <div style="display:inline-flex; gap: 2px">
+                    <div class="u-inline-flex-gap">
                         {% if r.is_previewable %}
                             <a class="button is-link is-small preview-button"
                                id="{{ r.pk }}">{% translate "Peržiūrėti" %}</a>
@@ -85,7 +85,6 @@
                         {% if not selected_version.external_version %}
                             href="{% url 'resource-change' pk=r.id version_id=r.metadata_version.id %}"
                         {% else %}
-                            style="pointer-events: none; opacity: 0.5;"
                             aria-disabled="true"
                         {% endif %}
                         id="change_resource"
@@ -110,7 +109,6 @@
                         <button type="submit"
                             class="button is-link is-small is-pulled-right {% if selected_version.external_version %}is-disabled{% endif %}"
                             {% if selected_version.external_version %}
-                                style="pointer-events: none; opacity: 0.5;"
                                 aria-disabled="true"
                             {% else %}
                                 data-action="confirm" data-confirm-message="{% translate 'Ar jūs tikrai norite ištrinti šią pateiktį?' %}"
@@ -184,8 +182,7 @@
     <div class="modal-card">
         <header class="modal-card-head">
             <h1 class="modal-card-title">{% translate "Peržiūrėti" %}</h1>
-            <button class="button is-link is-small preview-fullscreen-toggle" type="button"
-                    style="margin-right:1rem;"
+            <button class="button is-link is-small preview-fullscreen-toggle u-mr-1rem" type="button"
                     data-label-expand="{% translate 'Visas ekranas' %}"
                     data-label-compress="{% translate 'Sumažinti' %}"
                     aria-label="{% translate 'Visas ekranas' %}">

--- a/vitrina/datasets/templates/vitrina/datasets/jurisdictions.html
+++ b/vitrina/datasets/templates/vitrina/datasets/jurisdictions.html
@@ -33,7 +33,7 @@
                                 href="/datasets/stats/jurisdiction/{{ o.id }}"
                             {% endif %}
                                 id="{{ o.id }}">
-                            <strong style="color: black;">{{ o.title }}</strong>
+                            <strong class="u-color-black">{{ o.title }}</strong>
                         </a>
                         <div class="stays-right">
                             <a href="">{{ o.count }}</a>
@@ -50,7 +50,7 @@
                                 href="/datasets/stats/jurisdiction/{{ org.filter_value }}?{{ request.GET.urlencode }}"
                             {% endif %}
                             id="{{ area.filter_value }}_id">
-                            <strong style="color: black;">{{ org.display_value }}</strong>
+                            <strong class="u-color-black">{{ org.display_value }}</strong>
                         </a>
                         <div class="stays-right">
                             <a href="/datasets/{{ org.url }}">

--- a/vitrina/datasets/templates/vitrina/datasets/list.html
+++ b/vitrina/datasets/templates/vitrina/datasets/list.html
@@ -238,8 +238,7 @@
                                         <span class="tag is-white has-text-dark">
                                             {% translate "Brandos lygis" %}:
                                             {% with level=i.object.get_level|add:"0" %}
-                                                <span class="u-ml-half"
-                                                      class="{% if level and level > 0 %}has-text-warning{% endif %}">
+                                                <span class="u-ml-half{% if level and level > 0 %} has-text-warning{% endif %}">
                                                     {% for i in "12345" %}
                                                         {% if level > 0 and forloop.counter <= level %}
                                                             <i class="fas fa-star"></i>

--- a/vitrina/datasets/templates/vitrina/datasets/list.html
+++ b/vitrina/datasets/templates/vitrina/datasets/list.html
@@ -238,7 +238,7 @@
                                         <span class="tag is-white has-text-dark">
                                             {% translate "Brandos lygis" %}:
                                             {% with level=i.object.get_level|add:"0" %}
-                                                <span style="margin-left: 0.5em"
+                                                <span class="u-ml-half"
                                                       class="{% if level and level > 0 %}has-text-warning{% endif %}">
                                                     {% for i in "12345" %}
                                                         {% if level > 0 and forloop.counter <= level %}

--- a/vitrina/datasets/templates/vitrina/datasets/organizations.html
+++ b/vitrina/datasets/templates/vitrina/datasets/organizations.html
@@ -28,7 +28,7 @@
             {% for org in organization_data %}
                 <div class="is-flex">
                     <a href="/datasets/?selected_facets=organization_exact%3A{{ org.filter_value }}" id="{{ org.id }}_id">
-                        <strong style="color: black;">{{ org.display_value }}</strong>
+                        <strong class="u-color-black">{{ org.display_value }}</strong>
                     </a>
                     <div class="stays-right">
                         <a href="/datasets/?selected_facets=organization_exact%3A{{ org.filter_value }}">{{ org.count }}</a>

--- a/vitrina/datasets/templates/vitrina/datasets/publications.html
+++ b/vitrina/datasets/templates/vitrina/datasets/publications.html
@@ -28,7 +28,7 @@
                         <div class="is-flex">
                             <a href="/datasets/stats/publication/quarter/{{ y }}?{{ request.GET.urlencode }}"
                                 id="{{ y }}_id">
-                                <strong style="color: black;">
+                                <strong class="u-color-black">
                                     {% if 'Q1' in y %}
                                         I
                                     {% elif 'Q2' in y %}
@@ -63,7 +63,7 @@
                 {% for y, yv in year_stats.items reversed %}
 {#                    {% for m, mv in yv.items reversed %}#}
                         <div class="is-flex">
-                            <strong style="color: black;">
+                            <strong class="u-color-black">
                                 {% if '01' in y|slice:"5:" %}
                                     <a id="{{ y }}_id" href="/datasets/?date_from={{ y|slice:":4" }}-01-01&date_to={{ y|slice:":4" }}-01-31">
                                         {% translate "Sausis" %}
@@ -156,7 +156,7 @@
                     <div class="is-flex">
                         <a href="/datasets/stats/publication/year/{{ y }}?{{ request.GET.urlencode }}"
                             id="{{ y }}_id">
-                            <strong style="color: black;">{{ y }}</strong>
+                            <strong class="u-color-black">{{ y }}</strong>
                         </a>
                         <div class="stays-right"><a href="/datasets/?date_from={{ y }}-01-01&date_to={{ y }}-12-31">{{ yv }}</a></div>
                     </div>

--- a/vitrina/datasets/templates/vitrina/datasets/published_dates.html
+++ b/vitrina/datasets/templates/vitrina/datasets/published_dates.html
@@ -32,7 +32,7 @@
 
             <div class="mb-5">
                <div>
-                   <div class="tab-content mt-5" style="display: none;" id="bar_id">
+                   <div class="tab-content mt-5 u-hidden" id="bar_id">
                        <div class="is-flex">
                             <span>{% translate "Įkėlimo data" %}</span>
                             {% include "vitrina/datasets/stats_parameter_translation.html" %}
@@ -43,7 +43,7 @@
                                     <div class="is-flex">
                                         <a href="/datasets/stats/publication/quarter/{{ y }}?{{ request.GET.urlencode }}"
                                             id="{{ y }}_id">
-                                            <strong style="color: black;">
+                                            <strong class="u-color-black">
                                                 {% if 'Q1' in y %}
                                                     I
                                                 {% elif 'Q2' in y %}
@@ -78,7 +78,7 @@
                             {% for y, yv in year_stats.items reversed %}
             {#                    {% for m, mv in yv.items reversed %}#}
                                     <div class="is-flex">
-                                        <strong style="color: black;">
+                                        <strong class="u-color-black">
                                             {% if '01' in y|slice:"5:" %}
                                                 <a id="{{ y }}_id" href="/datasets/?date_from={{ y|slice:":4" }}-01-01&date_to={{ y|slice:":4" }}-01-31">
                                                     {% translate "Sausis" %}
@@ -171,7 +171,7 @@
                                 <div class="is-flex">
                                     <a href="/datasets/stats/publication/year/{{ y }}?{{ request.GET.urlencode }}"
                                         id="{{ y }}_id">
-                                        <strong style="color: black;">{{ y }}</strong>
+                                        <strong class="u-color-black">{{ y }}</strong>
                                     </a>
                                     <div class="stays-right"><a href="/datasets/?date_from={{ y }}-01-01&date_to={{ y }}-12-31">{{ yv }}</a></div>
                                 </div>
@@ -182,7 +182,7 @@
                             {% endfor %}
                         {% endif %}
                    </div>
-                   <div class="tab-content" style="display: none;" id="time_id">
+                   <div class="tab-content u-hidden" id="time_id">
                         {% if data %}
                             {% include "vitrina/statistics/stats_graph.html" %}
                         {% endif %}

--- a/vitrina/datasets/templates/vitrina/datasets/resource_form_buttons.html
+++ b/vitrina/datasets/templates/vitrina/datasets/resource_form_buttons.html
@@ -4,8 +4,7 @@
   {% if use_custom_radio %}
     {% if organization_id %}
       <a href="{% url 'organization-datasets' pk=organization_id %}"
-         class="has-text-info mr-4"
-         style="align-self: center;">
+         class="has-text-info mr-4 u-self-center">
         {% translate "Atšaukti" %}
       </a>
   {% endif %}
@@ -15,8 +14,7 @@
   {% else %}
     {% if organization_id %}
       <a href="{% url 'resource-subclass-add' pk=organization_id %}"
-         class="has-text-info mr-4"
-         style="align-self: center;">
+         class="has-text-info mr-4 u-self-center">
         {% translate "Grįžti" %}
       </a>
     {% endif %}

--- a/vitrina/datasets/templates/vitrina/datasets/resource_information.html
+++ b/vitrina/datasets/templates/vitrina/datasets/resource_information.html
@@ -27,11 +27,11 @@
         </p>
       </div>
       {% if organization_id %}
-        <div class="is-flex is-align-items-center" style="width: 20%;">
-          <div class="is-flex-grow-1 mr-2" style="display: flex; align-items: center;">
+        <div class="is-flex is-align-items-center u-w-20">
+          <div class="is-flex-grow-1 mr-2 u-flex-center">
             <progress class="progress is-info is-small" value="{{ current_percentage }}" max="100"></progress>
           </div>
-          <p class="mb-0" style="line-height: 1;">
+          <p class="mb-0 u-lh-1">
             {{ current_step }}/2
           </p>
         </div>

--- a/vitrina/datasets/templates/vitrina/datasets/resource_subclass_form.html
+++ b/vitrina/datasets/templates/vitrina/datasets/resource_subclass_form.html
@@ -27,7 +27,7 @@
       <div class="columns is-multiline">
         {% for radio in form.subclass %}
           <div class="column is-one-third">
-            <label class="box" style="cursor: pointer;">
+            <label class="box u-clickable">
               {{ radio.tag }}
               {{ radio.choice_label|safe }}
             </label>

--- a/vitrina/dcat/templates/vitrina/dcat/_wizard_dataset_delete_fragment.html
+++ b/vitrina/dcat/templates/vitrina/dcat/_wizard_dataset_delete_fragment.html
@@ -36,12 +36,11 @@
             {% translate "Atšaukti" %}
         </a>
 
-        <form id="delete-form"
+        <form class="u-inline-block" id="delete-form"
               method="post"
               hx-post="{{ delete_url }}"
               hx-target="#wizard-main-pane"
-              hx-swap="innerHTML"
-              style="display: inline-block;">
+              hx-swap="innerHTML">
             {% csrf_token %}
             <button type="submit" class="button is-danger">{% translate "Ištrinti" %}</button>
         </form>

--- a/vitrina/middleware.py
+++ b/vitrina/middleware.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from typing import Any
 
+from django.conf import settings
 from django.contrib.auth import logout
 from django.utils.deprecation import MiddlewareMixin
 from django.utils.timezone import now
@@ -23,6 +24,44 @@ class LogContextMiddleware:
             finally:
                 reset_log_context(token)
         return self.get_response(request)
+
+
+class CSPScopeMiddleware:
+    """Relax the Content-Security-Policy to the permissive (inline-allowing) policy for the
+    Django admin, the coordinator admin and any request that renders the django-CMS toolbar
+    (logged-in editors). Those surfaces emit third-party inline scripts/styles (admin widgets,
+    CKEditor, the CMS toolbar) that cannot carry our nonce, so the strict nonce policy would
+    break — or, in the current report-only phase, spam violation reports on them.
+
+    Works with django-csp's per-response overrides, setting both the enforced (`_csp_replace`)
+    and report-only (`_csp_replace_ro`) variants so it keeps working after the strict policy is
+    promoted from report-only to enforced.
+
+    MUST be listed AFTER ``csp.middleware.CSPMiddleware`` in MIDDLEWARE so that its response
+    phase runs first and the override is in place before CSPMiddleware writes the header.
+    """
+
+    ADMIN_PREFIXES = ("/admin/", "/coordinator-admin/")
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        if self._needs_permissive(request):
+            override = {
+                "script-src": settings.CSP_PERMISSIVE_SCRIPT_SRC,
+                "style-src": settings.CSP_PERMISSIVE_STYLE_SRC,
+            }
+            response._csp_replace = override
+            response._csp_replace_ro = override
+        return response
+
+    def _needs_permissive(self, request: HttpRequest) -> bool:
+        if request.path_info.startswith(self.ADMIN_PREFIXES):
+            return True
+        toolbar = getattr(request, "toolbar", None)
+        return bool(toolbar is not None and getattr(toolbar, "show_toolbar", False))
 
 
 class NoAutoLocaleMiddleware(MiddlewareMixin):

--- a/vitrina/orgs/forms.py
+++ b/vitrina/orgs/forms.py
@@ -536,7 +536,7 @@ def get_document_field_title():
     if template:
         return mark_safe(
             f"<span>{_('Prašymas')} *</span>&nbsp;&nbsp;&nbsp;"
-            f"<span style='font-size: 0.9rem; font-weight: 500'>"
+            f"<span class='u-fs-09rem u-fw-500'>"
             f"<a href={template.document.url} download><i class='fa fa-file'></i> {template.text}</a>"
             f"</span>"
         )

--- a/vitrina/orgs/templates/vitrina/orgs/apikeys.html
+++ b/vitrina/orgs/templates/vitrina/orgs/apikeys.html
@@ -72,13 +72,13 @@
                                     {% if i.client_name %}{{ i.client_name }}{% else %}{{ i.client_id }}{% endif %}
                                 </a>
                             </td>
-                                <td style="width:10%">
+                                <td class="u-w-10">
                                     <a href="{% url 'organization-apikeys-update' organization.id i.pk %}"
                                        class="button is-primary is-small">
                                         {% translate "Redaguoti" %}
                                     </a>
                                 </td>
-                                <td style="width:10%">
+                                <td class="u-w-10">
                                     <a href="{% url 'organization-apikeys-delete' organization.id i.pk %}"
                                        class="button is-danger is-small">
                                         {% translate "Pašalinti" %}
@@ -118,20 +118,20 @@
                                     {% if i.client_name %}{{ i.client_name }}{% else %}{{ i.client_id }}{% endif %}
                                 </a>
                             </td>
-                                <td style="width:10%">
+                                <td class="u-w-10">
                                     <a href="{% url 'organization-apikeys-update' organization.id i.pk %}"
                                        class="button is-primary is-small">
                                         {% translate "Redaguoti" %}
                                     </a>
                                 </td>
-                                <td style="width:10%">
+                                <td class="u-w-10">
                                     <a href="{% url 'organization-apikeys-delete' organization.id i.pk %}"
                                        class="button is-danger is-small">
                                         {% translate "Pašalinti" %}
                                     </a>
                                 </td>
                                 {% if can_manage_keys %}
-                                    <td style="width:10%">
+                                    <td class="u-w-10">
                                     <a href="{% url 'organization-apikeys-toggle' organization.id i.pk %}"
                                        class="button is-warning is-small">
                                         {% if i.enabled %}

--- a/vitrina/orgs/templates/vitrina/orgs/apikeys_detail.html
+++ b/vitrina/orgs/templates/vitrina/orgs/apikeys_detail.html
@@ -59,9 +59,9 @@
                         <th>{% translate "Skaityti" %}</th>
                         <th>{% translate "Rašyti" %}</th>
                         <th>{% translate "Valyti" %}</th>
-                        <th style="width:10%"></th>
-                        <th style="width:10%"></th>
-                        <th style="width:10%"></th>
+                        <th class="u-w-10"></th>
+                        <th class="u-w-10"></th>
+                        <th class="u-w-10"></th>
                     </tr>
                     {% for k, v in scopes.items %}
                         <tr>

--- a/vitrina/orgs/templates/vitrina/orgs/coretable.html
+++ b/vitrina/orgs/templates/vitrina/orgs/coretable.html
@@ -32,7 +32,7 @@
                 </th>
                 <td class="is-vcentered">
                         {% for item in organization.whitelisted_names %}
-                            <div class="is-flex is-justify-content-center mb-1" style="width: 100%;">
+                            <div class="is-flex is-justify-content-center mb-1 u-w-full">
                                 <span class="tag is-inline-flex is-align-items-center">
                                     {{ item }}
                                 </span>

--- a/vitrina/orgs/templates/vitrina/orgs/jurisdictions.html
+++ b/vitrina/orgs/templates/vitrina/orgs/jurisdictions.html
@@ -30,7 +30,7 @@
                         {% if selected_jurisdiction %}
                             {% for jurisdiction in jurisdictions %}
                                 {% if jurisdiction.title == selected_jurisdiction %}
-                                <div class="columns is-gapless  m-0 mt-1" style="cursor: pointer;"
+                                <div class="columns is-gapless  m-0 mt-1 u-clickable"
                                      role="button" tabindex="0"
                                      data-action="remove-filter" data-filter="{{ jurisdiction.id }}"
                                 >
@@ -98,7 +98,7 @@
 
             <div class="mb-5">
                <div>
-                   <div class="tab-content mt-5" style="display: none;" id="bar_id">
+                   <div class="tab-content mt-5 u-hidden" id="bar_id">
                         <div class="is-flex">
                             <span>{{ title }}</span>
                             <div class="stays-right">
@@ -113,7 +113,7 @@
                                 {% else %}
                                     <a href="{{ list_url }}{{ item.url }}" id="{{ item.filter_value }}">
                                 {% endif %}
-                                    <strong style="color: black;">{{ item.title }}</strong>
+                                    <strong class="u-color-black">{{ item.title }}</strong>
                                 </a>
                                 <div class="stays-right">
                                     <a href="">{{ item.count|intcomma:False }}</a>
@@ -122,7 +122,7 @@
                             <progress class="progress is-info" value="{{ item.count }}" max="{{ max_count }}"></progress>
                         {% endfor %}
                    </div>
-                   <div class="tab-content" style="display: none;" id="time_id">
+                   <div class="tab-content u-hidden" id="time_id">
                         {% if time_chart_data %}
                             {% include "vitrina/statistics/stats_graph.html" %}
                         {% endif %}

--- a/vitrina/orgs/templates/vitrina/orgs/organization_create_search.html
+++ b/vitrina/orgs/templates/vitrina/orgs/organization_create_search.html
@@ -4,16 +4,15 @@
 {% block current_title %}{% translate "Nauja organizacija" %}{% endblock %}
 
 {% block content %}
-<input 
+<input class="u-w-full" 
     id="company_name_input"
     type="text" 
     name="city" 
     list="company_name_input_choices"
     placeholder="Paieška ribojama, įveskite bent 3 simbolius"
-    style="width: 100%;"
 >
 {% include "vitrina/orgs/organization_create_search_items.html" %}
-<button id="organization_create_continue_button" style="margin-top: 10px;"> {% translate "Tęsti" %}</button>
+<button class="u-mt-10" id="organization_create_continue_button"> {% translate "Tęsti" %}</button>
 {% endblock %}
 
 {% block scripts %}

--- a/vitrina/orgs/templates/vitrina/orgs/wizard.html
+++ b/vitrina/orgs/templates/vitrina/orgs/wizard.html
@@ -39,7 +39,7 @@
                             <img src="{{ organization.image.url }}"
                                  alt="{{ organization.title }}"
                                  data-avatar-fallback>
-                            <span class="wizard-org-avatar-letter" style="display:none;">{{ organization.title|first|upper }}</span>
+                            <span class="wizard-org-avatar-letter u-hidden">{{ organization.title|first|upper }}</span>
                         {% else %}
                             <span class="wizard-org-avatar-letter">{{ organization.title|first|upper }}</span>
                         {% endif %}

--- a/vitrina/projects/templates/vitrina/projects/apikeys_detail.html
+++ b/vitrina/projects/templates/vitrina/projects/apikeys_detail.html
@@ -27,7 +27,7 @@
                     <tr>
                         <th>{% translate "Panaudojimo atvejis" %}</th>
                         <th>{% translate "Leidimas" %}</th>
-                        <th style="width:10%"></th>
+                        <th class="u-w-10"></th>
                     </tr>
                     {% for k, v in scopes.items %}
                         <tr>

--- a/vitrina/projects/templates/vitrina/projects/client.html
+++ b/vitrina/projects/templates/vitrina/projects/client.html
@@ -39,7 +39,7 @@
                             {{ client.name }}
                         </a>
                     </td>
-                    <td style="width:10%">
+                    <td class="u-w-10">
                         <a href="{% url 'project-clients-update' project.pk client.uuid %}"
                            class="button is-primary is-small">
                             {% translate "Redaguoti" %}

--- a/vitrina/projects/templates/vitrina/projects/client_detail.html
+++ b/vitrina/projects/templates/vitrina/projects/client_detail.html
@@ -65,10 +65,9 @@
                 {% for scope in scopes %}
                     <tr>
                         <th scope="row">{{ scope.scope }}</th>
-                        <td style="width:10%">
-                            <form method="post"
-                                action="{% url 'project-clients-scopes-detail-toggle' project.pk client.uuid scope.uuid %}"
-                                style="display:inline;">
+                        <td class="u-w-10">
+                            <form class="u-inline" method="post"
+                                action="{% url 'project-clients-scopes-detail-toggle' project.pk client.uuid scope.uuid %}">
                                 {% csrf_token %}
                                 <button type="submit" class="button is-warning is-small">
                                     {% if scope.is_active %}

--- a/vitrina/projects/templates/vitrina/projects/permissions.html
+++ b/vitrina/projects/templates/vitrina/projects/permissions.html
@@ -76,12 +76,12 @@
                     </tr>
                     {% for k, v in scopes.items %}
                         <tr>
-                            <td style="width:10%">
+                            <td class="u-w-10">
                                 <a href="{{ k.get_absolute_url }}">
                                     {{ k }}
                                 </a>
                             </td>
-                            <td style="width:10%">
+                            <td class="u-w-10">
                                 <span class="icon">
                                     {% if v.0 %}
                                         {% if v.0.enabled == None %}

--- a/vitrina/requests/templates/vitrina/requests/dataset_status.html
+++ b/vitrina/requests/templates/vitrina/requests/dataset_status.html
@@ -49,7 +49,7 @@
             <div class="is-flex">
                 <div class="stays-right">
                     <form action="/requests/stats/{{ filter }}{% if current_object %}/{{ current_object }}{% endif %}" method="GET">
-                        <div><span style="float:right">{% translate "Rūšiuoti" %}</span></div>
+                        <div><span class="u-float-right">{% translate "Rūšiuoti" %}</span></div>
                         <div class="select">
                             <select name="sort" id="sorting-parameter" data-action-change="submit-form">
                                 <option value="sort-year-desc" {% if sort == 'sort-year-desc' %}selected{% endif %}>{% translate "Naujausi" %}</option>
@@ -68,7 +68,7 @@
                         <div class="is-flex">
                             <a href="/requests/stats/publication/quarter/{{ y }}?{{ request.GET.urlencode }}"
                                 id="{{ y }}_id">
-                                <strong style="color: black;">
+                                <strong class="u-color-black">
                                     {% if 'Q1' in y %}
                                         I
                                     {% elif 'Q2' in y %}
@@ -103,7 +103,7 @@
                 {% for y, yv in year_stats.items reversed %}
 {#                    {% for m, mv in yv.items reversed %}#}
                         <div class="is-flex">
-                            <strong style="color: black;">
+                            <strong class="u-color-black">
                                 {% if '01' in y|slice:"5:" %}
                                     <a id="{{ y }}_id" href="/datasets/?date_from={{ y|slice:":4" }}-01-01&date_to={{ y|slice:":4" }}-01-31">
                                         {% translate "Sausis" %}
@@ -196,7 +196,7 @@
                     <div class="is-flex">
                         <a href="/requests/stats/publication/year/{{ y }}?{{ request.GET.urlencode }}"
                             id="{{ y }}_id">
-                            <strong style="color: black;">{{ y }}</strong>
+                            <strong class="u-color-black">{{ y }}</strong>
                         </a>
                         <div class="stays-right"><a href="/datasets/?date_from={{ y }}-01-01&date_to={{ y }}-12-31">{{ yv }}</a></div>
                     </div>

--- a/vitrina/requests/templates/vitrina/requests/jurisdiction.html
+++ b/vitrina/requests/templates/vitrina/requests/jurisdiction.html
@@ -49,7 +49,7 @@
             <div class="is-flex">
                 <div class="stays-right">
                     <form action="/requests/stats/{{ filter }}{% if current_object %}/{{ current_object }}{% endif %}" method="GET">
-                        <div><span style="float:right">{% translate "Rūšiuoti" %}</span></div>
+                        <div><span class="u-float-right">{% translate "Rūšiuoti" %}</span></div>
                         <div class="select">
                             <select name="sort" id="sorting-parameter" data-action-change="submit-form">
                                 <option value="sort-year-desc" {% if sort == 'sort-year-desc' %}selected{% endif %}>{% translate "Naujausi" %}</option>
@@ -68,7 +68,7 @@
                         <div class="is-flex">
                             <a href="/requests/stats/publication/quarter/{{ y }}?{{ request.GET.urlencode }}"
                                 id="{{ y }}_id">
-                                <strong style="color: black;">
+                                <strong class="u-color-black">
                                     {% if 'Q1' in y %}
                                         I
                                     {% elif 'Q2' in y %}
@@ -103,7 +103,7 @@
                 {% for y, yv in year_stats.items reversed %}
 {#                    {% for m, mv in yv.items reversed %}#}
                         <div class="is-flex">
-                            <strong style="color: black;">
+                            <strong class="u-color-black">
                                 {% if '01' in y|slice:"5:" %}
                                     <a id="{{ y }}_id" href="/datasets/?date_from={{ y|slice:":4" }}-01-01&date_to={{ y|slice:":4" }}-01-31">
                                         {% translate "Sausis" %}
@@ -196,7 +196,7 @@
                     <div class="is-flex">
                         <a href="/requests/stats/publication/year/{{ y }}?{{ request.GET.urlencode }}"
                             id="{{ y }}_id">
-                            <strong style="color: black;">{{ y }}</strong>
+                            <strong class="u-color-black">{{ y }}</strong>
                         </a>
                         <div class="stays-right"><a href="/datasets/?date_from={{ y }}-01-01&date_to={{ y }}-12-31">{{ yv }}</a></div>
                     </div>

--- a/vitrina/requests/templates/vitrina/requests/list.html
+++ b/vitrina/requests/templates/vitrina/requests/list.html
@@ -96,36 +96,31 @@
                                 {% if i.status == 'REJECTED' %}
                                     <span class="icon image is-64x64 is-inline-block">
                                         <i
-                                            style="font-size: 68px;"
-                                            class="far fa-times-circle has-text-danger">
+                                            class="far fa-times-circle has-text-danger u-fs-68">
                                         </i>
                                     </span>
                                 {% elif i.status == 'APPROVED' %}
                                     <span class="icon image is-64x64 is-inline-block">
                                         <i
-                                            style="font-size: 68px;"
-                                            class="far fa-eye has-text-info">
+                                            class="far fa-eye has-text-info u-fs-68">
                                         </i>
                                     </span>
                                 {% elif i.status == 'STATUS_CHANGED' %}
                                     <span class="icon image is-64x64 is-inline-block">
                                         <i
-                                            style="font-size: 68px;"
-                                            class="far fa-calendar-check has-text-warning">
+                                            class="far fa-calendar-check has-text-warning u-fs-68">
                                         </i>
                                     </span>
                                 {% elif i.status == 'OPENED' %}
                                     <span class="icon image is-64x64 is-inline-block">
                                         <i
-                                            style="font-size: 68px;"
-                                            class="far fa-check-square has-text-success">
+                                            class="far fa-check-square has-text-success u-fs-68">
                                         </i>
                                     </span>
                                 {% else %}
                                     <span class="icon image is-64x64 is-inline-block">
                                         <i
-                                            style="font-size: 68px;"
-                                            class="far fa-file has-text-dark">
+                                            class="far fa-file has-text-dark u-fs-68">
                                         </i>
                                     </span>
                                 {% endif %}

--- a/vitrina/requests/templates/vitrina/requests/organization.html
+++ b/vitrina/requests/templates/vitrina/requests/organization.html
@@ -49,7 +49,7 @@
             <div class="is-flex">
                 <div class="stays-right">
                     <form action="/requests/stats/{{ filter }}{% if current_object %}/{{ current_object }}{% endif %}" method="GET">
-                        <div><span style="float:right">{% translate "Rūšiuoti" %}</span></div>
+                        <div><span class="u-float-right">{% translate "Rūšiuoti" %}</span></div>
                         <div class="select">
                             <select name="sort" id="sorting-parameter" data-action-change="submit-form">
                                 <option value="sort-year-desc" {% if sort == 'sort-year-desc' %}selected{% endif %}>{% translate "Naujausi" %}</option>
@@ -68,7 +68,7 @@
                         <div class="is-flex">
                             <a href="/requests/stats/publication/quarter/{{ y }}?{{ request.GET.urlencode }}"
                                 id="{{ y }}_id">
-                                <strong style="color: black;">
+                                <strong class="u-color-black">
                                     {% if 'Q1' in y %}
                                         I
                                     {% elif 'Q2' in y %}
@@ -103,7 +103,7 @@
                 {% for y, yv in year_stats.items reversed %}
 {#                    {% for m, mv in yv.items reversed %}#}
                         <div class="is-flex">
-                            <strong style="color: black;">
+                            <strong class="u-color-black">
                                 {% if '01' in y|slice:"5:" %}
                                     <a id="{{ y }}_id" href="/datasets/?date_from={{ y|slice:":4" }}-01-01&date_to={{ y|slice:":4" }}-01-31">
                                         {% translate "Sausis" %}
@@ -196,7 +196,7 @@
                     <div class="is-flex">
                         <a href="/requests/stats/publication/year/{{ y }}?{{ request.GET.urlencode }}"
                             id="{{ y }}_id">
-                            <strong style="color: black;">{{ y }}</strong>
+                            <strong class="u-color-black">{{ y }}</strong>
                         </a>
                         <div class="stays-right"><a href="/datasets/?date_from={{ y }}-01-01&date_to={{ y }}-12-31">{{ yv }}</a></div>
                     </div>

--- a/vitrina/requests/templates/vitrina/requests/publications.html
+++ b/vitrina/requests/templates/vitrina/requests/publications.html
@@ -49,7 +49,7 @@
             <div class="is-flex">
                 <div class="stays-right">
                     <form action="/requests/stats/{{ filter }}{% if current_object %}/{{ current_object }}{% endif %}" method="GET">
-                        <div><span style="float:right">{% translate "Rūšiuoti" %}</span></div>
+                        <div><span class="u-float-right">{% translate "Rūšiuoti" %}</span></div>
                         <div class="select">
                             <select name="sort" id="sorting-parameter" data-action-change="submit-form">
                                 <option value="sort-year-desc" {% if sort == 'sort-year-desc' %}selected{% endif %}>{% translate "Naujausi" %}</option>
@@ -68,7 +68,7 @@
                         <div class="is-flex">
                             <a href="/requests/stats/publication/quarter/{{ y }}?{{ request.GET.urlencode }}"
                                 id="{{ y }}_id">
-                                <strong style="color: black;">
+                                <strong class="u-color-black">
                                     {% if 'Q1' in y %}
                                         I
                                     {% elif 'Q2' in y %}
@@ -103,7 +103,7 @@
                 {% for y, yv in year_stats.items reversed %}
 {#                    {% for m, mv in yv.items reversed %}#}
                         <div class="is-flex">
-                            <strong style="color: black;">
+                            <strong class="u-color-black">
                                 {% if '01' in y|slice:"5:" %}
                                     <a id="{{ y }}_id" href="/datasets/?date_from={{ y|slice:":4" }}-01-01&date_to={{ y|slice:":4" }}-01-31">
                                         {% translate "Sausis" %}
@@ -196,7 +196,7 @@
                     <div class="is-flex">
                         <a href="/requests/stats/publication/year/{{ y }}?{{ request.GET.urlencode }}"
                             id="{{ y }}_id">
-                            <strong style="color: black;">{{ y }}</strong>
+                            <strong class="u-color-black">{{ y }}</strong>
                         </a>
                         <div class="stays-right"><a href="/datasets/?date_from={{ y }}-01-01&date_to={{ y }}-12-31">{{ yv }}</a></div>
                     </div>

--- a/vitrina/requests/templates/vitrina/requests/status.html
+++ b/vitrina/requests/templates/vitrina/requests/status.html
@@ -49,7 +49,7 @@
             <div class="is-flex">
                 <div class="stays-right">
                     <form action="/requests/stats/{{ filter }}{% if current_object %}/{{ current_object }}{% endif %}" method="GET">
-                        <div><span style="float:right">{% translate "Rūšiuoti" %}</span></div>
+                        <div><span class="u-float-right">{% translate "Rūšiuoti" %}</span></div>
                         <div class="select">
                             <select name="sort" id="sorting-parameter" data-action-change="submit-form">
                                 <option value="sort-year-desc" {% if sort == 'sort-year-desc' %}selected{% endif %}>{% translate "Naujausi" %}</option>
@@ -68,7 +68,7 @@
                         <div class="is-flex">
                             <a href="/requests/stats/publication/quarter/{{ y }}?{{ request.GET.urlencode }}"
                                 id="{{ y }}_id">
-                                <strong style="color: black;">
+                                <strong class="u-color-black">
                                     {% if 'Q1' in y %}
                                         I
                                     {% elif 'Q2' in y %}
@@ -103,7 +103,7 @@
                 {% for y, yv in year_stats.items reversed %}
 {#                    {% for m, mv in yv.items reversed %}#}
                         <div class="is-flex">
-                            <strong style="color: black;">
+                            <strong class="u-color-black">
                                 {% if '01' in y|slice:"5:" %}
                                     <a id="{{ y }}_id" href="/datasets/?date_from={{ y|slice:":4" }}-01-01&date_to={{ y|slice:":4" }}-01-31">
                                         {% translate "Sausis" %}
@@ -196,7 +196,7 @@
                     <div class="is-flex">
                         <a href="/requests/stats/publication/year/{{ y }}?{{ request.GET.urlencode }}"
                             id="{{ y }}_id">
-                            <strong style="color: black;">{{ y }}</strong>
+                            <strong class="u-color-black">{{ y }}</strong>
                         </a>
                         <div class="stays-right"><a href="/datasets/?date_from={{ y }}-01-01&date_to={{ y }}-12-31">{{ yv }}</a></div>
                     </div>

--- a/vitrina/resources/templates/vitrina/resources/detail.html
+++ b/vitrina/resources/templates/vitrina/resources/detail.html
@@ -24,7 +24,6 @@
                         <a href="{% url 'resource-change' pk=resource.pk version_id=resource.metadata_version.pk %}"
                            class="button is-primary is-normal m-t-md is-size-6-mobile{% if is_disabled %} is-disabled{% endif %}"
                            {% if is_disabled %}
-                               style="pointer-events: none; opacity: 0.5;"
                                aria-disabled="true"
                            {% endif %}>
                             {% translate "Redaguoti" %}
@@ -260,7 +259,6 @@
                             <a href="{% url 'resource-model-create' resource.dataset.pk resource.metadata_version.pk resource.pk %}"
                                class="button is-primary is-normal m-t-md is-size-6-mobile{% if is_disabled %} is-disabled{% endif %}"
                                {% if is_disabled %}
-                                   style="pointer-events: none; opacity: 0.5;"
                                    aria-disabled="true"
                                {% endif %}>
                                 {% translate "Naujas modelis" %}

--- a/vitrina/settings.py
+++ b/vitrina/settings.py
@@ -714,6 +714,10 @@ def _csp_strict_sources(sources, *, keep_unsafe_eval):
 _csp_strict = deepcopy(_csp_enforced)
 _csp_strict["script-src"] = _csp_strict_sources(_csp_enforced["script-src"], keep_unsafe_eval=True)
 _csp_strict["style-src"] = _csp_strict_sources(_csp_enforced["style-src"], keep_unsafe_eval=True)
+# Browsers POST violation reports here so they are collected in the application log
+# instead of only appearing in each visitor's devtools console. `report-uri` is
+# deprecated in favour of `report-to`, but it is what browsers still implement widely.
+_csp_strict["report-uri"] = ["/csp-report/"]
 
 CONTENT_SECURITY_POLICY_REPORT_ONLY = {"DIRECTIVES": _csp_strict}
 # -----------------------------------------------------------------------------------------------

--- a/vitrina/settings.py
+++ b/vitrina/settings.py
@@ -186,6 +186,9 @@ SERIALIZATION_MODULES = {
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "csp.middleware.CSPMiddleware",
+    # Relaxes CSP to permissive for admin / CMS-toolbar surfaces. Must stay right after
+    # CSPMiddleware so its response phase runs before the CSP header is written.
+    "vitrina.middleware.CSPScopeMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
@@ -670,6 +673,50 @@ CONTENT_SECURITY_POLICY = {
         "form-action": ["'self'"],
     },
 }
+
+# --- Strict (nonce-based) CSP, currently shipped REPORT-ONLY ------------------------------------
+# The block above is the ENFORCED policy and still allows 'unsafe-inline'. Below we derive the
+# target strict policy from it (single source of truth for the host allow-lists) and ship it as
+# Content-Security-Policy-Report-Only: browsers report violations without blocking anything, so we
+# can validate the allow-list in a real environment (the register/reCAPTCHA page, maps, charts,
+# UML/mermaid, CMS, admin, ...) before enforcing.
+#
+# TODO(after report-only validation): promote to enforcement by making the strict directives the
+# value of CONTENT_SECURITY_POLICY and dropping CONTENT_SECURITY_POLICY_REPORT_ONLY. The admin/CMS
+# CSPScopeMiddleware already targets both variants, so no middleware change is needed for the switch.
+from copy import deepcopy  # noqa: E402
+
+from csp.constants import NONCE  # noqa: E402
+
+_csp_enforced = CONTENT_SECURITY_POLICY["DIRECTIVES"]
+
+# Permissive script/style sources (still allow inline) — reused by CSPScopeMiddleware to relax
+# CSP on admin / CMS-toolbar responses.
+CSP_PERMISSIVE_SCRIPT_SRC = list(_csp_enforced["script-src"])
+CSP_PERMISSIVE_STYLE_SRC = list(_csp_enforced["style-src"])
+
+
+def _csp_strict_sources(sources, *, keep_unsafe_eval):
+    # Prepend the nonce sentinel and drop 'unsafe-inline'. Once a nonce is present browsers ignore
+    # 'unsafe-inline' anyway, but we remove it to make the intent explicit. 'unsafe-eval' is kept
+    # for Alpine.js (the org wizard compiles expressions with new Function()); removing it needs
+    # the Alpine CSP build and a mermaid/UML check — deferred.
+    strict = [NONCE]
+    for source in sources:
+        if source == "'unsafe-inline'":
+            continue
+        if source == "'unsafe-eval'" and not keep_unsafe_eval:
+            continue
+        strict.append(source)
+    return strict
+
+
+_csp_strict = deepcopy(_csp_enforced)
+_csp_strict["script-src"] = _csp_strict_sources(_csp_enforced["script-src"], keep_unsafe_eval=True)
+_csp_strict["style-src"] = _csp_strict_sources(_csp_enforced["style-src"], keep_unsafe_eval=True)
+
+CONTENT_SECURITY_POLICY_REPORT_ONLY = {"DIRECTIVES": _csp_strict}
+# -----------------------------------------------------------------------------------------------
 
 if env("RECAPTCHA_SILENCE_KEY_ERROR", default=False):
     SILENCED_SYSTEM_CHECKS = ["django_recaptcha.recaptcha_test_key_error"]

--- a/vitrina/static/css/csp-utilities.css
+++ b/vitrina/static/css/csp-utilities.css
@@ -1,0 +1,90 @@
+/*
+ * CSP utility classes.
+ *
+ * These replace inline style="" attributes across the templates so the site can
+ * run under a strict Content-Security-Policy that drops style-src 'unsafe-inline'
+ * (see the CSP hardening work / pentest WEB-5). Each rule is a 1:1 port of a former
+ * inline style; class names encode the properties they set. No !important unless the
+ * original inline style used it.
+ *
+ * NOTE: .u-hidden intentionally omits !important so JavaScript (el.style.display / jQuery
+ * .show()) can still reveal elements that start hidden — matching the previous behaviour.
+ */
+
+/* Disabled look — applied wherever the .is-disabled marker class is used
+   (previously each such element also carried an inline pointer-events/opacity style). */
+.is-disabled { pointer-events: none; opacity: 0.5; }
+
+/* Display */
+.u-hidden { display: none; }
+.u-inline { display: inline; }
+.u-inline-block { display: inline-block; }
+.u-flex { display: flex; }
+.u-flex-center { display: flex; align-items: center; }
+.u-flex-between-center-full { display: flex; justify-content: space-between; align-items: center; width: 100%; }
+.u-inline-flex-gap { display: inline-flex; gap: 2px; }
+.u-self-center { align-self: center; }
+.u-flex-auto-mb { flex: auto; margin-bottom: 0.5em; }
+
+/* Position */
+.u-pos-relative { position: relative; }
+.u-abs-top-right { position: absolute; top: 0.75rem; right: 0.75rem; z-index: 10; }
+.u-abs-top-right-2 { position: absolute; top: 10px; right: 12px; }
+.u-bg-cover { position: absolute; width: 100%; height: 100%; object-fit: cover; z-index: -1; }
+
+/* Sizing */
+.u-w-full { width: 100%; }
+.u-w-10 { width: 10%; }
+.u-w-20 { width: 20%; }
+.u-w-30 { width: 30%; }
+.u-uml-canvas { width: 800px; height: 640px; }
+.u-h-300 { height: 300px; }
+.u-h-400 { height: 400px; }
+.u-maxw-200 { max-width: 200px; }
+.u-maxw-600-center { max-width: 600px; margin: 0 auto; }
+.u-maxh-96 { max-height: 96px; }
+
+/* Spacing */
+.u-m-5 { margin: 5px; }
+.u-mt-10 { margin-top: 10px; }
+.u-mt-20 { margin-top: 20px; }
+.u-ml-half { margin-left: 0.5em; }
+.u-mr-1rem { margin-right: 1rem; }
+.u-px-1rem { padding-left: 1rem; padding-right: 1rem; }
+.u-pb-30 { padding-bottom: 30px; }
+
+/* Typography */
+.u-color-black { color: black; }
+.u-color-green { color: green; }
+.u-color-gray { color: gray; }
+.u-color-007bff { color: #007bff; }
+.u-color-007db2 { color: #007db2; }
+.u-color-20c997 { color: #20c997; }
+.u-color-28a745 { color: #28a745; }
+.u-color-6c757d { color: #6c757d; }
+.u-color-6f42c1 { color: #6f42c1; }
+.u-color-dc3545 { color: #dc3545; }
+.u-color-fd7e14 { color: #fd7e14; }
+.u-fs-68 { font-size: 68px; }
+.u-fw-bold { font-weight: bold; }
+.u-monospace { font-family: monospace; }
+.u-underline { text-decoration: underline; }
+.u-lh-1 { line-height: 1; }
+.u-float-right { float: right; }
+
+/* Borders / backgrounds / misc */
+.u-no-shadow { box-shadow: none; }
+.u-clickable { cursor: pointer; }
+.u-overflow-x { overflow-x: auto; margin-bottom: 0; }
+.u-radius-12 { border-radius: 12px; }
+.u-border-f1 { border-radius: 4px; border: 1px solid #F1F1F1; }
+.u-border-pink { border: 2px solid #ff9999; border-radius: 12px; }
+.u-border-gray { border: 1px solid #d0d0d0; border-radius: 4px; }
+.u-code-box { background-color: #f2f2f2; padding: 6px; border-radius: 3px; border: 1px solid #ddd; }
+
+/* Metadata status tag colours */
+.u-status-develop { background-color: #eaedfa; color: #304cd3; }
+.u-status-discont { background-color: #fff5e5; color: #ffa525; }
+
+/* Organization card placeholder avatar box */
+.u-avatar-box { width: 48px; height: 48px; display: flex; align-items: center; justify-content: center; background-color: rgba(0, 0, 0, 0.04); border-radius: 6px; }

--- a/vitrina/static/css/csp-utilities.css
+++ b/vitrina/static/css/csp-utilities.css
@@ -11,9 +11,10 @@
  * .show()) can still reveal elements that start hidden — matching the previous behaviour.
  */
 
-/* Disabled look — applied wherever the .is-disabled marker class is used
-   (previously each such element also carried an inline pointer-events/opacity style). */
-.is-disabled { pointer-events: none; opacity: 0.5; }
+/* Disabled look for buttons/links — replaces the inline pointer-events/opacity style
+   the disabled .button elements used to carry. Scoped to .button so it does not affect
+   other components that use .is-disabled with their own styling (e.g. wizard-picker-card). */
+.button.is-disabled { pointer-events: none; opacity: 0.5; }
 
 /* Display */
 .u-hidden { display: none; }
@@ -37,7 +38,7 @@
 .u-w-10 { width: 10%; }
 .u-w-20 { width: 20%; }
 .u-w-30 { width: 30%; }
-.u-uml-canvas { width: 800px; height: 640px; }
+.u-w-800-h-640 { width: 800px; height: 640px; }
 .u-h-300 { height: 300px; }
 .u-h-400 { height: 400px; }
 .u-maxw-200 { max-width: 200px; }
@@ -66,7 +67,9 @@
 .u-color-dc3545 { color: #dc3545; }
 .u-color-fd7e14 { color: #fd7e14; }
 .u-fs-68 { font-size: 68px; }
+.u-fs-09rem { font-size: 0.9rem; }
 .u-fw-bold { font-weight: bold; }
+.u-fw-500 { font-weight: 500; }
 .u-monospace { font-family: monospace; }
 .u-underline { text-decoration: underline; }
 .u-lh-1 { line-height: 1; }

--- a/vitrina/statistics/templates/vitrina/statistics/stats.html
+++ b/vitrina/statistics/templates/vitrina/statistics/stats.html
@@ -31,7 +31,7 @@
             {% endif %}
            <div class="mb-5">
                <div>
-                   <div class="tab-content mt-5" style="display: none;" id="bar_id">
+                   <div class="tab-content mt-5 u-hidden" id="bar_id">
                         <div class="is-flex">
                             <span>{{ title }}</span>
                             <div class="stays-right">
@@ -46,7 +46,7 @@
                                 {% else %}
                                     <a href="{{ list_url }}{{ item.url }}" id="{{ item.filter_value }}">
                                 {% endif %}
-                                    <strong style="color: black;">{{ item.display_value }}</strong>
+                                    <strong class="u-color-black">{{ item.display_value }}</strong>
                                 </a>
                                 <div class="stays-right">
                                     <a href="">{{ item.count|intcomma:False }}</a>
@@ -55,7 +55,7 @@
                             <progress class="progress is-info" value="{{ item.count }}" max="{{ max_count }}"></progress>
                         {% endfor %}
                    </div>
-                   <div class="tab-content" style="display: none;" id="time_id">
+                   <div class="tab-content u-hidden" id="time_id">
                         {% if time_chart_data %}
                             {% include "vitrina/statistics/stats_graph.html" %}
                         {% endif %}

--- a/vitrina/structure/templates/vitrina/structure/api.html
+++ b/vitrina/structure/templates/vitrina/structure/api.html
@@ -38,7 +38,7 @@
 
            <div>
                {% for key, tab in tabs.items %}
-               <div class="tab-content" style="display: none;" id="{{ key }}_id">
+               <div class="tab-content u-hidden" id="{{ key }}_id">
                    {{ tab.query|safe }}
                </div>
                {% endfor %}

--- a/vitrina/structure/templates/vitrina/structure/dataset_structure.html
+++ b/vitrina/structure/templates/vitrina/structure/dataset_structure.html
@@ -3,7 +3,7 @@
 {% load comment_tags util_tags %}
 
 {% block current_title %}
-    <div style="display: flex; justify-content: space-between; align-items: center; width: 100%;">
+    <div class="u-flex-between-center-full">
         <span>{% translate "Duomenų ištekliaus struktūra" %}</span>
         {% if versions %}
             {% include "version_picker.html" with url_name="dataset-structure" dataset=dataset versions=versions selected_version=selected_version %}
@@ -47,7 +47,6 @@
         {% if selected_version %}
             <a class="button mb-5 ml-2 is-primary {% if is_disabled %}is-disabled{% endif %}"
                 {% if is_disabled %}
-                    style="pointer-events: none; opacity: 0.5;"
                     aria-disabled="true"
                 {% else %}
                     href="{% url 'dataset-structure-import' view.kwargs.pk selected_version.pk %}"
@@ -56,7 +55,6 @@
             </a>
             <a class="button mb-5 ml-2 is-primary {% if is_disabled %}is-disabled{% endif %}"
                 {% if is_disabled %}
-                    style="pointer-events: none; opacity: 0.5;"
                     aria-disabled="true"
                 {% else %}
                     href="{% url 'model-create' dataset.pk selected_version.pk %}"
@@ -66,7 +64,6 @@
             {% if publish_button %}
                 <a class="button mb-5 ml-2 is-primary {% if is_disabled %}is-disabled{% endif %}"
                     {% if is_disabled %}
-                        style="pointer-events: none; opacity: 0.5;"
                         aria-disabled="true"
                     {% else %}
                         href="{% url 'version-create' dataset.pk selected_version.pk %}"
@@ -82,8 +79,7 @@
                 {% translate "Naujas modelis" %}
             </a>
             {% if publish_button %}
-                <a class="button is-primary mb-5 ml-2 is-disabled"
-                    style="pointer-events: none; opacity: 0.5;">
+                <a class="button is-primary mb-5 ml-2 is-disabled">
                     {% translate "Publikuoti versiją" %}
                 </a>
             {% endif %}
@@ -185,8 +181,8 @@
                 <div class="column is-2">
                     {% if metadata.status.codename %}
                         {% if metadata.status.codename == "develop" %}
-                            <span class="tag has-tooltip"
-                                    data-tooltip="{% translate 'Būsena' %}" style="background-color: #eaedfa; color: #304cd3;">
+                            <span class="tag has-tooltip u-status-develop"
+                                    data-tooltip="{% translate 'Būsena' %}">
                                 {{ metadata.status.name }}
                             </span>
                         {% elif metadata.status.codename == "completed" %}
@@ -195,8 +191,8 @@
                                 {{ metadata.status.name }}
                             </span>
                         {% elif metadata.status.codename == "discont" %}
-                            <span class="tag has-tooltip"
-                                    data-tooltip="{% translate 'Būsena' %}" style="background-color: #fff5e5; color: #ffa525;">
+                            <span class="tag has-tooltip u-status-discont"
+                                    data-tooltip="{% translate 'Būsena' %}">
                                 {{ metadata.status.name }}
                             </span>
                         {% elif metadata.status.codename == "deprecated" %}
@@ -262,7 +258,6 @@
                                 title="{% translate 'Ištrinti' %}"
                                 aria-label="{% translate 'Ištrinti modelį' %}"
                                 {% if is_disabled %}
-                                    style="pointer-events: none; opacity: 0.5;"
                                     aria-disabled="true"
                                 {% endif %}
                             >

--- a/vitrina/structure/templates/vitrina/structure/model_data_table.html
+++ b/vitrina/structure/templates/vitrina/structure/model_data_table.html
@@ -23,7 +23,7 @@
         </a>
       </p>
         {% endif %}
-       <input type="file" id="fileInput" style="display:none" />
+       <input class="u-hidden" type="file" id="fileInput" />
       {% endif %}
       <p class="control">
         <button type="button" class="button" data-action="download-data">
@@ -91,7 +91,7 @@
                 </div>
             </div>
             {% for tag in tags %}
-                <span class="tag" id="remove_tag_{{ forloop.counter0 }}_id" style="margin: 5px;">
+                <span class="tag u-m-5" id="remove_tag_{{ forloop.counter0 }}_id">
                     {{ tag }}
                     <button
                         id="remove_tag_{{ tag }}_id"
@@ -139,7 +139,7 @@
                                 </small>
                             </div>
 
-                            <div id="{{ col }}_filter_id" style="display: none">
+                            <div class="u-hidden" id="{{ col }}_filter_id">
                                 <div class="table-menu">
                                     <div class="field has-addons">
                                       <div class="control">
@@ -165,7 +165,7 @@
                                     </div>
                                     <div class="mb-3 is-inine-block">
                                         <div class="buttons is-right">
-                                            <span style="flex: auto; margin-bottom: 0.5em;">{% translate "Rūšiuoti" %}</span>
+                                            <span class="u-flex-auto-mb">{% translate "Rūšiuoti" %}</span>
                                             <button id="{{ col }}_order_asc_id"
                                                     class="button is-primary is-small"
                                                     data-action="order-by" data-col="{{ col }}" data-order="false"

--- a/vitrina/structure/templates/vitrina/structure/model_structure.html
+++ b/vitrina/structure/templates/vitrina/structure/model_structure.html
@@ -56,7 +56,7 @@
 
             {% if metadata.status.codename %}
                 {% if metadata.status.codename == "develop" %}
-                    <span class="ml-3 tag" style="background-color: #eaedfa; color: #304cd3;">
+                    <span class="ml-3 tag u-status-develop">
                         {{ metadata.status.name }}
                     </span>
                 {% elif metadata.status.codename == "completed" %}
@@ -64,7 +64,7 @@
                         {{ metadata.status.name }}
                     </span>
                 {% elif metadata.status.codename == "discont" %}
-                   <span class="ml-3 tag" style="background-color: #fff5e5; color: #ffa525;">
+                   <span class="ml-3 tag u-status-discont">
                         {{ metadata.status.name }}
                    </span>
                 {% elif metadata.status.codename == "deprecated" %}
@@ -139,7 +139,6 @@
             <a
                 class="button is-primary {% if is_disabled %}is-disabled{% endif %}"
                 {% if is_disabled %}
-                    style="pointer-events: none; opacity: 0.5;"
                     aria-disabled="true"
                 {% else %}
                     href="{% url 'model-update' dataset.pk version_id model.name %}"
@@ -249,8 +248,8 @@
                         <div class="column is-1">
                             {% if prop_metadata.status.codename %}
                                 {% if prop_metadata.status.codename == "develop" %}
-                                    <span class="tag has-tooltip"
-                                          data-tooltip="{% translate 'Būsena' %}" style="background-color: #eaedfa; color: #304cd3;">
+                                    <span class="tag has-tooltip u-status-develop"
+                                          data-tooltip="{% translate 'Būsena' %}">
                                         {{ prop_metadata.status.name }}
                                     </span>
                                 {% elif prop_metadata.status.codename == "completed" %}
@@ -259,8 +258,8 @@
                                         {{ prop_metadata.status.name }}
                                     </span>
                                 {% elif prop_metadata.status.codename == "discont" %}
-                                   <span class="tag has-tooltip"
-                                         data-tooltip="{% translate 'Būsena' %}" style="background-color: #fff5e5; color: #ffa525;">
+                                   <span class="tag has-tooltip u-status-discont"
+                                         data-tooltip="{% translate 'Būsena' %}">
                                         {{ prop_metadata.status.name }}
                                    </span>
                                 {% elif prop_metadata.status.codename == "deprecated" %}
@@ -337,7 +336,6 @@
                 </a>
             {% else %}
                 <a class="button is-primary is-disabled"
-                   style="pointer-events: none; opacity: 0.5;"
                    aria-disabled="true">
                     {% translate "Naujas duomenų laukas" %}
                 </a>
@@ -498,7 +496,7 @@
                         {% translate "Naujas leidimas" %}
                     </a>
                 {% else %}
-                    <a class="button is-primary is-disabled" style="pointer-events: none; opacity: 0.5;" aria-disabled="true">
+                    <a class="button is-primary is-disabled" aria-disabled="true">
                         {% translate "Naujas leidimas" %}
                     </a>
                 {% endif %}

--- a/vitrina/structure/templates/vitrina/structure/object_data_table.html
+++ b/vitrina/structure/templates/vitrina/structure/object_data_table.html
@@ -98,7 +98,7 @@
                                     {% get_geometry_srid prop.metadata.first.type_args as srid %}
                                     {% if srid %}
                                         {% convert_coordinates value srid as value %}
-                                        <div id="map_{{ prop.name }}" style="height: 300px;" data-geometry="{{ value }}"></div>
+                                        <div class="u-h-300" id="map_{{ prop.name }}" data-geometry="{{ value }}"></div>
                                     {% endif %}
                                 </td>
                             {% else %}

--- a/vitrina/structure/templates/vitrina/structure/property_graph.html
+++ b/vitrina/structure/templates/vitrina/structure/property_graph.html
@@ -12,7 +12,7 @@
             {% endfor %}
         </div>
     {% else %}
-        <div id="map" style="height: 400px;"></div>
+        <div class="u-h-400" id="map"></div>
     {% endif %}
 {% elif errors %}
     <div class="message is-danger">

--- a/vitrina/structure/templates/vitrina/structure/property_structure.html
+++ b/vitrina/structure/templates/vitrina/structure/property_structure.html
@@ -96,7 +96,7 @@
 
             {% if metadata.status.codename %}
                 {% if metadata.status.codename == "develop" %}
-                    <span class="ml-3 tag" style="background-color: #eaedfa; color: #304cd3;">
+                    <span class="ml-3 tag u-status-develop">
                         {{ metadata.status.name }}
                     </span>
                 {% elif metadata.status.codename == "completed" %}
@@ -104,7 +104,7 @@
                         {{ metadata.status.name }}
                     </span>
                 {% elif metadata.status.codename == "discont" %}
-                   <span class="ml-3 tag" style="background-color: #fff5e5; color: #ffa525;">
+                   <span class="ml-3 tag u-status-discont">
                         {{ metadata.status.name }}
                    </span>
                 {% elif metadata.status.codename == "deprecated" %}
@@ -181,7 +181,6 @@
                     </a>
                 {% else %}
                     <a class="button is-primary is-disabled"
-                       style="pointer-events: none; opacity: 0.5;"
                        aria-disabled="true">
                         {% translate "Redaguoti" %}
                     </a>
@@ -257,8 +256,8 @@
                             <div class="column is-2">
                                 {% if enum_meta.status.codename %}
                                     {% if enum_meta.status.codename == "develop" %}
-                                        <span class="tag has-tooltip"
-                                              data-tooltip="{% translate 'Būsena' %}" style="background-color: #eaedfa; color: #304cd3;">
+                                        <span class="tag has-tooltip u-status-develop"
+                                              data-tooltip="{% translate 'Būsena' %}">
                                             {{ enum_meta.status.name }}
                                         </span>
                                     {% elif enum_meta.status.codename == "completed" %}
@@ -267,8 +266,8 @@
                                             {{ enum_meta.status.name }}
                                         </span>
                                     {% elif enum_meta.status.codename == "discont" %}
-                                        <span class="tag has-tooltip"
-                                              data-tooltip="{% translate 'Būsena' %}" style="background-color: #fff5e5; color: #ffa525;">
+                                        <span class="tag has-tooltip u-status-discont"
+                                              data-tooltip="{% translate 'Būsena' %}">
                                             {{ enum_meta.status.name }}
                                         </span>
                                     {% elif enum_meta.status.codename == "deprecated" %}
@@ -323,12 +322,10 @@
                                         </a>
                                     {% else %}
                                         <a class="button is-primary is-small is-disabled"
-                                           style="pointer-events: none; opacity: 0.5;"
                                            aria-disabled="true">
                                             {% translate "Keisti" %}
                                         </a>
                                         <a class="button is-link is-small is-disabled"
-                                           style="pointer-events: none; opacity: 0.5;"
                                            aria-disabled="true">
                                             {% translate "Ištrinti" %}
                                         </a>
@@ -349,7 +346,6 @@
                             </a>
                         {% else %}
                             <a class="button is-primary is-disabled"
-                               style="pointer-events: none; opacity: 0.5;"
                                aria-disabled="true">
                                 {% translate "Nauja reikšmė" %}
                             </a>

--- a/vitrina/structure/templates/vitrina/structure/scope_detail.html
+++ b/vitrina/structure/templates/vitrina/structure/scope_detail.html
@@ -37,7 +37,7 @@
         <table class="table is-fullwidth">
             <tbody>
                 <tr>
-                    <th style="width:30%">{% translate "Kodinis pavadinimas" %}</th>
+                    <th class="u-w-30">{% translate "Kodinis pavadinimas" %}</th>
                     <td>{{ metadata.ref }}</td>
                 </tr>
                 {% if metadata.prepare %}
@@ -84,12 +84,10 @@
                 </form>
             {% else %}
                 <a class="button is-primary is-disabled"
-                   style="pointer-events: none; opacity: 0.5;"
                    aria-disabled="true">
                     {% translate "Keisti" %}
                 </a>
                 <a class="button is-danger is-light is-disabled"
-                   style="pointer-events: none; opacity: 0.5;"
                    aria-disabled="true">
                     {% translate "Ištrinti" %}
                 </a>

--- a/vitrina/structure/templates/vitrina/structure/scopes.html
+++ b/vitrina/structure/templates/vitrina/structure/scopes.html
@@ -56,12 +56,10 @@
                                         </form>
                                     {% else %}
                                         <a class="button is-link is-small is-disabled"
-                                           style="pointer-events: none; opacity: 0.5;"
                                            aria-disabled="true">
                                             {% translate "Keisti" %}
                                         </a>
                                         <a class="button is-link is-small is-disabled"
-                                           style="pointer-events: none; opacity: 0.5;"
                                            aria-disabled="true">
                                             {% translate "Ištrinti" %}
                                         </a>

--- a/vitrina/structure/templates/vitrina/structure/uml_canvas.html
+++ b/vitrina/structure/templates/vitrina/structure/uml_canvas.html
@@ -5,7 +5,7 @@
 <div class="message is-warning">
     <div class="message-body">
         <span>{% translate "Įvyko klaida generuojant diagramą. Susisiekite su administracija." %}</span></br></br>
-        <pre style="border: 1px solid #d0d0d0; border-radius: 4px;"><code>{{ uml_diagram.error_message }}</code></pre>
+        <pre class="u-border-gray"><code>{{ uml_diagram.error_message }}</code></pre>
     </div>
 </div>
 
@@ -90,7 +90,7 @@
 <div id="viewport"{% if expanded %} class="is-expanded"{% endif %} data-expanded="{{ expanded|yesno:'true,false' }}">
     {% if uml_diagram.status != "UP_TO_DATE" %}
         <div class="uml-loader">
-            <progress class="progress is-info is-small" max="100" style="max-width: 200px;"></progress>
+            <progress class="progress is-info is-small u-maxw-200" max="100"></progress>
             <p class="m-t-md">{% translate "Generuojama diagrama..." %}</p>
         </div>
     {% else %}

--- a/vitrina/structure/templates/vitrina/structure/uml_diagram.html
+++ b/vitrina/structure/templates/vitrina/structure/uml_diagram.html
@@ -3,7 +3,7 @@
 {% load comment_tags util_tags %}
 
 {% block current_title %}
-    <div style="display: flex; justify-content: space-between; align-items: center; width: 100%;">
+    <div class="u-flex-between-center-full">
         <span>{% translate "Duomenų ištekliaus struktūros UML diagrama" %}</span>
         {% if versions %}
             {% include "version_picker.html" with url_name="dataset-structure" dataset=dataset versions=versions selected_version=selected_version %}

--- a/vitrina/templates/base.html
+++ b/vitrina/templates/base.html
@@ -27,6 +27,7 @@
           content="{% block pageOgDescription %}Atvirų duomenų portalas - tai vieningas prieigos taškas prie visų Lietuvoje atvertų duomenų rinkinių ir suteikiantis technologines priemones atvirų duomenų teikėjams parengti ir publikuoti atvertų duomenų rinkinių metaduomenis.{% endblock %}"/>
 
     <link type="text/css" href="{% static 'css/bundle.css' %}" rel="stylesheet" media="screen">
+    <link type="text/css" href="{% static 'css/csp-utilities.css' %}" rel="stylesheet" media="screen">
     <link rel="preload" href="{% static 'img/landing/ladp.svg' %}" as="image">
     <link rel="preload" href="{% static 'img/landing/bg.webp' %}" as="image">
     <link href="{% static 'fontawesomefree/css/all.min.css' %}" rel="stylesheet" type="text/css">

--- a/vitrina/templates/component/clearable_file_input.html
+++ b/vitrina/templates/component/clearable_file_input.html
@@ -10,7 +10,7 @@
 {% endif %}
 <button type="button" id="{{ widget.name }}_button" data-action="open-file-select" data-field="{{widget.name}}">{{ widget.file_input_text }}</button>
 <span id="{{ widget.name }}_span"></span>
-<input type="file" name="{{ widget.name }}" data-action-change="file-selected" data-field="{{widget.name}}" style="display: none;" {% include "django/forms/widgets/attrs.html" %}>
+<input class="u-hidden" type="file" name="{{ widget.name }}" data-action-change="file-selected" data-field="{{widget.name}}" {% include "django/forms/widgets/attrs.html" %}>
 
 {% block form_scripts %}
     <script type="text/javascript" nonce="{{ request.csp_nonce }}">

--- a/vitrina/templates/component/disabled_text.html
+++ b/vitrina/templates/component/disabled_text.html
@@ -1,3 +1,3 @@
-<div style="background-color: #f2f2f2; padding: 6px; border-radius: 3px; border: 1px solid #ddd;">
+<div class="u-code-box">
     <p>{{ widget.value }}</p>
 </div>

--- a/vitrina/templates/component/hero.html
+++ b/vitrina/templates/component/hero.html
@@ -3,8 +3,8 @@
 
 <section class="hero is-small" id="main-content">
     <div class="hero-body">
-        <div class="container landing-page-image" style="margin-top: 20px;">
-                <img src="{% static 'img/landing/bg.webp' %}" alt="Background Image"  style="position: absolute; width: 100%; height: 100%; object-fit: cover; z-index: -1;">
+        <div class="container landing-page-image u-mt-20">
+                <img class="u-bg-cover" src="{% static 'img/landing/bg.webp' %}" alt="Background Image">
             <div class="columns">
                 <div id="adp-landing-logo" class="column is-6">
                     <img src="{% static 'img/landing/ladp.svg' %}" alt="header" fetchpriority="high"/>

--- a/vitrina/templates/component/organization_card.html
+++ b/vitrina/templates/component/organization_card.html
@@ -1,17 +1,17 @@
 {% load i18n %}
-<div class="card" style="box-shadow: none;">
-    <header class="card-header" style="box-shadow: none;">
+<div class="card u-no-shadow">
+    <header class="card-header u-no-shadow">
         <p class="card-header-title">
             {{ header }}
         </p>
     </header>
-    <div class="card-content" style="padding-left:1rem; padding-right:1rem;">
+    <div class="card-content u-px-1rem">
         <div class="media">
             {% if organization %}
             {% if organization.image %}
             <div class="media-left">
                 <figure class="image is-48x48">
-                    <img src="{{ organization.image.url }}" alt="{{ organization.name }}" style="border-radius:4px; border:1px solid  #F1F1F1;">
+                    <img class="u-border-f1" src="{{ organization.image.url }}" alt="{{ organization.name }}">
                 </figure>
             </div>
             {% endif %}
@@ -20,7 +20,7 @@
                 <p class="title is-6">{{ organization.title }}</p>
                 {% endif %}
                 <p class="subtitle is-6">
-                    <a href="{% url 'organization-detail' organization.pk %}" rel="noopener" style="text-decoration: underline;">
+                    <a class="u-underline" href="{% url 'organization-detail' organization.pk %}" rel="noopener">
                     {% firstof name organization.name %}
                     </a>
                 </p>
@@ -56,15 +56,7 @@
             {% else %}
             <div class="media-left">
                 <figure class="image is-48x48">
-                    <span style="
-                        width:48px;
-                        height:48px;
-                        display:flex;
-                        align-items:center;
-                        justify-content:center;
-                        background-color:rgba(0,0,0,0.04);
-                        border-radius:6px;
-                        ">
+                    <span class="u-avatar-box">
                         <svg viewBox="0 0 24 24" width="24" height="24"
                             xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
                             <path

--- a/vitrina/templates/component/stats_parameter_select.html
+++ b/vitrina/templates/component/stats_parameter_select.html
@@ -14,7 +14,7 @@
                             {% endfor %}
                         {% endif %}
                     {% endfor %}
-                    <div><span style="float:right">{{option_data.label}}</span></div>
+                    <div><span class="u-float-right">{{option_data.label}}</span></div>
                     <div class="dropdown is-hoverable">
                         <div class="dropdown-trigger">
                             <button class="button" type="button" aria-haspopup="true" aria-controls="{{ option_type }}-menu">
@@ -26,16 +26,15 @@
                                     {% endfor %}
                                 </span>
                                 <span class="icon is-small">
-                                    <i class="fas fa-angle-down" style="color: #007db2;" aria-hidden="true"></i>
+                                    <i class="fas fa-angle-down u-color-007db2" aria-hidden="true"></i>
                                 </span>
                             </button>
                         </div>
                         <div class="dropdown-menu" id="{{ option_type }}-menu">
                             <div class="dropdown-content">
                                 {% for option in option_data.fields %}
-                                    <a href="#" class="dropdown-item"
+                                    <a href="#" class="dropdown-item{% if option.value == option_data.selected %} u-fw-bold{% endif %}"
                                        data-action="update-url" data-type="{{ option_type }}" data-value="{{ option.value }}" data-label="{{ option.label }}"
-                                       style="{% if option.value == option_data.selected %}font-weight: bold;{% endif %}"
                                     >
                                         {{ option.label }}
                                     </a>

--- a/vitrina/templates/component/thematic_categories.html
+++ b/vitrina/templates/component/thematic_categories.html
@@ -30,15 +30,14 @@
                     </div>
                 {% endfor %}
                 <div class="column is-3-fullhd is-3-desktop is-4-tablet">
-                    <div class="container category-box" style="position: relative;">
+                    <div class="container category-box u-pos-relative">
                         <a href="https://duomenys.stat.gov.lt/sveikatos-duomenys/"
                            class="category-icon"
                            target="_blank"
                            rel="noopener"
                            title="{% translate 'Atsidaro naujame lange' %}"
                         >
-                            <i class="fa-solid fa-arrow-up-right-from-square fa-xs"
-                               style="position: absolute; top: 10px; right: 12px;"
+                            <i class="fa-solid fa-arrow-up-right-from-square fa-xs u-abs-top-right-2"
                                aria-hidden="true"></i>
                             <div class="columns is-vcentered">
                                 <div class="column is-4">

--- a/vitrina/templates/history.html
+++ b/vitrina/templates/history.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 {% block current_title %}
-<div style="display: flex; justify-content: space-between; align-items: center; width: 100%;">
+<div class="u-flex-between-center-full">
     <span>{% translate "Veiksmų istorija" %}</span>
     {% if versions %}
         {% include "version_picker.html" with url_name="dataset-structure-history" dataset=dataset versions=versions selected_version=selected_version %}

--- a/vitrina/templates/status_codes/400.html
+++ b/vitrina/templates/status_codes/400.html
@@ -16,7 +16,7 @@
             <a href="{% url 'home' %}" class="button is-primary">{% trans "Grįžti į pradžią" %}</a>
         </div>
 
-        <div class="box mt-6" style="max-width: 600px; margin: 0 auto;">
+        <div class="box mt-6 u-maxw-600-center">
             <p class="has-text-weight-semibold">{% trans "Reikalinga pagalba?" %}</p>
             <p>{% trans "Susisiekite su mumis:" %} <a href="mailto:atviriduomenys@vssa.lt">atviriduomenys@vssa.lt</a></p>
         </div>

--- a/vitrina/templates/status_codes/403.html
+++ b/vitrina/templates/status_codes/403.html
@@ -16,7 +16,7 @@
             <a href="{% url 'home' %}" class="button is-primary">{% trans "Grįžti į pradžią" %}</a>
         </div>
 
-        <div class="box mt-6" style="max-width: 600px; margin: 0 auto;">
+        <div class="box mt-6 u-maxw-600-center">
             <p class="has-text-weight-semibold">{% trans "Reikalinga pagalba?" %}</p>
             <p>{% trans "Susisiekite su mumis:" %} <a href="mailto:atviriduomenys@vssa.lt">atviriduomenys@vssa.lt</a></p>
         </div>

--- a/vitrina/templates/status_codes/404.html
+++ b/vitrina/templates/status_codes/404.html
@@ -16,7 +16,7 @@
             <a href="{% url 'home' %}" class="button is-primary">{% trans "Grįžti į pradžią" %}</a>
         </div>
 
-        <div class="box mt-6" style="max-width: 600px; margin: 0 auto;">
+        <div class="box mt-6 u-maxw-600-center">
             <p class="has-text-weight-semibold">{% trans "Reikalinga pagalba?" %}</p>
             <p>{% trans "Susisiekite su mumis:" %} <a href="mailto:atviriduomenys@vssa.lt">atviriduomenys@vssa.lt</a></p>
         </div>

--- a/vitrina/templates/status_codes/500.html
+++ b/vitrina/templates/status_codes/500.html
@@ -16,7 +16,7 @@
             <a href="{% url 'home' %}" class="button is-primary">{% trans "Grįžti į pradžią" %}</a>
         </div>
 
-        <div class="box mt-6" style="max-width: 600px; margin: 0 auto;">
+        <div class="box mt-6 u-maxw-600-center">
             <p class="has-text-weight-semibold">{% trans "Reikalinga pagalba?" %}</p>
             <p>{% trans "Susisiekite su mumis:" %} <a href="mailto:atviriduomenys@vssa.lt">atviriduomenys@vssa.lt</a></p>
         </div>

--- a/vitrina/uapi/templates/agents/agent_env_detail.html
+++ b/vitrina/uapi/templates/agents/agent_env_detail.html
@@ -127,14 +127,13 @@
             </div>
 
             <div class="column is-7">
-                <div class="has-background-light is-relative px-4 py-3" style="position: relative;">
+                <div class="has-background-light is-relative px-4 py-3 u-pos-relative">
                     <button data-action="copy" data-target="credentials-text"
-                            class="button is-light is-small"
-                            style="position: absolute; top: 0.75rem; right: 0.75rem; z-index: 10;">
+                            class="button is-light is-small u-abs-top-right">
                         <span class="icon is-small"><i class="fas fa-copy"></i></span>
                         <span>Kopijuoti</span>
                     </button>
-                    <pre style="overflow-x: auto; margin-bottom: 0;">
+                    <pre class="u-overflow-x">
                         <code id="credentials-text">
 [default]
 server = {{ auth_server_host }}
@@ -174,14 +173,13 @@ scopes =
             </div>
 
             <div class="column is-7">
-                <div class="has-background-light is-relative px-4 py-3" style="position: relative;">
+                <div class="has-background-light is-relative px-4 py-3 u-pos-relative">
                     <button data-action="copy" data-target="config-text"
-                            class="button is-light is-small"
-                            style="position: absolute; top: 0.75rem; right: 0.75rem; z-index: 10;">
+                            class="button is-light is-small u-abs-top-right">
                         <span class="icon is-small"><i class="fas fa-copy"></i></span>
                         <span>Kopijuoti</span>
                     </button>
-                    <pre style="overflow-x: auto; margin-bottom: 0;">
+                    <pre class="u-overflow-x">
                         <code id="config-text">
 backends:
     AR:

--- a/vitrina/uapi/templates/requests/request_detail.html
+++ b/vitrina/uapi/templates/requests/request_detail.html
@@ -94,7 +94,7 @@
 
 <p class="title is-5 mb-4">{% translate "Informacija" %}</p>
 {% if request_history.details %}
-    <div class="notification is-light" style="border-radius: 12px;">
+    <div class="notification is-light u-radius-12">
         <p class="is-size-7 mb-2">
             <span class="is-size-6 has-text-dark">{{ request_history.details|linebreaksbr }}</span>
         </p>
@@ -109,7 +109,7 @@
 
 <p class="title is-5 mb-4">{% translate "Klaidos" %}</p>
 {% if formatted_error %}
-    <div class="notification is-danger is-light" style="border: 2px solid #ff9999; border-radius: 12px;">
+    <div class="notification is-danger is-light u-border-pink">
         <p class="is-size-7 mb-2">
             <span class="icon is-small mr-2">
                 <i class="fas fa-times-circle"></i>

--- a/vitrina/urls.py
+++ b/vitrina/urls.py
@@ -23,7 +23,7 @@ from django.contrib.sitemaps import views
 
 
 from vitrina import settings
-from vitrina.views import home, version_view
+from vitrina.views import home, version_view, csp_report_view
 from vitrina.orgs.admin import site
 from django.views.generic import TemplateView
 from vitrina.sitemaps import DatasetSitemap, RootSitemap, MoreViewSitemap
@@ -65,6 +65,7 @@ urlpatterns = [
     path("i18n/", include("django.conf.urls.i18n")),
     path("accounts/", include("vitrina.viisp.urls")),
     path("_version/", version_view, name="version"),
+    path("csp-report/", csp_report_view, name="csp-report"),
     path("jsi18n/", JavaScriptCatalog.as_view(), name="javascript-catalog"),
     path(
         "robots.txt",

--- a/vitrina/users/templates/vitrina/users/profile.html
+++ b/vitrina/users/templates/vitrina/users/profile.html
@@ -24,7 +24,7 @@
             </span>
         </div>
         <div class="column is-two-thirds">
-            <div class="field" style="display: flex;">
+            <div class="field u-flex">
                 <h1 class="title">{{ user.first_name }} {{ user.last_name }}</h1>
             </div>
             <div class="tabs">
@@ -41,7 +41,7 @@
                     </li>
                 </ul>
            </div>
-            <div class="tab-content mt-5" style="display: none;" id="info_id">
+            <div class="tab-content mt-5 u-hidden" id="info_id">
                 <div class="columns">
                     <div class="column is-one-third has-text-right">
                         <strong>{% translate "Užsiregistravo prieš" %}</strong>
@@ -111,7 +111,7 @@
                 </div>
                 {% endif %}
             </div>
-            <div class="tab-content" style="display: none;" id="sub_id">
+            <div class="tab-content u-hidden" id="sub_id">
                 <div class="column">
                     {% if newsletter_subscription %}
                         <article class="box media is-expanded">
@@ -164,9 +164,9 @@
                                         {% for field in sub.fields %}
                                             <p>{{ field.0 }}:
                                                 {% if field.1 %}
-                                                    <i class="fas fa-check-circle" style="color: green"></i>
+                                                    <i class="fas fa-check-circle u-color-green"></i>
                                                 {% else %}
-                                                    <i class="fas fa-minus-circle" style="color: gray"></i>
+                                                    <i class="fas fa-minus-circle u-color-gray"></i>
                                                 {% endif %}
                                             </p>
                                         {% endfor %}

--- a/vitrina/views.py
+++ b/vitrina/views.py
@@ -1,6 +1,8 @@
 from typing import Type, Any
 from importlib.metadata import version, PackageNotFoundError
 import json
+import logging
+from urllib.parse import urlsplit
 
 from django.core.exceptions import ImproperlyConfigured
 from django.core.paginator import Paginator
@@ -14,6 +16,8 @@ from django.views.generic import TemplateView
 from django.db.models import Count
 from django.views.generic.base import TemplateResponseMixin, ContextMixin
 from django.views.generic.edit import ProcessFormView
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
 
 from reversion.models import Version, Revision
 
@@ -327,3 +331,42 @@ def version_view(request):
         app_version = "unknown"
 
     return JsonResponse({"version": app_version})
+
+
+csp_logger = logging.getLogger("vitrina.csp")
+
+# Each unique finding is logged once per process. A report-only rollout on a public site
+# would otherwise repeat the same violation on every page view; the cap also bounds both
+# log volume and memory while the policy runs unattended.
+_seen_csp_violations: set[tuple[str, str, str]] = set()
+MAX_LOGGED_CSP_VIOLATIONS = 500
+
+
+@csrf_exempt
+@require_POST
+def csp_report_view(request: HttpRequest) -> HttpResponse:
+    """Collect Content-Security-Policy violation reports sent by browsers (report-uri).
+
+    Browsers post these without a CSRF token, hence the exemption. The view never raises
+    and always answers 204: a malformed, oversized or unexpected body is simply ignored.
+    """
+    try:
+        payload = json.loads(request.body[:10000].decode("utf-8"))
+    except (ValueError, UnicodeDecodeError):
+        return HttpResponse(status=204)
+
+    report = payload.get("csp-report", payload) if isinstance(payload, dict) else None
+    if not isinstance(report, dict):
+        return HttpResponse(status=204)
+
+    directive = str(report.get("effective-directive") or report.get("violated-directive") or "?")
+    blocked = str(report.get("blocked-uri") or "?")
+    page = urlsplit(str(report.get("document-uri") or "")).path
+
+    key = (directive, blocked, page)
+    if key in _seen_csp_violations or len(_seen_csp_violations) >= MAX_LOGGED_CSP_VIOLATIONS:
+        return HttpResponse(status=204)
+
+    _seen_csp_violations.add(key)
+    csp_logger.warning("CSP violation: directive=%s blocked=%s page=%s", directive, blocked, page)
+    return HttpResponse(status=204)

--- a/vitrina/views.py
+++ b/vitrina/views.py
@@ -342,13 +342,19 @@ _seen_csp_violations: set[tuple[str, str, str]] = set()
 MAX_LOGGED_CSP_VIOLATIONS = 500
 
 
+def _clean_csp_field(value: Any, limit: int = 200) -> str:
+    """Make a browser-supplied report field safe to log: no CR/LF (log-forging) and bounded."""
+    return str(value).replace("\r", " ").replace("\n", " ")[:limit]
+
+
 @csrf_exempt
 @require_POST
 def csp_report_view(request: HttpRequest) -> HttpResponse:
     """Collect Content-Security-Policy violation reports sent by browsers (report-uri).
 
-    Browsers post these without a CSRF token, hence the exemption. The view never raises
-    and always answers 204: a malformed, oversized or unexpected body is simply ignored.
+    Browsers post these without a CSRF token, hence the exemption. For a POST the view
+    never raises and answers 204 — a malformed, oversized or unexpected body is simply
+    ignored. (Non-POST requests get 405 from @require_POST.)
     """
     try:
         payload = json.loads(request.body[:10000].decode("utf-8"))
@@ -359,9 +365,9 @@ def csp_report_view(request: HttpRequest) -> HttpResponse:
     if not isinstance(report, dict):
         return HttpResponse(status=204)
 
-    directive = str(report.get("effective-directive") or report.get("violated-directive") or "?")
-    blocked = str(report.get("blocked-uri") or "?")
-    page = urlsplit(str(report.get("document-uri") or "")).path
+    directive = _clean_csp_field(report.get("effective-directive") or report.get("violated-directive") or "?")
+    blocked = _clean_csp_field(report.get("blocked-uri") or "?")
+    page = _clean_csp_field(urlsplit(str(report.get("document-uri") or "")).path)
 
     key = (directive, blocked, page)
     if key in _seen_csp_violations or len(_seen_csp_violations) >= MAX_LOGGED_CSP_VIOLATIONS:


### PR DESCRIPTION
Part 4 of CSP hardening (WEB-5). Removes all 170 inline style="" attributes from the public templates so the site can run under a strict style-src that drops 'unsafe-inline' (nonces cannot cover style attributes, only <style>).

- New vitrina/static/css/csp-utilities.css: one utility class per former inline style, linked in base.html after bundle.css. Force-added because /vitrina/static is gitignored, matching the existing favicon/img assets committed there.
- The repeated disabled look (pointer-events:none; opacity:.5, 21x) becomes a single rule on the existing .is-disabled marker class; those inline styles are just deleted (every such element already carries .is-disabled in the same branch).
- .u-hidden omits !important so JS/jQuery can still reveal elements that start hidden.
- The one dynamic style (conditional bold) becomes a conditional class.

Admin templates (extend Django admin base, which does not load csp-utilities.css) are intentionally left with inline styles — they fall under the separate admin/CMS scoped-CSP work. All 59 changed templates compile clean; utility classes cross-checked (every class used is defined, no dead rules). Visual regressions are the known risk to smoke-test in the two environments.

  ### Also included (was going to be a separate PR)                                                                                                                                                                          
                                                                                                                                                                                                                             
  **Strict nonce-based policy, shipped REPORT-ONLY.** The enforced policy is unchanged                                                                                                                                       
  (still permissive); the strict one is derived from it, adds the nonce and drops                                                                                                                                            
  `'unsafe-inline'` for script-src/style-src. `'unsafe-eval'` is kept — Alpine.js (org                                                                                                                                       
  wizard) compiles expressions with `new Function()`. Nothing is blocked: browsers only report.                                                                                                                              
                                                                                                                                                                                                                             
  **`CSPScopeMiddleware`** relaxes CSP to the permissive policy for the Django admin, the                                                                                                                                    
  coordinator admin and CMS-toolbar (editor) responses — those render third-party inline                                                                                                                                     
  that can't carry our nonce. It targets both the enforced and report-only variants, so                                                                                                                                      
  promoting to enforcement later needs no middleware change.                                                                                                                                                                 
                                                                                                                                                                                                                             
  **Violation collection (`report-uri`).** Reports are POSTed to `/csp-report/` and logged                                                                                                                                   
  under the `vitrina.csp` logger, so findings accumulate in the application log instead of                                                                                                                                   
  only appearing in each visitor's devtools console. Each unique                                                                                                                                                             
  (directive, blocked-uri, page) is logged once per process and the total is capped, so an                                                                                                                                   
  unattended report-only run cannot flood the log. The endpoint is csrf-exempt (browsers send                                                                                                                                
  no token), POST-only, size-limited and never raises.                                                                                                                                                                       
                                                                                                                                                                                                                             
  **Next step (after collecting data):** promote the strict directives to                                                                                                                                                    
  `CONTENT_SECURITY_POLICY` and drop the report-only block — TODO is in settings.py.   