### PR TITLE
#2771: Hide deprecated endpoint description format

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,12 @@ https://github.com/atviriduomenys/katalogas/issues/2762
 
 - Bump gunicorn 20.1.0 -> 23.0.0: setuptools 83 removed pkg_resources
 
+https://github.com/atviriduomenys/katalogas/issues/2771
+
+- Hide the deprecated "API specifikacijos formatas" (``endpoint_description_type``) field from
+  service forms, detail pages, and administration while preserving existing database values and
+  API output.
+
 https://github.com/atviriduomenys/katalogas/issues/2722
 
 - Make the "API specifikacija" (``dcat:endpointDescription``) field optional in the data service

--- a/README.rst
+++ b/README.rst
@@ -250,7 +250,7 @@ Run all tests:
 
 .. code:: sh
 
-    pytest -vvra --tb=short
+    pytest -vvra --tb=short tests
 
 Run a single test:
 

--- a/tests/datasets/test_forms.py
+++ b/tests/datasets/test_forms.py
@@ -200,9 +200,7 @@ class TestServiceResourceForm:
         assert "conforms_to" in form.errors
         assert "Su agentu susietos paslaugos privalo atitikti UDTS standartą." in form.errors["conforms_to"]
 
-    def test_wrong_endpoint_type_when_agent_selected(
-        self, organization: Organization, user: User, rf: RequestFactory
-    ):
+    def test_wrong_endpoint_type_when_agent_selected(self, organization: Organization, user: User, rf: RequestFactory):
         request = rf.get("/")
         request.resolver_match = resolve("/")
         request.user = user

--- a/tests/datasets/test_forms.py
+++ b/tests/datasets/test_forms.py
@@ -157,7 +157,6 @@ class TestServiceResourceForm:
         request.user = user
         agent = AgentFactory(organization=organization)
         Format.objects.get_or_create(title="JSON")
