### PR TITLE
#2791: Show the IS metadata wizard to every role it already allows

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,22 +8,14 @@ https://github.com/atviriduomenys/katalogas/issues/2791
 
 - Show the "Tvarkyti IS metaduomenis" button and open the IS metadata wizard for the resource
   coordinator, the resource manager and the superuser. The button asked for two conditions that
-  no single role met, so nobody reached the wizard, even though its forms already accepted these
-  users through ``has_perm`` and the wizard ACL. Only the shell was closed.
-- Do not offer "Redaguoti organizaciją" to the two resource roles, so the organization form is
-  reached from one place rather than two: the wizard already opens it from its root node. The
-  resource coordinator keeps the right and still edits the organization there. Nothing changes
-  for the open data roles, and no ACL rule moves.
-- A staff account that is not a superuser stays outside the wizard. The team weighed ``is_staff``
-  and settled on ``is_superuser``, which both administrators who need the wizard hold. ``has_perm``
-  still grants staff the wizard forms through a direct URL, so the shell is narrower than the
-  forms behind it; the docstring of ``can_manage_is_metadata`` records the decision.
-- Send a logged out visitor of a wizard URL to the login page again, with the ``next`` parameter
-  intact. Every wizard view overrode ``handle_no_permission`` unconditionally, and
-  ``LoginRequiredMixin`` routes an anonymous request through that same method.
-- Stop the wizard requesting the organization form for a user who may not edit the organization:
-  it answered a redirect that HTMX swapped into the pane as a whole page. A short note takes its
-  place, and the root node still returns the pane to the organization state.
+  no single role met, so nobody reached the wizard, although its forms already accepted these
+  users. Staff without ``is_superuser`` stays outside the wizard shell.
+- Do not offer "Redaguoti organizaciją" to the two resource roles: the wizard opens the same form
+  from its root node. Nobody loses access, and nothing changes for the open data roles.
+- Send a logged out visitor of a wizard URL to the login page again, with ``next`` intact.
+- Stop the wizard requesting the organization form for a user who may not edit the organization,
+  which answered a redirect that HTMX swapped into the pane as a whole page. A short note takes
+  its place, and the root node still returns the pane to the organization state.
 - Replace ``is_organization_resource_manager`` with ``can_manage_is_metadata``, add
   ``can_edit_organization_details``, and gather the four wizard views' access rules into
   ``WizardAccessMixin``.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,12 @@ https://github.com/atviriduomenys/katalogas/issues/2791
 - Gather the access rules of the four wizard views into ``WizardAccessMixin``. Each of them
   carried its own copy of ``has_permission`` and ``handle_no_permission``, which is why the same
   anonymous redirect bug sat in all four. The method resolution order does not change.
+- A staff account that is not a superuser stays outside the wizard shell for now, which leaves it
+  narrower than the forms it opens: ``determine_user_role`` maps ``is_staff`` to
+  ``Role.GLOBAL_MANAGER``, every wizard ACL rule lists that role, and ``has_perm`` grants staff
+  everything, so such a user reaches the forms through a direct URL but sees no button. The
+  three roles above are the ones the team asked for; the docstring of ``can_manage_is_metadata``
+  records the open question.
 
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,13 @@ https://github.com/atviriduomenys/katalogas/issues/2791
   everything, so such a user reaches the forms through a direct URL but sees no button. The
   three roles above are the ones the team asked for; the docstring of ``can_manage_is_metadata``
   records the open question.
+- Stop the wizard asking for the organization form on behalf of a user who may not edit the
+  organization. The pane loaded ``organization-change`` on open, and the root node of the tree
+  asked for it again on click, but ``Action.UPDATE`` on an organization belongs to the
+  coordinators alone. A resource manager therefore got a redirect, which HTMX swapped into the
+  pane as a whole organization page. The wizard now sends that request only for a user who holds
+  the right, and shows a short note in its place for everyone else. The bug predates this change,
+  but until now no resource manager had a button to reach it.
 
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,9 @@ https://github.com/atviriduomenys/katalogas/issues/2791
   An anonymous request now falls back to ``super().handle_no_permission()``, which keeps the
   ``next`` parameter, and an authenticated but unauthorized one still lands on the organization
   page. This matches ``OrganizationUpdateView``.
+- Gather the access rules of the four wizard views into ``WizardAccessMixin``. Each of them
+  carried its own copy of ``has_permission`` and ``handle_no_permission``, which is why the same
+  anonymous redirect bug sat in all four. The method resolution order does not change.
 
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,14 @@ https://github.com/atviriduomenys/katalogas/issues/2791
   everything, so such a user reaches the forms through a direct URL but sees no button. The
   three roles above are the ones the team asked for; the docstring of ``can_manage_is_metadata``
   records the open question.
+- Keep the "Redaguoti organizaciją" button away from the two resource roles. The resource
+  coordinator holds ``Action.UPDATE`` and so was offered it, but the team asked that both
+  resource roles describe the organization through the IS metadata wizard instead. A new
+  ``can_edit_organization_details`` decides that button, and it hides it only when every role
+  the user holds on that organization is a resource one. The open data roles keep exactly the
+  access they had, a superuser keeps both buttons, and no ACL changes: the wizard still asks
+  ``can_update_organization`` when its root node loads the organization form, because that is
+  the right ``OrganizationUpdateView`` checks.
 - Stop the wizard asking for the organization form on behalf of a user who may not edit the
   organization. The pane loaded ``organization-change`` on open, and the root node of the tree
   asked for it again on click, but ``Action.UPDATE`` on an organization belongs to the

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,61 +6,28 @@ v 1.25.0 (current)
 
 https://github.com/atviriduomenys/katalogas/issues/2791
 
-- Show the "Tvarkyti IS metaduomenis" button, and open the IS metadata wizard, for every role that
-  the wizard already allows: the resource coordinator, the resource manager and the superuser.
-  Until now the button asked for two conditions that no single role met. The resource manager
-  passed the wizard check but failed ``can_update_organization``, because updating a
-  ``Representative`` is a coordinator right, so the button was never rendered for them. The
-  resource coordinator and the superuser passed ``can_update_organization`` but failed the wizard
-  check, which asked for the ``resource_manager`` role alone, so they were shown the "Redaguoti
-  organizaciją" button instead. Nobody saw the wizard.
-- The ACL of the wizard forms already granted ``CREATE_WIZARD``, ``UPDATE_WIZARD`` and
-  ``DELETE_WIZARD`` to both resource roles, and ``has_perm`` already granted everything to a
-  superuser, so this change opens the wizard shell to the users its forms already accepted.
-- Replace ``is_organization_resource_manager`` with ``can_manage_is_metadata``, and rename the
-  template flag ``is_information_system_administrator`` to ``can_manage_is_metadata``.
-- The organization page now shows both buttons where both apply: a resource coordinator gets
-  "Tvarkyti IS metaduomenis" and "Redaguoti organizaciją".
-- Send a logged out visitor of a wizard URL to the login page again. Every wizard view overrode
-  ``handle_no_permission`` unconditionally, and ``LoginRequiredMixin`` routes an anonymous request
-  through that same method, so the login flow was replaced by a redirect to the organization page.
-  An anonymous request now falls back to ``super().handle_no_permission()``, which keeps the
-  ``next`` parameter, and an authenticated but unauthorized one still lands on the organization
-  page. This matches ``OrganizationUpdateView``.
-- Gather the access rules of the four wizard views into ``WizardAccessMixin``. Each of them
-  carried its own copy of ``has_permission`` and ``handle_no_permission``, which is why the same
-  anonymous redirect bug sat in all four. The method resolution order does not change.
-- A staff account that is not a superuser stays outside the wizard shell. The team weighed
-  ``is_staff``, the global manager, and settled on ``is_superuser``, which the two
-  administrators who need the wizard both hold. That leaves the shell narrower than the forms it
-  opens: ``determine_user_role`` maps ``is_staff`` to ``Role.GLOBAL_MANAGER``, every wizard ACL
-  rule lists that role, and ``has_perm`` grants staff everything, so such a user reaches the
-  forms through a direct URL but sees no button. The docstring of ``can_manage_is_metadata``
-  records the decision.
-- Keep the "Redaguoti organizaciją" button away from the two resource roles, so that the
-  organization form is offered in one place rather than two: the wizard already opens it from
-  its root node. The resource coordinator keeps the right itself and still edits the
-  organization there. A new ``can_edit_organization_details`` decides the button, and hides it
-  only when every role the user holds on that organization is a resource one, so a user who
-  also holds an open data role there keeps what that role gave them. The open data roles keep
-  exactly the access they had, a superuser keeps both buttons, and no ACL rule moves.
-- Stop the wizard asking for the organization form on behalf of a user who may not edit the
-  organization. The pane loaded ``organization-change`` on open, and the root node of the tree
-  asked for it again on click, but ``Action.UPDATE`` on an organization belongs to the
-  coordinators alone. A resource manager therefore got a redirect, which HTMX swapped into the
-  pane as a whole organization page. The wizard now sends that request only for a user who holds
-  the right, and shows a short note in its place for everyone else. That note keys off the
-  organization node, because ``x-init`` selects that node as soon as Alpine starts, and it lives
-  outside ``#wizard-main-pane``, because an HTMX swap replaces everything inside that element and
-  would carry the note away with the first child form. The pane itself hides while the
-  organization node is the selected one, and the root row still calls ``select(...)``, so a
-  resource manager can leave a child form and come back to the organization state. The bug
-  predates this change, but until now no resource manager had a button to reach it.
+- Show the "Tvarkyti IS metaduomenis" button and open the IS metadata wizard for the resource
+  coordinator, the resource manager and the superuser. The button asked for two conditions that
+  no single role met, so nobody reached the wizard, even though its forms already accepted these
+  users through ``has_perm`` and the wizard ACL. Only the shell was closed.
+- Do not offer "Redaguoti organizaciją" to the two resource roles, so the organization form is
+  reached from one place rather than two: the wizard already opens it from its root node. The
+  resource coordinator keeps the right and still edits the organization there. Nothing changes
+  for the open data roles, and no ACL rule moves.
+- A staff account that is not a superuser stays outside the wizard. The team weighed ``is_staff``
+  and settled on ``is_superuser``, which both administrators who need the wizard hold. ``has_perm``
+  still grants staff the wizard forms through a direct URL, so the shell is narrower than the
+  forms behind it; the docstring of ``can_manage_is_metadata`` records the decision.
+- Send a logged out visitor of a wizard URL to the login page again, with the ``next`` parameter
+  intact. Every wizard view overrode ``handle_no_permission`` unconditionally, and
+  ``LoginRequiredMixin`` routes an anonymous request through that same method.
+- Stop the wizard requesting the organization form for a user who may not edit the organization:
+  it answered a redirect that HTMX swapped into the pane as a whole page. A short note takes its
+  place, and the root node still returns the pane to the organization state.
+- Replace ``is_organization_resource_manager`` with ``can_manage_is_metadata``, add
+  ``can_edit_organization_details``, and gather the four wizard views' access rules into
+  ``WizardAccessMixin``.
 
