### PR TITLE
[No ticket] Adds selected value description to DCAT access_rights field

### DIFF
--- a/vitrina/datasets/models.py
+++ b/vitrina/datasets/models.py
@@ -218,6 +218,12 @@ class Dataset(Resource):
         NON_PUBLIC: _("Nevieši"),
         CONFIDENTIAL: _("Konfidencialūs"),
     }
+    ACCESS_RIGHTS_DESCRIPTIONS = {
+        PUBLIC: _("Metaduomenys publikuojami viešai visiems vartotojams."),
+        RESTRICTED: _("Metaduomenys publikuojami viešai visiems vartotojams."),
+        NON_PUBLIC: _("Metaduomenys publikuojami tik visiems registruotiems viešojo sektoriaus duomenų tvarkytojams."),
+        CONFIDENTIAL: _("Metaduomenys publikuojami tik institucijos metaduomenų tvarkytojui."),
+    }
 
     API_ORIGIN = "api"
 

--- a/vitrina/dcat/forms/dataset_forms.py
+++ b/vitrina/dcat/forms/dataset_forms.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any
 
 from crispy_forms.helper import FormHelper
@@ -36,6 +37,14 @@ from vitrina.dcat.widgets import (
 from vitrina.fields import StringListField
 from vitrina.helpers import inline_fields
 from vitrina.orgs.models import Organization
+
+
+def access_rights_field_layout(form: forms.Form) -> Field:
+    current_value = form["access_rights"].value() or ""
+    descriptions = {key: str(value) for key, value in Dataset.ACCESS_RIGHTS_DESCRIPTIONS.items()}
+    form.access_rights_description_text = descriptions.get(current_value, "")
+    form.access_rights_descriptions_json = json.dumps(descriptions)
+    return Field("access_rights", template="vitrina/dcat/_access_rights_field.html")
 
 
 class ApplicableLegislationFormMixin(forms.Form):
@@ -406,7 +415,7 @@ class ServiceResourceForm(ContactFormMixin, DatasetNameMixin, BaseResourceForm):
             Field("tags"),
             Field("organization"),
             Field("category"),
-            Field("access_rights"),
+            access_rights_field_layout(self),
             Field("conforms_to"),
             Field("description"),
             Field("follows"),
@@ -571,7 +580,7 @@ class DatasetResourceForm(ApplicableLegislationFormMixin, ContactFormMixin, Data
                 Field("temporal_end"),
             ),
             Field("category"),
-            Field("access_rights"),
+            access_rights_field_layout(self),
             Field("conforms_to"),
             Field("creator"),
             Field("documentation"),

--- a/vitrina/dcat/templates/vitrina/dcat/_access_rights_field.html
+++ b/vitrina/dcat/templates/vitrina/dcat/_access_rights_field.html
@@ -1,0 +1,33 @@
+{% load crispy_forms_bulma_field %}
+
+<div
+  id="div_{{ field.auto_id }}"
+  class="field{% if wrapper_class %} {{ wrapper_class }}{% endif %}"
+>
+  {% if field.label %}
+    <label for="{{ field.id_for_label }}" class="label{% if label_class %} {{ label_class }}{% endif %}">
+      {{ field.label }}
+      {% if field.field.required %}
+        <span class="asterisk">*</span>
+      {% endif %}
+    </label>
+  {% endif %}
+
+  {% include 'bulma/layout/select.html' %}
+
+  {% if form_show_errors %}
+    {% for error in field.errors %}
+      <p id="error_{{ forloop.counter }}_{{ field.auto_id }}" class="help is-danger">
+        {{ error }}
+      </p>
+    {% endfor %}
+  {% endif %}
+
+  <p
+    id="access_rights_description"
+    class="help access-rights-description"
+    {% if not form.access_rights_description_text %}style="display: none;"{% endif %}
+  >{{ form.access_rights_description_text }}</p>
+
+  {% include 'bulma/layout/help_text.html' %}
+</div>

--- a/vitrina/dcat/templates/vitrina/dcat/_wizard_access_rights_script.html
+++ b/vitrina/dcat/templates/vitrina/dcat/_wizard_access_rights_script.html
@@ -1,0 +1,13 @@
+{% if form.access_rights %}
+    <script nonce="{{ request.csp_nonce }}">
+        (function() {
+            var descriptions = {{ form.access_rights_descriptions_json|safe }};
+            var $select = $("#id_access_rights");
+            var $description = $("#access_rights_description");
+            $select.on("change select2:select select2:unselect", function() {
+                var text = descriptions[$select.val()] || "";
+                $description.text(text).toggle(!!text);
+            });
+        })();
+    </script>
+{% endif %}

--- a/vitrina/dcat/templates/vitrina/dcat/_wizard_dataset_create_fragment.html
+++ b/vitrina/dcat/templates/vitrina/dcat/_wizard_dataset_create_fragment.html
@@ -38,4 +38,5 @@
     </div>
 </form>
 {% include "vitrina/dcat/_wizard_codename_preview_script.html" %}
+{% include "vitrina/dcat/_wizard_access_rights_script.html" %}
 <div id="wizard-footer-extra" hx-swap-oob="innerHTML"></div>

--- a/vitrina/dcat/templates/vitrina/dcat/_wizard_dataset_fragment.html
+++ b/vitrina/dcat/templates/vitrina/dcat/_wizard_dataset_fragment.html
@@ -60,6 +60,7 @@
 
 </form>
 {% include "vitrina/dcat/_wizard_codename_preview_script.html" %}
+{% include "vitrina/dcat/_wizard_access_rights_script.html" %}
 <div id="wizard-footer-extra" hx-swap-oob="innerHTML">
     {% if can_delete %}
         <a href="{% url 'dcat-dataset-delete' organization_id=organization.pk dataset_id=dataset.pk %}"

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-21 15:50+0300\n"
+"POT-Creation-Date: 2026-07-31 09:57+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,6 +17,12 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "Organizacija"
+msgstr "Organization"
+
+msgid "Duomenų skelbėjas"
+msgstr "Data publisher"
 
 msgid "Versijos duomenys"
 msgstr "Version data"
@@ -52,9 +58,6 @@ msgstr "API key"
 
 msgid "Taikymo sritis"
 msgstr "Application area"
-
-msgid "Organizacija"
-msgstr "Organization"
 
 msgid "Duomenų išteklius"
 msgstr "Resource"
@@ -111,11 +114,9 @@ msgstr "Categories"
 msgid "Atnaujinti pasirinktų sąvokų schemų sąvokas"
 msgstr "Update selected concept scheme concepts"
 
-#, python-brace-format
 msgid "Sėkmingai atnaujintos {} sąvokų schemų sąvokos. Pilnas sąrašas: <br>{}"
 msgstr "Successfully updated {} concept scheme concepts. Full list: <br>{}"
 
-#, python-brace-format
 msgid "Nepavyko atsisiųsti dalies sąvokų. Pilnas sąrašas: <br>{}"
 msgstr "Failed to download some concepts. Full list: <br>{}"
 
@@ -344,27 +345,21 @@ msgstr "Spatial coverage"
 msgid "Teritorinės aprėptys"
 msgstr "Spatial coverages"
 
-#, python-brace-format
 msgid "Nepavyko gauti uri: {}. Klaida: {}."
 msgstr "Failed to get uri: {}. Error: {}."
 
-#, python-brace-format
 msgid "{} nėra validus URI."
 msgstr "{} is not valid URI."
 
-#, python-brace-format
 msgid "Nepavyko gauti uri: {}. Uri atsakymas tuščias."
 msgstr "Failed to get uri: {}. Uri response is empty."
 
-#, python-brace-format
 msgid "Nepavyko gauti uri: {}. Gautas rezultatas nėra RDF formato."
 msgstr "Failed to get uri: {}. Response is not in RDF format."
 
-#, python-brace-format
 msgid "Sąvokų schemoje {} nerasta jokių \"{}\" elementų."
 msgstr "Concept scheme {} does not have any \"{}\" elements."
 
-#, python-brace-format
 msgid "Sąvokoje {} nerastas \"{}\" elementas."
 msgstr "Concept {} does not have \"{}\" element."
 
@@ -1189,6 +1184,17 @@ msgstr "Non Public"
 msgid "Konfidencialūs"
 msgstr "Confidential"
 
+msgid "Metaduomenys publikuojami viešai visiems vartotojams."
+msgstr "Metadata is published publicly for all users."
+
+msgid ""
+"Metaduomenys publikuojami tik visiems registruotiems viešojo sektoriaus "
+"duomenų tvarkytojams."
+msgstr "Metadata is published only for all registered public sector data publishers."
+
+msgid "Metaduomenys publikuojami tik institucijos metaduomenų tvarkytojui."
+msgstr "Metadata is published only to the institution's metadata publisher."
+
 msgid "Duomenų ištekliui suteiktas pavadinimas. Atitinka dct:title."
 msgstr "A name given to the record. Corresponds to dct:title."
 
@@ -2003,9 +2009,6 @@ msgstr "Delete"
 
 msgid "Atsisiuntimo formatas"
 msgstr "Download format"
-
-msgid "Duomenų skelbėjas"
-msgstr "Data publisher"
 
 msgid "Kontaktinė informacija"
 msgstr "Contact information"
@@ -3324,8 +3327,10 @@ msgstr "Reject"
 msgid "Veiksmai"
 msgstr "Action"
 
-msgid "Duomenų teikėjo \""
-msgstr "Data providers"
+#, python-brace-format
+msgid ""
+"Duomenų teikėjo \"<a href=\"{url}\">{obj}</a>\" prašymas pakeistas sėkmingai."
+msgstr "Data provider's \"<a href=\"{url}\">{obj}</a>\" request has been changed successfully."
 
 msgid "Šablonas pakeistas sėkmingai."
 msgstr "Password was changed successfully"
@@ -6131,6 +6136,9 @@ msgstr "Show"
 msgid "Pašalinti filtrą"
 msgstr "Delete filter"
 
+msgid "Filtruoti"
+msgstr "Filter"
+
 msgid "Rūšiavimo veiksmas"
 msgstr "Sort action"
 
@@ -6148,9 +6156,6 @@ msgstr "Sort ascending"
 
 msgid "Slėpti"
 msgstr "Hide"
-
-msgid "Filtruoti"
-msgstr "Filter"
 
 msgid "Duomenų laukai"
 msgstr "Properties"
@@ -7191,8 +7196,21 @@ msgstr "Members"
 msgid "Redaguoti naudotoją"
 msgstr "Edit user"
 
-msgid "Naudotojas \""
-msgstr "User"
+#, python-brace-format
+msgid "Naudotojas \"<a href=\"{url}\">{obj}</a>\" pakeistas sėkmingai."
+msgstr "User \"<a href=\"{url}\">{obj}</a>\" changed successfully."
+
+#, python-brace-format
+msgid "Organizacijos \"{obj}\" {role}: <a href=\"{url}\">{email}</a>"
+msgstr "Organization's \"{obj}\" {role}: <a href=\"{url}\">{email}</a>"
+
+#, python-brace-format
+msgid "Duomenų ištekliaus \"{obj}\" {role}: <a href=\"{url}\">{email}</a>"
+msgstr "Resource \"{obj}\" {role}: <a href=\"{url}\">{email}</a>"
+
+#, python-brace-format
+msgid "Naudotojas \"<a href=\"{url}\">{obj}</a>\" pašalintas sėkmingai."
+msgstr "User \"<a href=\"{url}\">{obj}</a>\" deleted successfully."
 
 msgid "Vienkartinis prisijungimo kodas"
 msgstr "Single use login code"

--- a/vitrina/locale/lt/LC_MESSAGES/django.po
+++ b/vitrina/locale/lt/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-21 12:37+0300\n"
+"POT-Creation-Date: 2026-07-31 09:57+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,6 +19,12 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n % 10 == 1 && (n % 100 > 19 || n % 100 < "
 "11) ? 0 : (n % 10 >= 2 && n % 10 <=9) && (n % 100 > 19 || n % 100 < 11) ? "
 "1 : n % 1 != 0 ? 2: 3);\n"
+
+msgid "Organizacija"
+msgstr ""
+
+msgid "Duomenų skelbėjas"
+msgstr ""
 
 msgid "Versijos duomenys"
 msgstr ""
@@ -51,9 +57,6 @@ msgid "API raktas"
 msgstr ""
 
 msgid "Taikymo sritis"
-msgstr ""
-
-msgid "Organizacija"
 msgstr ""
 
 msgid "Duomenų išteklius"
@@ -110,11 +113,9 @@ msgstr ""
 msgid "Atnaujinti pasirinktų sąvokų schemų sąvokas"
 msgstr ""
 
-#, python-brace-format
 msgid "Sėkmingai atnaujintos {} sąvokų schemų sąvokos. Pilnas sąrašas: <br>{}"
 msgstr ""
 
-#, python-brace-format
 msgid "Nepavyko atsisiųsti dalies sąvokų. Pilnas sąrašas: <br>{}"
 msgstr ""
 
@@ -330,27 +331,21 @@ msgstr ""
 msgid "Teritorinės aprėptys"
 msgstr ""
 
-#, python-brace-format
 msgid "Nepavyko gauti uri: {}. Klaida: {}."
 msgstr ""
 
-#, python-brace-format
 msgid "{} nėra validus URI."
 msgstr ""
 
-#, python-brace-format
 msgid "Nepavyko gauti uri: {}. Uri atsakymas tuščias."
 msgstr ""
 
-#, python-brace-format
 msgid "Nepavyko gauti uri: {}. Gautas rezultatas nėra RDF formato."
 msgstr ""
 
-#, python-brace-format
 msgid "Sąvokų schemoje {} nerasta jokių \"{}\" elementų."
 msgstr ""
 
-#, python-brace-format
 msgid "Sąvokoje {} nerastas \"{}\" elementas."
 msgstr ""
 
@@ -1107,6 +1102,17 @@ msgstr ""
 msgid "Konfidencialūs"
 msgstr ""
 
+msgid "Metaduomenys publikuojami viešai visiems vartotojams."
+msgstr ""
+
+msgid ""
+"Metaduomenys publikuojami tik visiems registruotiems viešojo sektoriaus "
+"duomenų tvarkytojams."
+msgstr ""
+
+msgid "Metaduomenys publikuojami tik institucijos metaduomenų tvarkytojui."
+msgstr ""
+
 msgid "Duomenų ištekliui suteiktas pavadinimas. Atitinka dct:title."
 msgstr ""
 
@@ -1825,9 +1831,6 @@ msgid "Pašalinti"
 msgstr ""
 
 msgid "Atsisiuntimo formatas"
-msgstr ""
-
-msgid "Duomenų skelbėjas"
 msgstr ""
 
 msgid "Kontaktinė informacija"
@@ -3052,7 +3055,9 @@ msgstr ""
 msgid "Veiksmai"
 msgstr ""
 
-msgid "Duomenų teikėjo \""
+#, python-brace-format
+msgid ""
+"Duomenų teikėjo \"<a href=\"{url}\">{obj}</a>\" prašymas pakeistas sėkmingai."
 msgstr ""
 
 msgid "Šablonas pakeistas sėkmingai."
@@ -3320,9 +3325,6 @@ msgid ""
 msgstr ""
 
 msgid "Redaguokite organizacijos informaciją"
-msgstr ""
-
-msgid "Gali turėti"
 msgstr ""
 
 msgid "Šioje organizacijoje dar nėra turinio."
@@ -3611,9 +3613,6 @@ msgstr ""
 
 msgid ""
 "Organizacijos informacinių sistemų metaduomenų pildymas pagal DCAT-AP-LT"
-msgstr ""
-
-msgid "Kūrimo tvarka"
 msgstr ""
 
 msgid "Suskleisti viską"
@@ -5639,6 +5638,9 @@ msgstr ""
 msgid "Pašalinti filtrą"
 msgstr ""
 
+msgid "Filtruoti"
+msgstr ""
+
 msgid "Rūšiavimo veiksmas"
 msgstr ""
 
@@ -5655,9 +5657,6 @@ msgid "Rūšiuoti didėjimo tvarka"
 msgstr ""
 
 msgid "Slėpti"
-msgstr ""
-
-msgid "Filtruoti"
 msgstr ""
 
 msgid "Duomenų laukai"
@@ -6649,7 +6648,20 @@ msgstr ""
 msgid "Redaguoti naudotoją"
 msgstr ""
 
-msgid "Naudotojas \""
+#, python-brace-format
+msgid "Naudotojas \"<a href=\"{url}\">{obj}</a>\" pakeistas sėkmingai."
+msgstr ""
+
+#, python-brace-format
+msgid "Organizacijos \"{obj}\" {role}: <a href=\"{url}\">{email}</a>"
+msgstr ""
+
+#, python-brace-format
+msgid "Duomenų ištekliaus \"{obj}\" {role}: <a href=\"{url}\">{email}</a>"
+msgstr ""
+
+#, python-brace-format
+msgid "Naudotojas \"<a href=\"{url}\">{obj}</a>\" pašalintas sėkmingai."
 msgstr ""
 
 msgid "Vienkartinis prisijungimo kodas"

--- a/webpack/src/css/wizard.scss
+++ b/webpack/src/css/wizard.scss
@@ -312,6 +312,11 @@
     letter-spacing: 0.6px;
 }
 