-        Format.objects.get_or_create(title="OpenAPI")
         Concept.objects.get_or_create(code="UAPI", defaults={"valid_since": "2000-01-01"})
 
         data = {
@@ -184,7 +183,6 @@ class TestServiceResourceForm:
         request.user = user
         agent = AgentFactory(organization=organization)
         Format.objects.get_or_create(title="JSON")
-        Format.objects.get_or_create(title="OpenAPI")
         concepts_schema, _ = ConceptSchema.objects.get_or_create(
             uri="https://data.gov.lt/id/non-standard/DataServiceStandard"
         )
@@ -202,7 +200,7 @@ class TestServiceResourceForm:
         assert "conforms_to" in form.errors
         assert "Su agentu susietos paslaugos privalo atitikti UDTS standartą." in form.errors["conforms_to"]
 
-    def test_wrong_endpoint_type_and_description_type_when_agent_selected(
+    def test_wrong_endpoint_type_when_agent_selected(
         self, organization: Organization, user: User, rf: RequestFactory
     ):
         request = rf.get("/")
@@ -215,19 +213,13 @@ class TestServiceResourceForm:
         data = {
             "agent": agent,
             "endpoint_type": wrong_format,
-            "endpoint_description_type": wrong_format,
             "access_rights": Dataset.PUBLIC,
         }
 
         form = ServiceResourceForm(data=data, request=request, organization=organization)
 
         assert "endpoint_type" in form.errors
-        assert "endpoint_description_type" in form.errors
         assert "Pasirinkus agentą, API formatas privalo būti 'JSON'" in form.errors["endpoint_type"]
-        assert (
-            "Pasirinkus agentą, API specifikacijos formatas privalo būti 'OpenAPI'"
-            in form.errors["endpoint_description_type"]
-        )
 
     def test_agent_must_be_selected_if_conforms_to_is_uapi(
         self, organization: Organization, user: User, rf: RequestFactory
@@ -280,7 +272,6 @@ class TestServiceResourceForm:
         request.user = user
         agent = AgentFactory(organization=organization)
         json_format, _ = Format.objects.get_or_create(title="JSON")
-        openapi_format, _ = Format.objects.get_or_create(title="OpenAPI")
         uapi_concept, _ = Concept.objects.get_or_create(code="UAPI", defaults={"valid_since": "2000-01-01"})
 
         data = {
@@ -293,7 +284,6 @@ class TestServiceResourceForm:
         assert not form.is_valid()
         form_cleaned_data = form.cleaned_data
         assert form_cleaned_data["endpoint_type"] == json_format
-        assert form_cleaned_data["endpoint_description_type"] == openapi_format
         assert form_cleaned_data["conforms_to"] == uapi_concept
 
 

--- a/tests/datasets/test_views.py
+++ b/tests/datasets/test_views.py
@@ -397,7 +397,6 @@ class TestDatasetDetailView:
             in response.text
         )
         assert "JSON" in response.text
-        assert "OpenAPI" in response.text
         assert uapi_concept.label in response.text
 
     def test_data_service_view_without_agent(self, app: DjangoTestApp):
@@ -421,6 +420,7 @@ class TestDatasetDetailView:
         assert data_service.endpoint_url in response.text
         assert data_service.endpoint_description in response.text
         assert data_service.endpoint_type.title in response.text
+        assert endpoint_description_format.title not in response.text
 
 
 @pytest.mark.haystack
@@ -1734,13 +1734,11 @@ class TestDatasetUpdateView:
     def test_dataset_update_service_agent(self, app: DjangoTestApp) -> None:
         organization = OrganizationFactory()
         json_format = Format.objects.get(title="JSON")
-        openapi_format = Format.objects.get(title="OpenAPI")
         dataservice = DatasetServiceFactory(
             organization=organization,
             endpoint_url=None,
             endpoint_description=None,
             endpoint_type=json_format,
-            endpoint_description_type=openapi_format,
         )
         agent = AgentFactory(organization=organization)
         user = UserFactory(is_staff=True)

--- a/tests/datasets/test_views.py
+++ b/tests/datasets/test_views.py
@@ -403,12 +403,14 @@ class TestDatasetDetailView:
     def test_data_service_view_without_agent(self, app: DjangoTestApp):
         org = OrganizationFactory()
         user = UserFactory(is_staff=True, organization=org)
+        endpoint_format = Format.objects.create(title="Service endpoint format")
+        endpoint_description_format = Format.objects.create(title="Service endpoint description format")
         data_service = DatasetServiceFactory(
             organization=org,
             endpoint_url="http://test.com",
-            endpoint_type=Format.objects.first(),
+            endpoint_type=endpoint_format,
             endpoint_description="http://example.com",
-            endpoint_description_type=Format.objects.first(),
+            endpoint_description_type=endpoint_description_format,
         )
 
         app.set_user(user)
@@ -419,7 +421,6 @@ class TestDatasetDetailView:
         assert data_service.endpoint_url in response.text
         assert data_service.endpoint_description in response.text
         assert data_service.endpoint_type.title in response.text
-        assert data_service.endpoint_description_type.title in response.text
 
 
 @pytest.mark.haystack
@@ -2236,7 +2237,6 @@ class TestDatasetCreateView:
         form["contact"] = contact.pk
         form["agent"] = agent.pk
         form["endpoint_type"] = Format.objects.get(title="JSON").pk
-        form["endpoint_description_type"] = Format.objects.get(title="OpenAPI").pk
         form["conforms_to"] = Concept.objects.get(code="UAPI").pk
 
         response = form.submit()

--- a/vitrina/api/helpers.py
+++ b/vitrina/api/helpers.py
@@ -93,7 +93,6 @@ def get_datasets_for_rdf(qs):
             "endpoint_url": _safe_uri(dataset.endpoint_url),
             "endpoint_type": _get_format(dataset.endpoint_type),
             "endpoint_description": _safe_uri(dataset.endpoint_description),
-            "endpoint_description_type": dataset.endpoint_description_type,
             "related_datasets": (
                 _get_rel_dataset(relation)
                 for relation in dataset.related_datasets.filter(relation__name=Relation.SERVICE)

--- a/vitrina/datasets/admin.py
+++ b/vitrina/datasets/admin.py
@@ -79,7 +79,11 @@ class DatasetAdmin(TranslatableAdmin, RevisionCommentVersionAdmin):
         if request.user.has_perm("vitrina_datasets.view_dataset") and not request.user.has_perm(
             "vitrina_datasets.change_dataset"
         ):
-            readonly_fields.extend([field.name for field in self.model._meta.fields])
+            readonly_fields.extend([
+                field.name
+                for field in self.model._meta.fields
+                if field.name != 'endpoint_description_type'
+            ])
 
         return readonly_fields
 

--- a/vitrina/datasets/admin.py
+++ b/vitrina/datasets/admin.py
@@ -79,11 +79,9 @@ class DatasetAdmin(TranslatableAdmin, RevisionCommentVersionAdmin):
         if request.user.has_perm("vitrina_datasets.view_dataset") and not request.user.has_perm(
             "vitrina_datasets.change_dataset"
         ):
-            readonly_fields.extend([
-                field.name
-                for field in self.model._meta.fields
-                if field.name != 'endpoint_description_type'
-            ])
+            readonly_fields.extend(
+                [field.name for field in self.model._meta.fields if field.name != "endpoint_description_type"]
+            )
 
         return readonly_fields
 

--- a/vitrina/datasets/admin.py
+++ b/vitrina/datasets/admin.py
@@ -79,9 +79,8 @@ class DatasetAdmin(TranslatableAdmin, RevisionCommentVersionAdmin):
         if request.user.has_perm("vitrina_datasets.view_dataset") and not request.user.has_perm(
             "vitrina_datasets.change_dataset"
         ):
-            readonly_fields.extend(
-                [field.name for field in self.model._meta.fields if field.name != "endpoint_description_type"]
-            )
+            excluded_fields = set(DatasetAdminForm.Meta.exclude)
+            readonly_fields.extend(field.name for field in self.model._meta.fields if field.name not in excluded_fields)
 
         return readonly_fields
 

--- a/vitrina/datasets/form_helpers.py
+++ b/vitrina/datasets/form_helpers.py
@@ -23,7 +23,6 @@ DATASET_STANDARD_URI = "https://data.gov.lt/id/non-standard/DatasetStandard"
 
 UAPI_CONCEPT_CODE = "UAPI"
 JSON_FORMAT = "JSON"
-OPENAPI_FORMAT = "OpenAPI"
 
 
 def validate_dataset_name(name: str | None, dataset: Dataset | None, organization: Organization) -> None:
@@ -110,11 +109,6 @@ def set_default_agent_endpoint_fields(cleaned_data: dict[str, Any]) -> dict[str,
             raise ValidationError(error_template.format(JSON_FORMAT))
         cleaned_data["endpoint_type"] = json_format
 
-    if not cleaned_data.get("endpoint_description_type"):
-        if not (openapi_format := Format.objects.filter(title=OPENAPI_FORMAT).first()):
-            raise ValidationError(error_template.format(OPENAPI_FORMAT))
-        cleaned_data["endpoint_description_type"] = openapi_format
-
     if not cleaned_data.get("conforms_to"):
         if not (uapi_concept := Concept.objects.filter(code=UAPI_CONCEPT_CODE).first()):
             raise ValidationError(error_template.format(UAPI_CONCEPT_CODE))
@@ -129,7 +123,6 @@ def validate_agent_endpoint_fields(
     endpoint_url: str | None,
     endpoint_type: str | None,
     endpoint_description: str | None,
-    endpoint_description_type: str | None,
 ) -> list[tuple[str, str]]:
     errors = []
     if agent:
@@ -142,14 +135,6 @@ def validate_agent_endpoint_fields(
         if endpoint_type and endpoint_type.title != JSON_FORMAT:
             errors.append(
                 ("endpoint_type", _("Pasirinkus agentą, API formatas privalo būti '{0}'").format(JSON_FORMAT))
-            )
-
-        if endpoint_description_type and endpoint_description_type.title != OPENAPI_FORMAT:
-            errors.append(
-                (
-                    "endpoint_description_type",
-                    _("Pasirinkus agentą, API specifikacijos formatas privalo būti '{0}'").format(OPENAPI_FORMAT),
-                )
             )
 
         if conforms_to and conforms_to.code != UAPI_CONCEPT_CODE:

--- a/vitrina/datasets/form_helpers.py
+++ b/vitrina/datasets/form_helpers.py
@@ -121,7 +121,7 @@ def validate_agent_endpoint_fields(
     agent: Agent | None,
     conforms_to: Concept | None,
     endpoint_url: str | None,
-    endpoint_type: str | None,
+    endpoint_type: Format | None,
     endpoint_description: str | None,
 ) -> list[tuple[str, str]]:
     errors = []

--- a/vitrina/datasets/forms.py
+++ b/vitrina/datasets/forms.py
@@ -329,7 +329,6 @@ class ServiceResourceForm(BaseResourceForm):
             "endpoint_url",
             "endpoint_type",
             "endpoint_description",
-            "endpoint_description_type",
             "name",
             "contact",
             "organization",
@@ -371,7 +370,6 @@ class ServiceResourceForm(BaseResourceForm):
             Field("endpoint_url"),
             Field("endpoint_type"),
             Field("endpoint_description"),
-            Field("endpoint_description_type"),
             Field("access_rights"),
             Field("contact"),
             Field("organization"),
@@ -391,7 +389,6 @@ class ServiceResourceForm(BaseResourceForm):
             endpoint_url=cleaned_data.get("endpoint_url"),
             endpoint_type=cleaned_data.get("endpoint_type"),
             endpoint_description=cleaned_data.get("endpoint_description"),
-            endpoint_description_type=cleaned_data.get("endpoint_description_type"),
         )
         for field_name, error_message in errors:
             self.add_error(field_name, error_message)
@@ -681,6 +678,7 @@ class DatasetAdminForm(forms.ModelForm):
             "numchild",
             "path",
             "publisher",
+            "endpoint_description_type",
         )
 
 

--- a/vitrina/datasets/models.py
+++ b/vitrina/datasets/models.py
@@ -664,16 +664,8 @@ class Dataset(Resource):
         limit_choices_to={"concept_schemas__uri": DATASET_TYPE_SCHEME_URI},
     )
 
-    # TODO: To be removed:
+    # Deprecated fields
     # ---------------------------8<-------------------------------------
-    endpoint_description_type = models.ForeignKey(
-        "vitrina_resources.Format",
-        on_delete=models.SET_NULL,
-        verbose_name=_("API specifikacijos formatas"),
-        null=True,
-        blank=True,
-        related_name="format_endpoint_description_types",
-    )
     meta = models.TextField(blank=True, null=True)
 
     # TODO: https://github.com/atviriduomenys/katalogas/issues/9
@@ -738,6 +730,15 @@ class Dataset(Resource):
         blank=True,
         on_delete=models.SET_NULL,
         related_name="primary_datasets",
+    )
+    # TODO: Remove as part of https://github.com/atviriduomenys/katalogas/issues/2771
+    endpoint_description_type = models.ForeignKey(
+        "vitrina_resources.Format",
+        on_delete=models.SET_NULL,
+        verbose_name=_("API specifikacijos formatas"),
+        null=True,
+        blank=True,
+        related_name="format_endpoint_description_types",
     )
     # --------------------------->8-------------------------------------
 

--- a/vitrina/datasets/models.py
+++ b/vitrina/datasets/models.py
@@ -482,14 +482,6 @@ class Dataset(Resource):
         null=True,
         blank=True,
     )
-    endpoint_description_type = models.ForeignKey(
-        "vitrina_resources.Format",
-        on_delete=models.SET_NULL,
-        verbose_name=_("API specifikacijos formatas"),
-        null=True,
-        blank=True,
-        related_name="format_endpoint_description_types",
-    )
     service = models.BooleanField(
         _("DataService rinkinys"),
         default=False,
@@ -674,6 +666,14 @@ class Dataset(Resource):
 
     # TODO: To be removed:
     # ---------------------------8<-------------------------------------
+    endpoint_description_type = models.ForeignKey(
+        "vitrina_resources.Format",
+        on_delete=models.SET_NULL,
+        verbose_name=_("API specifikacijos formatas"),
+        null=True,
+        blank=True,
+        related_name="format_endpoint_description_types",
+    )
     meta = models.TextField(blank=True, null=True)
 
     # TODO: https://github.com/atviriduomenys/katalogas/issues/9
@@ -2066,7 +2066,7 @@ class DatasetStructure(models.Model):
     )
     file = FilerFileField(blank=True, null=True, related_name="file_structure", on_delete=models.SET_NULL)
 
-    # Deprecatd feilds
+    # Deprecated fields
     standardized = models.BooleanField(blank=True, null=True)
     mime_type = models.CharField(max_length=255, blank=True, null=True)
     distribution_version = models.IntegerField(blank=True, null=True)

--- a/vitrina/datasets/templates/vitrina/datasets/coretable.html
+++ b/vitrina/datasets/templates/vitrina/datasets/coretable.html
@@ -357,16 +357,6 @@
         </tr>
         <tr>
             <th>
-                {% translate "API specifikacijos formatas" %}
-                <span class="icon info-icon has-tooltip-multiline is-middle"
-                      data-tooltip="{% translate 'API dokumentacijos formatas (pvz., JSON, YAML)' %}">
-                    <i class="fas fa-info-circle"></i>
-                </span>
-            </th>
-            <td>{{ dataset.endpoint_description_type|default:"" }}</td>
-        </tr>
-        <tr>
-            <th>
                 {% translate "Atitinka" %}
                 <span class="icon info-icon has-tooltip-multiline is-middle"
                       data-tooltip="{% translate 'Nurodo kokį standartą atitinka paslauga. (pvz., UDTS)' %}">

--- a/vitrina/datasets/views.py
+++ b/vitrina/datasets/views.py
@@ -924,7 +924,6 @@ class DatasetCreateView(
             self.object.endpoint_url = None
             self.object.endpoint_type = None
             self.object.endpoint_description = None
-            self.object.endpoint_description_type = None
             self.object.service = False
         if subclass.name == DCATResourceSubclass.SERIES:
             self.object.series = True

--- a/vitrina/dcat/forms/dataset_forms.py
+++ b/vitrina/dcat/forms/dataset_forms.py
@@ -2,7 +2,7 @@ import json
 from typing import Any
 
 from crispy_forms.helper import FormHelper
-from crispy_forms.layout import Div, Layout, Field
+from crispy_forms.layout import Layout, Field
 from django import forms
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
@@ -332,7 +332,6 @@ class ServiceResourceForm(ContactFormMixin, DatasetNameMixin, BaseResourceForm):
             "contact",
             "endpoint_description",
             "endpoint_type",  # Not in DCAT
-            "endpoint_description_type",  # Not in DCAT
             "tags",
             "organization",
             "category",
@@ -348,7 +347,6 @@ class ServiceResourceForm(ContactFormMixin, DatasetNameMixin, BaseResourceForm):
 
         widgets = {
             "endpoint_type": Select2Widget,
-            "endpoint_description_type": Select2Widget,
             "organization": OrganizationSingleWidget,
             "access_rights": Select2Widget,
             "follows": Select2MultipleWidget,
@@ -374,8 +372,6 @@ class ServiceResourceForm(ContactFormMixin, DatasetNameMixin, BaseResourceForm):
             "Kontaktinė informacija, kurią galima naudoti siunčiant pastabas apie duomenų paslaugą. "
             "Atitinka dcat:contactPoint."
         )
-
-        self.fields["endpoint_description_type"].help_text = _("Prieigos taško aprašo formatas.")
 
         self.fields["organization"].required = True
         self.fields["organization"].label = _("Duomenų teikėjas")
@@ -407,11 +403,7 @@ class ServiceResourceForm(ContactFormMixin, DatasetNameMixin, BaseResourceForm):
             Field("endpoint_url"),
             Field("contact"),
             Field("endpoint_description"),
-            Div(
-                Div(Field("endpoint_type"), css_class="column"),
-                Div(Field("endpoint_description_type"), css_class="column is-right"),
-                css_class="columns is-align-items-flex-start",
-            ),
+            Field("endpoint_type"),
             Field("tags"),
             Field("organization"),
             Field("category"),

--- a/vitrina/locale/en/LC_MESSAGES/django.po
+++ b/vitrina/locale/en/LC_MESSAGES/django.po
@@ -844,10 +844,6 @@ msgstr "If agent is selected, this field must be left emtpy."
 msgid "Pasirinkus agentą, API formatas privalo būti '{0}'"
 msgstr "If an agent is selected, the API format must be '{0}'."
 
-#, python-brace-format
-msgid "Pasirinkus agentą, API specifikacijos formatas privalo būti '{0}'"
-msgstr "If an agent is selected, the API specification format must be '{0}'."
-
 msgid "Su agentu susietos paslaugos privalo atitikti UDTS standartą."
 msgstr "Services associated with an agent must comply with the UAPI standard."
 
@@ -1885,9 +1881,6 @@ msgstr "Technical format (e.g., REST, SOAP)"
 msgid "Nuoroda į API dokumentaciją (pvz., OpenAPI, Swagger)"
 msgstr "Link to API documentation (e.g., OpenAPI, Swagger)"
 
-msgid "API dokumentacijos formatas (pvz., JSON, YAML)"
-msgstr "API documentation format (e.g., JSON, YAML)"
-
 msgid "Nurodo kokį standartą atitinka paslauga. (pvz., UDTS)"
 msgstr "Specifies which standard the service conforms to (e.g., UAPI)."
 
@@ -2477,9 +2470,6 @@ msgid ""
 msgstr ""
 "Contact information that can be used for sending comments about the service. "
 "Corresponds to dcat:contactPoint"
-
-msgid "Prieigos taško aprašo formatas."
-msgstr "Endpoint description format."
 
 msgid "Duomenų teikėjas"
 msgstr "Data provider"

--- a/vitrina/locale/lt/LC_MESSAGES/django.po
+++ b/vitrina/locale/lt/LC_MESSAGES/django.po
@@ -792,10 +792,6 @@ msgstr ""
 msgid "Pasirinkus agentą, API formatas privalo būti '{0}'"
 msgstr ""
 
-#, python-brace-format
-msgid "Pasirinkus agentą, API specifikacijos formatas privalo būti '{0}'"
-msgstr ""
-
 msgid "Su agentu susietos paslaugos privalo atitikti UDTS standartą."
 msgstr ""
 
@@ -1717,9 +1713,6 @@ msgstr ""
 msgid "Nuoroda į API dokumentaciją (pvz., OpenAPI, Swagger)"
 msgstr ""
 
-msgid "API dokumentacijos formatas (pvz., JSON, YAML)"
-msgstr ""
-
 msgid "Nurodo kokį standartą atitinka paslauga. (pvz., UDTS)"
 msgstr ""
 
@@ -2277,9 +2270,6 @@ msgstr ""
 msgid ""
 "Kontaktinė informacija, kurią galima naudoti siunčiant pastabas apie duomenų "
 "paslaugą. Atitinka dcat:contactPoint."
-msgstr ""
-
-msgid "Prieigos taško aprašo formatas."
 msgstr ""
 
 msgid "Duomenų teikėjas"

--- a/vitrina/uapi/views/views.py
+++ b/vitrina/uapi/views/views.py
@@ -96,7 +96,6 @@ class DatasetViewSet(UAPIExceptionHandlerMixin, AgentAuthViewSetMixin, ModelView
                 "frequency",
                 "publisher",
                 "endpoint_type",
-                "endpoint_description_type",
                 "current_structure",
             )
             .filter(


### PR DESCRIPTION
## Summary

- Hide the deprecated `endpoint_description_type` field from legacy and DCAT service forms.
- Remove it from service detail pages, admin editing, validation/defaulting, RDF context, and UAPI query optimization.
- Preserve the nullable database field and historical migrations so existing values remain available internally.
- Keep endpoint URL, endpoint type, endpoint description, service-level conformance, and generated OpenAPI links unchanged.
- Remove obsolete translations and update regression tests.

## Why

`endpoint_description_type` was a Katalogas-specific extension that interpreted
`dcat:endpointDescription` as a `dcat:Distribution` with additional format metadata.
This structure is not defined by DCAT-AP/DCAT-AP-LT and was not used in practice.
The field is therefore deprecated and no longer exposed, while existing database
values are preserved for compatibility.