-
-
-v 1.24.0 (2026-08-21)
-==================
 
 https://github.com/atviriduomenys/katalogas/issues/2785
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,12 @@ https://github.com/atviriduomenys/katalogas/issues/2791
   template flag ``is_information_system_administrator`` to ``can_manage_is_metadata``.
 - The organization page now shows both buttons where both apply: a resource coordinator gets
   "Tvarkyti IS metaduomenis" and "Redaguoti organizaciją".
+- Send a logged out visitor of a wizard URL to the login page again. Every wizard view overrode
+  ``handle_no_permission`` unconditionally, and ``LoginRequiredMixin`` routes an anonymous request
+  through that same method, so the login flow was replaced by a redirect to the organization page.
+  An anonymous request now falls back to ``super().handle_no_permission()``, which keeps the
+  ``next`` parameter, and an authenticated but unauthorized one still lands on the organization
+  page. This matches ``OrganizationUpdateView``.
 
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,9 @@ https://github.com/atviriduomenys/katalogas/issues/2791
   ``WizardAccessMixin``.
 
 
+v 1.24.0 (2026-08-21)
+==================
+
 https://github.com/atviriduomenys/katalogas/issues/2785
 
 - Bump `spinta` version `1.0.0` -> `1.1.0`.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,8 +41,11 @@ https://github.com/atviriduomenys/katalogas/issues/2791
   asked for it again on click, but ``Action.UPDATE`` on an organization belongs to the
   coordinators alone. A resource manager therefore got a redirect, which HTMX swapped into the
   pane as a whole organization page. The wizard now sends that request only for a user who holds
-  the right, and shows a short note in its place for everyone else. The bug predates this change,
-  but until now no resource manager had a button to reach it.
+  the right, and shows a short note in its place for everyone else. The note and the "loading a
+  form" placeholder both key off the organization node, because ``x-init`` selects that node as
+  soon as Alpine starts, so a condition on an empty selection would never hold and the pane would
+  sit on "Įkeliama forma..." for good. The bug predates this change, but until now no resource
+  manager had a button to reach it.
 
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,11 +41,13 @@ https://github.com/atviriduomenys/katalogas/issues/2791
   asked for it again on click, but ``Action.UPDATE`` on an organization belongs to the
   coordinators alone. A resource manager therefore got a redirect, which HTMX swapped into the
   pane as a whole organization page. The wizard now sends that request only for a user who holds
-  the right, and shows a short note in its place for everyone else. The note and the "loading a
-  form" placeholder both key off the organization node, because ``x-init`` selects that node as
-  soon as Alpine starts, so a condition on an empty selection would never hold and the pane would
-  sit on "Įkeliama forma..." for good. The bug predates this change, but until now no resource
-  manager had a button to reach it.
+  the right, and shows a short note in its place for everyone else. That note keys off the
+  organization node, because ``x-init`` selects that node as soon as Alpine starts, and it lives
+  outside ``#wizard-main-pane``, because an HTMX swap replaces everything inside that element and
+  would carry the note away with the first child form. The pane itself hides while the
+  organization node is the selected one, and the root row still calls ``select(...)``, so a
+  resource manager can leave a child form and come back to the organization state. The bug
+  predates this change, but until now no resource manager had a button to reach it.
 
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,12 +30,13 @@ https://github.com/atviriduomenys/katalogas/issues/2791
 - Gather the access rules of the four wizard views into ``WizardAccessMixin``. Each of them
   carried its own copy of ``has_permission`` and ``handle_no_permission``, which is why the same
   anonymous redirect bug sat in all four. The method resolution order does not change.
-- A staff account that is not a superuser stays outside the wizard shell for now, which leaves it
-  narrower than the forms it opens: ``determine_user_role`` maps ``is_staff`` to
-  ``Role.GLOBAL_MANAGER``, every wizard ACL rule lists that role, and ``has_perm`` grants staff
-  everything, so such a user reaches the forms through a direct URL but sees no button. The
-  three roles above are the ones the team asked for; the docstring of ``can_manage_is_metadata``
-  records the open question.
+- A staff account that is not a superuser stays outside the wizard shell. The team weighed
+  ``is_staff``, the global manager, and settled on ``is_superuser``, which the two
+  administrators who need the wizard both hold. That leaves the shell narrower than the forms it
+  opens: ``determine_user_role`` maps ``is_staff`` to ``Role.GLOBAL_MANAGER``, every wizard ACL
+  rule lists that role, and ``has_perm`` grants staff everything, so such a user reaches the
+  forms through a direct URL but sees no button. The docstring of ``can_manage_is_metadata``
+  records the decision.
 - Keep the "Redaguoti organizaciją" button away from the two resource roles, so that the
   organization form is offered in one place rather than two: the wizard already opens it from
   its root node. The resource coordinator keeps the right itself and still edits the

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,24 @@ Changes
 v 1.25.0 (current)
 ==================
 
+https://github.com/atviriduomenys/katalogas/issues/2791
+
+- Show the "Tvarkyti IS metaduomenis" button, and open the IS metadata wizard, for every role that
+  the wizard already allows: the resource coordinator, the resource manager and the superuser.
+  Until now the button asked for two conditions that no single role met. The resource manager
+  passed the wizard check but failed ``can_update_organization``, because updating a
+  ``Representative`` is a coordinator right, so the button was never rendered for them. The
+  resource coordinator and the superuser passed ``can_update_organization`` but failed the wizard
+  check, which asked for the ``resource_manager`` role alone, so they were shown the "Redaguoti
+  organizaciją" button instead. Nobody saw the wizard.
+- The ACL of the wizard forms already granted ``CREATE_WIZARD``, ``UPDATE_WIZARD`` and
+  ``DELETE_WIZARD`` to both resource roles, and ``has_perm`` already granted everything to a
+  superuser, so this change opens the wizard shell to the users its forms already accepted.
+- Replace ``is_organization_resource_manager`` with ``can_manage_is_metadata``, and rename the
+  template flag ``is_information_system_administrator`` to ``can_manage_is_metadata``.
+- The organization page now shows both buttons where both apply: a resource coordinator gets
+  "Tvarkyti IS metaduomenis" and "Redaguoti organizaciją".
+
 
 
 v 1.24.0 (2026-08-21)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,14 +36,13 @@ https://github.com/atviriduomenys/katalogas/issues/2791
   everything, so such a user reaches the forms through a direct URL but sees no button. The
   three roles above are the ones the team asked for; the docstring of ``can_manage_is_metadata``
   records the open question.
-- Keep the "Redaguoti organizaciją" button away from the two resource roles. The resource
-  coordinator holds ``Action.UPDATE`` and so was offered it, but the team asked that both
-  resource roles describe the organization through the IS metadata wizard instead. A new
-  ``can_edit_organization_details`` decides that button, and it hides it only when every role
-  the user holds on that organization is a resource one. The open data roles keep exactly the
-  access they had, a superuser keeps both buttons, and no ACL changes: the wizard still asks
-  ``can_update_organization`` when its root node loads the organization form, because that is
-  the right ``OrganizationUpdateView`` checks.
+- Keep the "Redaguoti organizaciją" button away from the two resource roles, so that the
+  organization form is offered in one place rather than two: the wizard already opens it from
+  its root node. The resource coordinator keeps the right itself and still edits the
+  organization there. A new ``can_edit_organization_details`` decides the button, and hides it
+  only when every role the user holds on that organization is a resource one, so a user who
+  also holds an open data role there keeps what that role gave them. The open data roles keep
+  exactly the access they had, a superuser keeps both buttons, and no ACL rule moves.
 - Stop the wizard asking for the organization form on behalf of a user who may not edit the
   organization. The pane loaded ``organization-change`` on open, and the root node of the tree
   asked for it again on click, but ``Action.UPDATE`` on an organization belongs to the

--- a/tests/dcat/views/test_wizard_views.py
+++ b/tests/dcat/views/test_wizard_views.py
@@ -132,6 +132,8 @@ class TestOrganizationWizardView:
 
         notice = response.html.find(id="wizard-org-notice")
         assert notice is not None
+        # Django renders a `{# #}` comment that spans lines as plain text, so guard against one.
+        assert "{#" not in response.text and "{% comment" not in response.text
         assert notice["x-show"] == f"mode === 'detail' && selected && selected.key === 'org:{org.pk}'"
 
         pane = response.html.find(id="wizard-main-pane")

--- a/tests/dcat/views/test_wizard_views.py
+++ b/tests/dcat/views/test_wizard_views.py
@@ -122,20 +122,42 @@ class TestOrganizationWizardView:
         )
 
     def test_resource_manager_pane_explains_the_missing_organization_form(self, app: DjangoTestApp):
-        # `x-init` selects the organization node at once, so the notice and the "loading a form"
-        # placeholder both have to key off that node rather than off an empty selection.
+        # `x-init` selects the organization node at once, so the notice keys off that node rather
+        # than off an empty selection, and it sits outside `#wizard-main-pane` because an HTMX
+        # swap replaces everything inside that element.
         org = OrganizationFactory()
         app.set_user(_representative(org, Representative.RESOURCE_MANAGER).user)
 
         response = app.get(reverse("organization-wizard", kwargs={"pk": org.pk}))
 
-        pane = response.html.find(id="wizard-main-pane")
-        notice = pane.find("div", class_="notification")
+        notice = response.html.find(id="wizard-org-notice")
         assert notice is not None
-        assert notice["x-show"] == f"selected && selected.key === 'org:{org.pk}'"
+        assert notice["x-show"] == f"mode === 'detail' && selected && selected.key === 'org:{org.pk}'"
 