+.wizard-form-body .help.access-rights-description {
+    color: #375677;
+    font-weight: 600;
+}
+
 /* Remove native borders — the .field card is the visible border */
 .wizard-form-body .input,
 .wizard-form-body .textarea {


### PR DESCRIPTION
**Summary:**
Adds short description about currently selected value for `access_rights` field in DCAT wizard forms (Dataset and Service).

Possible values:
* Vieši – Metaduomenys publikuojami viešai visiems vartotojams
* Apriboti – Metaduomenys publikuojami viešai visiems vartotojams
* Nevieši – Metaduomenys publikuojami tik visiems registruotiems viešojo sektoriaus duomenų tvarkytojams
* Konfidencialūs – Metaduomenys publikuojami tik institucijos metaduomenų tvarkytojui

"Vieši" and "Apriboti" has same value, as requested.

**Screenshots:**

<img width="689" height="158" alt="Screenshot 2026-07-31 at 10 10 27" src="https://github.com/user-attachments/assets/59df79b4-a597-4113-bb92-3e4fe3a24dce" />

<img width="684" height="149" alt="Screenshot 2026-07-31 at 10 10 50" src="https://github.com/user-attachments/assets/498c2f60-f850-4f2b-8826-a494d8945953" />

**Testing URL:** https://ft-new-access-descriptions.branch-test.data.gov.lt/
