### PR TITLE
Statistikos endpoint

### DIFF
--- a/vitrina/api/urls.py
+++ b/vitrina/api/urls.py
@@ -21,6 +21,7 @@ from vitrina.api.views import (
     edp_dcat_ap_restricted_rdf,
     TaskViewSet,
     DistributionCreateAfterUploadToStorage,
+    stats,
 )
 
 router = DefaultRouter(trailing_slash=False)
@@ -141,6 +142,7 @@ urlpatterns = [
         TemplateView.as_view(template_name="vitrina/api/public_api.html"),
         name="public-api",
     ),
+    path("public/api/1/stats", stats, name="api-stats"),
     path("edp/dcat-ap.rdf", edp_dcat_ap_rdf, name="edp-dcat-ap-rdf"),
     path(
         "edp/dcat-ap-restricted.rdf",

--- a/vitrina/api/views.py
+++ b/vitrina/api/views.py
@@ -2,10 +2,13 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import PermissionDenied
 from django.db.models import QuerySet
 from django.db.utils import IntegrityError
+from django.contrib.auth.models import AnonymousUser
 from django.http import HttpRequest
 from django.http import HttpResponse
+from django.http import JsonResponse
 from django.templatetags.static import static
 from django.utils import timezone
+from django.views.decorators.http import require_safe
 from django.apps import apps
 from drf_yasg import openapi
 from drf_yasg.generators import OpenAPISchemaGenerator
@@ -50,6 +53,9 @@ from vitrina.api.serializers import (
 from vitrina.catalogs.models import Catalog
 from vitrina.classifiers.models import Category, Licence
 from vitrina.datasets.models import Dataset, DatasetStructure
+from vitrina.orgs.models import Organization
+from vitrina.projects.models import Project
+from vitrina.projects.services import get_projects
 from vitrina.resources.models import DatasetDistribution
 from vitrina.statistics.models import ModelDownloadStats
 from vitrina.structure.models import Metadata
@@ -784,3 +790,55 @@ def edp_dcat_ap_rdf(request: HttpRequest) -> HttpResponse:
 
 def edp_dcat_ap_restricted_rdf(request: HttpRequest) -> HttpResponse:
     return render_rdf_response(request, Dataset.edp_restricted.all(), only_link_rendered_datasets=True)
+
+
+STATS_SCOPES = ("public", "all")
+
+
+@require_safe
+def stats(request: HttpRequest) -> JsonResponse:
+    """Aggregate counters for the landing page.
+
+    ``scope=public`` counts what an anonymous visitor can reach in this instance.
+    ``scope=all`` counts everything registered in it, regardless of access rights;
+    an instance holding restricted data would otherwise report zero.
+
+    Neither variant looks at the requesting user, so the response is the same for
+    everyone and safe to store in a shared cache.
+    """
+    scope = request.GET.get("scope", "public")
+    if scope not in STATS_SCOPES:
+        return JsonResponse(
+            {"error": "Unsupported scope '%s'. Use one of: %s." % (scope, ", ".join(STATS_SCOPES))},
+            status=400,
+        )
+
+    not_deleted = {"deleted__isnull": True, "deleted_on__isnull": True}
+
+    if scope == "public":
+        organizations = Organization.public.count()
+        # AnonymousUser on purpose, not request.user: the counter must match what
+        # the dataset list shows to a visitor who is not logged in, and it must be
+        # the same number for everybody so that it can be cached.
+        datasets = Dataset.restricted.for_user(AnonymousUser()).count()
+        projects = get_projects(AnonymousUser(), approved_only=True).count()
+    else:
+        organizations = Organization.objects.filter(**not_deleted).count()
+        datasets = Dataset.objects.filter(organization_id__isnull=False, **not_deleted).count()
+        # Only approved use cases are counted in either scope: an unapproved one
+        # has not been reviewed yet and should not appear in a public counter.
+        projects = Project.objects.filter(status=Project.APPROVED, **not_deleted).count()
+
+    response = JsonResponse(
+        {
+            "scope": scope,
+            "organizations": organizations,
+            "datasets": datasets,
+            "projects": projects,
+        }
+    )
+    # The landing page is served from another host, and the payload is aggregate
+    # counts only, so it is exposed to any origin.
+    response["Access-Control-Allow-Origin"] = "*"
+    response["Cache-Control"] = "public, max-age=300"
+    return response


### PR DESCRIPTION
## Kas pridedama

Vienas viešas endpointas, grąžinantis agreguotus skaičius skėtiniam puslapiui, kuris jungs atvirų duomenų ir valstybės informacinių sistemų duomenų katalogus.

```
GET /public/api/1/stats?scope=public   (numatytoji)
GET /public/api/1/stats?scope=all

→ {"scope": "public", "organizations": 520, "datasets": 2828, "projects": 30}
```

`scope=public` skaičiuoja tai, ką šioje instancijoje pasiekia neprisijungęs lankytojas: naudojamas tas pats `for_user` filtras kaip ir rinkinių sąraše, tik su neprisijungusiu naudotoju, todėl skaitiklis sutampa su tuo, ką žmogus pamatys paspaudęs. `scope=all` skaičiuoja viską, kas joje registruota, nepaisant prieigos teisių. Nė vienas variantas nežiūri į tai, kas kreipiasi — `request.user` skaičiavime nedalyvauja — tad atsakymas visiems vienodas ir tinkamas kešuoti. Panaudojimo atvejai abiem atvejais skaičiuojami tik patvirtinti.

## Kam reikia `scope=all`

Atskyrus duomenų bazes, ribotos prieigos katalogo bazėje beveik visi rinkiniai bus neprieinami neprisijungusiam lankytojui, tad jo „viešas" skaitiklis rodytų nulį. Bandomojoje aplinkoje patikrinta: iš 1793 neviešų rinkinių neprisijungusiam matomi 0. `scope=all` leidžia parodyti, kiek rinkinių jame registruota.

## Ko čia nėra ir nebus

Skėtinis puslapis į šitą repozitoriją nekeliauja. Katalogas atiduoda skaičius; puslapis, kuris juos rodo, ir sprendimas, kurį `scope` jam naudoti, lieka už katalogo ribų.

## Pagrindas

Statistika pirmą kartą realizuota Tomo Murausko pilotinėje šakoje `ft/portalo-konfiguracija-ir-statistikos-api`. Kitos tos šakos dalys — portalo pavadinimas ir logotipas, paieškos facet'ų pataisa, `settings.py` numatytosios reikšmės — čia neįtrauktos ir teikiamos atskirai.

## Patikrinta

Bandomojoje aplinkoje su nuasmenintu produkcijos dumpu:

| | `scope=public` | `scope=all` |
|---|---|---|
| Organizacijos | 520 | 526 |
| Duomenų rinkiniai | 2828 | 4649 |
| Panaudojimo atvejai | 30 | 30 |

Be parametro grąžinama `public`. Nežinoma `scope` reikšmė — HTTP 400 su paaiškinimu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
