### PR TITLE
dvms#262: Prevent browser caching for authenticated users

### DIFF
--- a/tests/security/test_cache_headers.py
+++ b/tests/security/test_cache_headers.py
@@ -1,0 +1,48 @@
+from unittest.mock import Mock
+
+import pytest
+from django.http import HttpResponse
+from django.test import RequestFactory
+from django.contrib.auth.models import AnonymousUser
+
+from vitrina.middleware import NoCacheMiddleware
+
+
+ALL_PATHS = [
+    "/datasets/",
+    "/projects/",
+    "/requests/",
+    "/update-request-jurisdiction-filters/",
+    "/update-request-org-filters/",
+    "/partner/api/",
+    "/partner/api/1/datasets",
+    "/opening-tips/",
+    "/opening-tips/saugykla/",
+    "/robots.txt",
+    "/",
+    "/static/css/style.css",
+]
+
+
+def _apply_middleware(path, *, authenticated):
+    def view(request):
+        return HttpResponse("ok")
+
+    request = RequestFactory().get(path)
+    request.user = Mock(is_authenticated=True) if authenticated else AnonymousUser()
+    return NoCacheMiddleware(get_response=view)(request)
+
+
+@pytest.mark.parametrize("path", ALL_PATHS)
+def test_authenticated_user_gets_no_cache_headers(path):
+    response = _apply_middleware(path, authenticated=True)
+    assert "no-cache" in response["Cache-Control"]
+    assert "no-store" in response["Cache-Control"]
+    assert response["Pragma"] == "no-cache"
+
+
+@pytest.mark.parametrize("path", ALL_PATHS)
+def test_anonymous_user_does_not_get_no_cache_headers(path):
+    response = _apply_middleware(path, authenticated=False)
+    assert "Cache-Control" not in response
+    assert "Pragma" not in response

--- a/vitrina/middleware.py
+++ b/vitrina/middleware.py
@@ -95,7 +95,7 @@ class NoCacheMiddleware:
 
     def __call__(self, request):
         response = self.get_response(request)
-        if getattr(request, 'user', None) and request.user.is_authenticated:
+        if getattr(request, "user", None) and request.user.is_authenticated:
             response["Cache-Control"] = "no-cache, no-store, must-revalidate"
             response["Pragma"] = "no-cache"
         return response

--- a/vitrina/middleware.py
+++ b/vitrina/middleware.py
@@ -84,6 +84,23 @@ class LogoutMiddleware:
         return response
 
 
+class NoCacheMiddleware:
+    """Prevent browser from caching responses served to authenticated users.
+
+    Must be placed after AuthenticationMiddleware so request.user is available.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        if getattr(request, 'user', None) and request.user.is_authenticated:
+            response["Cache-Control"] = "no-cache, no-store, must-revalidate"
+            response["Pragma"] = "no-cache"
+        return response
+
+
 class AutoRevisionCommentMiddleware(MiddlewareMixin):
     """
     Automatically sets a default reversion comment for CUD operations based on the view

--- a/vitrina/settings.py
+++ b/vitrina/settings.py
@@ -194,6 +194,7 @@ MIDDLEWARE = [
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "vitrina.middleware.LogContextMiddleware",
+    "vitrina.middleware.NoCacheMiddleware",
     "allauth.account.middleware.AccountMiddleware",
     "django_otp.middleware.OTPMiddleware",
     "reversion.middleware.RevisionMiddleware",


### PR DESCRIPTION
**Prevent browser caching for authenticated users**

Adds `NoCacheMiddleware` that sets `Cache-Control: no-cache, no-store, must-revalidate` and `Pragma: no-cache` headers on all responses served to authenticated users, preventing sensitive data from being cached in the browser. The middleware is placed after `AuthenticationMiddleware` so `request.user` is available.

Includes tests (`tests/security/test_cache_headers.py`) that verify:
- All common paths receive no-cache headers for authenticated users
- Anonymous users do not receive these headers (existing caching behavior preserved)

Fixes atviriduomenys/dvms#262