### PR TITLE
2753 Filter dcat:servesDataset links in the EDP DCAT-AP export

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,13 @@ https://github.com/atviriduomenys/katalogas/issues/2755
   lock file because ``django-cms`` needs it. With their own dependencies, this drops 16 packages.
 - Move ``freezegun`` and ``requests-mock`` to the dev group. The tests are their only user.
 
+https://github.com/atviriduomenys/katalogas/issues/2753
+
+- Filter ``dcat:servesDataset`` links in the EDP DCAT-AP export (`/edp/dcat-ap.rdf` and
+  `/edp/dcat-ap-restricted.rdf`). A data service listed the URL of every related dataset, also of
+  non-public and deleted ones, which the European Data Portal turned into empty catalogue records.
+  A service now links only to datasets that the export publishes.
+
 https://github.com/atviriduomenys/dvms/issues/515
 
 - Replace unsanitized ``mark_safe`` with ``format_html`` in admin display methods and form labels

--- a/tests/api/test_views.py
+++ b/tests/api/test_views.py
@@ -19,12 +19,15 @@ from vitrina.catalogs.factories import CatalogFactory
 from vitrina.classifiers.factories import CategoryFactory
 from vitrina.datasets.factories import (
     DatasetFactory,
+    DatasetRelationFactory,
+    DatasetServiceFactory,
     DatasetStructureFactory,
     DatasetGroupFactory,
     DCATResourceSubclassFactory,
     DatasetGroupCategoryUriFactory,
+    RelationFactory,
 )
-from vitrina.datasets.models import Dataset
+from vitrina.datasets.models import Dataset, Relation
 from vitrina.orgs.factories import RepresentativeFactory, OrganizationFactory
 from vitrina.resources.factories import DatasetDistributionFactory
 from vitrina.statistics.models import ModelDownloadStats
@@ -3366,3 +3369,59 @@ def test_edp_dcat_ap_rdf_only_inventored_and_opened_statuses(
     assert res.status_code == 200
     assert "Inventored dataset" in res.text
     assert "Other status dataset" not in res.text
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "url_name, access_rights",
+    [
+        ("edp-dcat-ap-rdf", Dataset.PUBLIC),
+        ("edp-dcat-ap-restricted-rdf", Dataset.RESTRICTED),
+    ],
+)
+def test_edp_dcat_ap_rdf_serves_dataset_excludes_hidden_datasets(app: DjangoTestApp, url_name, access_rights):
+    Dataset.objects.all().delete()
+    organization = OrganizationFactory()
+    service = DatasetServiceFactory(organization=organization, access_rights=access_rights, status=Dataset.HAS_DATA)
+    relation = RelationFactory(name=Relation.SERVICE)
+    served = DatasetFactory(
+        access_rights=access_rights,
+        is_public=True,
+        status=Dataset.HAS_DATA,
+        organization=organization,
+    )
+    hidden = DatasetFactory(
+        access_rights=access_rights,
+        is_public=False,
+        status=Dataset.HAS_DATA,
+        organization=organization,
+    )
+    planned = DatasetFactory(
+        access_rights=access_rights,
+        is_public=True,
+        status=Dataset.PLANNED,
+        organization=organization,
+    )
+    deleted = DatasetFactory(
+        access_rights=access_rights,
+        is_public=True,
+        status=Dataset.HAS_DATA,
+        organization=organization,
+        deleted=True,
+        deleted_on=timezone.now(),
+    )
+    exported_in_other_feed = DatasetFactory(
+        access_rights=Dataset.RESTRICTED if access_rights == Dataset.PUBLIC else Dataset.PUBLIC,
+        is_public=True,
+        status=Dataset.HAS_DATA,
+        organization=organization,
+    )
+    for dataset in (served, hidden, planned, deleted, exported_in_other_feed):
+        DatasetRelationFactory(relation=relation, part_of=service, dataset=dataset)
+
+    res = app.get(reverse(url_name))
+
+    assert res.status_code == 200
+    assert f'<dcat:Dataset rdf:about="http://localhost/datasets/{served.pk}/" />' in res.text
+    for dataset in (hidden, planned, deleted, exported_in_other_feed):
+        assert f"/datasets/{dataset.pk}/" not in res.text