-        placeholder = pane.find("div", attrs={"x-show": lambda v: v and v.startswith("mode === 'detail'")})
-        assert f"selected.key !== 'org:{org.pk}'" in placeholder["x-show"]
+        pane = response.html.find(id="wizard-main-pane")
+        assert notice not in pane.find_all("div")
+        assert f"!(selected && selected.key === 'org:{org.pk}')" in pane["x-show"]
+
+    def test_resource_manager_can_return_to_the_organization_node(self, app: DjangoTestApp):
+        # Without a `select(...)` call the row only toggles the subtree, so a manager who opened a
+        # child form could never get the pane back to the organization state.
+        org = OrganizationFactory()
+        app.set_user(_representative(org, Representative.RESOURCE_MANAGER).user)
+
+        response = app.get(reverse("organization-wizard", kwargs={"pk": org.pk}))
+
+        root_row = response.html.find("li", class_="wizard-tree-root").find("div", class_="wizard-tree-row")
+        assert f"select('org:{org.pk}')" in root_row["@click.stop"]
+        assert root_row.get("hx-get") is None
+
+    def test_resource_coordinator_sees_no_organization_notice(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        app.set_user(_representative(org, Representative.RESOURCE_COORDINATOR).user)
+
+        response = app.get(reverse("organization-wizard", kwargs={"pk": org.pk}))
+
+        assert response.html.find(id="wizard-org-notice") is None
+        assert response.html.find(id="wizard-main-pane")["x-show"] == "mode !== 'create'"
 
 
 class TestOrganizationDetailWizardButton:

--- a/tests/dcat/views/test_wizard_views.py
+++ b/tests/dcat/views/test_wizard_views.py
@@ -180,12 +180,44 @@ class TestOrganizationDetailWizardButton:
 
         assert response.html.find(id="open_organization_wizard") is not None
 
-    def test_coordinator_still_sees_organization_edit_button(self, app: DjangoTestApp):
+    @pytest.mark.parametrize("role", [Representative.RESOURCE_COORDINATOR, Representative.RESOURCE_MANAGER])
+    def test_resource_role_does_not_see_organization_edit_button(self, app: DjangoTestApp, role: str):
+        # The resource roles describe the organization through the wizard, so the organization
+        # form is not offered to them here even though the coordinator holds `Action.UPDATE`.
         org = OrganizationFactory()
-        app.set_user(_representative(org, Representative.RESOURCE_COORDINATOR).user)
+        app.set_user(_representative(org, role).user)
 
         response = app.get(reverse("organization-detail", kwargs={"pk": org.pk}))
 
+        assert response.html.find(id="change_organization") is None
+
+    @pytest.mark.parametrize(
+        "role",
+        [
+            Representative.OPEN_DATA_COORDINATOR,
+            Representative.OPEN_DATA_MANAGER,
+            Representative.OPEN_DATA_PUBLISHER,
+        ],
+    )
+    def test_open_data_roles_keep_what_they_had(self, app: DjangoTestApp, role: str):
+        # Only the coordinator among them may update the organization, and this branch changes
+        # nothing for any of the three.
+        org = OrganizationFactory()
+        app.set_user(_representative(org, role).user)
+
+        response = app.get(reverse("organization-detail", kwargs={"pk": org.pk}))
+
+        expected = role == Representative.OPEN_DATA_COORDINATOR
+        assert (response.html.find(id="change_organization") is not None) is expected
+        assert response.html.find(id="open_organization_wizard") is None
+
+    def test_superuser_sees_both_buttons(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        app.set_user(UserFactory(is_superuser=True))
+
+        response = app.get(reverse("organization-detail", kwargs={"pk": org.pk}))
+
+        assert response.html.find(id="open_organization_wizard") is not None
         assert response.html.find(id="change_organization") is not None
 
     def test_unrelated_user_sees_no_button(self, app: DjangoTestApp):

--- a/tests/dcat/views/test_wizard_views.py
+++ b/tests/dcat/views/test_wizard_views.py
@@ -182,8 +182,8 @@ class TestOrganizationDetailWizardButton:
 
     @pytest.mark.parametrize("role", [Representative.RESOURCE_COORDINATOR, Representative.RESOURCE_MANAGER])
     def test_resource_role_does_not_see_organization_edit_button(self, app: DjangoTestApp, role: str):
-        # The resource roles describe the organization through the wizard, so the organization
-        # form is not offered to them here even though the coordinator holds `Action.UPDATE`.
+        # Removed from this page so the same form is not offered twice: the wizard opens it from
+        # its root node. The coordinator keeps `Action.UPDATE` and still edits it there.
         org = OrganizationFactory()
         app.set_user(_representative(org, role).user)
 

--- a/tests/dcat/views/test_wizard_views.py
+++ b/tests/dcat/views/test_wizard_views.py
@@ -69,6 +69,10 @@ class TestOrganizationWizardView:
         assert response.location == reverse("organization-detail", kwargs={"pk": org.pk})
 
     def test_deleted_representative_is_redirected(self, app: DjangoTestApp):
+        # Only the shell is closed to a soft-deleted representative. `has_perm` ignores the
+        # `deleted` flag, so the forms behind the shell still answer such a row. Nothing in the
+        # code sets the flag today (the member views delete the row), so this guards the helper,
+        # not a live revocation path.
         org = OrganizationFactory()
         rep = _representative(org, Representative.RESOURCE_MANAGER)
         rep.deleted = True

--- a/tests/dcat/views/test_wizard_views.py
+++ b/tests/dcat/views/test_wizard_views.py
@@ -101,6 +101,26 @@ class TestOrganizationWizardView:
 
         assert response.status_code == 200
 
+    def test_resource_manager_pane_does_not_ask_for_the_organization_form(self, app: DjangoTestApp):
+        # `Action.UPDATE` on an organization belongs to the coordinators, so asking for that
+        # fragment would answer a redirect that HTMX swaps into the pane as a whole page.
+        org = OrganizationFactory()
+        app.set_user(_representative(org, Representative.RESOURCE_MANAGER).user)
+
+        response = app.get(reverse("organization-wizard", kwargs={"pk": org.pk}))
+
+        assert response.html.find(id="wizard-main-pane").get("hx-get") is None
+
+    def test_resource_coordinator_pane_asks_for_the_organization_form(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        app.set_user(_representative(org, Representative.RESOURCE_COORDINATOR).user)
+
+        response = app.get(reverse("organization-wizard", kwargs={"pk": org.pk}))
+
+        assert response.html.find(id="wizard-main-pane").get("hx-get") == reverse(
+            "organization-change", kwargs={"pk": org.pk}
+        )
+
 
 class TestOrganizationDetailWizardButton:
     @pytest.mark.parametrize("role", [Representative.RESOURCE_COORDINATOR, Representative.RESOURCE_MANAGER])

--- a/tests/dcat/views/test_wizard_views.py
+++ b/tests/dcat/views/test_wizard_views.py
@@ -121,6 +121,22 @@ class TestOrganizationWizardView:
             "organization-change", kwargs={"pk": org.pk}
         )
 
+    def test_resource_manager_pane_explains_the_missing_organization_form(self, app: DjangoTestApp):
+        # `x-init` selects the organization node at once, so the notice and the "loading a form"
+        # placeholder both have to key off that node rather than off an empty selection.
+        org = OrganizationFactory()
+        app.set_user(_representative(org, Representative.RESOURCE_MANAGER).user)
+
+        response = app.get(reverse("organization-wizard", kwargs={"pk": org.pk}))
+
+        pane = response.html.find(id="wizard-main-pane")
+        notice = pane.find("div", class_="notification")
+        assert notice is not None
+        assert notice["x-show"] == f"selected && selected.key === 'org:{org.pk}'"
+
+        placeholder = pane.find("div", attrs={"x-show": lambda v: v and v.startswith("mode === 'detail'")})
+        assert f"selected.key !== 'org:{org.pk}'" in placeholder["x-show"]
+
 
 class TestOrganizationDetailWizardButton:
     @pytest.mark.parametrize("role", [Representative.RESOURCE_COORDINATOR, Representative.RESOURCE_MANAGER])

--- a/tests/dcat/views/test_wizard_views.py
+++ b/tests/dcat/views/test_wizard_views.py
@@ -10,6 +10,14 @@ from vitrina.users.factories import UserFactory
 
 pytestmark = pytest.mark.django_db
 
+# Every view of the wizard takes its access rules from `WizardAccessMixin`.
+WIZARD_URL_NAMES = [
+    "organization-wizard",
+    "organization-wizard-tree",
+    "organization-wizard-nodes",
+    "organization-wizard-create",
+]
+
 
 def _representative(org, role: str) -> Representative:
     return RepresentativeFactory(
@@ -20,19 +28,23 @@ def _representative(org, role: str) -> Representative:
 
 
 class TestOrganizationWizardView:
-    def test_unauthenticated_redirects_to_login(self, app: DjangoTestApp):
+    @pytest.mark.parametrize("url_name", WIZARD_URL_NAMES)
+    def test_unauthenticated_redirects_to_login(self, app: DjangoTestApp, url_name: str):
         org = OrganizationFactory()
+        url = reverse(url_name, kwargs={"pk": org.pk})
 
-        response = app.get(reverse("organization-wizard", kwargs={"pk": org.pk}))
+        response = app.get(url)
 
         assert response.status_code == 302
         assert settings.LOGIN_URL in response.location
+        assert url in response.location
 
-    def test_unrelated_user_is_redirected_to_organization(self, app: DjangoTestApp):
+    @pytest.mark.parametrize("url_name", WIZARD_URL_NAMES)
+    def test_unrelated_user_is_redirected_to_organization(self, app: DjangoTestApp, url_name: str):
         org = OrganizationFactory()
         app.set_user(UserFactory())
 
-        response = app.get(reverse("organization-wizard", kwargs={"pk": org.pk}))
+        response = app.get(reverse(url_name, kwargs={"pk": org.pk}))
 
         assert response.status_code == 302
         assert response.location == reverse("organization-detail", kwargs={"pk": org.pk})

--- a/tests/dcat/views/test_wizard_views.py
+++ b/tests/dcat/views/test_wizard_views.py
@@ -10,7 +10,7 @@ from vitrina.users.factories import UserFactory
 
 pytestmark = pytest.mark.django_db
 
-# Every view of the wizard takes its access rules from `WizardAccessMixin`.
+# Every wizard view takes its access rules from `WizardAccessMixin`.
 WIZARD_URL_NAMES = [
     "organization-wizard",
     "organization-wizard-tree",
@@ -27,6 +27,44 @@ def _representative(org, role: str) -> Representative:
     )
 
 
+def _role_user(role: str):
+    return lambda org: _representative(org, role).user
+
+
+def _unrelated_user(org):
+    return UserFactory()
+
+
+def _superuser(org):
+    return UserFactory(is_superuser=True)
+
+
+def _other_organization_manager(org):
+    return _representative(OrganizationFactory(), Representative.RESOURCE_MANAGER).user
+
+
+def _deleted_resource_manager(org):
+    rep = _representative(org, Representative.RESOURCE_MANAGER)
+    rep.deleted = True
+    rep.save()
+    return rep.user
+
+
+DENIED_USERS = [
+    pytest.param(_unrelated_user, id="unrelated"),
+    pytest.param(_other_organization_manager, id="other-organization-manager"),
+    pytest.param(_role_user(Representative.OPEN_DATA_COORDINATOR), id="open-data-coordinator"),
+    # `has_perm` ignores `deleted`, so only the shell closes for a soft-deleted representative.
+    pytest.param(_deleted_resource_manager, id="deleted-resource-manager"),
+]
+
+ALLOWED_USERS = [
+    pytest.param(_role_user(Representative.RESOURCE_COORDINATOR), id="resource-coordinator"),
+    pytest.param(_role_user(Representative.RESOURCE_MANAGER), id="resource-manager"),
+    pytest.param(_superuser, id="superuser"),
+]
+
+
 class TestOrganizationWizardView:
     @pytest.mark.parametrize("url_name", WIZARD_URL_NAMES)
     def test_unauthenticated_redirects_to_login(self, app: DjangoTestApp, url_name: str):
@@ -40,105 +78,54 @@ class TestOrganizationWizardView:
         assert url in response.location
 
     @pytest.mark.parametrize("url_name", WIZARD_URL_NAMES)
-    def test_unrelated_user_is_redirected_to_organization(self, app: DjangoTestApp, url_name: str):
+    @pytest.mark.parametrize("make_user", DENIED_USERS)
+    def test_denied_user_is_redirected_to_organization(self, app: DjangoTestApp, make_user, url_name: str):
         org = OrganizationFactory()
-        app.set_user(UserFactory())
+        app.set_user(make_user(org))
 
         response = app.get(reverse(url_name, kwargs={"pk": org.pk}))
 
         assert response.status_code == 302
         assert response.location == reverse("organization-detail", kwargs={"pk": org.pk})
 
-    def test_representative_of_another_organization_is_redirected(self, app: DjangoTestApp):
+    @pytest.mark.parametrize("make_user", ALLOWED_USERS)
+    def test_allowed_user_gets_200(self, app: DjangoTestApp, make_user):
         org = OrganizationFactory()
-        other_org = OrganizationFactory()
-        app.set_user(_representative(other_org, Representative.RESOURCE_MANAGER).user)
-
-        response = app.get(reverse("organization-wizard", kwargs={"pk": org.pk}))
-
-        assert response.status_code == 302
-        assert response.location == reverse("organization-detail", kwargs={"pk": org.pk})
-
-    def test_open_data_role_is_redirected(self, app: DjangoTestApp):
-        org = OrganizationFactory()
-        app.set_user(_representative(org, Representative.OPEN_DATA_COORDINATOR).user)
-
-        response = app.get(reverse("organization-wizard", kwargs={"pk": org.pk}))
-
-        assert response.status_code == 302
-        assert response.location == reverse("organization-detail", kwargs={"pk": org.pk})
-
-    def test_deleted_representative_is_redirected(self, app: DjangoTestApp):
-        # Only the shell is closed to a soft-deleted representative. `has_perm` ignores the
-        # `deleted` flag, so the forms behind the shell still answer such a row. Nothing in the
-        # code sets the flag today (the member views delete the row), so this guards the helper,
-        # not a live revocation path.
-        org = OrganizationFactory()
-        rep = _representative(org, Representative.RESOURCE_MANAGER)
-        rep.deleted = True
-        rep.save()
-        app.set_user(rep.user)
-
-        response = app.get(reverse("organization-wizard", kwargs={"pk": org.pk}))
-
-        assert response.status_code == 302
-        assert response.location == reverse("organization-detail", kwargs={"pk": org.pk})
-
-    @pytest.mark.parametrize("role", [Representative.RESOURCE_COORDINATOR, Representative.RESOURCE_MANAGER])
-    def test_resource_role_gets_200(self, app: DjangoTestApp, role: str):
-        org = OrganizationFactory()
-        app.set_user(_representative(org, role).user)
+        app.set_user(make_user(org))
 
         response = app.get(reverse("organization-wizard", kwargs={"pk": org.pk}))
 
         assert response.status_code == 200
 
-    def test_superuser_gets_200(self, app: DjangoTestApp):
-        org = OrganizationFactory()
-        app.set_user(UserFactory(is_superuser=True))
-
-        response = app.get(reverse("organization-wizard", kwargs={"pk": org.pk}))
-
-        assert response.status_code == 200
-
-    def test_resource_manager_pane_does_not_ask_for_the_organization_form(self, app: DjangoTestApp):
-        # `Action.UPDATE` on an organization belongs to the coordinators, so asking for that
-        # fragment would answer a redirect that HTMX swaps into the pane as a whole page.
-        org = OrganizationFactory()
-        app.set_user(_representative(org, Representative.RESOURCE_MANAGER).user)
-
-        response = app.get(reverse("organization-wizard", kwargs={"pk": org.pk}))
-
-        assert response.html.find(id="wizard-main-pane").get("hx-get") is None
-
-    def test_resource_coordinator_pane_asks_for_the_organization_form(self, app: DjangoTestApp):
+    def test_pane_asks_for_the_organization_form(self, app: DjangoTestApp):
         org = OrganizationFactory()
         app.set_user(_representative(org, Representative.RESOURCE_COORDINATOR).user)
 
         response = app.get(reverse("organization-wizard", kwargs={"pk": org.pk}))
 
-        assert response.html.find(id="wizard-main-pane").get("hx-get") == reverse(
-            "organization-change", kwargs={"pk": org.pk}
-        )
+        pane = response.html.find(id="wizard-main-pane")
+        assert pane["hx-get"] == reverse("organization-change", kwargs={"pk": org.pk})
+        assert pane["x-show"] == "mode !== 'create'"
+        assert response.html.find(id="wizard-org-notice") is None
 
-    def test_resource_manager_pane_explains_the_missing_organization_form(self, app: DjangoTestApp):
-        # `x-init` selects the organization node at once, so the notice keys off that node rather
-        # than off an empty selection, and it sits outside `#wizard-main-pane` because an HTMX
-        # swap replaces everything inside that element.
+    def test_pane_explains_the_missing_organization_form(self, app: DjangoTestApp):
+        # Asking for a form the resource manager may not open answers a redirect that HTMX would
+        # swap into the pane as a whole page, so a notice keyed to the organization node takes
+        # its place — outside the pane, which an HTMX swap empties.
         org = OrganizationFactory()
         app.set_user(_representative(org, Representative.RESOURCE_MANAGER).user)
 
         response = app.get(reverse("organization-wizard", kwargs={"pk": org.pk}))
 
-        notice = response.html.find(id="wizard-org-notice")
-        assert notice is not None
-        # Django renders a `{# #}` comment that spans lines as plain text, so guard against one.
-        assert "{#" not in response.text and "{% comment" not in response.text
-        assert notice["x-show"] == f"mode === 'detail' && selected && selected.key === 'org:{org.pk}'"
-
         pane = response.html.find(id="wizard-main-pane")
-        assert notice not in pane.find_all("div")
+        notice = response.html.find(id="wizard-org-notice")
+        assert pane.get("hx-get") is None
         assert f"!(selected && selected.key === 'org:{org.pk}')" in pane["x-show"]
+        assert notice is not None
+        assert notice not in pane.find_all("div")
+        assert notice["x-show"] == f"mode === 'detail' && selected && selected.key === 'org:{org.pk}'"
+        # A `{# #}` comment that spans lines renders as plain text.
+        assert "{#" not in response.text
 
     def test_resource_manager_can_return_to_the_organization_node(self, app: DjangoTestApp):
         # Without a `select(...)` call the row only toggles the subtree, so a manager who opened a
@@ -152,78 +139,29 @@ class TestOrganizationWizardView:
         assert f"select('org:{org.pk}')" in root_row["@click.stop"]
         assert root_row.get("hx-get") is None
 
-    def test_resource_coordinator_sees_no_organization_notice(self, app: DjangoTestApp):
-        org = OrganizationFactory()
-        app.set_user(_representative(org, Representative.RESOURCE_COORDINATOR).user)
-
-        response = app.get(reverse("organization-wizard", kwargs={"pk": org.pk}))
-
-        assert response.html.find(id="wizard-org-notice") is None
-        assert response.html.find(id="wizard-main-pane")["x-show"] == "mode !== 'create'"
-
 
 class TestOrganizationDetailWizardButton:
-    @pytest.mark.parametrize("role", [Representative.RESOURCE_COORDINATOR, Representative.RESOURCE_MANAGER])
-    def test_resource_role_sees_button(self, app: DjangoTestApp, role: str):
-        org = OrganizationFactory()
-        app.set_user(_representative(org, role).user)
-
-        response = app.get(reverse("organization-detail", kwargs={"pk": org.pk}))
-
-        assert response.html.find(id="open_organization_wizard") is not None
-
-    def test_superuser_sees_button(self, app: DjangoTestApp):
-        org = OrganizationFactory()
-        app.set_user(UserFactory(is_superuser=True))
-
-        response = app.get(reverse("organization-detail", kwargs={"pk": org.pk}))
-
-        assert response.html.find(id="open_organization_wizard") is not None
-
-    @pytest.mark.parametrize("role", [Representative.RESOURCE_COORDINATOR, Representative.RESOURCE_MANAGER])
-    def test_resource_role_does_not_see_organization_edit_button(self, app: DjangoTestApp, role: str):
-        # Removed from this page so the same form is not offered twice: the wizard opens it from
-        # its root node. The coordinator keeps `Action.UPDATE` and still edits it there.
-        org = OrganizationFactory()
-        app.set_user(_representative(org, role).user)
-
-        response = app.get(reverse("organization-detail", kwargs={"pk": org.pk}))
-
-        assert response.html.find(id="change_organization") is None
-
     @pytest.mark.parametrize(
-        "role",
+        ("make_user", "sees_wizard", "sees_edit"),
         [
-            Representative.OPEN_DATA_COORDINATOR,
-            Representative.OPEN_DATA_MANAGER,
-            Representative.OPEN_DATA_PUBLISHER,
+            # The two resource roles reach the organization form from the wizard's root node
+            # instead, so this page stops offering it to them.
+            pytest.param(_role_user(Representative.RESOURCE_COORDINATOR), True, False, id="resource-coordinator"),
+            pytest.param(_role_user(Representative.RESOURCE_MANAGER), True, False, id="resource-manager"),
+            pytest.param(_superuser, True, True, id="superuser"),
+            # Nothing changes for the open data roles: only their coordinator may update the
+            # organization, and none of them reaches the wizard.
+            pytest.param(_role_user(Representative.OPEN_DATA_COORDINATOR), False, True, id="open-data-coordinator"),
+            pytest.param(_role_user(Representative.OPEN_DATA_MANAGER), False, False, id="open-data-manager"),
+            pytest.param(_role_user(Representative.OPEN_DATA_PUBLISHER), False, False, id="open-data-publisher"),
+            pytest.param(_unrelated_user, False, False, id="unrelated"),
         ],
     )
-    def test_open_data_roles_keep_what_they_had(self, app: DjangoTestApp, role: str):
-        # Only the coordinator among them may update the organization, and this branch changes
-        # nothing for any of the three.
+    def test_buttons_offered_to_each_role(self, app: DjangoTestApp, make_user, sees_wizard: bool, sees_edit: bool):
         org = OrganizationFactory()
-        app.set_user(_representative(org, role).user)
+        app.set_user(make_user(org))
 
         response = app.get(reverse("organization-detail", kwargs={"pk": org.pk}))
 
-        expected = role == Representative.OPEN_DATA_COORDINATOR
-        assert (response.html.find(id="change_organization") is not None) is expected
-        assert response.html.find(id="open_organization_wizard") is None
-
-    def test_superuser_sees_both_buttons(self, app: DjangoTestApp):
-        org = OrganizationFactory()
-        app.set_user(UserFactory(is_superuser=True))
-
-        response = app.get(reverse("organization-detail", kwargs={"pk": org.pk}))
-
-        assert response.html.find(id="open_organization_wizard") is not None
-        assert response.html.find(id="change_organization") is not None
-
-    def test_unrelated_user_sees_no_button(self, app: DjangoTestApp):
-        org = OrganizationFactory()
-        app.set_user(UserFactory())
-
-        response = app.get(reverse("organization-detail", kwargs={"pk": org.pk}))
-
-        assert response.html.find(id="open_organization_wizard") is None
+        assert (response.html.find(id="open_organization_wizard") is not None) is sees_wizard
+        assert (response.html.find(id="change_organization") is not None) is sees_edit

--- a/tests/dcat/views/test_wizard_views.py
+++ b/tests/dcat/views/test_wizard_views.py
@@ -1,0 +1,121 @@
+import pytest
+from django.conf import settings
+from django.contrib.contenttypes.models import ContentType
+from django.urls import reverse
+from django_webtest import DjangoTestApp
+
+from vitrina.orgs.factories import OrganizationFactory, RepresentativeFactory
+from vitrina.orgs.models import Representative
+from vitrina.users.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def _representative(org, role: str) -> Representative:
+    return RepresentativeFactory(
+        content_type=ContentType.objects.get_for_model(org),
+        object_id=org.pk,
+        role=role,
+    )
+
+
+class TestOrganizationWizardView:
+    def test_unauthenticated_redirects_to_login(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+
+        response = app.get(reverse("organization-wizard", kwargs={"pk": org.pk}))
+
+        assert response.status_code == 302
+        assert settings.LOGIN_URL in response.location
+
+    def test_unrelated_user_is_redirected_to_organization(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        app.set_user(UserFactory())
+
+        response = app.get(reverse("organization-wizard", kwargs={"pk": org.pk}))
+
+        assert response.status_code == 302
+        assert response.location == reverse("organization-detail", kwargs={"pk": org.pk})
+
+    def test_representative_of_another_organization_is_redirected(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        other_org = OrganizationFactory()
+        app.set_user(_representative(other_org, Representative.RESOURCE_MANAGER).user)
+
+        response = app.get(reverse("organization-wizard", kwargs={"pk": org.pk}))
+
+        assert response.status_code == 302
+        assert response.location == reverse("organization-detail", kwargs={"pk": org.pk})
+
+    def test_open_data_role_is_redirected(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        app.set_user(_representative(org, Representative.OPEN_DATA_COORDINATOR).user)
+
+        response = app.get(reverse("organization-wizard", kwargs={"pk": org.pk}))
+
+        assert response.status_code == 302
+        assert response.location == reverse("organization-detail", kwargs={"pk": org.pk})
+
+    def test_deleted_representative_is_redirected(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        rep = _representative(org, Representative.RESOURCE_MANAGER)
+        rep.deleted = True
+        rep.save()
+        app.set_user(rep.user)
+
+        response = app.get(reverse("organization-wizard", kwargs={"pk": org.pk}))
+
+        assert response.status_code == 302
+        assert response.location == reverse("organization-detail", kwargs={"pk": org.pk})
+
+    @pytest.mark.parametrize("role", [Representative.RESOURCE_COORDINATOR, Representative.RESOURCE_MANAGER])
+    def test_resource_role_gets_200(self, app: DjangoTestApp, role: str):
+        org = OrganizationFactory()
+        app.set_user(_representative(org, role).user)
+
+        response = app.get(reverse("organization-wizard", kwargs={"pk": org.pk}))
+
+        assert response.status_code == 200
+
+    def test_superuser_gets_200(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        app.set_user(UserFactory(is_superuser=True))
+
+        response = app.get(reverse("organization-wizard", kwargs={"pk": org.pk}))
+
+        assert response.status_code == 200
+
+
+class TestOrganizationDetailWizardButton:
+    @pytest.mark.parametrize("role", [Representative.RESOURCE_COORDINATOR, Representative.RESOURCE_MANAGER])
+    def test_resource_role_sees_button(self, app: DjangoTestApp, role: str):
+        org = OrganizationFactory()
+        app.set_user(_representative(org, role).user)
+
+        response = app.get(reverse("organization-detail", kwargs={"pk": org.pk}))
+
+        assert response.html.find(id="open_organization_wizard") is not None
+
+    def test_superuser_sees_button(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        app.set_user(UserFactory(is_superuser=True))
+
+        response = app.get(reverse("organization-detail", kwargs={"pk": org.pk}))
+
+        assert response.html.find(id="open_organization_wizard") is not None
+
+    def test_coordinator_still_sees_organization_edit_button(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        app.set_user(_representative(org, Representative.RESOURCE_COORDINATOR).user)
+
+        response = app.get(reverse("organization-detail", kwargs={"pk": org.pk}))
+
+        assert response.html.find(id="change_organization") is not None
+
+    def test_unrelated_user_sees_no_button(self, app: DjangoTestApp):
+        org = OrganizationFactory()
+        app.set_user(UserFactory())
+
+        response = app.get(reverse("organization-detail", kwargs={"pk": org.pk}))
+
+        assert response.html.find(id="open_organization_wizard") is None

--- a/vitrina/dcat/views/wizard_views.py
+++ b/vitrina/dcat/views/wizard_views.py
@@ -23,13 +23,16 @@ from vitrina.orgs.services import can_manage_is_metadata
 from vitrina.orgs.views import OrganizationBaseViewMixin
 
 
-class OrganizationWizardView(
+class WizardAccessMixin(
     LoginRequiredMixin,
     PermissionRequiredMixin,
     OrganizationBaseViewMixin,
-    TemplateView,
 ):
-    template_name = "vitrina/orgs/wizard.html"
+    """Access rules shared by every view of the IS metadata wizard.
+
+    ``OrganizationBaseViewMixin.setup`` resolves the organization before ``dispatch``
+    asks about permissions, so ``self.organization`` is always set here.
+    """
 
     organization: Organization
 
@@ -37,9 +40,15 @@ class OrganizationWizardView(
         return can_manage_is_metadata(self.request.user, self.organization)
 
     def handle_no_permission(self) -> HttpResponseBase:
+        # ``LoginRequiredMixin`` sends an anonymous request through this method too, so
+        # falling back to ``super()`` keeps the login redirect and its ``next`` parameter.
         if not self.request.user.is_authenticated:
             return super().handle_no_permission()
         return redirect("organization-detail", pk=self.organization.pk)
+
+
+class OrganizationWizardView(WizardAccessMixin, TemplateView):
+    template_name = "vitrina/orgs/wizard.html"
 
     def get_context_data(self, **kwargs) -> dict:
         context = super().get_context_data(**kwargs)
@@ -63,21 +72,8 @@ class OrganizationWizardView(
         return context
 
 
-class OrganizationWizardTreeView(
-    LoginRequiredMixin,
-    PermissionRequiredMixin,
-    OrganizationBaseViewMixin,
-    TemplateView,
-):
+class OrganizationWizardTreeView(WizardAccessMixin, TemplateView):
     template_name = "vitrina/orgs/_wizard_tree_children_fragment.html"
-
-    def has_permission(self) -> bool:
-        return can_manage_is_metadata(self.request.user, self.organization)
-
-    def handle_no_permission(self) -> HttpResponseBase:
-        if not self.request.user.is_authenticated:
-            return super().handle_no_permission()
-        return redirect("organization-detail", pk=self.organization.pk)
 
     def get_context_data(self, **kwargs) -> dict:
         context = super().get_context_data(**kwargs)
@@ -86,39 +82,13 @@ class OrganizationWizardTreeView(
         return context
 
 
-class OrganizationWizardNodesView(
-    LoginRequiredMixin,
-    PermissionRequiredMixin,
-    OrganizationBaseViewMixin,
-    View,
-):
-    def has_permission(self) -> bool:
-        return can_manage_is_metadata(self.request.user, self.organization)
-
-    def handle_no_permission(self) -> HttpResponseBase:
-        if not self.request.user.is_authenticated:
-            return super().handle_no_permission()
-        return redirect("organization-detail", pk=self.organization.pk)
-
+class OrganizationWizardNodesView(WizardAccessMixin, View):
     def get(self, request: WSGIRequest, *args, **kwargs) -> HttpResponseBase:
         _, nodes_by_key = _build_wizard_tree(self.organization)
         return JsonResponse(nodes_by_key)
 
 
-class OrganizationWizardCreateRedirectView(
-    LoginRequiredMixin,
-    PermissionRequiredMixin,
-    OrganizationBaseViewMixin,
-    View,
-):
-    def has_permission(self) -> bool:
-        return can_manage_is_metadata(self.request.user, self.organization)
-
-    def handle_no_permission(self) -> HttpResponseBase:
-        if not self.request.user.is_authenticated:
-            return super().handle_no_permission()
-        return redirect("organization-detail", pk=self.organization.pk)
-
+class OrganizationWizardCreateRedirectView(WizardAccessMixin, View):
     def get(self, request: WSGIRequest, *args, **kwargs) -> HttpResponseBase:
         child_type = request.GET.get("type", "")
         parent_type = request.GET.get("parent_type", "")

--- a/vitrina/dcat/views/wizard_views.py
+++ b/vitrina/dcat/views/wizard_views.py
@@ -37,6 +37,8 @@ class OrganizationWizardView(
         return can_manage_is_metadata(self.request.user, self.organization)
 
     def handle_no_permission(self) -> HttpResponseBase:
+        if not self.request.user.is_authenticated:
+            return super().handle_no_permission()
         return redirect("organization-detail", pk=self.organization.pk)
 
     def get_context_data(self, **kwargs) -> dict:
@@ -73,6 +75,8 @@ class OrganizationWizardTreeView(
         return can_manage_is_metadata(self.request.user, self.organization)
 
     def handle_no_permission(self) -> HttpResponseBase:
+        if not self.request.user.is_authenticated:
+            return super().handle_no_permission()
         return redirect("organization-detail", pk=self.organization.pk)
 
     def get_context_data(self, **kwargs) -> dict:
@@ -92,6 +96,8 @@ class OrganizationWizardNodesView(
         return can_manage_is_metadata(self.request.user, self.organization)
 
     def handle_no_permission(self) -> HttpResponseBase:
+        if not self.request.user.is_authenticated:
+            return super().handle_no_permission()
         return redirect("organization-detail", pk=self.organization.pk)
 
     def get(self, request: WSGIRequest, *args, **kwargs) -> HttpResponseBase:
@@ -109,6 +115,8 @@ class OrganizationWizardCreateRedirectView(
         return can_manage_is_metadata(self.request.user, self.organization)
 
     def handle_no_permission(self) -> HttpResponseBase:
+        if not self.request.user.is_authenticated:
+            return super().handle_no_permission()
         return redirect("organization-detail", pk=self.organization.pk)
 
     def get(self, request: WSGIRequest, *args, **kwargs) -> HttpResponseBase:

--- a/vitrina/dcat/views/wizard_views.py
+++ b/vitrina/dcat/views/wizard_views.py
@@ -28,11 +28,7 @@ class WizardAccessMixin(
     PermissionRequiredMixin,
     OrganizationBaseViewMixin,
 ):
-    """Access rules shared by every view of the IS metadata wizard.
-
-    ``OrganizationBaseViewMixin.setup`` resolves the organization before ``dispatch``
-    asks about permissions, so ``self.organization`` is always set here.
-    """
+    """Access rules shared by every view of the IS metadata wizard."""
 
     organization: Organization
 
@@ -40,8 +36,7 @@ class WizardAccessMixin(
         return can_manage_is_metadata(self.request.user, self.organization)
 
     def handle_no_permission(self) -> HttpResponseBase:
-        # ``LoginRequiredMixin`` sends an anonymous request through this method too, so
-        # falling back to ``super()`` keeps the login redirect and its ``next`` parameter.
+        # ``LoginRequiredMixin`` routes anonymous requests here too; ``super()`` keeps ``next``.
         if not self.request.user.is_authenticated:
             return super().handle_no_permission()
         return redirect("organization-detail", pk=self.organization.pk)

--- a/vitrina/dcat/views/wizard_views.py
+++ b/vitrina/dcat/views/wizard_views.py
@@ -19,7 +19,7 @@ from vitrina.dcat.wizard import (
     _build_wizard_tree,
 )
 from vitrina.orgs.models import Organization
-from vitrina.orgs.services import is_organization_resource_manager
+from vitrina.orgs.services import can_manage_is_metadata
 from vitrina.orgs.views import OrganizationBaseViewMixin
 
 
@@ -34,7 +34,7 @@ class OrganizationWizardView(
     organization: Organization
 
     def has_permission(self) -> bool:
-        return is_organization_resource_manager(self.request.user, self.organization)
+        return can_manage_is_metadata(self.request.user, self.organization)
 
     def handle_no_permission(self) -> HttpResponseBase:
         return redirect("organization-detail", pk=self.organization.pk)
@@ -70,7 +70,7 @@ class OrganizationWizardTreeView(
     template_name = "vitrina/orgs/_wizard_tree_children_fragment.html"
 
     def has_permission(self) -> bool:
-        return is_organization_resource_manager(self.request.user, self.organization)
+        return can_manage_is_metadata(self.request.user, self.organization)
 
     def handle_no_permission(self) -> HttpResponseBase:
         return redirect("organization-detail", pk=self.organization.pk)
@@ -89,7 +89,7 @@ class OrganizationWizardNodesView(
     View,
 ):
     def has_permission(self) -> bool:
-        return is_organization_resource_manager(self.request.user, self.organization)
+        return can_manage_is_metadata(self.request.user, self.organization)
 
     def handle_no_permission(self) -> HttpResponseBase:
         return redirect("organization-detail", pk=self.organization.pk)
@@ -106,7 +106,7 @@ class OrganizationWizardCreateRedirectView(
     View,
 ):
     def has_permission(self) -> bool:
-        return is_organization_resource_manager(self.request.user, self.organization)
+        return can_manage_is_metadata(self.request.user, self.organization)
 
     def handle_no_permission(self) -> HttpResponseBase:
         return redirect("organization-detail", pk=self.organization.pk)

--- a/vitrina/orgs/services.py
+++ b/vitrina/orgs/services.py
@@ -528,6 +528,15 @@ def can_manage_is_metadata(user: User, organization: Organization) -> bool:
 
     Superusers, plus the resource coordinators and the resource managers of that
     organization. The wizard forms themselves guard each object through ``has_perm``.
+
+    A staff account that is not a superuser is deliberately left out, and this is the one
+    place where the shell is narrower than the forms behind it. ``determine_user_role`` maps
+    ``is_staff`` to ``Role.GLOBAL_MANAGER``, every wizard ACL rule lists that role, and
+    ``has_perm`` returns ``True`` for staff outright, so such a user can post to the wizard
+    forms through a direct URL while the button and the shell stay closed to them (see
+    ``test_dataset_create_wizard_permission_global_manager``). The three roles above are the
+    ones the team asked for; whether the global manager joins them is an open question, so
+    widen this helper rather than working around it if the answer turns out to be yes.
     """
     if not user.is_authenticated:
         return False

--- a/vitrina/orgs/services.py
+++ b/vitrina/orgs/services.py
@@ -554,6 +554,42 @@ def can_manage_is_metadata(user: User, organization: Organization) -> bool:
     )
 
 
+def _direct_organization_roles(user: User, organization: Organization) -> set[str]:
+    """The roles this user holds on the organization itself, ignoring revoked rows."""
+    return set(
+        Representative.objects.filter(
+            user=user,
+            content_type=ContentType.objects.get_for_model(Organization),
+            object_id=organization.pk,
+        )
+        .exclude(deleted=True)
+        .values_list("role", flat=True)
+    )
+
+
+def can_edit_organization_details(user: User, organization: Organization) -> bool:
+    """Who sees the "Redaguoti organizaciją" button on the organization page.
+
+    The resource coordinator holds ``Action.UPDATE``, but the team asked that neither of the
+    resource roles be offered the organization form there: they describe the organization
+    through the IS metadata wizard instead. The open data roles keep exactly the access they
+    had, and a superuser keeps both buttons.
+
+    The wizard itself still asks ``can_update_organization``, because that is the right
+    ``OrganizationUpdateView`` checks when its root node loads the form.
+    """
+    if not user.is_authenticated:
+        return False
+    if user.is_superuser:
+        return True
+    if not has_perm(user, Action.UPDATE, Representative, organization):
+        return False
+    roles = _direct_organization_roles(user, organization)
+    # Hidden only when every role they hold here is a resource one; holding an open data role
+    # as well leaves that role's access untouched.
+    return not (roles and roles <= Representative.RESOURCE_ROLE_KEYS)
+
+
 def is_manager(user: User, node: Model) -> bool:
     if isinstance(node, Organization):
         for rep in user.representative_set.all():

--- a/vitrina/orgs/services.py
+++ b/vitrina/orgs/services.py
@@ -523,15 +523,22 @@ def is_supervisor(user: User, node: Model) -> bool:
     return False
 
 
-def is_organization_resource_manager(user: User, organization: Organization) -> bool:
+def can_manage_is_metadata(user: User, organization: Organization) -> bool:
+    """Who may open the IS metadata wizard of an organization.
+
+    Superusers, plus the resource coordinators and the resource managers of that
+    organization. The wizard forms themselves guard each object through ``has_perm``.
+    """
     if not user.is_authenticated:
         return False
+    if user.is_superuser:
+        return True
     return (
         Representative.objects.filter(
             user=user,
             content_type=ContentType.objects.get_for_model(Organization),
             object_id=organization.pk,
-            role=Representative.RESOURCE_MANAGER,
+            role__in=sorted(Representative.RESOURCE_ROLE_KEYS),
         )
         .exclude(deleted=True)
         .exists()

--- a/vitrina/orgs/services.py
+++ b/vitrina/orgs/services.py
@@ -529,14 +529,16 @@ def can_manage_is_metadata(user: User, organization: Organization) -> bool:
     Superusers, plus the resource coordinators and the resource managers of that
     organization. The wizard forms themselves guard each object through ``has_perm``.
 
-    A staff account that is not a superuser is deliberately left out, and this is the one
-    place where the shell is narrower than the forms behind it. ``determine_user_role`` maps
-    ``is_staff`` to ``Role.GLOBAL_MANAGER``, every wizard ACL rule lists that role, and
-    ``has_perm`` returns ``True`` for staff outright, so such a user can post to the wizard
-    forms through a direct URL while the button and the shell stay closed to them (see
-    ``test_dataset_create_wizard_permission_global_manager``). The three roles above are the
-    ones the team asked for; whether the global manager joins them is an open question, so
-    widen this helper rather than working around it if the answer turns out to be yes.
+    A staff account that is not a superuser is left out on purpose. The team weighed
+    ``is_staff``, which is the global manager, and settled on ``is_superuser``: the two
+    administrators who need the wizard both hold it.
+
+    That leaves the shell narrower than the forms behind it, and this is the one place where
+    that is true. ``determine_user_role`` maps ``is_staff`` to ``Role.GLOBAL_MANAGER``, every
+    wizard ACL rule lists that role, and ``has_perm`` returns ``True`` for staff outright, so
+    such a user can post to the wizard forms through a direct URL while the button and the
+    shell stay closed to them (see ``test_dataset_create_wizard_permission_global_manager``).
+    Widen this helper rather than working around it if that ever has to change.
     """
     if not user.is_authenticated:
         return False

--- a/vitrina/orgs/services.py
+++ b/vitrina/orgs/services.py
@@ -556,40 +556,27 @@ def can_manage_is_metadata(user: User, organization: Organization) -> bool:
     )
 
 
-def _direct_organization_roles(user: User, organization: Organization) -> set[str]:
-    """The roles this user holds on the organization itself, ignoring revoked rows."""
-    return set(
-        Representative.objects.filter(
-            user=user,
-            content_type=ContentType.objects.get_for_model(Organization),
-            object_id=organization.pk,
-        )
-        .exclude(deleted=True)
-        .values_list("role", flat=True)
-    )
-
-
 def can_edit_organization_details(user: User, organization: Organization) -> bool:
     """Who sees the "Redaguoti organizaciją" button on the organization page.
 
-    The resource coordinator holds ``Action.UPDATE`` and keeps it: the button is gone from this
-    page only so that the same organization form is not offered twice, since the wizard already
-    opens it from its root node. This is a matter of where the form is reached from, not of who
-    may edit the organization, so no ACL rule moves and the wizard still asks
-    ``can_update_organization`` when its root node loads the form.
+    Anyone who may update the organization, except the people who already reach that same form
+    from the wizard's root node: the button is gone from this page only so the form is offered
+    in one place rather than two. Nobody loses access, and no ACL rule moves. A superuser keeps
+    both buttons, which is what the team asked for.
 
-    The open data roles keep exactly the access they had, and a superuser keeps both buttons.
+    Asking ``can_manage_is_metadata`` rather than listing roles keeps this in step with the
+    wizard by construction, however a user came by their access — a direct role, an
+    organizational one, or a flag. The permission asked for is ``Action.UPDATE`` on the
+    organization, which is what ``OrganizationUpdateView`` itself checks, so the button and the
+    form it leads to cannot drift apart.
     """
     if not user.is_authenticated:
         return False
     if user.is_superuser:
         return True
-    if not has_perm(user, Action.UPDATE, Representative, organization):
+    if not has_perm(user, Action.UPDATE, organization):
         return False
-    roles = _direct_organization_roles(user, organization)
-    # Hidden only when every role they hold here is a resource one; holding an open data role
-    # as well leaves that role's access untouched.
-    return not (roles and roles <= Representative.RESOURCE_ROLE_KEYS)
+    return not can_manage_is_metadata(user, organization)
 
 
 def is_manager(user: User, node: Model) -> bool:

--- a/vitrina/orgs/services.py
+++ b/vitrina/orgs/services.py
@@ -538,7 +538,7 @@ def can_manage_is_metadata(user: User, organization: Organization) -> bool:
             user=user,
             content_type=ContentType.objects.get_for_model(Organization),
             object_id=organization.pk,
-            role__in=sorted(Representative.RESOURCE_ROLE_KEYS),
+            role__in=Representative.RESOURCE_ROLE_KEYS,
         )
         .exclude(deleted=True)
         .exists()

--- a/vitrina/orgs/services.py
+++ b/vitrina/orgs/services.py
@@ -570,13 +570,13 @@ def _direct_organization_roles(user: User, organization: Organization) -> set[st
 def can_edit_organization_details(user: User, organization: Organization) -> bool:
     """Who sees the "Redaguoti organizaciją" button on the organization page.
 
-    The resource coordinator holds ``Action.UPDATE``, but the team asked that neither of the
-    resource roles be offered the organization form there: they describe the organization
-    through the IS metadata wizard instead. The open data roles keep exactly the access they
-    had, and a superuser keeps both buttons.
+    The resource coordinator holds ``Action.UPDATE`` and keeps it: the button is gone from this
+    page only so that the same organization form is not offered twice, since the wizard already
+    opens it from its root node. This is a matter of where the form is reached from, not of who
+    may edit the organization, so no ACL rule moves and the wizard still asks
+    ``can_update_organization`` when its root node loads the form.
 
-    The wizard itself still asks ``can_update_organization``, because that is the right
-    ``OrganizationUpdateView`` checks when its root node loads the form.
+    The open data roles keep exactly the access they had, and a superuser keeps both buttons.
     """
     if not user.is_authenticated:
         return False

--- a/vitrina/orgs/services.py
+++ b/vitrina/orgs/services.py
@@ -524,21 +524,11 @@ def is_supervisor(user: User, node: Model) -> bool:
 
 
 def can_manage_is_metadata(user: User, organization: Organization) -> bool:
-    """Who may open the IS metadata wizard of an organization.
+    """Who may open the IS metadata wizard: superusers and the organization's resource roles.
 
-    Superusers, plus the resource coordinators and the resource managers of that
-    organization. The wizard forms themselves guard each object through ``has_perm``.
-
-    A staff account that is not a superuser is left out on purpose. The team weighed
-    ``is_staff``, which is the global manager, and settled on ``is_superuser``: the two
-    administrators who need the wizard both hold it.
-
-    That leaves the shell narrower than the forms behind it, and this is the one place where
-    that is true. ``determine_user_role`` maps ``is_staff`` to ``Role.GLOBAL_MANAGER``, every
-    wizard ACL rule lists that role, and ``has_perm`` returns ``True`` for staff outright, so
-    such a user can post to the wizard forms through a direct URL while the button and the
-    shell stay closed to them (see ``test_dataset_create_wizard_permission_global_manager``).
-    Widen this helper rather than working around it if that ever has to change.
+    Staff without ``is_superuser`` is left out on purpose; the team weighed ``is_staff`` and
+    settled on ``is_superuser``. ``has_perm`` still grants staff the wizard forms through a
+    direct URL, so widen this helper rather than working around it.
     """
     if not user.is_authenticated:
         return False
@@ -559,16 +549,8 @@ def can_manage_is_metadata(user: User, organization: Organization) -> bool:
 def can_edit_organization_details(user: User, organization: Organization) -> bool:
     """Who sees the "Redaguoti organizaciją" button on the organization page.
 
-    Anyone who may update the organization, except the people who already reach that same form
-    from the wizard's root node: the button is gone from this page only so the form is offered
-    in one place rather than two. Nobody loses access, and no ACL rule moves. A superuser keeps
-    both buttons, which is what the team asked for.
-
-    Asking ``can_manage_is_metadata`` rather than listing roles keeps this in step with the
-    wizard by construction, however a user came by their access — a direct role, an
-    organizational one, or a flag. The permission asked for is ``Action.UPDATE`` on the
-    organization, which is what ``OrganizationUpdateView`` itself checks, so the button and the
-    form it leads to cannot drift apart.
+    Anyone with ``Action.UPDATE``, except those who already open the same form from the wizard's
+    root node. Nobody loses access, no ACL rule moves, and a superuser keeps both buttons.
     """
     if not user.is_authenticated:
         return False

--- a/vitrina/orgs/templates/vitrina/orgs/detail.html
+++ b/vitrina/orgs/templates/vitrina/orgs/detail.html
@@ -29,15 +29,16 @@
                 <div class="column">
                     <h2 class="custom-title is-size-4-mobile no-margin-bottom">{{ organization.title }}</h2>
                 </div>
-				{% if can_update_organization %}
+				{% if can_manage_is_metadata or can_update_organization %}
 					<div class="column buttons is-one-third">
-						{% if is_information_system_administrator %}
+						{% if can_manage_is_metadata %}
 							<a href="{% url 'organization-wizard' pk=organization.id %}"
 							   class="button is-primary is-normal is-fullwidth m-t-md is-size-6-mobile"
 							   id="open_organization_wizard">
 								{% translate "Tvarkyti IS metaduomenis" %}
 							</a>
-						{% else %}
+						{% endif %}
+						{% if can_update_organization %}
                             <a href="{%url 'organization-change' pk=organization.id %}"
                                class="button is-primary is-normal is-fullwidth m-t-md is-size-6-mobile"
                                id="change_organization">

--- a/vitrina/orgs/templates/vitrina/orgs/detail.html
+++ b/vitrina/orgs/templates/vitrina/orgs/detail.html
@@ -29,7 +29,7 @@
                 <div class="column">
                     <h2 class="custom-title is-size-4-mobile no-margin-bottom">{{ organization.title }}</h2>
                 </div>
-				{% if can_manage_is_metadata or can_update_organization %}
+				{% if can_manage_is_metadata or can_edit_organization_details %}
 					<div class="column buttons is-one-third">
 						{% if can_manage_is_metadata %}
 							<a href="{% url 'organization-wizard' pk=organization.id %}"
@@ -38,7 +38,7 @@
 								{% translate "Tvarkyti IS metaduomenis" %}
 							</a>
 						{% endif %}
-						{% if can_update_organization %}
+						{% if can_edit_organization_details %}
                             <a href="{%url 'organization-change' pk=organization.id %}"
                                class="button is-primary is-normal is-fullwidth m-t-md is-size-6-mobile"
                                id="change_organization">

--- a/vitrina/orgs/templates/vitrina/orgs/wizard.html
+++ b/vitrina/orgs/templates/vitrina/orgs/wizard.html
@@ -112,9 +112,11 @@
                         </li>
                         <li class="wizard-tree-node wizard-tree-root" x-data="{ open: true }"
                             @treetoggleall.window="if ($event.detail) open = true">
-                            {# The organization form belongs to `Action.UPDATE` on the organization, which the
-                               resource manager does not hold. Asking for it anyway answers a redirect to the
-                               organization page, and HTMX swaps that whole page into the pane. #}
+                            {% comment %}
+                                The organization form belongs to `Action.UPDATE` on the organization, which
+                                the resource manager does not hold. Asking for it anyway answers a redirect
+                                to the organization page, and HTMX swaps that whole page into the pane.
+                            {% endcomment %}
                             <div class="wizard-tree-row is-flex is-align-items-center"
                                  :class="selected && selected.key === 'org:{{ organization.pk }}' && mode === 'detail' ? 'is-active' : ''"
                                  {% if can_update_organization %}
@@ -165,8 +167,10 @@
                 <main class="column wizard-main">
 
                     {% if not can_update_organization %}
-                    {# Lives outside `#wizard-main-pane`: an HTMX swap replaces everything inside it, so a
-                       notice kept in there would be gone the moment the first child form loads. #}
+                    {% comment %}
+                        Lives outside `#wizard-main-pane`: an HTMX swap replaces everything inside it, so a
+                        notice kept in there would be gone the moment the first child form loads.
+                    {% endcomment %}
                     <div id="wizard-org-notice" class="notification is-light"
                          x-show="mode === 'detail' && selected && selected.key === 'org:{{ organization.pk }}'"
                          x-cloak>

--- a/vitrina/orgs/templates/vitrina/orgs/wizard.html
+++ b/vitrina/orgs/templates/vitrina/orgs/wizard.html
@@ -177,13 +177,14 @@
                          {% endif %}>
 
                         {% if not can_update_organization %}
-                            <div class="notification is-light" x-show="!selected" x-cloak>
+                            <div class="notification is-light"
+                                 x-show="selected && selected.key === 'org:{{ organization.pk }}'" x-cloak>
                                 {% translate "Organizacijos duomenis redaguoja duomenų išteklių koordinatorius. Pasirinkite elementą medyje kairėje." %}
                             </div>
                         {% endif %}
 
                         {# Initial placeholder (replaced by HTMX on first select) #}
-                        <div x-show="mode === 'detail' && selected" x-cloak>
+                        <div x-show="mode === 'detail' && selected{% if not can_update_organization %} && selected.key !== 'org:{{ organization.pk }}'{% endif %}" x-cloak>
                             <header class="wizard-detail-header is-flex is-align-items-center mb-4">
                                 <span class="icon is-large has-text-grey-dark mr-3">
                                     <i class="fas fa-2x" :class="selected && selected.icon"></i>

--- a/vitrina/orgs/templates/vitrina/orgs/wizard.html
+++ b/vitrina/orgs/templates/vitrina/orgs/wizard.html
@@ -112,11 +112,7 @@
                         </li>
                         <li class="wizard-tree-node wizard-tree-root" x-data="{ open: true }"
                             @treetoggleall.window="if ($event.detail) open = true">
-                            {% comment %}
-                                The organization form belongs to `Action.UPDATE` on the organization, which
-                                the resource manager does not hold. Asking for it anyway answers a redirect
-                                to the organization page, and HTMX swaps that whole page into the pane.
-                            {% endcomment %}
+                            {# Asking for a form the user may not open swaps a redirect into the pane #}
                             <div class="wizard-tree-row is-flex is-align-items-center"
                                  :class="selected && selected.key === 'org:{{ organization.pk }}' && mode === 'detail' ? 'is-active' : ''"
                                  {% if can_update_organization %}
@@ -167,10 +163,7 @@
                 <main class="column wizard-main">
 
                     {% if not can_update_organization %}
-                    {% comment %}
-                        Lives outside `#wizard-main-pane`: an HTMX swap replaces everything inside it, so a
-                        notice kept in there would be gone the moment the first child form loads.
-                    {% endcomment %}
+                    {# Outside `#wizard-main-pane`, which an HTMX swap empties #}
                     <div id="wizard-org-notice" class="notification is-light"
                          x-show="mode === 'detail' && selected && selected.key === 'org:{{ organization.pk }}'"
                          x-cloak>
@@ -178,7 +171,7 @@
                     </div>
                     {% endif %}
 
-                    {# HTMX fragment target — auto-loads org form on page open for whoever may edit it #}
+                    {# HTMX fragment target — auto-loads the org form for whoever may edit it #}
                     <div id="wizard-main-pane"
                          x-show="mode !== 'create'{% if not can_update_organization %} && !(selected && selected.key === 'org:{{ organization.pk }}'){% endif %}"
                          {% if can_update_organization %}

--- a/vitrina/orgs/templates/vitrina/orgs/wizard.html
+++ b/vitrina/orgs/templates/vitrina/orgs/wizard.html
@@ -122,10 +122,8 @@
                                  hx-target="#wizard-main-pane"
                                  hx-swap="innerHTML"
                                  hx-headers='{"X-Wizard-Request": "true"}'
-                                 @click.stop="select('org:{{ organization.pk }}'){% if wizard_tree %}; open = !open{% endif %}"
-                                 {% else %}
-                                 @click.stop="{% if wizard_tree %}open = !open{% endif %}"
-                                 {% endif %}>
+                                 {% endif %}
+                                 @click.stop="select('org:{{ organization.pk }}'){% if wizard_tree %}; open = !open{% endif %}">
                                 <span class="wizard-tree-caret has-text-grey"
                                       {% if wizard_tree %}
                                       :class="open ? 'is-open' : ''"
@@ -166,8 +164,19 @@
                 {# Right main pane — form fragments load here #}
                 <main class="column wizard-main">
 
+                    {% if not can_update_organization %}
+                    {# Lives outside `#wizard-main-pane`: an HTMX swap replaces everything inside it, so a
+                       notice kept in there would be gone the moment the first child form loads. #}
+                    <div id="wizard-org-notice" class="notification is-light"
+                         x-show="mode === 'detail' && selected && selected.key === 'org:{{ organization.pk }}'"
+                         x-cloak>
+                        {% translate "Organizacijos duomenis redaguoja duomenų išteklių koordinatorius. Pasirinkite elementą medyje kairėje." %}
+                    </div>
+                    {% endif %}
+
                     {# HTMX fragment target — auto-loads org form on page open for whoever may edit it #}
-                    <div id="wizard-main-pane" x-show="mode !== 'create'"
+                    <div id="wizard-main-pane"
+                         x-show="mode !== 'create'{% if not can_update_organization %} && !(selected && selected.key === 'org:{{ organization.pk }}'){% endif %}"
                          {% if can_update_organization %}
                          hx-get="{% url 'organization-change' pk=organization.pk %}"
                          hx-trigger="load"
@@ -176,15 +185,8 @@
                          hx-headers='{"X-Wizard-Request": "true"}'
                          {% endif %}>
 
-                        {% if not can_update_organization %}
-                            <div class="notification is-light"
-                                 x-show="selected && selected.key === 'org:{{ organization.pk }}'" x-cloak>
-                                {% translate "Organizacijos duomenis redaguoja duomenų išteklių koordinatorius. Pasirinkite elementą medyje kairėje." %}
-                            </div>
-                        {% endif %}
-
                         {# Initial placeholder (replaced by HTMX on first select) #}
-                        <div x-show="mode === 'detail' && selected{% if not can_update_organization %} && selected.key !== 'org:{{ organization.pk }}'{% endif %}" x-cloak>
+                        <div x-show="mode === 'detail' && selected" x-cloak>
                             <header class="wizard-detail-header is-flex is-align-items-center mb-4">
                                 <span class="icon is-large has-text-grey-dark mr-3">
                                     <i class="fas fa-2x" :class="selected && selected.icon"></i>

--- a/vitrina/orgs/templates/vitrina/orgs/wizard.html
+++ b/vitrina/orgs/templates/vitrina/orgs/wizard.html
@@ -112,13 +112,20 @@
                         </li>
                         <li class="wizard-tree-node wizard-tree-root" x-data="{ open: true }"
                             @treetoggleall.window="if ($event.detail) open = true">
+                            {# The organization form belongs to `Action.UPDATE` on the organization, which the
+                               resource manager does not hold. Asking for it anyway answers a redirect to the
+                               organization page, and HTMX swaps that whole page into the pane. #}
                             <div class="wizard-tree-row is-flex is-align-items-center"
                                  :class="selected && selected.key === 'org:{{ organization.pk }}' && mode === 'detail' ? 'is-active' : ''"
+                                 {% if can_update_organization %}
                                  hx-get="{% url 'organization-change' pk=organization.pk %}"
                                  hx-target="#wizard-main-pane"
                                  hx-swap="innerHTML"
                                  hx-headers='{"X-Wizard-Request": "true"}'
-                                 @click.stop="select('org:{{ organization.pk }}'){% if wizard_tree %}; open = !open{% endif %}">
+                                 @click.stop="select('org:{{ organization.pk }}'){% if wizard_tree %}; open = !open{% endif %}"
+                                 {% else %}
+                                 @click.stop="{% if wizard_tree %}open = !open{% endif %}"
+                                 {% endif %}>
                                 <span class="wizard-tree-caret has-text-grey"
                                       {% if wizard_tree %}
                                       :class="open ? 'is-open' : ''"
@@ -159,13 +166,21 @@
                 {# Right main pane — form fragments load here #}
                 <main class="column wizard-main">
 
-                    {# HTMX fragment target — auto-loads org form on page open #}
+                    {# HTMX fragment target — auto-loads org form on page open for whoever may edit it #}
                     <div id="wizard-main-pane" x-show="mode !== 'create'"
+                         {% if can_update_organization %}
                          hx-get="{% url 'organization-change' pk=organization.pk %}"
                          hx-trigger="load"
                          hx-target="#wizard-main-pane"
                          hx-swap="innerHTML"
-                         hx-headers='{"X-Wizard-Request": "true"}'>
+                         hx-headers='{"X-Wizard-Request": "true"}'
+                         {% endif %}>
+
+                        {% if not can_update_organization %}
+                            <div class="notification is-light" x-show="!selected" x-cloak>
+                                {% translate "Organizacijos duomenis redaguoja duomenų išteklių koordinatorius. Pasirinkite elementą medyje kairėje." %}
+                            </div>
+                        {% endif %}
 
                         {# Initial placeholder (replaced by HTMX on first select) #}
                         <div x-show="mode === 'detail' && selected" x-cloak>

--- a/vitrina/orgs/views.py
+++ b/vitrina/orgs/views.py
@@ -517,8 +517,7 @@ class OrganizationDetailView(PermissionRequiredMixin, PlanMixin, OrganizationBas
             language_code=self.request.LANGUAGE_CODE,
         )
         context_data["parent_links"].update({None: _("Informacija")})
-        # Only this page draws the two buttons, and both checks query `Representative`, so they
-        # stay out of `OrganizationBaseViewMixin` and off every other organization page.
+        # Only this page draws the buttons, so these queries stay off every other organization page.
         context_data["can_manage_is_metadata"] = can_manage_is_metadata(self.request.user, self.organization)
         context_data["can_edit_organization_details"] = can_edit_organization_details(
             self.request.user, self.organization

--- a/vitrina/orgs/views.py
+++ b/vitrina/orgs/views.py
@@ -144,10 +144,6 @@ class OrganizationBaseViewMixin:
         context_data["can_update_organization"] = has_perm(
             self.request.user, Action.UPDATE, Representative, self.organization
         )
-        context_data["can_manage_is_metadata"] = can_manage_is_metadata(self.request.user, self.organization)
-        context_data["can_edit_organization_details"] = can_edit_organization_details(
-            self.request.user, self.organization
-        )
         context_data["can_view_agents"] = has_perm(self.request.user, Action.VIEW, Agent, self.organization)
         context_data["can_view_keys"] = has_perm(self.request.user, Action.MANAGE_KEYS, Organization, self.organization)
         context_data["organization"] = self.organization
@@ -521,6 +517,12 @@ class OrganizationDetailView(PermissionRequiredMixin, PlanMixin, OrganizationBas
             language_code=self.request.LANGUAGE_CODE,
         )
         context_data["parent_links"].update({None: _("Informacija")})
+        # Only this page draws the two buttons, and both checks query `Representative`, so they
+        # stay out of `OrganizationBaseViewMixin` and off every other organization page.
+        context_data["can_manage_is_metadata"] = can_manage_is_metadata(self.request.user, self.organization)
+        context_data["can_edit_organization_details"] = can_edit_organization_details(
+            self.request.user, self.organization
+        )
         return context_data
 
 

--- a/vitrina/orgs/views.py
+++ b/vitrina/orgs/views.py
@@ -105,6 +105,7 @@ from vitrina.orgs.services import (
     has_perm,
     Action,
     hash_api_key,
+    can_edit_organization_details,
     can_manage_is_metadata,
     manage_subscriptions_for_representative,
     pre_representative_delete,
@@ -144,6 +145,9 @@ class OrganizationBaseViewMixin:
             self.request.user, Action.UPDATE, Representative, self.organization
         )
         context_data["can_manage_is_metadata"] = can_manage_is_metadata(self.request.user, self.organization)
+        context_data["can_edit_organization_details"] = can_edit_organization_details(
+            self.request.user, self.organization
+        )
         context_data["can_view_agents"] = has_perm(self.request.user, Action.VIEW, Agent, self.organization)
         context_data["can_view_keys"] = has_perm(self.request.user, Action.MANAGE_KEYS, Organization, self.organization)
         context_data["organization"] = self.organization

--- a/vitrina/orgs/views.py
+++ b/vitrina/orgs/views.py
@@ -105,7 +105,7 @@ from vitrina.orgs.services import (
     has_perm,
     Action,
     hash_api_key,
-    is_organization_resource_manager,
+    can_manage_is_metadata,
     manage_subscriptions_for_representative,
     pre_representative_delete,
     remove_representative_subscription,
@@ -143,9 +143,7 @@ class OrganizationBaseViewMixin:
         context_data["can_update_organization"] = has_perm(
             self.request.user, Action.UPDATE, Representative, self.organization
         )
-        context_data["is_information_system_administrator"] = is_organization_resource_manager(
-            self.request.user, self.organization
-        )
+        context_data["can_manage_is_metadata"] = can_manage_is_metadata(self.request.user, self.organization)
         context_data["can_view_agents"] = has_perm(self.request.user, Action.VIEW, Agent, self.organization)
         context_data["can_view_keys"] = has_perm(self.request.user, Action.MANAGE_KEYS, Organization, self.organization)
         context_data["organization"] = self.organization


### PR DESCRIPTION
The "Tvarkyti IS metaduomenis" button asked for two conditions that no single role met, so nobody reached the DCAT wizard:

- the resource manager passed the wizard check but failed `can_update_organization`, because updating a `Representative` is a coordinator right, so the button was never rendered;
- the resource coordinator and the superuser passed `can_update_organization` but failed the wizard check, which asked for the `resource_manager` role alone, so they were shown "Redaguoti organizaciją" instead.

Replace `is_organization_resource_manager` with `can_manage_is_metadata`: superusers pass, everyone else needs a live `Representative` row on that organization with either resource role. The wizard ACL already granted CREATE_WIZARD, UPDATE_WIZARD and DELETE_WIZARD to both resource roles, and `has_perm` already granted everything to a superuser, so this opens the shell to the users its forms already accepted rather than widening any permission.