--- a/tests/datasets/test_views.py
+++ b/tests/datasets/test_views.py
@@ -4843,6 +4843,18 @@ def test_dataset_rdf_download__datas_service(app: DjangoTestApp):
     )
 
 
+def test_dataset_rdf_download__data_service_links_non_public_served_dataset(app: DjangoTestApp):
+    organization = OrganizationFactory()
+    service = DatasetServiceFactory(organization=organization)
+    non_public = DatasetFactory(organization=organization, is_public=False)
+    DatasetRelationFactory(relation=RelationFactory(name=Relation.SERVICE), part_of=service, dataset=non_public)
+
+    res = app.get(reverse("dataset-rdf-download", args=[service.pk]))
+
+    assert res.status_code == 200
+    assert f'<dcat:Dataset rdf:about="http://localhost/datasets/{non_public.pk}/" />' in res.text
+
+
 class TestRemoveRequestView:
     def test_delete_dataset_comments_and_related_request_object(self, app: DjangoTestApp) -> None:
         user = UserFactory(is_staff=True)

--- a/vitrina/api/helpers.py
+++ b/vitrina/api/helpers.py
@@ -40,7 +40,8 @@ def _get_org_for_rdf(org: Organization | None) -> dict | None:
     }
 
 
-def get_datasets_for_rdf(qs):
+def get_datasets_for_rdf(qs, only_link_rendered_datasets: bool = False):
+    rendered_dataset_ids = set(qs.values_list("pk", flat=True)) if only_link_rendered_datasets else None
     datasets = (
         qs.select_related("organization")
         .prefetch_related("category")
@@ -50,6 +51,7 @@ def get_datasets_for_rdf(qs):
         .order_by("published")
     )
     for dataset in datasets:
+        service_relations = dataset.related_datasets.filter(relation__name=Relation.SERVICE).select_related("dataset")
         distributions = []
         if not dataset.service:
             distributions = [
@@ -96,7 +98,8 @@ def get_datasets_for_rdf(qs):
             "endpoint_description_type": dataset.endpoint_description_type,
             "related_datasets": (
                 _get_rel_dataset(relation)
-                for relation in dataset.related_datasets.filter(relation__name=Relation.SERVICE)
+                for relation in service_relations
+                if rendered_dataset_ids is None or relation.dataset_id in rendered_dataset_ids
             ),
             "access_rights": dataset.access_rights,
             "subclass": dataset.subclass,
@@ -108,10 +111,12 @@ def _encode_xml_control_chars(content: str) -> str:
     return content.replace("\t", "&#x9;")
 
 
-def render_rdf_response(request: HttpRequest, datasets: QuerySet[Dataset]) -> HttpResponse:
+def render_rdf_response(
+    request: HttpRequest, datasets: QuerySet[Dataset], only_link_rendered_datasets: bool = False
+) -> HttpResponse:
     content = render_to_string(
         DCAT_AP_RDF_TEMPLATE_NAME,
-        {"datasets": get_datasets_for_rdf(datasets)},
+        {"datasets": get_datasets_for_rdf(datasets, only_link_rendered_datasets=only_link_rendered_datasets)},
         request=request,
     )
     content = _encode_xml_control_chars(content).lstrip()

--- a/vitrina/api/views.py
+++ b/vitrina/api/views.py
@@ -779,8 +779,8 @@ class DatasetModelDownloadViewSet(CreateModelMixin, UpdateModelMixin, GenericVie
 
 
 def edp_dcat_ap_rdf(request: HttpRequest) -> HttpResponse:
-    return render_rdf_response(request, Dataset.edp_public.all())
+    return render_rdf_response(request, Dataset.edp_public.all(), only_link_rendered_datasets=True)
 
 
 def edp_dcat_ap_restricted_rdf(request: HttpRequest) -> HttpResponse:
-    return render_rdf_response(request, Dataset.edp_restricted.all())
+    return render_rdf_response(request, Dataset.edp_restricted.all(), only_link_rendered_datasets=True)


### PR DESCRIPTION
A data service listed the URL of every related dataset, also of non-public and deleted ones, which the European Data Portal turned into empty catalogue records.